### PR TITLE
build-export: Add missing \n to g_print calls

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -341,14 +341,14 @@ check_refs:
 
   bin_file = convert_app_absolute_path (argv[0], files);
   if (!g_file_query_exists (bin_file, NULL))
-    g_print ("WARNING: Binary not found for Exec line in %s: %s", path, command);
+    g_print ("WARNING: Binary not found for Exec line in %s: %s\n", path, command);
 
   *icon = g_key_file_get_string (key_file,
                                  G_KEY_FILE_DESKTOP_GROUP,
                                  G_KEY_FILE_DESKTOP_KEY_ICON,
                                  NULL);
   if (*icon && !g_str_has_prefix (*icon, app_id))
-    g_print ("WARNING: Icon not matching app id in %s: %s", path, *icon);
+    g_print ("WARNING: Icon not matching app id in %s: %s\n", path, *icon);
 
   *activatable = g_key_file_get_boolean (key_file,
                                          G_KEY_FILE_DESKTOP_GROUP,
@@ -376,7 +376,7 @@ validate_icon (const char *icon,
   svg  = g_strconcat (icon, ".svg", NULL);
   if (!find_file_in_tree (icondir, png) &&
       !find_file_in_tree (icondir, svg))
-    g_print ("WARNING: Icon referenced in desktop file but not exported: %s", icon);
+    g_print ("WARNING: Icon referenced in desktop file but not exported: %s\n", icon);
 
   return TRUE;
 }
@@ -438,7 +438,7 @@ validate_service_file (GFile *service_file,
 
   bin_file = convert_app_absolute_path (argv[0], files);
   if (!g_file_query_exists (bin_file, NULL))
-    g_print ("WARNING: Binary not found for Exec line in %s: %s", path, command);
+    g_print ("WARNING: Binary not found for Exec line in %s: %s\n", path, command);
 
   return TRUE;
 }


### PR DESCRIPTION
These get all mixed up into one line when using build-export