### PR TITLE
system-helper: Also check 'sudo' for the installation policykit rule

### DIFF
--- a/system-helper/org.freedesktop.Flatpak.rules
+++ b/system-helper/org.freedesktop.Flatpak.rules
@@ -2,7 +2,7 @@ polkit.addRule(function(action, subject) {
     if ((action.id == "org.freedesktop.Flatpak.app-install" ||
          action.id == "org.freedesktop.Flatpak.runtime-install") &&
         subject.active == true && subject.local == true &&
-        subject.isInGroup("wheel")) {
+        (subject.isInGroup("wheel") || subject.isInGroup("sudo"))) {
             return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
Some distros do not have a 'wheel' group by default, so 'sudo' should be
checked when determining whether the user is allowed to perform
system-wide installations.
