### PR TITLE
flatpak-run: Add a new --no-desktop option to prevent creation of cgroups

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -845,6 +845,8 @@ option_persist_cb (const gchar *option_name,
   return TRUE;
 }
 
+static gboolean option_no_desktop;
+
 static GOptionEntry context_options[] = {
   { "share", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_share_cb, "Share with host", "SHARE" },
   { "unshare", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_unshare_cb, "Unshare with host", "SHARE" },
@@ -860,6 +862,7 @@ static GOptionEntry context_options[] = {
   { "system-own-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_system_own_name_cb, "Allow app to own name on the system bus", "DBUS_NAME" },
   { "system-talk-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_system_talk_name_cb, "Allow app to talk to name on the system bus", "DBUS_NAME" },
   { "persist", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_persist_cb, "Persist home directory directory", "FILENAME" },
+  { "no-desktop", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_NONE, &option_no_desktop, "Don't require a running session (no cgroups creation)", NULL },
   { NULL }
 };
 
@@ -3160,7 +3163,7 @@ flatpak_run_app (const char     *app_ref,
 
   /* Must run this before spawning the dbus proxy, to ensure it
      ends up in the app cgroup */
-  if (!flatpak_run_in_transient_unit (app_ref_parts[1], error))
+  if (!option_no_desktop && !flatpak_run_in_transient_unit (app_ref_parts[1], error))
     return FALSE;
 
   if (!add_dbus_proxy_args (argv_array, session_bus_proxy_argv, (flags & FLATPAK_RUN_FLAG_LOG_SESSION_BUS) != 0, sync_fds, error))

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -292,6 +292,17 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--no-desktop</option></term>
+
+                <listitem><para>
+                    Don't require a running session, meaning that no cgroups creation will happen. This can be
+                    useful for certain scenarios when you might want to run a flatpak without a valid user
+                    session available (e.g. from a socket-activated systemd service), and not having a
+                    properly sandboxed environment is not an issue.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--log-session-bus</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
This is not intented for normal use, but it can be useful in cases where
we don't have a running session and sandboxing is not strictly required.

Fixes https://github.com/flatpak/flatpak/issues/170