### PR TITLE
prevent confusing errors

### DIFF
--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -199,12 +199,16 @@ builder_module_set_property (GObject      *object,
 {
   BuilderModule *self = BUILDER_MODULE (object);
   gchar **tmp;
+  char *p;
 
   switch (prop_id)
     {
     case PROP_NAME:
       g_clear_pointer (&self->name, g_free);
       self->name = g_value_dup_string (value);
+      if ((p = strchr (self->name, ' ')) ||
+          (p = strchr (self->name, '/')))
+        g_printerr ("Module names like '%s' containing '%c' are problematic. Expect errors.\n", self->name, *p);
       break;
 
     case PROP_SUBDIR:

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -282,7 +282,7 @@
             <variablelist>
                 <varlistentry>
                     <term><option>name</option> (string)</term>
-                    <listitem><para>The name of the module, used in e.g. build logs</para></listitem>
+                    <listitem><para>The name of the module, used in e.g. build logs. The name is also used for constructing filenames and commandline arguments, therefore using spaces or '/' in this string is a bad idea.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>disabled</option> (boolean)</term>


### PR DESCRIPTION
flatpak-builder does a lot of commandline construction, using the module names and other data from the .json file to construct options, filenames, etc. There's a ton of possible errors that can happen if the module name contains spaces or slashes.  