### PR TITLE
More decriptive "error: Build directory ... not finalized"

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -551,7 +551,7 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
   if (!g_file_query_exists (files, cancellable) ||
       !g_file_query_exists (metadata, cancellable))
     {
-      flatpak_fail (error, _("Build directory %s not initialized"), directory);
+      flatpak_fail (error, _("Build directory %s not initialized, use flatpak build-init"), directory);
       goto out;
     }
 
@@ -568,7 +568,7 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
 
   if (!opt_runtime && !g_file_query_exists (export, cancellable))
     {
-      flatpak_fail (error, "Build directory %s not finalized", directory);
+      flatpak_fail (error, "Build directory %s not finalized, use flatpak build-finish", directory);
       goto out;
     }
 


### PR DESCRIPTION
While creating first project, I forgot to create "export/" dir. Why not directly mention that `.../export` dir is missing?