### PR TITLE
tests: don't stomp on LD_LIBRARY_PATH

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -1,8 +1,8 @@
 TESTS_ENVIRONMENT += FLATPAK_TESTS_DEBUG=1 \
 	FLATPAK_TRIGGERSDIR=$$(cd $(top_srcdir) && pwd)/triggers \
 	FLATPAK_DBUSPROXY=$$(cd $(top_builddir) && pwd)/flatpak-dbus-proxy \
-	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd) \
-	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd) \
+	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
+	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH} \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
 	$(NULL)
 


### PR DESCRIPTION
We should append to it, but not totally replace it, or things like
running test under jhbuild will not work properly.