### PR TITLE
Skip tests that make a repository if /var/tmp lacks user xattrs

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -196,6 +196,14 @@ run_sh () {
     ${CMD_PREFIX} flatpak run --command=bash ${ARGS-} org.test.Hello -c "$*"
 }
 
+skip_without_user_xattrs () {
+    touch test-xattrs
+    if ! setfattr -n user.testvalue -v somevalue test-xattrs; then
+        echo "1..0 # SKIP this test requires xattr support"
+        exit 0
+    fi
+}
+
 skip_without_bwrap () {
     if [ -z "${FLATPAK_BWRAP:-}" ]; then
         # running installed-tests: assume we know what we're doing

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_without_user_xattrs
 
 echo "1..3"
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_without_user_xattrs
 
 echo "1..7"
 


### PR DESCRIPTION
---
For example, on an Ubuntu live system, we can run bwrap (the kernel
allows unprivileged user namespace creation by default) but we cannot
write xattrs in /var/tmp (because everything mutable is tmpfs).

This is very similar to a check I added to ostree: https://github.com/ostreedev/ostree/commit/3e3755c497bd85e22b01829c5715119d46394687