### PR TITLE
install dbus systemd service file snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ permission-store-dbus.[ch]
 flatpak-system-helper
 xdg-desktop-portal
 *.service
+flatpak.conf
 flatpak.env
 flatpak.sh
 document-portal/xdp-dbus.[ch]

--- a/Makefile.am
+++ b/Makefile.am
@@ -133,6 +133,15 @@ flatpak.env: env.d/flatpak.env.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
 		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
 
+dbussnippetdir = $(systemduserunitdir)/dbus.service.d
+dbussnippet_DATA = flatpak.conf
+EXTRA_DIST += dbus.service.d/flatpak.conf.in
+DISTCLEANFILES += flatpak.conf
+
+flatpak.conf: dbus.service.d/flatpak.conf.in
+	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
+		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = flatpak.pc
 EXTRA_DIST += flatpak.pc.in

--- a/dbus.service.d/flatpak.conf.in
+++ b/dbus.service.d/flatpak.conf.in
@@ -1,0 +1,2 @@
+[Service]
+Environment=XDG_DATA_DIRS=%h/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/


### PR DESCRIPTION
flatpak currently installs a gdm env.d and a bash profile.d file to
ensure XDG_DATA_DIRS is set to the right value.  Neither is sufficient
when the dbus daemon is activated as a system --user service.

This commit adds a dbus service file snippet to frob its environment
variable for that case.