### PR TITLE
flatpakrepo format: support using HTTPS links as value to GPGKey field

### DIFF
--- a/doc/flatpak-flatpakrepo.xml
+++ b/doc/flatpak-flatpakrepo.xml
@@ -74,7 +74,15 @@
                     <term><option>GPGKey</option> (string)</term>
                     <listitem><para>The base64-encoded gpg key for the remote.</para></listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term><option>GPGKeyUrl</option> (string)</term>
+                    <listitem><para>The url for a file containing the gpg key for the remote.</para></listitem>
+                </varlistentry>
             </variablelist>
+            <para>
+                If neither GPGKey nor GPGKeyUrl are specified, GPG verification is
+                disabled. If both keys are specified, GPGKey takes precedence.
+            </para>
         </refsect2>
     </refsect1>
 


### PR DESCRIPTION
At the moment you will need to decode your gpg key to base64 and put it inside the flatpak key itself to make a valid *.flatpakrepo file.  It could be convenient if i could specify a https link to the gpg key instead rather than having it inside the *.flatpakrepo file itself.