### PR TITLE
Improve git submodules... again

### DIFF
--- a/builder/builder-source-git.c
+++ b/builder/builder-source-git.c
@@ -328,10 +328,7 @@ git_mirror_submodules (const char     *repo_location,
           words = g_strsplit_set (lines[0], " \t", 4);
 
           if (g_strcmp0 (words[0], "160000") != 0)
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Not a gitlink tree: %s", path);
-              return FALSE;
-            }
+            continue;
 
           if (!git_mirror_repo (absolute_url, update, words[2], context, error))
             return FALSE;
@@ -483,10 +480,7 @@ git_extract_submodule (const char     *repo_location,
           words = g_strsplit_set (lines[0], " \t", 4);
 
           if (g_strcmp0 (words[0], "160000") != 0)
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Not a gitlink tree: %s", path);
-              return FALSE;
-            }
+            continue;
 
           mirror_dir = git_get_mirror_dir (absolute_url, context);
           mirror_dir_as_url = g_file_get_uri (mirror_dir);

--- a/builder/builder-source-git.c
+++ b/builder/builder-source-git.c
@@ -327,7 +327,7 @@ git_mirror_submodules (const char     *repo_location,
 
           words = g_strsplit_set (lines[0], " \t", 4);
 
-          if (g_strcmp0 (words[1], "commit") != 0)
+          if (g_strcmp0 (words[0], "160000") != 0)
             {
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Not a gitlink tree: %s", path);
               return FALSE;
@@ -482,7 +482,7 @@ git_extract_submodule (const char     *repo_location,
 
           words = g_strsplit_set (lines[0], " \t", 4);
 
-          if (g_strcmp0 (words[1], "commit") != 0)
+          if (g_strcmp0 (words[0], "160000") != 0)
             {
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Not a gitlink tree: %s", path);
               return FALSE;


### PR DESCRIPTION
Today I tried building a nightly Blender, and feeling way too courageous I tried building it against a nightly Boost.

Boost is full of submodules, and its submodules also have submodules. And some of them probably also have submodules, and... But some of these do bad things.

For example, Boost's submodule odelint has a `.gitmodules` file, which lists a submodule at the `doc` path. But that path isn't a `gitlink`, it's a regular folder.

That's because the `doc` path used to be a submodule, but then [the submodule got removed some 5 years ago](https://github.com/boostorg/odeint/commit/e719fbc35d805654ad5583cafc1d89e9c18bdd5d) and made into a proper folder with documentation inside.

However the `.gitmodules` file still lists it on the master branch (it only got removed on the develop branch a few months ago, but that hasn't been merged into master yet).

flatpak-builder fails on this submodule:

```
Failed to download sources: module boost: Not a gitlink tree: doc
```

However, git deals with it just fine... by ignoring the `doc` submodule. Turns out, when the path of the submodule isn't a `gitlink`, git just ignores it and moves on to the next one.

We probably should do the same in flatpak-builder, and this pull request does just that.