### PR TITLE
Expand ~ in paths passed to `flatpak remote-add`

### DIFF
--- a/app/flatpak-builtins-add-remote.c
+++ b/app/flatpak-builtins-add-remote.c
@@ -203,11 +203,12 @@ load_options (char *filename,
 {
   g_autoptr(GError) error = NULL;
   g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+  g_autofree char *expanded_filename = flatpak_expand_path (filename);
   char *str;
 
-  if (!g_key_file_load_from_file (keyfile, filename, 0, &error))
+  if (!g_key_file_load_from_file (keyfile, expanded_filename, 0, &error))
     {
-      g_printerr ("Can't load file %s: %s\n", filename, error->message);
+      g_printerr ("Can't load file %s: %s\n", expanded_filename, error->message);
       exit (1);
     }
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <pwd.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -3574,4 +3575,42 @@ flatpak_get_current_locale_subpaths (void)
   g_ptr_array_add (subpaths, NULL);
 
   return (char **)g_ptr_array_free (subpaths, FALSE);
+}
+
+char *
+flatpak_expand_path (char const *path)
+{
+  if (g_path_is_absolute (path) || path[0] != '~')
+    {
+      return g_strdup (path);
+    }
+  else if (!path[1] || path[1] == '/')
+    {
+      return g_build_filename (g_get_home_dir(), path + 1, NULL);
+    }
+  else
+    {
+      char *user = g_strdup (path + 1);
+      char *slash_pos = strchr (user, '/');
+      struct passwd *pw;
+
+      if (slash_pos)
+        *slash_pos = '\0';
+
+      pw = getpwnam (user);
+      g_free (user);
+
+      if (pw)
+        {
+          slash_pos = strchr (path, '/');
+          if (!slash_pos)
+            return g_strdup (pw->pw_dir);
+
+          return g_strconcat (pw->pw_dir, slash_pos, NULL);
+        }
+      else
+        {
+          return g_strdup (path);
+        }
+    }
 }

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -41,6 +41,8 @@ gint flatpak_strcmp0_ptr (gconstpointer a,
 const char * flatpak_path_match_prefix (const char *pattern,
                                         const char *path);
 
+char *flatpak_expand_path (char const *path);
+
 const char * flatpak_get_arch (void);
 const char ** flatpak_get_arches (void);
 


### PR DESCRIPTION
Just extra convenience. Should be used anywhere else a user provides a path too.