### PR TITLE
The link from README.md is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 Flatpak is a system for building, distributing and running sandboxed
 desktop applications on Linux.
 
-See https://flatpak.org/ for more information.
+See http://flatpak.org/ for more information.


### PR DESCRIPTION
It links to https://flatpak.org, which doesn't work. It looks like only `http` is supported.