### PR TITLE
Create directories before attempting to generate code into them

### DIFF
--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -4,6 +4,7 @@ dbus_built_sources = common/flatpak-dbus.c common/flatpak-dbus.h
 systemd_dbus_built_sources = common/flatpak-systemd-dbus.c common/flatpak-systemd-dbus.h
 
 $(dbus_built_sources) : data/org.freedesktop.Flatpak.xml
+	mkdir -p $(builddir)/common
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.Flatpak.	\
 		--c-namespace Flatpak				\
@@ -12,6 +13,7 @@ $(dbus_built_sources) : data/org.freedesktop.Flatpak.xml
 		$(NULL)
 
 $(systemd_dbus_built_sources) : data/org.freedesktop.systemd1.xml
+	mkdir -p $(builddir)/common
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.systemd1.	\
 		--c-namespace Systemd				\

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -6,6 +6,7 @@ xdp_dbus_built_sources = document-portal/xdp-dbus.c document-portal/xdp-dbus.h
 BUILT_SOURCES += $(xdp_dbus_built_sources)
 
 $(xdp_dbus_built_sources) : data/org.freedesktop.portal.Documents.xml
+	mkdir -p $(builddir)/document-portal
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.portal.	\
 		--c-namespace XdpDbus				\

--- a/permission-store/Makefile.am.inc
+++ b/permission-store/Makefile.am.inc
@@ -13,6 +13,7 @@ BUILT_SOURCES += $(nodist_xdg_permission_store_SOURCES)
 CLEANFILES += $(nodist_xdg_permission_store_SOURCES)
 
 $(nodist_xdg_permission_store_SOURCES) : data/org.freedesktop.impl.portal.PermissionStore.xml
+	mkdir -p $(builddir)/permission-store
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.impl.portal.	\
 		--c-namespace Xdg				\


### PR DESCRIPTION
If flatpak is built from a separate build directory, code generation fails because the directory structure is not in place. Create the necessary directories before code generation.