### PR TITLE
Readme.md: align image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# ![](flatpak.png) Flatpak
+<p align="center">
+  <img src="https://github.com/flatpak/flatpak/blob/master/flatpak.png?raw=true" alt="Flatpak icon"/>
+</p>
 
 Flatpak is a system for building, distributing and running sandboxed
 desktop applications on Linux.


### PR DESCRIPTION
Use css to align the Flatpak image on the Readme.md since markdown doesn't allow tweaking the positioning.
Sorry, I couldn't leave it like this :)