### PR TITLE
Various test fixes

### DIFF
--- a/document-portal/xdp-main.c
+++ b/document-portal/xdp-main.c
@@ -972,8 +972,13 @@ on_name_lost (GDBusConnection *connection,
               gpointer         user_data)
 {
   g_debug ("%s lost", name);
-  final_exit_status = 20;
-  g_set_error (&exit_error, G_DBUS_ERROR, G_DBUS_ERROR_FAILED, "D-Bus name \"%s\" lost", name);
+
+  if (final_exit_status == 0)
+    final_exit_status = 20;
+
+  if (exit_error == NULL)
+    g_set_error (&exit_error, G_DBUS_ERROR, G_DBUS_ERROR_FAILED, "D-Bus name \"%s\" lost", name);
+
   g_main_loop_quit (loop);
 }
 
@@ -991,7 +996,9 @@ session_bus_closed (GDBusConnection *connection,
                     gboolean         remote_peer_vanished,
                     GError          *bus_error)
 {
-  g_set_error (&exit_error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE, "Disconnected from session bus");
+  if (exit_error == NULL)
+    g_set_error (&exit_error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE, "Disconnected from session bus");
+
   g_main_loop_quit (loop);
 }
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -6,7 +6,9 @@ TESTS_ENVIRONMENT += FLATPAK_TESTS_DEBUG=1 \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
 	$(NULL)
 
-if !WITH_SYSTEM_BWRAP
+if WITH_SYSTEM_BWRAP
+TESTS_ENVIRONMENT += FLATPAK_BWRAP=$(BWRAP)
+else
 TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
 endif
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -74,6 +74,7 @@ tests/test-basic.sh: tests/package_version.txt
 
 dist_installed_test_extra_scripts += \
 	buildutil/tap-driver.sh \
+	tests/empty-configure \
 	tests/test-configure \
 	tests/make-test-app.sh \
 	tests/make-test-runtime.sh \
@@ -88,7 +89,6 @@ installed_test_data = \
 	tests/session.conf.in \
 	tests/0001-Add-test-logo.patch \
 	tests/org.test.Python.json \
-	tests/empty-configure \
 	tests/testpython.py \
 	tests/importme.py \
 	tests/importme2.py \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -81,7 +81,7 @@ dist_installed_test_extra_scripts += \
 	tests/make-test-bundles.sh \
 	$(NULL)
 
-installed_test_data = \
+dist_installed_test_data = \
 	tests/libtest.sh \
 	tests/org.test.Hello.png \
 	tests/package_version.txt \
@@ -105,8 +105,6 @@ dist_installed_test_keyring_DATA = \
 	$(NULL)
 dist_installed_test_dbs_DATA = tests/dbs/no_tables
 endif
-
-EXTRA_DIST += $(installed_test_data)
 
 dist_test_scripts = \
 	tests/test-basic.sh \

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -264,6 +264,7 @@ fi
 
 cleanup () {
     /bin/kill $DBUS_SESSION_BUS_PID
+    gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye || true
     fusermount -u $XDG_RUNTIME_DIR/doc || :
     rm -rf $TEST_DATA_DIR
 }

--- a/tests/make-test-bundles.sh
+++ b/tests/make-test-bundles.sh
@@ -25,3 +25,5 @@ flatpak build-bundle repo --repo-url=${URL} --gpg-keys=test-keyring/pubring.gpg 
 REF=`(cd repo/refs/heads; echo runtime/org.test.Platform/*/master)`
 ostree gpg-sign --repo=repo --gpg-homedir=test-keyring ${REF} 7B0961FD
 flatpak build-bundle --runtime repo --repo-url=${URL} --gpg-keys=test-keyring/pubring.gpg platform.flatpak org.test.Platform
+
+gpg-connect-agent --homedir test-keyring killagent /bye || true

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -33,8 +33,16 @@ for i in $@; do
                        _sysconfigdata ; do
             cp ${PYDIR}/$py.py ${DIR}/usr/lib/python2.7
         done
+        # These might not exist, depending how Python was configured; and the
+        # part after ${so} might be "module" or ".x86_64-linux-gnu" or
+        # something else
         for so in _locale strop ; do
-            cp ${PYDIR}/lib-dynload/${so}module.so ${DIR}/usr/lib/python2.7/lib-dynload
+            cp ${PYDIR}/lib-dynload/${so}*.so ${DIR}/usr/lib/python2.7/lib-dynload || :
+        done
+        for plat in $( cd ${PYDIR} && echo plat-* ); do
+            test -e ${PYDIR}/${plat} || continue
+            mkdir -p ${DIR}/usr/lib/python2.7/${plat}
+            cp ${PYDIR}/${plat}/*.py ${DIR}/usr/lib/python2.7/${plat}/
         done
     fi
 done

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -276,7 +276,7 @@ test_install_launch_uninstall (void)
     {
       gint exit_code = 0;
       char *argv[] = { (char *)bwrap, "--ro-bind", "/", "/", "/bin/true", NULL };
-      g_spawn_sync (NULL, argv, NULL, 0, NULL, NULL, NULL, NULL, &exit_code, &error);
+      g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL, &exit_code, &error);
       g_assert_no_error (error);
       if (exit_code != 0)
         {

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -314,8 +314,8 @@ test_install_launch_uninstall (void)
                                       &progress_count,
                                       NULL,
                                       &error);
-  g_assert (FLATPAK_IS_INSTALLED_REF (ref));
   g_assert_no_error (error);
+  g_assert (FLATPAK_IS_INSTALLED_REF (ref));
   g_assert_cmpint (progress_count, >, 0);
 
   quit_id = g_timeout_add (500, quit, NULL);
@@ -359,8 +359,8 @@ test_install_launch_uninstall (void)
                                       &progress_count,
                                       NULL,
                                       &error);
-  g_assert (FLATPAK_IS_INSTALLED_REF (ref));
   g_assert_no_error (error);
+  g_assert (FLATPAK_IS_INSTALLED_REF (ref));
   g_assert_cmpint (progress_count, >, 0);
 
   quit_id = g_timeout_add (500, quit, loop);
@@ -384,8 +384,8 @@ test_install_launch_uninstall (void)
   g_ptr_array_unref (refs);
 
   res = flatpak_installation_launch (inst, "org.test.Hello", NULL, NULL, NULL, NULL, &error);
-  g_assert_true (res);
   g_assert_no_error (error);
+  g_assert_true (res);
 
   quit_id = g_timeout_add (500, quit, loop);
   g_main_loop_run (loop);
@@ -402,8 +402,8 @@ test_install_launch_uninstall (void)
                                         &progress_count,
                                         NULL,
                                         &error);
-  g_assert_true (res);
   g_assert_no_error (error);
+  g_assert_true (res);
   //FIXME: no progress for uninstall
   //g_assert_cmpint (progress_count, >, 0);
 
@@ -428,8 +428,8 @@ test_install_launch_uninstall (void)
                                         &progress_count,
                                         NULL,
                                         &error);
-  g_assert_true (res);
   g_assert_no_error (error);
+  g_assert_true (res);
   //FIXME: no progress for uninstall
   //g_assert_cmpint (progress_count, >, 0);
 


### PR DESCRIPTION
Another Flatpak release, another round of fixes to the automated tests...

* Improve some diagnostics on failure by calling g_assert_no_error() first
* Enhance the Python test to cope with the way Debian compiles its Python, which is not quite the same as whatever OS (Fedora?) that test was initially run on
* Tell build-time tests which bwrap we are going to use even if it is a system copy, so that we can try it first and skip some tests if it doesn't work (for example in an unprivileged container, or a container where pivot_root fails with EINVAL)
* The document portal overwrites its GError when shutting down, which causes it to abort when the tests have made warnings fatal; fix that
* Improve how test data gets installed
* Tell gpg-agent to quit so it doesn't prevent container teardown (this doesn't seem to be a 100% complete solution unfortunately, but it's a step in the right direction)