### PR TITLE
flatpak-run: don't fail if there are no system fonts

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2278,9 +2278,12 @@ add_font_path_args (GPtrArray *argv_array)
   g_autoptr(GFile) user_font1 = NULL;
   g_autoptr(GFile) user_font2 = NULL;
 
-  add_args (argv_array,
-            "--bind", SYSTEM_FONTS_DIR, "/run/host/fonts",
-            NULL);
+  if (g_file_test (SYSTEM_FONTS_DIR, G_FILE_TEST_EXISTS))
+    {
+      add_args (argv_array,
+                "--bind", SYSTEM_FONTS_DIR, "/run/host/fonts",
+                NULL);
+    }
 
   home = g_file_new_for_path (g_get_home_dir ());
   user_font1 = g_file_resolve_relative_path (home, ".local/share/fonts");


### PR DESCRIPTION
In a minimal environment (like the one where we run installed-tests
in Debian), we might not have /usr/share/fonts.

---

This is highly unlikely "in real life", but it could conceivably happen if someone is deploying non-GUI Flatpak bundles (webapps? proprietary command-line tools? game servers?) on a headless system.

I'm currently applying this patch in Debian to make the installed-tests pass, but if you would prefer I can give flatpak a hard dependency on `fontconfig-config` (which itself depends on some reasonable fallback fonts) or on a fallback font like `fonts-dejavu-core`.