### PR TITLE
builder: check for name being defined in expand_modules

### DIFF
--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -172,6 +172,17 @@ expand_modules (GList *modules, GList **expanded, GHashTable *names, GError **er
       *expanded = g_list_concat (*expanded, submodules);
 
       name = builder_module_get_name (m);
+
+      if (name == NULL)
+        {
+          /* FIXME: We'd like to report *something* for the user
+                    to locate the errornous module definition.
+           */
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Module has no 'name' attribute set");
+          return FALSE;
+        }
+
       if (g_hash_table_lookup (names, name) != NULL)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,


### PR DESCRIPTION
If this is not checked, flatpak-builder might crash like this:

Starting program: /var/tmp/flatpak/bin/flatpak-builder -v --force-clean
-v --ccache --repo=/tmp/fb.repo --gpg-sign=tobiasmue@gnome.org
/tmp/fpbuilder org.gnome.Sdk.ASan.json
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-
gnu/libthread_db.so.1".
[New Thread 0x7ffff139c700 (LWP 20407)]

Thread 1 "flatpak-builder" received signal SIGSEGV, Segmentation fault.
0x00007ffff697c770 in g_str_hash () from /lib/x86_64-linux-
gnu/libglib-2.0.so.0
(gdb) bt
   from /lib/x86_64-linux-gnu/libglib-2.0.so.0
   from /lib/x86_64-linux-gnu/libglib-2.0.so.0
    expanded=expanded@entry=0x7fffffffdae0, names=names@entry=0x690a40,
    error=error@entry=0x7fffffffdc08) at builder/builder-manifest.c:175
    expanded=expanded@entry=0x696158, names=names@entry=0x690a40,
    error=error@entry=0x7fffffffdc08) at builder/builder-manifest.c:169
(self=self@entry=0x696050,
    context=context@entry=0x697970, error=error@entry=0x7fffffffdc08)
    at builder/builder-manifest.c:933
    at builder/builder-main.c:349
(gdb) up
   from /lib/x86_64-linux-gnu/libglib-2.0.so.0
(gdb)
    expanded=expanded@entry=0x7fffffffdae0, names=names@entry=0x690a40,
    error=error@entry=0x7fffffffdc08) at builder/builder-manifest.c:175
175	      if (g_hash_table_lookup (names, name) != NULL)
(gdb) l
170	        return FALSE;
171
172	      *expanded = g_list_concat (*expanded, submodules);
173
174	      name = builder_module_get_name (m);
175	      if (g_hash_table_lookup (names, name) != NULL)
176	        {
177	          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
178	                       "Duplicate modules named '%s'", name);
179	          return FALSE;
(gdb) p names
$1 = (GHashTable *) 0x690a40
(gdb) p name
$2 = 0x0
(gdb) p m
$3 = (BuilderModule *) 0x6978d0
(gdb) p *m
$4 = {parent = {g_type_instance = {g_class = 0x6959d0}, ref_count = 1,
    qdata = 0x0}, name = 0x0, subdir = 0x0, post_install = 0x0,
config_opts = 0x0, make_args = 0x0, make_install_args = 0x0, disabled
= 0,
rm_configure = 0, no_autogen = 0, no_parallel_make = 0,
no_python_timestamp_fix = 0, cmake = 0, builddir = 0, build_options =
0x0,
changes = 0x0, cleanup = 0x0, cleanup_platform = 0x0, sources = 0x0,
modules = 0x0}
(gdb)

This happens when a definition does not include a name, e.g.

            "modules": [
                {
                    "type": "archive",
                    "url": ""foo",
                    "sha256": "123"
                }