### PR TITLE
builder: Add a --override-manifest=PATH option

### DIFF
--- a/builder/builder-manifest.h
+++ b/builder/builder-manifest.h
@@ -86,6 +86,9 @@ gboolean        builder_manifest_create_platform (BuilderManifest *self,
                                                   BuilderContext  *context,
                                                   GError         **error);
 
+void            builder_manifest_apply_overrides (BuilderManifest *self,
+                                                  BuilderManifest *overrides);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderManifest, g_object_unref)
 
 G_END_DECLS

--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -1650,3 +1650,80 @@ builder_module_cleanup_collect (BuilderModule  *self,
         }
     }
 }
+
+void
+builder_module_apply_overrides (BuilderModule *self,
+                                BuilderModule *overrides)
+{
+  if (overrides->sources)
+    {
+      g_list_free_full (self->sources, g_object_unref);
+      self->sources = g_list_copy_deep (overrides->sources, (GCopyFunc) g_object_ref, NULL);
+    }
+  if (overrides->config_opts)
+    {
+      g_strfreev (self->config_opts);
+      self->config_opts = g_strdupv (overrides->config_opts);
+    }
+  if (overrides->make_args)
+    {
+      g_strfreev (self->make_args);
+      self->make_args = g_strdupv (overrides->make_args);
+    }
+  if (overrides->make_install_args)
+    {
+      g_strfreev (self->make_install_args);
+      self->make_install_args = g_strdupv (overrides->make_install_args);
+    }
+  if (overrides->rm_configure)
+    {
+      self->rm_configure = overrides->rm_configure;
+    }
+  if (overrides->no_autogen)
+    {
+      self->no_autogen = overrides->no_autogen;
+    }
+  if (overrides->no_parallel_make)
+    {
+      self->no_parallel_make = overrides->no_parallel_make;
+    }
+  if (overrides->no_python_timestamp_fix)
+    {
+      self->no_python_timestamp_fix = overrides->no_python_timestamp_fix;
+    }
+  if (overrides->cmake)
+    {
+      self->cmake = overrides->cmake;
+    }
+  if (overrides->builddir)
+    {
+      self->builddir = overrides->builddir;
+    }
+  if (overrides->subdir)
+    {
+      g_clear_pointer (&self->subdir, g_free);
+      self->subdir = g_strdup (overrides->subdir);
+    }
+  if (overrides->build_options)
+    {
+      if (self->build_options)
+        builder_options_apply_overrides (self->build_options, overrides->build_options);
+      else
+        self->build_options = g_object_ref (overrides->build_options);
+    }
+  if (overrides->post_install)
+    {
+      g_strfreev (self->post_install);
+      self->post_install = g_strdupv (overrides->post_install);
+    }
+  if (overrides->cleanup)
+    {
+      g_strfreev (self->cleanup);
+      self->cleanup = g_strdupv (overrides->cleanup);
+    }
+  if (overrides->cleanup_platform)
+    {
+      g_strfreev (self->cleanup_platform);
+      self->cleanup_platform = g_strdupv (overrides->cleanup_platform);
+    }
+}

--- a/builder/builder-module.h
+++ b/builder/builder-module.h
@@ -73,6 +73,9 @@ void     builder_module_cleanup_collect (BuilderModule  *self,
                                          BuilderContext *context,
                                          GHashTable     *to_remove_ht);
 
+void     builder_module_apply_overrides (BuilderModule *self,
+                                         BuilderModule *overrides);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderModule, g_object_unref)
 
 G_END_DECLS

--- a/builder/builder-options.c
+++ b/builder/builder-options.c
@@ -712,3 +712,47 @@ builder_options_checksum (BuilderOptions *self,
   if (arch_options)
     builder_options_checksum (arch_options, cache, context);
 }
+
+void
+builder_options_apply_overrides (BuilderOptions *self,
+                                 BuilderOptions *overrides)
+{
+  if (overrides->cflags)
+    {
+      g_clear_pointer (&self->cflags, g_free);
+      self->cflags = g_strdup (overrides->cflags);
+    }
+  if (overrides->cxxflags)
+    {
+      g_clear_pointer (&self->cxxflags, g_free);
+      self->cxxflags = g_strdup (overrides->cxxflags);
+    }
+  if (overrides->prefix)
+    {
+      g_clear_pointer (&self->prefix, g_free);
+      self->prefix = g_strdup (overrides->prefix);
+    }
+  if (overrides->env)
+    {
+      g_strfreev (self->env);
+      self->env = g_strdupv (overrides->env);
+    }
+  if (overrides->build_args)
+    {
+      g_strfreev (self->build_args);
+      self->build_args = g_strdupv (overrides->build_args);
+    }
+  if (overrides->strip)
+    {
+      self->strip = overrides->strip;
+    }
+  if (overrides->no_debuginfo)
+    {
+      self->no_debuginfo = overrides->no_debuginfo;
+    }
+  if (overrides->arch)
+    {
+      g_hash_table_destroy (self->arch);
+      self->arch = g_hash_table_ref (overrides->arch);
+    }
+}

--- a/builder/builder-options.h
+++ b/builder/builder-options.h
@@ -60,6 +60,9 @@ gboolean    builder_options_get_no_debuginfo (BuilderOptions *self,
 gboolean    builder_options_get_strip (BuilderOptions *self,
                                        BuilderContext *context);
 
+void        builder_options_apply_overrides (BuilderOptions *self,
+                                             BuilderOptions *overrides);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderOptions, g_object_unref)
 
 G_END_DECLS

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -750,6 +750,19 @@
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--override-manifest=PATH</option></term>
+
+                <listitem><para>
+                    Prefer the values in the JSON file at PATH over those in the
+                    MANIFEST with the same keys. For example, you may want to use
+                    a local checkout of a git repo rather than a remote URL. For
+                    build-options and modules, each member is copied individually
+                    rather than replacing the whole object, but the lists of
+                    sources are copied as a unit.
+                </para></listitem>
+            </varlistentry>
+
           </variablelist>
     </refsect1>
 


### PR DESCRIPTION
While developing an application with flatpak, the user (or a tool like
GNOME Builder) may want to do a build with a slightly different
configuration than the published one. This commit makes this easy by
allowing the user to specify a JSON file on the command line (which
would probably not be checked into version control) that has values
which override the ones in the MANIFEST.