### PR TITLE
builder: Don't download modules that won't be built

### DIFF
--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -1324,12 +1324,20 @@ builder_manifest_download (BuilderManifest *self,
                            BuilderContext  *context,
                            GError         **error)
 {
+  const char *stop_at = builder_context_get_stop_at (context);
   GList *l;
 
   g_print ("Downloading sources\n");
   for (l = self->expanded_modules; l != NULL; l = l->next)
     {
       BuilderModule *m = l->data;
+      const char *name = builder_module_get_name (m);
+
+      if (stop_at != NULL && strcmp (name, stop_at) == 0)
+        {
+          g_print ("Stopping at module %s\n", stop_at);
+          return TRUE;
+        }
 
       if (!builder_module_download_sources (m, update_vcs, context, error))
         return FALSE;

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -716,11 +716,11 @@
                 <term><option>--stop-at=MODULENAME</option></term>
 
                 <listitem><para>
-                     Stop building at the specified module, ignoring all the following ones.
-                     This is useful for debugging and development. For instance, you can
-                     build all the dependencies, but stop at the main application so that
-                     you can then do a build from a pre-existing checkout.
-                     Implies --build-only.
+                     Stop at the specified module, ignoring it and all the following ones
+                     in both the "download" and "build" phases. This is useful for debugging
+                     and development. For instance, you can build all the dependencies, but
+                     stop at the main application so that you can then do a build from a
+                     pre-existing checkout. Implies --build-only.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
In Builder with [these](https://bugzilla.gnome.org/show_bug.cgi?id=773764) patches, flatpak-builder fails when there aren't any git commits yet, which seems unnecessary. Is there any use case that would require the ignored modules to be downloaded?