### PR TITLE
flatpak-builder: support var runtimes

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -130,6 +130,10 @@
                     <listitem><para>The name of the development runtime that the application builds with.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>var</option> (string)</term>
+                    <listitem><para>The name of the var runtime to use.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>metadata</option> (string)</term>
                     <listitem><para>Use this file as the base metadata file when finishing.</para></listitem>
                 </varlistentry>


### PR DESCRIPTION
var runtimes are a clever hack to deal with populating rpms and the rpmdb.
It would be nice to support them in the json manifest.