### PR TITLE
Speed up summary regeneration

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2031,7 +2031,7 @@ flatpak_repo_update (OstreeRepo   *repo,
   g_autofree char *title = NULL;
 
   g_autoptr(GHashTable) refs = NULL;
-  GList *ordered_keys = NULL;
+  g_autoptr(GList) ordered_keys = NULL;
   GList *l = NULL;
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);


### PR DESCRIPTION
Two optimizations to the summary regeneration:

 * Only operate on flatpak refs
 * Only collect data once per revision

This makes a pretty big difference on my test repo with the following setup that's similar to our production Endless repos.
```
$ for ref in `ostree refs --repo ~/tmp/ostree/apps | sort`; do echo -n "$ref: "; ostree rev-parse --repo ~/tmp/ostree/apps $ref; done
app/org.gnome.Gnote/x86_64/eos3: 87ff33882acb8e2cf5665f6dc20cada1ac1f0d8639155d9b12389a17966094a3
app/org.gnome.Gnote/x86_64/eos3.0: 87ff33882acb8e2cf5665f6dc20cada1ac1f0d8639155d9b12389a17966094a3
app/org.gnome.Gnote/x86_64/master: 2ccbe50bb1325257e8a88dceacb69c42af253e18d80b9f0171a6627d33c52963
app/org.wesnoth.Wesnoth/x86_64/eos3: 6cafec1bedbe5b9c14e03bc7b026fb1ece533aca0043b3154fd8a29d624379af
app/org.wesnoth.Wesnoth/x86_64/eos3.0: 6cafec1bedbe5b9c14e03bc7b026fb1ece533aca0043b3154fd8a29d624379af
appstream/x86_64: 5c0e3c9ee9d3b20f49eb7ecdf84ec639201bc363b62329c8e2481ecb575af2cc
release/app/org.wesnoth.Wesnoth/x86_64/3.0.0: a07543d925f93199fd976c4df20b74734ce2e4fcf8655debdc41cd724c534fa1
release/app/org.wesnoth.Wesnoth/x86_64/3.0.1: a07543d925f93199fd976c4df20b74734ce2e4fcf8655debdc41cd724c534fa1
release/app/org.wesnoth.Wesnoth/x86_64/3.0.2: 6cafec1bedbe5b9c14e03bc7b026fb1ece533aca0043b3154fd8a29d624379af
# With master
$ time ./flatpak build-update-repo ~/tmp/ostree/apps
Updating appstream branch
Extracting icons for component org.gnome.Gnote.desktop
Extracting icons for component org.wesnoth.Wesnoth.desktop
Extracting icons for component org.gnome.Gnote.desktop
Extracting icons for component org.gnome.Gnote.desktop
Extracting icons for component org.wesnoth.Wesnoth.desktop
Updating summary

real	0m2.707s
user	0m2.100s
sys	0m0.598s
# With this branch
$ time ./flatpak build-update-repo ~/tmp/ostree/apps
Updating appstream branch
Extracting icons for component org.gnome.Gnote.desktop
Extracting icons for component org.wesnoth.Wesnoth.desktop
Extracting icons for component org.gnome.Gnote.desktop
Extracting icons for component org.gnome.Gnote.desktop
Extracting icons for component org.wesnoth.Wesnoth.desktop
Updating summary

real	0m0.586s
user	0m0.433s
sys	0m0.148s
```

https://github.com/flatpak/flatpak/issues/269