### PR TITLE
Avoid a crash during update --appstream

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1600,6 +1600,13 @@ flatpak_dir_pull (FlatpakDir          *self,
                                              cancellable, error))
         return FALSE;
 
+      if (summary_bytes == NULL)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Failed to get repository summary");
+          return FALSE;
+        }
+
       summary = g_variant_ref_sink (g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT,
                                                               summary_bytes, FALSE));
       if (!flatpak_summary_lookup_ref (summary,


### PR DESCRIPTION
It turns out that flatpak_dir_remote_fetch_summary can return TRUE,
yet leave summary_bytes NULL. The code further down does not deal
gracefully with summary_bytes being NULL, so error out early instead
of crashing.