### PR TITLE
exec* returns -1 on error

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -222,7 +222,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
 
   g_ptr_array_add (argv_array, NULL);
 
-  if (!execve (flatpak_get_bwrap (), (char **) argv_array->pdata, envp))
+  if (execve (flatpak_get_bwrap (), (char **) argv_array->pdata, envp) == -1)
     {
       g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno), "Unable to start app");
       return FALSE;

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -2052,7 +2052,7 @@ builder_manifest_run (BuilderManifest *self,
 
   commandline = g_strjoinv (" ", (char **) args->pdata);
 
-  if (!execvp ((char *) args->pdata[0], (char **) args->pdata))
+  if (execvp ((char *) args->pdata[0], (char **) args->pdata) == -1)
     {
       g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno), "Unable to start flatpak build");
       return FALSE;


### PR DESCRIPTION
...so use the == -1 idiom as already used in common/flatpak-run.c
(another fix would be to drop the if completely, as exec* doesn't
return on success)