### PR TITLE
Extra checks mounting /etc/{resolv.conf|localtime} without session helper

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -254,9 +254,9 @@ flatpak_complete_info (FlatpakCompletion *completion)
                 flatpak_complete_word (completion, "%s ", parts[3]);
             }
         }
-      if (user_dir)
+      if (system_dir)
         {
-          g_auto(GStrv) refs = flatpak_dir_find_installed_refs (user_dir, completion->argv[1], NULL, opt_arch,
+          g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, completion->argv[1], NULL, opt_arch,
                                                                 kinds, &error);
           if (refs == NULL)
             flatpak_completion_debug ("find remote refs error: %s", error->message);


### PR DESCRIPTION
When no session helper is available (e.g. running flatpak run from a
socket-activated service unit), we need to be extra careful before
making these two files appear inside the sandbox. Otherwise, if they
are not reachable on the host system (or just symlinks to non-existent
targets), flatpak won't be able to create the sandbox, which will fail
due to a "No such file or directory error".

https://github.com/flatpak/flatpak/issues/409