### PR TITLE
session-helper: return after sending DBus error

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -283,6 +283,7 @@ handle_host_command (FlatpakDevelopment *object,
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, code,
                                              "Failed to start command: %s",
                                              error->message);
+      return TRUE;
     }
 
   pid_data = g_new0 (PidData, 1);


### PR DESCRIPTION
Make sure we let the caller know we handled the message immediately after
sending our error reply.