### PR TITLE
flatpak-session-helper: Check for arg_argv being NULL

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -173,14 +173,13 @@ handle_host_command (FlatpakDevelopment *object,
   if (*arg_cwd_path == 0)
     arg_cwd_path = NULL;
 
-  if (*arg_argv[0] == 0)
+  if (arg_argv == NULL || *arg_argv == NULL || *arg_argv[0] == 0)
     {
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                              G_DBUS_ERROR_INVALID_ARGS,
                                              "No command given");
       return TRUE;
     }
-
 
   g_debug ("Running host command %s", arg_argv[0]);
 


### PR DESCRIPTION
To prevent crashers like the following:

Starting program: /var/tmp/flatpak/libexec/flatpak-session-helper
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7fffed8a9700 (LWP 7893)]
[New Thread 0x7fffed0a8700 (LWP 7894)]
[New Thread 0x7fffec439700 (LWP 7895)]
session-helper/flatpak-session-helper.c:176:20: runtime error: load of null pointer of type 'const gchar'

Thread 1 "flatpak-session" received signal SIGSEGV, Segmentation fault.
0x000000000040d6ce in handle_host_command (object=0x62100001ab90,
    invocation=0x61d000014dc0, arg_cwd_path=0x0, arg_argv=0x602000003dd0,
    arg_fds=0x61900000b130, arg_envs=0x61900001d2a0, flags=1)
    at session-helper/flatpak-session-helper.c:176
176   if (*arg_argv[0] == 0)
(gdb)