### PR TITLE
Set up logging to the journal

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -45,6 +45,30 @@ static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
 static char *opt_runtime;
 static char *opt_runtime_version;
+static FlatpakRunFlags journal_flags;
+
+static gboolean
+opt_journal_cb (const char  *option_name,
+                const char  *value,
+                gpointer     data,
+                GError     **error)
+{
+  if (strcmp (value, "yes") == 0)
+    journal_flags = FLATPAK_RUN_FLAG_JOURNAL;
+  else if (strcmp (value, "no") == 0)
+    journal_flags = FLATPAK_RUN_FLAG_NO_JOURNAL;
+  else if (strcmp (value, "auto") == 0)
+    journal_flags = 0;
+  else
+    {
+      journal_flags = 0;
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                   _("Unknown journal option %s, valid options are: yes, no, auto"), value);
+      return FALSE;
+    }
+
+  return TRUE;
+}
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to use"), N_("ARCH") },
@@ -55,6 +79,7 @@ static GOptionEntry options[] = {
   { "runtime-version", 0, 0, G_OPTION_ARG_STRING, &opt_runtime_version, N_("Runtime version to use"), N_("VERSION") },
   { "log-session-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_session_bus, N_("Log session bus calls"), NULL },
   { "log-system-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_system_bus, N_("Log system bus calls"), NULL },
+  { "journal", 0, 0, G_OPTION_ARG_CALLBACK, &opt_journal_cb, N_("Redirect stdout and stderr to the journal"), N_("VALUE") },
   { NULL }
 };
 
@@ -127,7 +152,8 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
                         opt_runtime_version,
                         (opt_devel ? FLATPAK_RUN_FLAG_DEVEL : 0) |
                         (opt_log_session_bus ? FLATPAK_RUN_FLAG_LOG_SESSION_BUS : 0) |
-                        (opt_log_system_bus ? FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS : 0),
+                        (opt_log_system_bus ? FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS : 0) |
+                        journal_flags,
                         opt_command,
                         &argv[rest_argv_start + 1],
                         rest_argc - 1,

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -98,6 +98,8 @@ typedef enum {
   FLATPAK_RUN_FLAG_LOG_SESSION_BUS    = (1 << 2),
   FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS     = (1 << 3),
   FLATPAK_RUN_FLAG_NO_SESSION_HELPER  = (1 << 4),
+  FLATPAK_RUN_FLAG_JOURNAL            = (1 << 5),
+  FLATPAK_RUN_FLAG_NO_JOURNAL         = (1 << 6)
 } FlatpakRunFlags;
 
 gboolean flatpak_run_setup_base_argv (GPtrArray      *argv_array,

--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@ AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 
 POLKIT_GOBJECT_REQUIRED=0.98
 
-PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0])
+PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0 libsystemd])
 PKG_CHECK_MODULES(SOUP, [libsoup-2.4])
 
 AC_ARG_ENABLE([system-helper],

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -319,6 +319,14 @@
                     your D-Bus policy.
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>--journal=VALUE</option></term>
+
+                <listitem><para>
+                    Control whether to redirect stdout and stderr of the sandbox to the systemd journal. Possible values are yes, no or auto. In the latter case, only redirect if stderr is not a tty. The default is auto.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 


### PR DESCRIPTION
Systemd does this for services it runs. In fact, for a while I thought we would just inherit this via activation: if your app is dbus activatable, dbus would forward the activation to systemd, which would set up journal redirection for flatpak, from where it gets 'inherited' by the sandbox. But a) this only works if dbus actually forwards the activation (for which you need to install not just a dbus service file but also a systemd unit), and b) it is probably a little too indirect and accidental.

I think we should do the same thing systemd does when we set up the sandbox. There should be a way to opt out of this in the manifest, and in the flatpak run commandline.