### PR TITLE
docs: Clarify which options can be used multiple times

### DIFF
--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -115,6 +115,7 @@
 
                 <listitem><para>
                     Exclude files matching PATTERN from the commit.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 
@@ -123,6 +124,7 @@
 
                 <listitem><para>
                     Don't exclude files matching PATTERN from the commit, even if they match the --export patterns.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 
@@ -158,7 +160,8 @@
                 <term><option>--gpg-sign=KEYID</option></term>
 
                 <listitem><para>
-                    Sign the commit with this GPG key
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build-init.xml
+++ b/doc/flatpak-build-init.xml
@@ -113,6 +113,7 @@
 
                 <listitem><para>
                     Add a tag to the metadata file.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 
@@ -121,6 +122,7 @@
 
                 <listitem><para>
                     When using --writable-sdk, in addition to the sdk, also install the specified extension.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build-sign.xml
+++ b/doc/flatpak-build-sign.xml
@@ -75,7 +75,8 @@
                 <term><option>--gpg-sign=KEYID</option></term>
 
                 <listitem><para>
-                    Sign the commit with this GPG key
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build-update-repo.xml
+++ b/doc/flatpak-build-update-repo.xml
@@ -81,7 +81,8 @@
                 <term><option>--gpg-sign=KEYID</option></term>
 
                 <listitem><para>
-                    Sign the commit with this GPG key
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -701,6 +701,7 @@
                 <listitem><para>
                     Sign the commit with this GPG key.
                     Used when exporting the build results.
+                    This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
Some of the options do not explicitly say they can be used multiple
times even though it's clear from the code that they can. This commit
fixes that by saying so in the manpages.