### PR TITLE
unrpm: prevent shell injection

### DIFF
--- a/builder/builder-source-archive.c
+++ b/builder/builder-source-archive.c
@@ -416,12 +416,12 @@ unrpm (GFile   *dir,
        GError **error)
 {
   gboolean res;
-  const gchar *argv[] = { "sh", "-c", NULL, NULL };
-  char *unrpm_cmdline = g_strdup_printf("rpm2cpio %s | cpio -i -d", rpm_path);
+  const gchar *argv[] = { "sh", "-c", "rpm2cpio \"$1\" | cpio -i -d",
+      "sh", /* shell's $0 */
+      rpm_path, /* shell's $1 */
+      NULL };
 
-  argv[2] = unrpm_cmdline;
   res = flatpak_spawnv (dir, NULL, error, argv);
-  g_free(unrpm_cmdline);
 
   return res;
 }


### PR DESCRIPTION
Substituting into a shell command-line without escaping is a bad idea.
If the argument is attacker-controlled, it's a security vulnerability;
if the argument is legitimate-user-controlled (as I think it is here)
it's merely wrong.

We could escape the filename with g_shell_quote(), but it's more
straightforward to take advantage of the shell's argument processing.
The first positional parameter (if given) is $0, and the rest are $@.

---

This is untested (do we have a test-case for RPM-based Flatpaks?) but should work.