### PR TITLE
flatpak should close up access to kernel keyring

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3026,6 +3026,11 @@ setup_seccomp (GPtrArray  *argv_array,
     /* Don't allow reading current quota use */
     {SCMP_SYS (quotactl)},
 
+    /* Don't allow access to the kernel keyring */
+    {SCMP_SYS (add_key)},
+    {SCMP_SYS (keyctl)},
+    {SCMP_SYS (request_key)},
+
     /* Scary VM/NUMA ops */
     {SCMP_SYS (move_pages)},
     {SCMP_SYS (mbind)},


### PR DESCRIPTION
The kernel keyring is currently accessible to sandboxed flatpak applications.  This is a problem because it means that those applications can, for instance, access the kerberos credentials of a user and impersonate the user, or read any secrets stored on the user's keyrings.  The kernel keyring subsystem has no notion of namespaces at the moment, so there's no way to "unshare" access to the keyrings used in the outside session from the sandbox.  Since the sandboxed user runs with the same UID as the outside, it can get full access to everything.

Aside from direct access to user keys, there's also the problem of indirect access to logon keys via kernel services (mainly filesystem access, I think, but other things. too). I think those are less of a concern, because access to those keys can be mediated at other layers (for instance, if we don't want users to have access to /mnt/export, then we just don't put that mount into the containers file tree) 

Probably for now we should disable access to the keyctl, add_key, and request_key syscalls until we have a better story.