### PR TITLE
multiarch: Bind-mount the ld.so binaries provided by app bundles

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3406,6 +3406,51 @@ setup_seccomp (GPtrArray  *argv_array,
 }
 #endif
 
+static const char *multiarch_ldso_names_x86_64[] =
+{
+  "ld-linux.so.2",
+  NULL
+};
+
+static const char *multiarch_ldso_names_aarch64[] =
+{
+  "ld-linux.so.3",
+  "ld-linux-armhf.so.3",
+  NULL
+};
+
+static void
+setup_multiarch_ldso_binds (GPtrArray  *argv_array,
+                            GFile      *app_files,
+                            const char *arch)
+{
+  g_autoptr(GFile) app_libdir = NULL;
+  const char **ldso_names = NULL;
+
+  /* We only do this for application bundles, not runtimes. */
+  if (!app_files)
+    return;
+
+  if (strcmp (arch, "x86_64") == 0)
+    ldso_names = multiarch_ldso_names_x86_64;
+  else if (strcmp (arch, "aarch64") == 0)
+    ldso_names = multiarch_ldso_names_aarch64;
+  else
+    return;
+
+  app_libdir = g_file_get_child (app_files, "lib");
+  for (; *ldso_names; ldso_names++)
+    {
+      g_autoptr(GFile) app_ldso = g_file_resolve_relative_path (app_libdir, *ldso_names);
+      if (g_file_query_exists (app_ldso, NULL))
+        {
+          g_autofree char *lib_ldso_path = g_build_filename ("/usr/lib", *ldso_names, NULL);
+          g_autofree char *app_ldso_path = g_file_get_path (app_ldso);
+          add_args (argv_array, "--ro-bind", app_ldso_path, lib_ldso_path, NULL);
+        }
+    }
+}
+
 gboolean
 flatpak_run_setup_base_argv (GPtrArray      *argv_array,
                              GArray         *fd_array,
@@ -3725,8 +3770,19 @@ flatpak_run_app (const char     *app_ref,
     envp = flatpak_run_apply_env_appid (envp, app_id_dir);
 
   add_args (argv_array,
-            "--ro-bind", flatpak_file_get_path_cached (runtime_files), "/usr",
+            "--bind", flatpak_file_get_path_cached (runtime_files), "/usr",
             "--lock-file", "/usr/.ref",
+            NULL);
+
+  if (app_context->features & FLATPAK_CONTEXT_FEATURE_MULTIARCH)
+    {
+      flags |= FLATPAK_RUN_FLAG_MULTIARCH;
+      setup_multiarch_ldso_binds (argv_array, app_files, app_ref_parts[2]);
+    }
+
+  add_args (argv_array,
+            "--remount-ro",
+            "/usr",
             NULL);
 
   if (app_files != NULL)
@@ -3741,9 +3797,6 @@ flatpak_run_app (const char     *app_ref,
 
   if (app_context->features & FLATPAK_CONTEXT_FEATURE_DEVEL)
     flags |= FLATPAK_RUN_FLAG_DEVEL;
-
-  if (app_context->features & FLATPAK_CONTEXT_FEATURE_MULTIARCH)
-    flags |= FLATPAK_RUN_FLAG_MULTIARCH;
 
   if (!flatpak_run_setup_base_argv (argv_array, fd_array, runtime_files, app_id_dir, app_ref_parts[2], flags, error))
     return FALSE;


### PR DESCRIPTION
Most applications built for 32-bit environments expect their dynamic linker executables under `/lib/<name>`. When running with the `multiarch` feature enabled, the runtime being used may not provide the 32-bit userland, and therefore the task is up to the application bundle.

When packagers are in control of which 32-bit binaries are included in the application bundle, they can modify the `DT_INTERP` entry of the ELF headers of binaries to make them search for the dynamic linker in a locatin under `/app`. This may not be always possible, especially if the bundled application downloads 32-bit prebuilt binaries designed to be run in a non-Flatpak environment.

This patch makes Flatpak search for the following dynamic linker names when the `multiarch` feature is enabled for an application bundle:
- For x86_64:
  - `/app/lib/ld-linux.so.2`
- For Aarch64:
  - `/app/lib/ld-linux.so.3`
  - `/app/lib/ld-linux-armhf.so.3`

…and if they are available, they are bind-mounted into `/lib`. This way binaries do not need to be modified to have a non-standard `DT_INTERP` value in their ELF headers.

Note that it is up to the application to provide a complete, suitable 32-bit userland, and it may be desired to modify the `LD_LIBRARY_PATH` environment variable adding the path of the 32-bit userland.
