### PR TITLE
utils: Print a debug message when launching subprocesses

### DIFF
--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -1001,7 +1001,7 @@ builder_manifest_init_app_dir (BuilderManifest *self,
   g_ptr_array_add (args, NULL);
 
   commandline = g_strjoinv (" ", (char **) args->pdata);
-  g_print ("Running: %s\n", commandline);
+  g_debug ("Running '%s'", commandline);
 
   subp =
     g_subprocess_newv ((const gchar * const *) args->pdata,
@@ -1234,7 +1234,7 @@ command (GFile      *app_dir,
   g_ptr_array_add (args, g_strdup (commandline));
   g_ptr_array_add (args, NULL);
 
-  g_print ("Running: %s\n", commandline);
+  g_debug ("Running '%s'", commandline);
 
   launcher = g_subprocess_launcher_new (0);
 
@@ -1406,7 +1406,7 @@ appstream_compose (GFile   *app_dir,
   va_end (ap);
 
   commandline = g_strjoinv (" ", (char **) args->pdata);
-  g_print ("Running: %s\n", commandline);
+  g_debug ("Running '%s'", commandline);
 
   launcher = g_subprocess_launcher_new (0);
 
@@ -1731,7 +1731,7 @@ builder_manifest_finish (BuilderManifest *self,
       g_ptr_array_add (args, NULL);
 
       commandline = g_strjoinv (" ", (char **) args->pdata);
-      g_print ("Running: %s\n", commandline);
+      g_debug ("Running '%s'", commandline);
 
       subp =
         g_subprocess_newv ((const gchar * const *) args->pdata,
@@ -1910,7 +1910,7 @@ builder_manifest_create_platform (BuilderManifest *self,
       g_ptr_array_add (args, NULL);
 
       commandline = g_strjoinv (" ", (char **) args->pdata);
-      g_print ("Running: %s\n", commandline);
+      g_debug ("Running '%s'", commandline);
 
       subp =
         g_subprocess_newv ((const gchar * const *) args->pdata,

--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -790,7 +790,7 @@ build (GFile          *app_dir,
   va_end (ap);
 
   commandline = g_strjoinv (" ", (char **) args->pdata);
-  g_print ("Running: %s\n", commandline);
+  g_debug ("Running '%s'", commandline);
 
   launcher = g_subprocess_launcher_new (0);
 

--- a/builder/builder-source-shell.c
+++ b/builder/builder-source-shell.c
@@ -141,7 +141,7 @@ run_script (BuilderContext *context,
   g_ptr_array_add (args, NULL);
 
   commandline = g_strjoinv (" ", (char **) args->pdata);
-  g_print ("Running: %s\n", commandline);
+  g_debug ("Running '%s'", commandline);
 
   launcher = g_subprocess_launcher_new (0);
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2600,7 +2600,7 @@ add_dbus_proxy_args (GPtrArray *argv_array,
   g_ptr_array_add (dbus_proxy_argv, NULL); /* NULL terminate */
 
   commandline = g_strjoinv (" ", (char **) dbus_proxy_argv->pdata);
-  g_debug ("Running %s", commandline);
+  g_debug ("Running '%s'", commandline);
 
   if (!g_spawn_async (NULL,
                       (char **) dbus_proxy_argv->pdata,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -1329,6 +1329,7 @@ flatpak_spawnv (GFile                *dir,
   g_autoptr(GOutputStream) out = NULL;
   g_autoptr(GMainLoop) loop = NULL;
   SpawnData data = {0};
+  g_autofree gchar *commandline = NULL;
 
   launcher = g_subprocess_launcher_new (0);
 
@@ -1340,6 +1341,9 @@ flatpak_spawnv (GFile                *dir,
       g_autofree char *path = g_file_get_path (dir);
       g_subprocess_launcher_set_cwd (launcher, path);
     }
+
+  commandline = g_strjoinv (" ", (gchar **) argv);
+  g_debug ("Running '%s'", commandline);
 
   subp = g_subprocess_launcher_spawnv (launcher, argv, error);
 


### PR DESCRIPTION
This commit makes flatpak print a debug message (which only appears to
the user if the -v option is used) whenever a subprocess is launched.
This should make debugging easier, both for flatpak users and
developers.