### PR TITLE
Fix the build

### DIFF
--- a/document-portal/xdp-main.c
+++ b/document-portal/xdp-main.c
@@ -13,7 +13,6 @@
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 #include "xdp-dbus.h"
-#include "xdp-impl-dbus.h"
 #include "xdp-util.h"
 #include "flatpak-db.h"
 #include "flatpak-dbus.h"


### PR DESCRIPTION
The xdp-impl-dbus.h header no longer exists - it came from an
earlier version of the document commands branch where I introduced
a separate interface. Just drop the include, it is not needed.