### PR TITLE
library-only build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,8 +114,16 @@ POLKIT_GOBJECT_REQUIRED=0.98
 PKG_CHECK_MODULES(BASE, [glib-2.0 gio-2.0 gio-unix-2.0])
 PKG_CHECK_MODULES(SOUP, [libsoup-2.4])
 
-PKG_CHECK_MODULES(POLKIT, \
-		  polkit-gobject-1 >= $POLKIT_GOBJECT_REQUIRED)
+AC_ARG_ENABLE([system-helper],
+              AC_HELP_STRING([--disable-system-helper],
+                             [Disable system helper]),
+              [],
+              [enable_system_helper=yes])
+if test "xenable_system_helper" = "xyes"; then
+  PKG_CHECK_MODULES(POLKIT, \
+  		    polkit-gobject-1 >= $POLKIT_GOBJECT_REQUIRED)
+fi
+AM_CONDITIONAL(BUILD_SYSTEM_HELPER, test x$enable_system_helper = xyes)
 
 AC_ARG_ENABLE([xauth],
               AC_HELP_STRING([--disable-xauth],

--- a/system-helper/Makefile.am.inc
+++ b/system-helper/Makefile.am.inc
@@ -1,3 +1,5 @@
+if BUILD_SYSTEM_HELPER
+
 libexec_PROGRAMS += \
 	flatpak-system-helper \
 	$(NULL)
@@ -35,3 +37,5 @@ polkit_policy_DATA =					\
 
 EXTRA_DIST += system-helper/org.freedesktop.Flatpak.policy.in system-helper/org.freedesktop.Flatpak.SystemHelper.conf system-helper/org.freedesktop.Flatpak.rules.in
 DISTCLEANFILES += system-helper/org.freedesktop.Flatpak.policy system-helper/org.freedesktop.Flatpak.rules system-helper/flatpak-system-helper.service system-helper/org.freedesktop.Flatpak.SystemHelper.service
+
+endif


### PR DESCRIPTION
I tried to fix up the gnome-software build in gnome-apps-nightly, but it still doesn't work - it uses the flatpak libraries, so it has flatpak as dependency. flatpak configure now requires polkit, so we end up pulling in mozjs for polkit, which is really to much when we just want libflatpak.

I would suggest either a configure flat to turn off the building of the system helper, or separating out the library. 