### PR TITLE
gdb in sandbox doesn't work

### DIFF
--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -121,7 +121,7 @@
                 <term><option>--devel</option></term>
 
                 <listitem><para>
-                    Use the devel runtime that is specified in the application metadata instead of the regular runtime.
+                    Use the devel runtime that is specified in the application metadata instead of the regular runtime, and use a seccomp profile that is less likely to break development tools.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
I was trying to debug some problem with a sandboxed app by using the sdk as runtime, and launching the app in gdb inside the sandbox. But gdb doesn't react to ^C, and setting breakpoints doesn't work.

I suspect that this warning might be related:

(gdb) r
Starting program: /app/bin/portal-test 
warning: Error disabling address space randomization: Operation not permitted
