### PR TITLE
test-basic: do not fail in non-English locales

### DIFF
--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+# This test looks for specific localized strings.
+export LC_ALL=C
+
 echo "1..3"
 
 ${FLATPAK} --version > version_out


### PR DESCRIPTION
One of the variations tested on Debian's reproducible build
infrastructure is that the second build is done in a French locale.
This test fails there, because it doesn't see "Usage:" in the help.