### PR TITLE
error message for flatpak build on non existing directory could be improved

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -116,8 +116,12 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
     command = argv[rest_argv_start + 1];
 
   app_deploy = g_file_new_for_commandline_arg (directory);
-
   metadata = g_file_get_child (app_deploy, "metadata");
+
+  if (!g_file_query_exists (app_deploy, NULL) ||
+      !g_file_query_exists (metadata, NULL))
+    return flatpak_fail (error, _("Build directory %s not initialized, use flatpak build-init"), directory);
+
   if (!g_file_load_contents (metadata, cancellable, &metadata_contents, &metadata_size, NULL, error))
     return FALSE;
 


### PR DESCRIPTION
When running flatpak build on a non-existing directory, the error message is not particularly helpful.
For my version, it behaves the following way:

```
$ flatpak build    /tmp/fpbuilder echo foo
error: Error opening file: No such file or directory
$

```
It would have helped me if it said something like   "The build directory >>/tmp/fpbuilder<< seems to not exist!  error: Error opening file: No such file or directory".


With strace I found out that it tries to open() /tmp/fpbuilder/metadata. When creating (i.e. touching) that file, flatpak prints "error: Key file does not have group 'Application'" which again, could be more helpful by at least including the filename in question.