### PR TITLE
session-helper: use proper fd with ioctl() for tty setup

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -142,7 +142,21 @@ child_setup_func (gpointer user_data)
   setpgid (0, 0);
 
   if (data->set_tty)
-    ioctl (data->tty, TIOCSCTTY, 0);
+    {
+      /* data->tty is our from fd which is closed at this point.
+       * so locate the destnation fd and use it for the ioctl.
+       */
+      for (i = 0; i < data->fd_map_len; i++)
+        {
+          if (fd_map[i].from == data->tty)
+            {
+              if (ioctl (fd_map[i].final, TIOCSCTTY, 0) == -1)
+                g_warning ("ioctl(%d, TIOCSCTTY, 0) failed: %s",
+                           fd_map[i].final, strerror (errno));
+              break;
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
This was using the "from" fd from the fd_map, which will have already been closed by time we reach this portion of the child setup.

Tracking the movement of FDs while resolving the remappings is rather tedious and error prone, so just locate the final fd before calling the ioctl() in child setup.

This fixes the following warning when creating a terminal with Vte.

```
sh: cannot set terminal process group (-1): Inappropriate ioctl for device
sh: no job control in this shell
```