### PR TITLE
Add support for unmaintained extensions

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3743,8 +3743,12 @@ flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
               //FIXME: is it really org.gnome.Platform/3.22/x86_64 or org.gnome.Platform/x86_64/3.22
               g_autoptr(GFile) child2 = g_file_get_child (child1, branch);
               g_autoptr(GFile) child3 = g_file_get_child (child2, arch);
+              g_autoptr(GFile) metadata = g_file_get_child (child3, "metadata");
+              g_autoptr(GFile) files = g_file_get_child (child3, "files");
 
-              if (g_file_query_exists (child3, cancellable) && !g_hash_table_contains(hash, name))
+              if (!g_hash_table_contains(hash, name) &&
+                  g_file_query_exists (metadata, cancellable) &&
+                  g_file_query_exists (files, cancellable))
                 g_hash_table_add (hash, g_strdup (name));
             }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4141,7 +4141,7 @@ flatpak_dir_get_if_deployed (FlatpakDir   *self,
   g_autoptr(GFile) deploy_dir = NULL;
   g_autoptr(GFile) unmaintained_extension_dir = NULL;
 
-  unmaintained_extension_dir = flatpak_dir_get_unmaintained_extension_dir_if_exists(self, ret);
+  unmaintained_extension_dir = flatpak_dir_get_unmaintained_extension_dir_if_exists(self, ref, cancellable);
   if (unmaintained_extension_dir)
     return g_steal_pointer(&unmaintained_extension_dir);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3680,7 +3680,9 @@ flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
   gboolean ret = FALSE;
 
   g_autoptr(GFile) dir = NULL;
+  g_autoptr(GFile) unmaintained_dir = NULL;
   g_autoptr(GFileEnumerator) dir_enum = NULL;
+  g_autoptr(GFileEnumerator) unmaintained_dir_enum = NULL;
   g_autoptr(GFileInfo) child_info = NULL;
   GError *temp_error = NULL;
 
@@ -3718,6 +3720,42 @@ flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
     {
       g_propagate_error (error, temp_error);
       goto out;
+    }
+
+  if (strcmp(type, "runtime"))
+    {
+      unmaintained_dir = g_file_get_child (self->basedir, "extension");
+      unmaintained_dir_enum = g_file_enumerate_children (unmaintained_dir, G_FILE_ATTRIBUTE_STANDARD_NAME,
+                                                         G_FILE_QUERY_INFO_NONE,
+                                                         cancellable,
+                                                         error);
+      if (!unmaintained_dir_enum)
+        goto out;
+
+      while ((child_info = g_file_enumerator_next_file (unmaintained_dir_enum, cancellable, &temp_error)) != NULL)
+        {
+          const char *name = g_file_info_get_name (child_info);
+
+          if (g_file_info_get_file_type (child_info) == G_FILE_TYPE_DIRECTORY &&
+              name[0] != '.' && (name_prefix == NULL || g_str_has_prefix (name, name_prefix)))
+            {
+              g_autoptr(GFile) child1 = g_file_get_child (unmaintained_dir, name);
+              //FIXME: is it really org.gnome.Platform/3.22/x86_64 or org.gnome.Platform/x86_64/3.22
+              g_autoptr(GFile) child2 = g_file_get_child (child1, branch);
+              g_autoptr(GFile) child3 = g_file_get_child (child2, arch);
+
+              if (g_file_query_exists (child3, cancellable) && !g_hash_table_contains(hash, name))
+                g_hash_table_add (hash, g_strdup (name));
+            }
+
+          g_clear_object (&child_info);
+        }
+
+      if (temp_error != NULL)
+        {
+          g_propagate_error (error, temp_error);
+          goto out;
+        }
     }
 
   ret = TRUE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3746,12 +3746,9 @@ flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
               //FIXME: is it really org.gnome.Platform/3.22/x86_64 or org.gnome.Platform/x86_64/3.22
               g_autoptr(GFile) child2 = g_file_get_child (child1, branch);
               g_autoptr(GFile) child3 = g_file_get_child (child2, arch);
-              g_autoptr(GFile) metadata = g_file_get_child (child3, "metadata");
-              g_autoptr(GFile) files = g_file_get_child (child3, "files");
 
               if (!g_hash_table_contains(hash, name) &&
-                  g_file_query_exists (metadata, cancellable) &&
-                  g_file_query_exists (files, cancellable))
+                  g_file_query_exists (child3, cancellable))
                 g_hash_table_add (hash, g_strdup (name));
             }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3722,7 +3722,7 @@ flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
       goto out;
     }
 
-  if (strcmp(type, "runtime"))
+  if (g_str_has_prefix(type, "runtime"))
     {
       unmaintained_dir = g_file_get_child (self->basedir, "extension");
       unmaintained_dir_enum = g_file_enumerate_children (unmaintained_dir, G_FILE_ATTRIBUTE_STANDARD_NAME,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4138,15 +4138,25 @@ flatpak_dir_get_if_deployed (FlatpakDir   *self,
 
 GFile *
 flatpak_dir_get_unmaintained_extension_dir_if_exists (FlatpakDir *self,
-                                            const char *ref,
-                                            GCancellable *cancellable)
+                                                      const char *ref,
+                                                      GCancellable *cancellable)
 {
   g_autoptr(GFile) extension_dir = NULL;
+  g_autoptr(GFile) extension_metadata = NULL;
+  g_autoptr(GFile) extension_files = NULL;
   g_autoptr(GFileInfo) extension_dir_info = NULL;
 
   extension_dir = flatpak_dir_get_unmaintained_extension_dir(self, ref);
 
   if (extension_dir == NULL)
+    return NULL;
+
+  extension_metadata = g_file_get_child (extension_dir, "metadata");
+  if (!g_file_query_exists (extension_metadata, cancellable))
+    return NULL;
+
+  extension_files = g_file_get_child (extension_dir, "files");
+  if (!g_file_query_exists (extension_files, cancellable))
     return NULL;
 
   extension_dir_info = g_file_query_info (extension_dir,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -557,9 +557,7 @@ flatpak_dir_load_deployed (FlatpakDir   *self,
   FlatpakDeploy *deploy;
   gsize metadata_size;
 
-  deploy_dir = flatpak_dir_get_unmaintained_extension_dir_if_exists (self, ref, cancellable);
-  if (deploy_dir == NULL)
-    deploy_dir = flatpak_dir_get_if_deployed (self, ref, checksum, cancellable);
+  deploy_dir = flatpak_dir_get_if_deployed (self, ref, checksum, cancellable);
   if (deploy_dir == NULL)
     {
       g_set_error (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED,
@@ -4103,6 +4101,11 @@ flatpak_dir_get_if_deployed (FlatpakDir   *self,
 {
   g_autoptr(GFile) deploy_base = NULL;
   g_autoptr(GFile) deploy_dir = NULL;
+  g_autoptr(GFile) unmaintained_extension_dir = NULL;
+
+  unmaintained_extension_dir = flatpak_dir_get_unmaintained_extension_dir_if_exists(self, ret);
+  if (unmaintained_extension_dir)
+    return g_steal_pointer(&unmaintained_extension_dir);
 
   deploy_base = flatpak_dir_get_deploy_dir (self, ref);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3730,7 +3730,10 @@ flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
                                                          cancellable,
                                                          error);
       if (!unmaintained_dir_enum)
-        goto out;
+        {
+          ret = TRUE;
+          goto out;
+        }
 
       while ((child_info = g_file_enumerator_next_file (unmaintained_dir_enum, cancellable, &temp_error)) != NULL)
         {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4134,6 +4134,8 @@ flatpak_dir_get_if_deployed (FlatpakDir   *self,
   g_autoptr(GFile) deploy_base = NULL;
   g_autoptr(GFile) deploy_dir = NULL;
 
+  deploy_base = flatpak_dir_get_deploy_dir (self, ref);
+
   if (checksum != NULL)
     {
       deploy_dir = g_file_get_child (deploy_base, checksum);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -135,9 +135,8 @@ GFile *     flatpak_dir_get_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_changed_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_deploy_dir (FlatpakDir *self,
                                         const char *ref);
-GFile *     flatpak_dir_get_unmaintained_extension_dir_if_exists (FlatpakDir *self,
-                                                                  const char *ref,
-                                                                  GCancellable *cancellable);
+GFile *     flatpak_dir_get_unmaintained_extension_dir (FlatpakDir *self,
+                                                        const char *ref);
 GVariant *  flatpak_dir_get_deploy_data (FlatpakDir   *dir,
                                          const char   *ref,
                                          GCancellable *cancellable,
@@ -156,6 +155,10 @@ GFile *     flatpak_dir_get_if_deployed (FlatpakDir   *self,
                                          const char   *ref,
                                          const char   *checksum,
                                          GCancellable *cancellable);
+GFile *     flatpak_dir_get_unmaintained_extension_dir_if_exists (FlatpakDir *self,
+                                                                  const char *ref,
+                                                                  GCancellable *cancellable);
+
 gboolean    flatpak_dir_remote_has_ref (FlatpakDir   *self,
                                         const char   *remote,
                                         const char   *ref);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -395,6 +395,13 @@ gboolean    flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
                                                GHashTable   *hash,
                                                GCancellable *cancellable,
                                                GError      **error);
+gboolean    flatpak_dir_collect_unmaintained_refs (FlatpakDir   *self,
+                                                   const char   *name_prefix,
+                                                   const char   *arch,
+                                                   const char   *branch,
+                                                   GHashTable   *hash,
+                                                   GCancellable *cancellable,
+                                                   GError      **error);
 char      *flatpak_dir_create_origin_remote (FlatpakDir   *self,
                                              const char   *url,
                                              const char   *id,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -135,6 +135,9 @@ GFile *     flatpak_dir_get_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_changed_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_deploy_dir (FlatpakDir *self,
                                         const char *ref);
+GFile *     flatpak_dir_get_unmaintained_extension_dir_if_exists (FlatpakDir *self,
+                                                                  const char *ref,
+                                                                  GCancellable *cancellable);
 GVariant *  flatpak_dir_get_deploy_data (FlatpakDir   *dir,
                                          const char   *ref,
                                          GCancellable *cancellable,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -136,7 +136,9 @@ GFile *     flatpak_dir_get_changed_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_deploy_dir (FlatpakDir *self,
                                         const char *ref);
 GFile *     flatpak_dir_get_unmaintained_extension_dir (FlatpakDir *self,
-                                                        const char *ref);
+                                                        const char *name,
+                                                        const char *arch,
+                                                        const char *branch);
 GVariant *  flatpak_dir_get_deploy_data (FlatpakDir   *dir,
                                          const char   *ref,
                                          GCancellable *cancellable,
@@ -156,7 +158,9 @@ GFile *     flatpak_dir_get_if_deployed (FlatpakDir   *self,
                                          const char   *checksum,
                                          GCancellable *cancellable);
 GFile *     flatpak_dir_get_unmaintained_extension_dir_if_exists (FlatpakDir *self,
-                                                                  const char *ref,
+                                                                  const char *name,
+                                                                  const char *arch,
+                                                                  const char *branch,
                                                                   GCancellable *cancellable);
 
 gboolean    flatpak_dir_remote_has_ref (FlatpakDir   *self,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3158,9 +3158,13 @@ flatpak_list_extensions (GKeyFile   *metakey,
 
           ref = g_build_filename ("runtime", extension, arch, branch, NULL);
 
-          //TODO: move getting unmaintained extension here
+          files = flatpak_find_unmaintained_extension_dir_if_exists (extension, arch, branch, NULL);
 
-          files = flatpak_find_files_dir_for_ref (ref, NULL, NULL);
+          if (files == NULL)
+            {
+              files = flatpak_find_files_dir_for_ref (ref, NULL, NULL);
+            }
+
           /* Prefer a full extension (org.freedesktop.Locale) over subdirectory ones (org.freedesktop.Locale.sv) */
           if (files != NULL)
             {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3185,7 +3185,10 @@ flatpak_list_extensions (GKeyFile   *metakey,
                 {
                   g_autofree char *extended_dir = g_build_filename (directory, refs[j] + strlen (prefix), NULL);
                   g_autofree char *dir_ref = g_build_filename ("runtime", refs[j], arch, branch, NULL);
-                  g_autoptr(GFile) subdir_files = flatpak_find_files_dir_for_ref (dir_ref, NULL, NULL);
+                  g_autoptr(GFile) subdir_files = flatpak_find_unmaintained_extension_dir_if_exists (refs[j], arch, branch, NULL);
+
+                  if (subdir_files == NULL)
+                    subdir_files = flatpak_find_files_dir_for_ref (dir_ref, NULL, NULL);
 
                   if (subdir_files)
                     {

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -140,6 +140,11 @@ char ** flatpak_list_deployed_refs (const char   *type,
                                     const char   *arch,
                                     GCancellable *cancellable,
                                     GError      **error);
+char ** flatpak_list_unmaintained_refs (const char   *name_prefix,
+                                        const char   *branch,
+                                        const char   *arch,
+                                        GCancellable *cancellable,
+                                        GError      **error);
 
 gboolean flatpak_overlay_symlink_tree (GFile        *source,
                                        GFile        *destination,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -127,6 +127,10 @@ char * flatpak_build_app_ref (const char *app,
 GFile * flatpak_find_files_dir_for_ref (const char   *ref,
                                         GCancellable *cancellable,
                                         GError      **error);
+GFile * flatpak_find_unmaintained_extension_dir_if_exists (const char   *name,
+                                                           const char   *arch,
+                                                           const char   *branch,
+                                                           GCancellable *cancellable);
 FlatpakDeploy * flatpak_find_deploy_for_ref (const char   *ref,
                                              GCancellable *cancellable,
                                              GError      **error);


### PR DESCRIPTION
This adds basic support for using extensions unmaintained by flatpak.
See #167