### PR TITLE
Integrate flatpak_dir_update_remote_configuration() with the system helper

### DIFF
--- a/system-helper/org.freedesktop.Flatpak.policy.in
+++ b/system-helper/org.freedesktop.Flatpak.policy.in
@@ -123,7 +123,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 


### PR DESCRIPTION
Add logic in flatpak_dir_update_remote_configuration() so that the step of
configuring the local remotes after fetching the required date from the
server's summary file is performed via the system helper when present.

Note this will require the user authorizing the action by introducing
the password explicitly when asked, but this is necessary as updating
the local remotes configuration is something that can't be allowed
without explicit authentication.