### PR TITLE
consider sources

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -82,7 +82,10 @@
             </itemizedlist>
 
             After this you will end up with a build of the application in <arg choice="plain">DIRECTORY</arg>, which you can
-            export to a repository with the <command>flatpak build-export</command> command.
+            export to a repository with the <command>flatpak build-export</command> command. If you use the <option>--repo</option>
+            option, flatpack-builder will do the export for you at the end of the build process. When flatpak-builder does the
+            export, it also stores the manifest that was used for the build in /app/manifest.json. The manifest is 'resolved',
+            i.e. git branch names are replaced by the actual commit IDs that were used in the build.
         </para>
         <para>
             At each of the above steps flatpak caches the result, and if you build the same file again, it will start


### PR DESCRIPTION
Since we are doing open source, we should put some consideration into preserving that aspect. Can we make the recipe that an app or runtime was built from easily available from the repo ? Ideally in a form that makes it easy to reproduce the build.