### PR TITLE
flatpak-builder: don't strip zip files

### DIFF
--- a/builder/builder-utils.c
+++ b/builder/builder-utils.c
@@ -187,6 +187,12 @@ is_elf_file (const char *path,
   if (!S_ISREG (stbuf.st_mode))
     return FALSE;
 
+  /* Self-extracting .zip files can be ELF-executables, but shouldn't be
+     treated like them - for example, stripping them breaks their
+     operation */
+  if (g_str_has_suffix (filename, ".zip"))
+    return FALSE;
+
   if ((strstr (filename, ".so.") != NULL ||
        g_str_has_suffix (filename, ".so")) ||
       (stbuf.st_mode & 0111) != 0)


### PR DESCRIPTION
It is allowed to make a self-executable zip, it will then be an ELF file
on Linux. The problem is that the current stripping code somehow breaks
that file (i.e. ./file.zip doesn't work anymore after stripping).

Signed-off-by: Niv Sardi <xaiki@evilgiggle.com>