### PR TITLE
Add BWRAP and --with-system-bubblewrap configure arguments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,13 +41,18 @@ AM_CPPFLAGS =							\
 	-DFLATPAK_BASEDIR=\"$(pkgdatadir)\"			\
 	-DFLATPAK_TRIGGERDIR=\"$(pkgdatadir)/triggers\"		\
 	-DSYSTEM_FONTS_DIR=\"$(SYSTEM_FONTS_DIR)\"		\
-	-DHELPER=\"$(libexecdir)/flatpak-bwrap\"		\
 	-DDBUSPROXY=\"$(libexecdir)/flatpak-dbus-proxy\"	\
 	-DG_LOG_DOMAIN=\"flatpak\"				\
 	-I$(srcdir)/libglnx					\
 	-I$(srcdir)/common					\
 	-I$(builddir)/common					\
 	$(NULL)
+
+if WITH_SYSTEM_BWRAP
+AM_CPPFLAGS += -DHELPER=\"$(BWRAP)\"
+else
+AM_CPPFLAGS += -DHELPER=\"$(libexecdir)/flatpak-bwrap\"
+endif
 
 triggersdir = $(pkgdatadir)/triggers
 dist_triggers_SCRIPTS = \
@@ -79,6 +84,8 @@ include permission-store/Makefile.am.inc
 include document-portal/Makefile.am.inc
 include tests/Makefile.am.inc
 
+if !WITH_SYSTEM_BWRAP
+
 bwrap_PROGRAMS = flatpak-bwrap
 flatpak_bwrap_SOURCES = $(bwrap_SOURCES)
 flatpak_bwrap_CFLAGS = $(bwrap_CFLAGS)
@@ -97,6 +104,8 @@ if PRIV_MODE_FILECAPS
 	$(SUDO_BIN) setcap cap_sys_admin,cap_net_admin,cap_sys_chroot,cap_setuid,cap_setgid+ep $(DESTDIR)$(libexecdir)/flatpak-bwrap
 endif
 endif
+
+endif # !WITH_SYSTEM_BWRAP
 
 completiondir = $(datadir)/bash-completion/completions
 completion_DATA = completion/flatpak

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -224,7 +224,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
 
   g_ptr_array_add (argv_array, NULL);
 
-  if (execve (flatpak_get_bwrap (), (char **) argv_array->pdata, envp) == -1)
+  if (execvpe (flatpak_get_bwrap (), (char **) argv_array->pdata, envp) == -1)
     {
       g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno), "Unable to start app");
       return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2004,7 +2004,7 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
           if (!g_spawn_sync ("/",
                              (char **) argv_array->pdata,
                              NULL,
-                             G_SPAWN_DEFAULT,
+                             G_SPAWN_SEARCH_PATH,
                              NULL, NULL,
                              NULL, NULL,
                              NULL, &trigger_error))

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,20 @@ AC_ARG_WITH(system_fonts_dir,
 SYSTEM_FONTS_DIR=$with_system_fonts_dir
 AC_SUBST(SYSTEM_FONTS_DIR)
 
+AC_ARG_VAR([BWRAP], [Bubblewrap executable])
+AC_ARG_WITH([system-bubblewrap],
+            [AS_HELP_STRING([--with-system-bubblewrap], [Use system bwrap executable [default=check $BWRAP]])],
+            [BWRAP="$withval"],
+            [BWRAP="${BWRAP:-false}"])
+AS_CASE([$BWRAP],
+        [yes],
+            [BWRAP=bwrap],
+        [no],
+            [BWRAP=false],
+        [auto],
+            [AC_CHECK_PROG([BWRAP], [bwrap], [bwrap], [false])])
+AM_CONDITIONAL([WITH_SYSTEM_BWRAP], [test "x$BWRAP" != xfalse])
+
 AC_CHECK_FUNCS(fdwalk)
 
 AC_CHECK_HEADER([sys/xattr.h], [], AC_MSG_ERROR([You must have sys/xattr.h from glibc]))

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -1,11 +1,14 @@
 TESTS_ENVIRONMENT += FLATPAK_TESTS_DEBUG=1 \
 	FLATPAK_TRIGGERSDIR=$$(cd $(top_srcdir) && pwd)/triggers \
-	FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap \
 	FLATPAK_DBUSPROXY=$$(cd $(top_builddir) && pwd)/flatpak-dbus-proxy \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd) \
 	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd) \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
 	$(NULL)
+
+if !WITH_SYSTEM_BWRAP
+TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
+endif
 
 testdb_CFLAGS = $(BASE_CFLAGS)
 testdb_LDADD = \


### PR DESCRIPTION
This lets distributors share a system copy of bubblewrap (>= 0.1.0)
between Flatpak and any other projects that benefit from it, if they are
careful to keep new versions in sync. The default is still to use the
bundled submodule, ensuring compatibility and simplifying dependencies.

Enable $PATH search everywhere that runs bwrap, so that $BWRAP doesn't
necessarily need to be a fully-qualified path.