### PR TITLE
Fix builddir option type in flatpak-builder documentation

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -336,7 +336,7 @@
                     <listitem><para>Use cmake instead of configure</para></listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term><option>builddir</option> (string)</term>
+                    <term><option>builddir</option> (boolean)</term>
                     <listitem><para>Use a build directory that is separate from the source directory</para></listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
builddir is actually boolean, not string.