### PR TITLE
Support mixed (multilib/multiarch) binaries in Flatpaks

### DIFF
--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -101,6 +101,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_LOG_SESSION_BUS    = (1 << 2),
   FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS     = (1 << 3),
   FLATPAK_RUN_FLAG_NO_SESSION_HELPER  = (1 << 4),
+  FLATPAK_RUN_FLAG_MULTIARCH          = (1 << 5),
 } FlatpakRunFlags;
 
 gboolean flatpak_run_setup_base_argv (GPtrArray      *argv_array,

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -158,12 +158,18 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
                  </para><para>
                     The <code>devel</code> feature allows the application to
                     access certain syscalls such as <code>ptrace()</code>, and
-                    <code>perf_event_open()</code>.
+                <code>perf_event_open()</code>.
+                </para><para>
+                    The <code>multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code>x86_64</code>
+                    architecture, 32-bit <code>x86</code> binaries will be allowed as
+                    well.
                 </para></listitem>
             </varlistentry>
 
@@ -173,7 +179,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -217,7 +217,7 @@
                 <listitem><para>
                     Allow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -228,7 +228,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel.
+                    FEATURE must be one of: devel, multiarch.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This adds a new `multiarch` feature which allows bundling e.g. 32-bit binaries to be run in a `x86_64` environment. By default, the seccomp filter is configured to allow only the native architecture. When the `multiarch` feature is enabled, the filter will be configured to allow running binaries of additional architectures supported. For `x86_64`, this allows `x86` 32-bit binaries; and for `aarch64`, allows 32-bit `arm` binaries.

Application bundles can use the feature e.g. in order to ship 32-bit binaries alongside with a mostly-64-bit application. This is particularly interesting when for applications that might launch themselves prebuilt programs for which 64-bit versions do not exist. For example, the Steam application is available as a 64-bit executable, but some of the games available are 32-bit only. A Flatpak bundle for the Steam application with `multiarch` enabled is able launch the 32-bit games — without the feature enabled, the seccomp filter would prevent them from running.

Multiple-architecture support is enabled by adding the `multiarch` value for the `features` key in the metadata file for a Flatpak:

```ini
[Context]
features=multiarch;
```

The corresponding `--allow=multiarch` command line option is supported in `flatpak build-finish` as well.