### PR TITLE
Add support to configure additional system installations

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -367,7 +367,7 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
           }
       }
 
-      system_dir = flatpak_dir_get_system ();
+      system_dir = flatpak_dir_get_system_default ();
       {
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, NULL, NULL, opt_arch,
                                                               FLATPAK_KINDS_RUNTIME, &error);
@@ -398,7 +398,7 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
           }
       }
 
-      system_dir = flatpak_dir_get_system ();
+      system_dir = flatpak_dir_get_system_default ();
       {
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, completion->argv[3], NULL, opt_arch,
                                                               FLATPAK_KINDS_RUNTIME, &error);

--- a/app/flatpak-builtins-document-list.c
+++ b/app/flatpak-builtins-document-list.c
@@ -129,7 +129,7 @@ flatpak_complete_document_list (FlatpakCompletion *completion)
           }
       }
 
-      system_dir = flatpak_dir_get_system ();
+      system_dir = flatpak_dir_get_system_default ();
       {
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, NULL, NULL, NULL,
                                                               FLATPAK_KINDS_APP, &error);

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -125,7 +125,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
 
   if (ref == NULL && opt_system)
     {
-      system_dir = flatpak_dir_get_system ();
+      system_dir = flatpak_dir_get_system_default ();
 
       ref = flatpak_dir_find_installed_ref (system_dir,
                                             id,
@@ -202,7 +202,7 @@ flatpak_complete_info (FlatpakCompletion *completion)
     user_dir = flatpak_dir_get_user ();
 
   if (opt_system)
-    system_dir = flatpak_dir_get_system ();
+    system_dir = flatpak_dir_get_system_default ();
 
   switch (completion->argc)
     {

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -221,8 +221,20 @@ handle_runtime_repo_deps (FlatpakDir *dir, GBytes *data, GError **error)
   old_remote = flatpak_dir_find_remote_by_uri (dir, runtime_url);
   if (old_remote == NULL && flatpak_dir_is_user (dir))
     {
-      g_autoptr(FlatpakDir) system_dir = flatpak_dir_get_system ();
-      old_remote = flatpak_dir_find_remote_by_uri (system_dir, runtime_url);
+      g_autoptr(GPtrArray) system_dirs = NULL;
+      int i;
+
+      system_dirs = flatpak_dir_get_system_list (NULL, error);
+      if (system_dirs == NULL)
+        return FALSE;
+
+      for (i = 0; i < system_dirs->len; i++)
+        {
+          FlatpakDir *system_dir = g_ptr_array_index (system_dirs, i);
+          old_remote = flatpak_dir_find_remote_by_uri (system_dir, runtime_url);
+          if (old_remote != NULL)
+            break;
+        }
     }
 
   if (old_remote != NULL)

--- a/app/flatpak-builtins-list-remotes.c
+++ b/app/flatpak-builtins-list-remotes.c
@@ -36,12 +36,12 @@ static gboolean opt_show_details;
 static gboolean opt_user;
 static gboolean opt_system;
 static gboolean opt_show_disabled;
-static char *opt_installation;
+static char **opt_installations;
 
 static GOptionEntry options[] = {
   { "user", 0, 0, G_OPTION_ARG_NONE, &opt_user, N_("Show user installations"), NULL },
   { "system", 0, 0, G_OPTION_ARG_NONE, &opt_system, N_("Show system-wide installations"), NULL },
-  { "installation", 0, 0, G_OPTION_ARG_STRING, &opt_installation, N_("Show a specific system-wide installation"), NULL },
+  { "installation", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_installations, N_("Show specific system-wide installations"), NULL },
   { "show-details", 'd', 0, G_OPTION_ARG_NONE, &opt_show_details, N_("Show remote details"), NULL },
   { "show-disabled", 0, 0, G_OPTION_ARG_NONE, &opt_show_disabled, N_("Show disabled remotes"), NULL },
   { NULL }
@@ -51,12 +51,10 @@ gboolean
 flatpak_builtin_list_remotes (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
-  g_autoptr(FlatpakDir) user_dir = NULL;
-  g_autoptr(FlatpakDir) system_dir = NULL;
-  g_autoptr(FlatpakDir) custom_dir = NULL;
-  FlatpakDir *dirs[2] = { 0 };
+  g_autoptr(GPtrArray) dirs = NULL;
   guint i = 0, n_dirs = 0, j;
   FlatpakTablePrinter *printer;
+  gboolean print_all_system = FALSE;
 
   context = g_option_context_new (_(" - List remote repositories"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
@@ -67,35 +65,49 @@ flatpak_builtin_list_remotes (int argc, char **argv, GCancellable *cancellable, 
   if (argc > 1)
     return usage_error (context, _("Too many arguments"), error);
 
-  if (!opt_user && !opt_system && opt_installation == NULL)
-    opt_system = TRUE;
+  if (!opt_user && !opt_system && opt_installations == NULL)
+    print_all_system = TRUE;
+
+  dirs = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 
   if (opt_user)
-    {
-      user_dir = flatpak_dir_get_user ();
-      dirs[n_dirs++] = user_dir;
-    }
+    g_ptr_array_add (dirs, flatpak_dir_get_user ());
 
   if (opt_system)
+    g_ptr_array_add (dirs, flatpak_dir_get_system_default ());
+
+  if (opt_installations != NULL)
     {
-      system_dir = flatpak_dir_get_system_default ();
-      dirs[n_dirs++] = system_dir;
+      int i = 0;
+
+      for (i = 0; opt_installations[i] != NULL; i++)
+        {
+          FlatpakDir *installation_dir = NULL;
+
+          /* Already included the default system installation. */
+          if (opt_system && g_strcmp0 (opt_installations[i], "default") == 0)
+            continue;
+
+          installation_dir = flatpak_dir_get_system_by_id (opt_installations[i], cancellable, error);
+          if (installation_dir == NULL)
+            return FALSE;
+
+          g_ptr_array_add (dirs, installation_dir);
+        }
     }
 
-  if (opt_installation != NULL)
+  if (print_all_system)
     {
-      custom_dir = flatpak_dir_get_system_by_id (opt_installation, cancellable, error);
-      if (custom_dir == NULL)
+      dirs = flatpak_dir_get_system_list (cancellable, error);
+      if (dirs == NULL)
         return FALSE;
-
-      dirs[n_dirs++] = custom_dir;
     }
 
   printer = flatpak_table_printer_new ();
 
-  for (j = 0; j < n_dirs; j++)
+  for (j = 0; j < dirs->len; j++)
     {
-      FlatpakDir *dir = dirs[j];
+      FlatpakDir *dir = g_ptr_array_index (dirs, j);
       g_auto(GStrv) remotes = NULL;
 
       remotes = flatpak_dir_list_remotes (dir, cancellable, error);
@@ -147,8 +159,9 @@ flatpak_builtin_list_remotes (int argc, char **argv, GCancellable *cancellable, 
               if (flatpak_dir_get_remote_noenumerate (dir, remote_name))
                 flatpak_table_printer_append_with_comma (printer, "no-enumerate");
 
-              if ((opt_user && opt_system) || (opt_user && opt_installation != NULL)
-                  || (opt_system && opt_installation != NULL))
+              if ((opt_user && opt_system) || (opt_user && opt_installations != NULL)
+                  || (opt_system && opt_installations != NULL)
+                  || (opt_installations != NULL && g_strv_length (opt_installations) > 1))
                 {
                   g_autofree char *dir_id = flatpak_dir_get_name (dir);
                   flatpak_table_printer_append_with_comma (printer, dir_id);

--- a/app/flatpak-builtins-list-remotes.c
+++ b/app/flatpak-builtins-list-remotes.c
@@ -75,7 +75,7 @@ flatpak_builtin_list_remotes (int argc, char **argv, GCancellable *cancellable, 
 
   if (opt_system)
     {
-      system_dir = flatpak_dir_get_system ();
+      system_dir = flatpak_dir_get_system_default ();
       dirs[n_dirs++] = system_dir;
     }
 

--- a/app/flatpak-builtins-list-remotes.c
+++ b/app/flatpak-builtins-list-remotes.c
@@ -150,16 +150,7 @@ flatpak_builtin_list_remotes (int argc, char **argv, GCancellable *cancellable, 
               if ((opt_user && opt_system) || (opt_user && opt_installation != NULL)
                   || (opt_system && opt_installation != NULL))
                 {
-                  g_autofree char *dir_id = NULL;
-                  if (flatpak_dir_is_user (dir))
-                    {
-                      dir_id = g_strdup ("user");
-                    }
-                  else
-                    {
-                      const char *system_dir_id = flatpak_dir_get_id (dir);
-                      dir_id = g_strdup_printf ("system (%s)", system_dir_id ? system_dir_id : "default");
-                    }
+                  g_autofree char *dir_id = flatpak_dir_get_name (dir);
                   flatpak_table_printer_append_with_comma (printer, dir_id);
                 }
             }

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -37,17 +37,47 @@ static gboolean opt_user;
 static gboolean opt_system;
 static gboolean opt_runtime;
 static gboolean opt_app;
+static char *opt_installation;
 static char *opt_arch;
 
 static GOptionEntry options[] = {
   { "user", 0, 0, G_OPTION_ARG_NONE, &opt_user, N_("Show user installations"), NULL },
   { "system", 0, 0, G_OPTION_ARG_NONE, &opt_system, N_("Show system-wide installations"), NULL },
+  { "installation", 0, 0, G_OPTION_ARG_STRING, &opt_installation, N_("Show a specific system-wide installation"), NULL },
   { "show-details", 'd', 0, G_OPTION_ARG_NONE, &opt_show_details, N_("Show arches and branches"), NULL },
   { "runtime", 0, 0, G_OPTION_ARG_NONE, &opt_runtime, N_("List installed runtimes"), NULL },
   { "app", 0, 0, G_OPTION_ARG_NONE, &opt_app, N_("List installed applications"), NULL },
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to show"), N_("ARCH") },
   { NULL }
 };
+
+/* Associates a flatpak installation's directory with
+ * the list of references for apps and runtimes */
+typedef struct
+{
+  FlatpakDir *dir;
+  GStrv app_refs;
+  GStrv runtime_refs;
+} RefsData;
+
+static RefsData *
+refs_data_new (FlatpakDir *dir, const GStrv app_refs, const GStrv runtime_refs)
+{
+  RefsData *refs_data = g_new0 (RefsData, 1);
+  refs_data->dir = g_object_ref (dir);
+  refs_data->app_refs = g_strdupv ((char **) app_refs);
+  refs_data->runtime_refs = g_strdupv ((char **) runtime_refs);
+  return refs_data;
+}
+
+static void
+refs_data_free (RefsData *refs_data)
+{
+  g_object_unref (refs_data->dir);
+  g_strfreev (refs_data->app_refs);
+  g_strfreev (refs_data->runtime_refs);
+  g_free (refs_data);
+}
 
 static char **
 join_strv (char **a, char **b)
@@ -75,175 +105,245 @@ join_strv (char **a, char **b)
 }
 
 static gboolean
-print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gboolean print_user, const char *arch, GCancellable *cancellable, GError **error)
+find_refs_for_dir (FlatpakDir *dir, GStrv *apps, GStrv *runtimes, GCancellable *cancellable, GError **error)
 {
-  g_autofree char *last = NULL;
-
-  g_auto(GStrv) system = NULL;
-  g_auto(GStrv) system_app = NULL;
-  g_auto(GStrv) system_runtime = NULL;
-  g_auto(GStrv) user = NULL;
-  g_auto(GStrv) user_app = NULL;
-  g_auto(GStrv) user_runtime = NULL;
-  g_autoptr(FlatpakDir) user_dir = NULL;
-  g_autoptr(FlatpakDir) system_dir = NULL;
-  int s, u;
-
-  if (print_user)
+  if (flatpak_dir_ensure_repo (dir, cancellable, NULL))
     {
-      user_dir = flatpak_dir_get_user ();
-      if (flatpak_dir_ensure_repo (user_dir, cancellable, NULL))
-        {
-          if (app && !flatpak_dir_list_refs (user_dir, "app", &user_app, cancellable, error))
-            return FALSE;
-          if (runtime && !flatpak_dir_list_refs (user_dir, "runtime", &user_runtime, cancellable, error))
-            return FALSE;
-        }
-    }
-
-  if (print_system)
-    {
-      system_dir = flatpak_dir_get_system_default ();
-      if (flatpak_dir_ensure_repo (system_dir, cancellable, NULL))
-        {
-          if (app && !flatpak_dir_list_refs (system_dir, "app", &system_app, cancellable, error))
-            return FALSE;
-          if (runtime && !flatpak_dir_list_refs (system_dir, "runtime", &system_runtime, cancellable, error))
-            return FALSE;
-        }
-    }
-
-  FlatpakTablePrinter *printer = flatpak_table_printer_new ();
-
-  user = join_strv (user_app, user_runtime);
-  system = join_strv (system_app, system_runtime);
-
-  for (s = 0, u = 0; system[s] != NULL || user[u] != NULL; )
-    {
-      char *ref, *partial_ref;
-      g_auto(GStrv) parts = NULL;
-      const char *repo = NULL;
-      gboolean is_user;
-      FlatpakDir *dir = NULL;
-      g_autoptr(GVariant) deploy_data = NULL;
-
-      if (system[s] == NULL)
-        is_user = TRUE;
-      else if (user[u] == NULL)
-        is_user = FALSE;
-      else if (strcmp (system[s], user[u]) <= 0)
-        is_user = FALSE;
-      else
-        is_user = TRUE;
-
-      if (is_user)
-        {
-          ref = user[u++];
-          dir = user_dir;
-        }
-      else
-        {
-          ref = system[s++];
-          dir = system_dir;
-        }
-
-      parts = g_strsplit (ref, "/", -1);
-      partial_ref = strchr (ref, '/') + 1;
-
-      if (arch != NULL && strcmp (arch, parts[1]) != 0)
-        continue;
-
-      deploy_data = flatpak_dir_get_deploy_data (dir, ref, cancellable, error);
-      if (deploy_data == NULL)
+      if (apps != NULL && !flatpak_dir_list_refs (dir, "app", apps, cancellable, error))
         return FALSE;
+      if (runtimes != NULL && !flatpak_dir_list_refs (dir, "runtime", runtimes, cancellable, error))
+        return FALSE;
+    }
 
-      repo = flatpak_deploy_data_get_origin (deploy_data);
+  return TRUE;
+}
 
-      if (opt_show_details)
+static gboolean
+print_table_for_refs (gboolean print_apps, GPtrArray* refs_array, const char *arch, GCancellable *cancellable, GError **error)
+{
+  FlatpakTablePrinter *printer = flatpak_table_printer_new ();
+  int i;
+
+  for (i = 0; i < refs_array->len; i++)
+    {
+      RefsData *refs_data = NULL;
+      FlatpakDir *dir = NULL;
+      g_auto(GStrv) dir_refs = NULL;
+      g_autofree char *last = NULL;
+      int j;
+
+      refs_data = (RefsData *) g_ptr_array_index (refs_array, i);
+      dir = refs_data->dir;
+      dir_refs = join_strv (refs_data->app_refs, refs_data->runtime_refs);
+
+      for (j = 0; dir_refs[j] != NULL; j++)
         {
-          const char *active = flatpak_deploy_data_get_commit (deploy_data);
-          const char *alt_id = flatpak_deploy_data_get_alt_id (deploy_data);
-          g_autofree char *latest = NULL;
-          g_autofree char *size_s = NULL;
-          guint64 size = 0;
-          g_autofree const char **subpaths = NULL;
+          char *ref, *partial_ref;
+          g_auto(GStrv) parts = NULL;
+          const char *repo = NULL;
+          g_autoptr(GVariant) deploy_data = NULL;
 
-          latest = flatpak_dir_read_latest (dir, repo, ref, NULL, NULL, NULL);
-          if (latest)
+          ref = dir_refs[j];
+
+          parts = g_strsplit (ref, "/", -1);
+          partial_ref = strchr (ref, '/') + 1;
+
+          if (arch != NULL && strcmp (arch, parts[1]) != 0)
+            continue;
+
+          deploy_data = flatpak_dir_get_deploy_data (dir, ref, cancellable, error);
+          if (deploy_data == NULL)
+            return FALSE;
+
+          repo = flatpak_deploy_data_get_origin (deploy_data);
+
+          if (opt_show_details)
             {
-              if (strcmp (active, latest) == 0)
+              const char *active = flatpak_deploy_data_get_commit (deploy_data);
+              const char *alt_id = flatpak_deploy_data_get_alt_id (deploy_data);
+              g_autofree char *latest = NULL;
+              g_autofree char *size_s = NULL;
+              guint64 size = 0;
+              g_autofree const char **subpaths = NULL;
+
+              latest = flatpak_dir_read_latest (dir, repo, ref, NULL, NULL, NULL);
+              if (latest)
                 {
-                  g_free (latest);
-                  latest = g_strdup ("-");
+                  if (strcmp (active, latest) == 0)
+                    {
+                      g_free (latest);
+                      latest = g_strdup ("-");
+                    }
+                  else
+                    {
+                      latest[MIN (strlen (latest), 12)] = 0;
+                    }
+                }
+              else
+                {
+                  latest = g_strdup ("?");
+                }
+
+              flatpak_table_printer_add_column (printer, partial_ref);
+              flatpak_table_printer_add_column (printer, repo);
+
+              flatpak_table_printer_add_column_len (printer, active, 12);
+              flatpak_table_printer_add_column_len (printer, latest, 12);
+
+              size = flatpak_deploy_data_get_installed_size (deploy_data);
+              size_s = g_format_size (size);
+              flatpak_table_printer_add_column (printer, size_s);
+
+              flatpak_table_printer_add_column (printer, ""); /* Options */
+
+              if (refs_array->len > 1)
+                {
+                  g_autofree char *source = NULL;
+                  if (flatpak_dir_is_user (dir))
+                    {
+                      source = g_strdup ("user");
+                    }
+                  else
+                    {
+                      const char *system_source = flatpak_dir_get_id (dir);
+                      source = g_strdup_printf ("system (%s)", system_source ? system_source : "default");
+                    }
+
+                  flatpak_table_printer_append_with_comma (printer, source);
+                }
+
+              if (alt_id)
+                {
+                  g_autofree char *alt_id_str = g_strdup_printf ("alt-id=%.12s", alt_id);
+                  flatpak_table_printer_append_with_comma (printer, alt_id_str);
+                }
+
+              if (strcmp (parts[0], "app") == 0)
+                {
+                  g_autofree char *current;
+
+                  current = flatpak_dir_current_ref (dir, parts[1], cancellable);
+                  if (current && strcmp (ref, current) == 0)
+                    flatpak_table_printer_append_with_comma (printer, "current");
+                }
+              else
+                {
+                  if (print_apps)
+                    flatpak_table_printer_append_with_comma (printer, "runtime");
+                }
+
+              subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
+              if (subpaths[0] == NULL)
+                {
+                  flatpak_table_printer_add_column (printer, "");
+                }
+              else
+                {
+                  int i;
+                  flatpak_table_printer_add_column (printer, ""); /* subpaths */
+                  for (i = 0; subpaths[i] != NULL; i++)
+                    flatpak_table_printer_append_with_comma (printer, subpaths[i]);
                 }
             }
           else
             {
-              latest = g_strdup ("?");
+              if (last == NULL || strcmp (last, parts[1]) != 0)
+                {
+                  flatpak_table_printer_add_column (printer, parts[1]);
+                  g_clear_pointer (&last, g_free);
+                  last = g_strdup (parts[1]);
+                }
             }
-
-          flatpak_table_printer_add_column (printer, partial_ref);
-          flatpak_table_printer_add_column (printer, repo);
-
-          flatpak_table_printer_add_column_len (printer, active, 12);
-          flatpak_table_printer_add_column_len (printer, latest, 12);
-
-          size = flatpak_deploy_data_get_installed_size (deploy_data);
-          size_s = g_format_size (size);
-          flatpak_table_printer_add_column (printer, size_s);
-
-          flatpak_table_printer_add_column (printer, ""); /* Options */
-
-          if (print_user && print_system)
-            flatpak_table_printer_append_with_comma (printer, is_user ? "user" : "system");
-
-          if (alt_id)
-            {
-              g_autofree char *alt_id_str = g_strdup_printf ("alt-id=%.12s", alt_id);
-              flatpak_table_printer_append_with_comma (printer, alt_id_str);
-            }
-
-          if (strcmp (parts[0], "app") == 0)
-            {
-              g_autofree char *current;
-
-              current = flatpak_dir_current_ref (dir, parts[1], cancellable);
-              if (current && strcmp (ref, current) == 0)
-                flatpak_table_printer_append_with_comma (printer, "current");
-            }
-          else
-            {
-              if (app)
-                flatpak_table_printer_append_with_comma (printer, "runtime");
-            }
-
-          subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
-          if (subpaths[0] == NULL)
-            {
-              flatpak_table_printer_add_column (printer, "");
-            }
-          else
-            {
-              int i;
-              flatpak_table_printer_add_column (printer, ""); /* subpaths */
-              for (i = 0; subpaths[i] != NULL; i++)
-                flatpak_table_printer_append_with_comma (printer, subpaths[i]);
-            }
+          flatpak_table_printer_finish_row (printer);
         }
-      else
-        {
-          if (last == NULL || strcmp (last, parts[1]) != 0)
-            {
-              flatpak_table_printer_add_column (printer, parts[1]);
-              g_clear_pointer (&last, g_free);
-              last = g_strdup (parts[1]);
-            }
-        }
-      flatpak_table_printer_finish_row (printer);
     }
 
   flatpak_table_printer_print (printer);
   flatpak_table_printer_free (printer);
+
+  return TRUE;
+}
+
+static gboolean
+print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gboolean print_user, const char *installation, const char *arch, GCancellable *cancellable, GError **error)
+{
+  g_autoptr(GPtrArray) refs_array = NULL;
+  gboolean print_all = !print_user && !print_system && (installation == NULL);
+
+  refs_array = g_ptr_array_new_with_free_func ((GDestroyNotify) refs_data_free);
+  if (print_user || print_all)
+    {
+      g_autoptr(FlatpakDir) user_dir = NULL;
+      g_auto(GStrv) user_app = NULL;
+      g_auto(GStrv) user_runtime = NULL;
+
+      user_dir =flatpak_dir_get_user ();
+      if (!find_refs_for_dir (user_dir, app ? &user_app : NULL, runtime ? &user_runtime : NULL, cancellable, error))
+        return FALSE;
+      g_ptr_array_add (refs_array, refs_data_new (user_dir, user_app, user_runtime));
+    }
+
+  if (print_all)
+    {
+      g_autoptr(GPtrArray) system_dirs = NULL;
+      int i;
+
+      system_dirs = flatpak_dir_get_system_list (cancellable, error);
+      if (system_dirs == NULL)
+        return FALSE;
+
+      for (i = 0; i < system_dirs->len; i++)
+        {
+          FlatpakDir *dir = g_ptr_array_index (system_dirs, i);
+          g_auto(GStrv) apps = NULL;
+          g_auto(GStrv) runtimes = NULL;
+
+          if (!find_refs_for_dir (dir, app ? &apps : NULL, runtime ? &runtimes : NULL, cancellable, error))
+            return FALSE;
+          g_ptr_array_add (refs_array, refs_data_new (dir, apps, runtimes));
+        }
+    }
+  else
+    {
+      if (print_system)
+        {
+          g_autoptr(FlatpakDir) system_dir = NULL;
+          g_auto(GStrv) system_app = NULL;
+          g_auto(GStrv) system_runtime = NULL;
+
+          system_dir = flatpak_dir_get_system_default ();
+          if (!find_refs_for_dir (system_dir, app ? &system_app : NULL, runtime ? &system_runtime : NULL, cancellable, error))
+            return FALSE;
+          g_ptr_array_add (refs_array, refs_data_new (system_dir, system_app, system_runtime));
+        }
+
+      if (installation != NULL)
+        {
+          g_autoptr(FlatpakDir) system_dir = NULL;
+          g_auto(GStrv) installation_apps = NULL;
+          g_auto(GStrv) installation_runtimes = NULL;
+
+          system_dir = flatpak_dir_get_system_by_id (installation, cancellable, error);
+          if (system_dir == NULL)
+            return FALSE;
+
+
+          if (system_dir == NULL)
+            {
+              g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                           "Can't find installation %s", opt_installation);
+              return FALSE;
+            }
+
+          if (!find_refs_for_dir (system_dir, app ? &installation_apps : NULL, runtime ? &installation_runtimes : NULL, cancellable, error))
+            return FALSE;
+
+          g_ptr_array_add (refs_array, refs_data_new (system_dir, installation_apps, installation_runtimes));
+        }
+    }
+
+  if (!print_table_for_refs (app, refs_array, arch, cancellable, error))
+    return FALSE;
 
   return TRUE;
 }
@@ -266,8 +366,9 @@ flatpak_builtin_list (int argc, char **argv, GCancellable *cancellable, GError *
     opt_app = TRUE;
 
   if (!print_installed_refs (opt_app, opt_runtime,
-                             opt_system || (!opt_user && !opt_system),
-                             opt_user || (!opt_user && !opt_system),
+                             opt_system,
+                             opt_user,
+                             opt_installation,
                              opt_arch,
                              cancellable, error))
     return FALSE;

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -91,8 +91,7 @@ print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gbo
 
   if (print_user)
     {
-      user_dir = flatpak_dir_get (TRUE);
-
+      user_dir = flatpak_dir_get_user ();
       if (flatpak_dir_ensure_repo (user_dir, cancellable, NULL))
         {
           if (app && !flatpak_dir_list_refs (user_dir, "app", &user_app, cancellable, error))
@@ -104,7 +103,7 @@ print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gbo
 
   if (print_system)
     {
-      system_dir = flatpak_dir_get (FALSE);
+      system_dir = flatpak_dir_get_system_default ();
       if (flatpak_dir_ensure_repo (system_dir, cancellable, NULL))
         {
           if (app && !flatpak_dir_list_refs (system_dir, "app", &system_app, cancellable, error))

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -198,17 +198,7 @@ print_table_for_refs (gboolean print_apps, GPtrArray* refs_array, const char *ar
 
               if (refs_array->len > 1)
                 {
-                  g_autofree char *source = NULL;
-                  if (flatpak_dir_is_user (dir))
-                    {
-                      source = g_strdup ("user");
-                    }
-                  else
-                    {
-                      const char *system_source = flatpak_dir_get_id (dir);
-                      source = g_strdup_printf ("system (%s)", system_source ? system_source : "default");
-                    }
-
+                  g_autofree char *source = flatpak_dir_get_name (dir);
                   flatpak_table_printer_append_with_comma (printer, source);
                 }
 

--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -136,7 +136,7 @@ flatpak_complete_override (FlatpakCompletion *completion)
           }
       }
 
-      system_dir = flatpak_dir_get_system ();
+      system_dir = flatpak_dir_get_system_default ();
       {
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, NULL, NULL, NULL,
                                                               FLATPAK_KINDS_APP, &error);

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -111,7 +111,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
     {
       g_autofree char *current_ref = NULL;
       g_autoptr(FlatpakDir) user_dir = flatpak_dir_get_user ();
-      g_autoptr(FlatpakDir) system_dir = flatpak_dir_get_system ();
+      g_autoptr(FlatpakDir) system_dir = flatpak_dir_get_system_default ();
 
       current_ref = flatpak_dir_current_ref (user_dir, id, cancellable);
       if (current_ref == NULL)
@@ -228,7 +228,7 @@ flatpak_complete_run (FlatpakCompletion *completion)
           }
       }
 
-      system_dir = flatpak_dir_get_system ();
+      system_dir = flatpak_dir_get_system_default ();
       {
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, NULL, NULL, opt_arch,
                                                               FLATPAK_KINDS_APP, &error);

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -236,7 +236,7 @@ flatpak_option_context_parse (GOptionContext     *context,
 
   if (!(flags & FLATPAK_BUILTIN_FLAG_NO_DIR))
     {
-      dir = flatpak_dir_get (opt_user);
+      dir = opt_user ? flatpak_dir_get_user () : flatpak_dir_get_system_default ();
 
       if (!flatpak_dir_ensure_path (dir, cancellable, error))
         return FALSE;

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -39,6 +39,7 @@ static gboolean opt_version;
 static gboolean opt_default_arch;
 static gboolean opt_supported_arches;
 static gboolean opt_user;
+static char *opt_installation;
 
 typedef struct
 {
@@ -115,6 +116,7 @@ static GOptionEntry empty_entries[] = {
 GOptionEntry user_entries[] = {
   { "user", 0, 0, G_OPTION_ARG_NONE, &opt_user, N_("Work on user installations"), NULL },
   { "system", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_user, N_("Work on system-wide installations (default)"), NULL },
+  { "installation", 0, 0, G_OPTION_ARG_STRING, &opt_installation, N_("Work on a specific system-wide installation"), NULL },
   { NULL }
 };
 
@@ -236,7 +238,16 @@ flatpak_option_context_parse (GOptionContext     *context,
 
   if (!(flags & FLATPAK_BUILTIN_FLAG_NO_DIR))
     {
-      dir = opt_user ? flatpak_dir_get_user () : flatpak_dir_get_system_default ();
+      if (opt_user)
+        dir = flatpak_dir_get_user ();
+      else if (opt_installation == NULL)
+        dir = flatpak_dir_get_system_default ();
+      else
+        {
+          dir = flatpak_dir_get_system_by_id (opt_installation, cancellable, error);
+          if (dir == NULL)
+            return FALSE;
+        }
 
       if (!flatpak_dir_ensure_path (dir, cancellable, error))
         return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1412,11 +1412,14 @@ flatpak_dir_update_appstream (FlatpakDir          *self,
         }
       else
         {
+          const char *installation = flatpak_dir_get_id (self);
+
           g_debug ("Calling system helper: DeployAppstream");
           if (!flatpak_system_helper_call_deploy_appstream_sync (system_helper,
                                                                  flatpak_file_get_path_cached (ostree_repo_get_path (child_repo)),
                                                                  remote,
                                                                  arch,
+                                                                 installation ? installation : "",
                                                                  cancellable,
                                                                  error))
             return FALSE;
@@ -3973,6 +3976,7 @@ flatpak_dir_install (FlatpakDir          *self,
     {
       g_autoptr(OstreeRepo) child_repo = NULL;
       g_auto(GLnxLockFile) child_repo_lock = GLNX_LOCK_FILE_INIT;
+      const char *installation = flatpak_dir_get_id (self);
       const char *empty_subpaths[] = {NULL};
       const char **subpaths;
       g_autofree char *child_repo_path = NULL;
@@ -4052,6 +4056,7 @@ flatpak_dir_install (FlatpakDir          *self,
                                                    child_repo_path ? child_repo_path : "",
                                                    helper_flags, ref, remote_name,
                                                    (const char * const *) subpaths,
+                                                   installation ? installation : "",
                                                    cancellable,
                                                    error))
         return FALSE;
@@ -4105,6 +4110,7 @@ flatpak_dir_install_bundle (FlatpakDir          *self,
     {
       FlatpakSystemHelper *system_helper;
       g_autoptr(GVariant) gpg_data_v = NULL;
+      const char *installation = flatpak_dir_get_id (self);
 
       system_helper = flatpak_dir_get_system_helper (self);
       g_assert (system_helper != NULL);
@@ -4118,6 +4124,7 @@ flatpak_dir_install_bundle (FlatpakDir          *self,
       if (!flatpak_system_helper_call_install_bundle_sync (system_helper,
                                                            flatpak_file_get_path_cached (file),
                                                            0, gpg_data_v,
+                                                           installation ? installation : "",
                                                            &ref,
                                                            cancellable,
                                                            error))
@@ -4448,11 +4455,14 @@ flatpak_dir_update (FlatpakDir          *self,
       active_checksum = flatpak_dir_read_active (self, ref, NULL);
       if (g_strcmp0 (active_checksum, latest_checksum) != 0)
         {
+          const char *installation = flatpak_dir_get_id (self);
+
           g_debug ("Calling system helper: Deploy");
           if (!flatpak_system_helper_call_deploy_sync (system_helper,
                                                        child_repo_path ? child_repo_path : "",
                                                        helper_flags, ref, remote_name,
                                                        subpaths,
+                                                       installation ? installation : "",
                                                        cancellable,
                                                        error))
             return FALSE;
@@ -4545,6 +4555,7 @@ flatpak_dir_uninstall (FlatpakDir          *self,
   if (flatpak_dir_use_system_helper (self))
     {
       FlatpakSystemHelper *system_helper;
+      const char *installation = flatpak_dir_get_id (self);
 
       system_helper = flatpak_dir_get_system_helper (self);
       g_assert (system_helper != NULL);
@@ -4552,6 +4563,7 @@ flatpak_dir_uninstall (FlatpakDir          *self,
       g_debug ("Calling system helper: Uninstall");
       if (!flatpak_system_helper_call_uninstall_sync (system_helper,
                                                       flags, ref,
+                                                      installation ? installation : "",
                                                       cancellable, error))
         return FALSE;
 
@@ -6516,6 +6528,7 @@ flatpak_dir_remove_remote (FlatpakDir   *self,
       FlatpakSystemHelper *system_helper;
       g_autoptr(GVariant) gpg_data_v = NULL;
       FlatpakHelperConfigureRemoteFlags flags = 0;
+      const char *installation = flatpak_dir_get_id (self);
 
       gpg_data_v = g_variant_ref_sink (g_variant_new_from_data (G_VARIANT_TYPE ("ay"), "", 0, TRUE, NULL, NULL));
 
@@ -6530,6 +6543,7 @@ flatpak_dir_remove_remote (FlatpakDir   *self,
                                                              flags, remote_name,
                                                              "",
                                                              gpg_data_v,
+                                                             installation ? installation : "",
                                                              cancellable, error))
         return FALSE;
 
@@ -6625,6 +6639,7 @@ flatpak_dir_modify_remote (FlatpakDir   *self,
       FlatpakSystemHelper *system_helper;
       g_autofree char *config_data = g_key_file_to_data (config, NULL, NULL);
       g_autoptr(GVariant) gpg_data_v = NULL;
+      const char *installation = flatpak_dir_get_id (self);
 
       if (gpg_data != NULL)
         gpg_data_v = variant_new_ay_bytes (gpg_data);
@@ -6639,6 +6654,7 @@ flatpak_dir_modify_remote (FlatpakDir   *self,
                                                              0, remote_name,
                                                              config_data,
                                                              gpg_data_v,
+                                                             installation ? installation : "",
                                                              cancellable, error))
         return FALSE;
 
@@ -6934,6 +6950,7 @@ flatpak_dir_update_remote_configuration (FlatpakDir   *self,
         FlatpakSystemHelper *system_helper;
         g_autofree char *config_data = g_key_file_to_data (config, NULL, NULL);
         g_autoptr(GVariant) gpg_data_v = NULL;
+        const char *installation = flatpak_dir_get_id (self);
 
         gpg_data_v = g_variant_ref_sink (g_variant_new_from_data (G_VARIANT_TYPE ("ay"), "", 0, TRUE, NULL, NULL));
 
@@ -6945,6 +6962,7 @@ flatpak_dir_update_remote_configuration (FlatpakDir   *self,
                                                                0, remote,
                                                                config_data,
                                                                gpg_data_v,
+                                                               installation ? installation : "",
                                                                cancellable, error))
           return FALSE;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -718,6 +718,12 @@ flatpak_dir_get_path (FlatpakDir *self)
   return self->basedir;
 }
 
+GFile *
+flatpak_dir_get_changed_path (FlatpakDir *self)
+{
+  return g_file_get_child (self->basedir, ".changed");
+}
+
 const char *
 flatpak_dir_get_id (FlatpakDir *self)
 {
@@ -727,10 +733,31 @@ flatpak_dir_get_id (FlatpakDir *self)
   return NULL;
 }
 
-GFile *
-flatpak_dir_get_changed_path (FlatpakDir *self)
+const char *
+flatpak_dir_get_display_name (FlatpakDir *self)
 {
-  return g_file_get_child (self->basedir, ".changed");
+  if (self->extra_data != NULL)
+    return self->extra_data->display_name;
+
+  return NULL;
+}
+
+gint
+flatpak_dir_get_priority (FlatpakDir *self)
+{
+  if (self->extra_data != NULL)
+    return self->extra_data->priority;
+
+  return 0;
+}
+
+FlatpakDirStorageType
+flatpak_dir_get_storage_type (FlatpakDir *self)
+{
+  if (self->extra_data != NULL)
+    return self->extra_data->storage_type;
+
+  return FLATPAK_DIR_STORAGE_TYPE_DEFAULT;
 }
 
 char *

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -196,7 +196,7 @@ flatpak_deploy_new (GFile *dir, GKeyFile *metadata)
 }
 
 GFile *
-flatpak_get_system_base_dir_location (void)
+flatpak_get_system_default_base_dir_location (void)
 {
   static gsize path = 0;
 
@@ -540,7 +540,7 @@ flatpak_save_override_keyfile (GKeyFile   *metakey,
   if (user)
     base_dir = flatpak_get_user_base_dir_location ();
   else
-    base_dir = flatpak_get_system_base_dir_location ();
+    base_dir = flatpak_get_system_default_base_dir_location ();
 
   override_dir = g_file_get_child (base_dir, "overrides");
   file = g_file_get_child (override_dir, app_id);
@@ -5673,7 +5673,7 @@ flatpak_dir_clone (FlatpakDir *self)
 FlatpakDir *
 flatpak_dir_get_system_default (void)
 {
-  g_autoptr(GFile) path = flatpak_get_system_base_dir_location ();
+  g_autoptr(GFile) path = flatpak_get_system_default_base_dir_location ();
   return flatpak_dir_new (path, FALSE);
 }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -615,6 +615,12 @@ flatpak_dir_get_path (FlatpakDir *self)
   return self->basedir;
 }
 
+const char *
+flatpak_dir_get_id (FlatpakDir *self)
+{
+  return self->id;
+}
+
 GFile *
 flatpak_dir_get_changed_path (FlatpakDir *self)
 {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -780,6 +780,21 @@ flatpak_dir_get_id (FlatpakDir *self)
   return NULL;
 }
 
+char *
+flatpak_dir_get_name (FlatpakDir *self)
+{
+  const char *id = NULL;
+
+  if (self->user)
+    return g_strdup ("user");
+
+  id = flatpak_dir_get_id (self);
+  if (id != NULL && g_strcmp0 (id, "default") != 0)
+    return g_strdup_printf ("system (%s)", id);
+
+  return g_strdup ("system");
+}
+
 const char *
 flatpak_dir_get_display_name (FlatpakDir *self)
 {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5671,7 +5671,7 @@ flatpak_dir_clone (FlatpakDir *self)
 }
 
 FlatpakDir *
-flatpak_dir_get_system (void)
+flatpak_dir_get_system_default (void)
 {
   g_autoptr(GFile) path = flatpak_get_system_base_dir_location ();
   return flatpak_dir_new (path, FALSE);
@@ -5690,7 +5690,7 @@ flatpak_dir_get (gboolean user)
   if (user)
     return flatpak_dir_get_user ();
   else
-    return flatpak_dir_get_system ();
+    return flatpak_dir_get_system_default ();
 }
 
 static char *

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -484,7 +484,7 @@ flatpak_load_override_keyfile (const char *app_id, gboolean user, GError **error
   g_autoptr(GKeyFile) metakey = g_key_file_new ();
   g_autoptr(FlatpakDir) dir = NULL;
 
-  dir = flatpak_dir_get (user);
+  dir = user ? flatpak_dir_get_user () : flatpak_dir_get_system_default ();
 
   metadata_contents = flatpak_dir_load_override (dir, app_id, &metadata_size, error);
   if (metadata_contents == NULL)
@@ -5682,15 +5682,6 @@ flatpak_dir_get_user (void)
 {
   g_autoptr(GFile) path = flatpak_get_user_base_dir_location ();
   return flatpak_dir_new (path, TRUE);
-}
-
-FlatpakDir *
-flatpak_dir_get (gboolean user)
-{
-  if (user)
-    return flatpak_dir_get_user ();
-  else
-    return flatpak_dir_get_system_default ();
 }
 
 static char *

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -152,6 +152,7 @@ gboolean    flatpak_dir_is_user (FlatpakDir *self);
 void        flatpak_dir_set_no_system_helper (FlatpakDir *self,
                                               gboolean    no_system_helper);
 GFile *     flatpak_dir_get_path (FlatpakDir *self);
+const char *flatpak_dir_get_id (FlatpakDir *self);
 GFile *     flatpak_dir_get_changed_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_deploy_dir (FlatpakDir *self,
                                         const char *ref);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -165,6 +165,7 @@ GFile *     flatpak_dir_get_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_changed_path (FlatpakDir *self);
 const char *flatpak_dir_get_id (FlatpakDir *self);
 const char *flatpak_dir_get_display_name (FlatpakDir *self);
+char *      flatpak_dir_get_name (FlatpakDir *self);
 gint        flatpak_dir_get_priority (FlatpakDir *self);
 FlatpakDirStorageType flatpak_dir_get_storage_type (FlatpakDir *self);
 GFile *     flatpak_dir_get_deploy_dir (FlatpakDir *self,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -162,8 +162,11 @@ gboolean    flatpak_dir_is_user (FlatpakDir *self);
 void        flatpak_dir_set_no_system_helper (FlatpakDir *self,
                                               gboolean    no_system_helper);
 GFile *     flatpak_dir_get_path (FlatpakDir *self);
-const char *flatpak_dir_get_id (FlatpakDir *self);
 GFile *     flatpak_dir_get_changed_path (FlatpakDir *self);
+const char *flatpak_dir_get_id (FlatpakDir *self);
+const char *flatpak_dir_get_display_name (FlatpakDir *self);
+gint        flatpak_dir_get_priority (FlatpakDir *self);
+FlatpakDirStorageType flatpak_dir_get_storage_type (FlatpakDir *self);
 GFile *     flatpak_dir_get_deploy_dir (FlatpakDir *self,
                                         const char *ref);
 GFile *     flatpak_dir_get_unmaintained_extension_dir (FlatpakDir *self,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -114,8 +114,10 @@ GQuark       flatpak_dir_error_quark (void);
 #define FLATPAK_DEPLOY_DATA_GVARIANT_STRING "(ssasta{sv})"
 #define FLATPAK_DEPLOY_DATA_GVARIANT_FORMAT G_VARIANT_TYPE (FLATPAK_DEPLOY_DATA_GVARIANT_STRING)
 
-GFile *  flatpak_get_system_default_base_dir_location (void);
-GFile *  flatpak_get_user_base_dir_location (void);
+GPtrArray * flatpak_get_system_base_dir_locations (GCancellable *cancellable,
+                                                   GError      **error);
+GFile *     flatpak_get_system_default_base_dir_location (void);
+GFile *     flatpak_get_user_base_dir_location (void);
 
 GKeyFile *     flatpak_load_override_keyfile (const char *app_id,
                                               gboolean    user,
@@ -142,8 +144,10 @@ GKeyFile *     flatpak_deploy_get_metadata (FlatpakDeploy *deploy);
 FlatpakDir *  flatpak_dir_new (GFile   *basedir,
                                gboolean user);
 FlatpakDir *  flatpak_dir_clone (FlatpakDir *self);
-FlatpakDir  *flatpak_dir_get_system_default (void);
 FlatpakDir  *flatpak_dir_get_user (void);
+FlatpakDir  *flatpak_dir_get_system_default (void);
+GPtrArray   *flatpak_dir_get_system_list (GCancellable *cancellable,
+                                          GError      **error);
 gboolean    flatpak_dir_is_user (FlatpakDir *self);
 void        flatpak_dir_set_no_system_helper (FlatpakDir *self,
                                               gboolean    no_system_helper);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -114,7 +114,7 @@ GQuark       flatpak_dir_error_quark (void);
 #define FLATPAK_DEPLOY_DATA_GVARIANT_STRING "(ssasta{sv})"
 #define FLATPAK_DEPLOY_DATA_GVARIANT_FORMAT G_VARIANT_TYPE (FLATPAK_DEPLOY_DATA_GVARIANT_STRING)
 
-GFile *  flatpak_get_system_base_dir_location (void);
+GFile *  flatpak_get_system_default_base_dir_location (void);
 GFile *  flatpak_get_user_base_dir_location (void);
 
 GKeyFile *     flatpak_load_override_keyfile (const char *app_id,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -100,6 +100,13 @@ typedef enum {
   FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA = 1 << 1,
 } FlatpakPullFlags;
 
+typedef enum {
+  FLATPAK_DIR_STORAGE_TYPE_DEFAULT = 0,
+  FLATPAK_DIR_STORAGE_TYPE_HARD_DISK = 1 << 0,
+  FLATPAK_DIR_STORAGE_TYPE_SDCARD = 1 << 1,
+  FLATPAK_DIR_STORAGE_TYPE_MMC = 1 << 2,
+} FlatpakDirStorageType;
+
 GQuark       flatpak_dir_error_quark (void);
 
 /**

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -142,7 +142,6 @@ GKeyFile *     flatpak_deploy_get_metadata (FlatpakDeploy *deploy);
 FlatpakDir *  flatpak_dir_new (GFile   *basedir,
                                gboolean user);
 FlatpakDir *  flatpak_dir_clone (FlatpakDir *self);
-FlatpakDir  *flatpak_dir_get (gboolean user);
 FlatpakDir  *flatpak_dir_get_system_default (void);
 FlatpakDir  *flatpak_dir_get_user (void);
 gboolean    flatpak_dir_is_user (FlatpakDir *self);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -143,7 +143,7 @@ FlatpakDir *  flatpak_dir_new (GFile   *basedir,
                                gboolean user);
 FlatpakDir *  flatpak_dir_clone (FlatpakDir *self);
 FlatpakDir  *flatpak_dir_get (gboolean user);
-FlatpakDir  *flatpak_dir_get_system (void);
+FlatpakDir  *flatpak_dir_get_system_default (void);
 FlatpakDir  *flatpak_dir_get_user (void);
 gboolean    flatpak_dir_is_user (FlatpakDir *self);
 void        flatpak_dir_set_no_system_helper (FlatpakDir *self,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -148,6 +148,9 @@ FlatpakDir  *flatpak_dir_get_user (void);
 FlatpakDir  *flatpak_dir_get_system_default (void);
 GPtrArray   *flatpak_dir_get_system_list (GCancellable *cancellable,
                                           GError      **error);
+FlatpakDir  *flatpak_dir_get_system_by_id (const char   *id,
+                                           GCancellable *cancellable,
+                                           GError      **error);
 gboolean    flatpak_dir_is_user (FlatpakDir *self);
 void        flatpak_dir_set_no_system_helper (FlatpakDir *self,
                                               gboolean    no_system_helper);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -940,7 +940,7 @@ flatpak_list_deployed_refs (const char   *type,
   hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   user_dir = flatpak_dir_get_user ();
-  system_dir = flatpak_dir_get_system ();
+  system_dir = flatpak_dir_get_system_default ();
 
   if (!flatpak_dir_collect_deployed_refs (user_dir, type, name_prefix,
                                           branch, arch, hash, cancellable,
@@ -1023,7 +1023,7 @@ flatpak_find_deploy_dir_for_ref (const char   *ref,
   g_autoptr(GFile) deploy = NULL;
 
   user_dir = flatpak_dir_get_user ();
-  system_dir = flatpak_dir_get_system ();
+  system_dir = flatpak_dir_get_system_default ();
 
   dir = user_dir;
   deploy = flatpak_dir_get_if_deployed (dir, ref, NULL, cancellable);
@@ -1091,7 +1091,7 @@ flatpak_find_deploy_for_ref (const char   *ref,
   g_autoptr(GError) my_error = NULL;
 
   user_dir = flatpak_dir_get_user ();
-  system_dir = flatpak_dir_get_system ();
+  system_dir = flatpak_dir_get_system_default ();
 
   deploy = flatpak_dir_load_deployed (user_dir, ref, NULL, cancellable, &my_error);
   if (deploy == NULL && g_error_matches (my_error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED))

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -65,17 +65,20 @@
       <arg type='s' name='ref' direction='in'/>
       <arg type='s' name='origin' direction='in'/>
       <arg type='as' name='subpaths' direction='in'/>
+      <arg type='s' name='installation' direction='in'/>
     </method>
 
     <method name="DeployAppstream">
       <arg type='ay' name='repo_path' direction='in'/>
       <arg type='s' name='origin' direction='in'/>
       <arg type='s' name='arch' direction='in'/>
+      <arg type='s' name='installation' direction='in'/>
     </method>
 
     <method name="Uninstall">
       <arg type='u' name='flags' direction='in'/>
       <arg type='s' name='ref' direction='in'/>
+      <arg type='s' name='installation' direction='in'/>
     </method>
 
     <method name="InstallBundle">
@@ -84,6 +87,7 @@
       <arg type='ay' name='gpg_key' direction='in'>
         <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       </arg>
+      <arg type='s' name='installation' direction='in'/>
       <arg type='s' name='ref' direction='out'/>
     </method>
 
@@ -94,6 +98,7 @@
       <arg type='ay' name='gpg_key' direction='in'>
         <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       </arg>
+      <arg type='s' name='installation' direction='in'/>
     </method>
 
   </interface>

--- a/lib/Makefile.am.inc
+++ b/lib/Makefile.am.inc
@@ -1,5 +1,5 @@
 lib_LTLIBRARIES += libflatpak.la
-noinst_PROGRAMS += test-libflatpak
+noinst_PROGRAMS += test-libflatpak test-libflatpak-installations
 
 flatpakincludedir = $(includedir)/flatpak
 
@@ -103,6 +103,21 @@ test_libflatpak_CFLAGS = \
 	$(NULL)
 
 test_libflatpak_LDADD = \
+	$(BASE_LIBS)	\
+        libflatpak.la \
+	$(NULL)
+
+test_libflatpak_installations_SOURCES = \
+        lib/test-lib-installations.c      \
+	$(NULL)
+
+test_libflatpak_installations_CFLAGS = \
+	$(BASE_CFLAGS) \
+	-I$(top_srcdir)/lib \
+	-I$(top_builddir)/lib \
+	$(NULL)
+
+test_libflatpak_installations_LDADD = \
 	$(BASE_LIBS)	\
         libflatpak.la \
 	$(NULL)

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -188,7 +188,7 @@ FlatpakInstallation *
 flatpak_installation_new_system (GCancellable *cancellable,
                                  GError      **error)
 {
-  return flatpak_installation_new_for_dir (flatpak_dir_get_system (), cancellable, error);
+  return flatpak_installation_new_for_dir (flatpak_dir_get_system_default (), cancellable, error);
 }
 
 /**

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -249,6 +249,44 @@ flatpak_installation_new_system (GCancellable *cancellable,
 }
 
 /**
+ * flatpak_installation_new_system_with_id:
+ * @id: (nullable): the ID of the system-wide installation
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Creates a new #FlatpakInstallation for the system-wide installation @id.
+ *
+ * Returns: (transfer full): a new #FlatpakInstallation
+ *
+ * Since: 0.6.15
+ */
+FlatpakInstallation *
+flatpak_installation_new_system_with_id (const char   *id,
+                                         GCancellable *cancellable,
+                                         GError      **error)
+{
+  g_autoptr(FlatpakDir) install_dir = NULL;
+  g_autoptr(FlatpakInstallation) installation = NULL;
+  g_autoptr(GError) local_error = NULL;
+
+  install_dir = flatpak_dir_get_system_by_id (id, cancellable, error);
+  if (install_dir == NULL)
+    return NULL;
+
+  installation = flatpak_installation_new_for_dir (g_object_ref (install_dir),
+                                                   cancellable,
+                                                   &local_error);
+  if (installation == NULL)
+    {
+      g_debug ("Error creating Flatpak installation: %s", local_error->message);
+      g_propagate_error (error, g_steal_pointer (&local_error));
+    }
+
+  g_debug ("Found Flatpak installation for '%s'", id);
+  return g_steal_pointer (&installation);
+}
+
+/**
  * flatpak_installation_new_user:
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -406,6 +406,92 @@ flatpak_installation_get_path (FlatpakInstallation *self)
 }
 
 /**
+ * flatpak_installation_get_id:
+ * @self: a #FlatpakInstallation
+ *
+ * Returns the ID of the system installation for @self.
+ *
+ * Returns: (transfer none): a string with the installation's ID
+ *
+ * Since: 0.6.15
+ */
+const char *
+flatpak_installation_get_id (FlatpakInstallation *self)
+{
+  g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
+
+  return flatpak_dir_get_id (dir);
+}
+
+/**
+ * flatpak_installation_get_display_name:
+ * @self: a #FlatpakInstallation
+ *
+ * Returns the display name of the system installation for @self.
+ *
+ * Returns: (transfer none): a string with the installation's display name
+ *
+ * Since: 0.6.15
+ */
+const char *
+flatpak_installation_get_display_name (FlatpakInstallation *self)
+{
+  g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
+
+  return flatpak_dir_get_display_name (dir);
+}
+
+/**
+ * flatpak_installation_get_priority:
+ * @self: a #FlatpakInstallation
+ *
+ * Returns the numeric priority of the system installation for @self.
+ *
+ * Returns: an integer with the configured priority value
+ *
+ * Since: 0.6.15
+ */
+gint
+flatpak_installation_get_priority (FlatpakInstallation *self)
+{
+  g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
+
+  return flatpak_dir_get_priority (dir);
+}
+
+/**
+ * flatpak_installation_get_storage_type:
+ * @self: a #FlatpakInstallation
+ *
+ * Returns the type of storage of the system installation for @self.
+ *
+ * Returns: a #FlatpakStorageType
+ *
+ * Since: 0.6.15
+ */FlatpakStorageType
+flatpak_installation_get_storage_type (FlatpakInstallation *self)
+{
+  g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
+
+  switch (flatpak_dir_get_storage_type (dir))
+    {
+    case FLATPAK_DIR_STORAGE_TYPE_HARD_DISK:
+      return FLATPAK_STORAGE_TYPE_HARD_DISK;
+
+    case FLATPAK_DIR_STORAGE_TYPE_SDCARD:
+      return FLATPAK_STORAGE_TYPE_SDCARD;
+
+    case FLATPAK_DIR_STORAGE_TYPE_MMC:
+      return FLATPAK_STORAGE_TYPE_MMC;
+
+    default:
+      return FLATPAK_STORAGE_TYPE_DEFAULT;
+    }
+
+  return FLATPAK_STORAGE_TYPE_DEFAULT;
+}
+
+/**
  * flatpak_installation_launch:
  * @self: a #FlatpakInstallation
  * @name: name of the app to launch

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -71,6 +71,24 @@ typedef enum {
   FLATPAK_INSTALL_FLAGS_NONE      = 0,
 } FlatpakInstallFlags;
 
+/**
+ * FlatpakStorageType:
+ * @FLATPAK_STORAGE_TYPE_DEFAULT: default
+ * @FLATPAK_STORAGE_TYPE_HARD_DISK: installation is on a hard disk
+ * @FLATPAK_STORAGE_TYPE_SDCARD: installation is on a SD card
+ * @FLATPAK_STORAGE_TYPE_MMC: installation is on an MMC
+ *
+ * Flags to alter the behavior of flatpak_installation_install_full().
+ *
+ * Since: 0.6.15
+ */
+typedef enum {
+  FLATPAK_STORAGE_TYPE_DEFAULT = 0,
+  FLATPAK_STORAGE_TYPE_HARD_DISK = 1 << 0,
+  FLATPAK_STORAGE_TYPE_SDCARD = 1 << 1,
+  FLATPAK_STORAGE_TYPE_MMC = 1 << 2,
+} FlatpakStorageType;
+
 
 #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakInstallation, g_object_unref)
@@ -117,6 +135,10 @@ FLATPAK_EXTERN gboolean             flatpak_installation_drop_caches (FlatpakIns
                                                                       GError             **error);
 FLATPAK_EXTERN gboolean             flatpak_installation_get_is_user (FlatpakInstallation *self);
 FLATPAK_EXTERN GFile               *flatpak_installation_get_path (FlatpakInstallation *self);
+FLATPAK_EXTERN const char          *flatpak_installation_get_id (FlatpakInstallation *self);
+FLATPAK_EXTERN const char          *flatpak_installation_get_display_name (FlatpakInstallation *self);
+FLATPAK_EXTERN gint                 flatpak_installation_get_priority (FlatpakInstallation *self);
+FLATPAK_EXTERN FlatpakStorageType   flatpak_installation_get_storage_type (FlatpakInstallation *self);
 FLATPAK_EXTERN gboolean             flatpak_installation_launch (FlatpakInstallation *self,
                                                                  const char          *name,
                                                                  const char          *arch,

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -80,6 +80,8 @@ FLATPAK_EXTERN const char  *flatpak_get_default_arch (void);
 
 FLATPAK_EXTERN const char *const *flatpak_get_supported_arches (void);
 
+FLATPAK_EXTERN GPtrArray *flatpak_get_system_installations (GCancellable *cancellable,
+                                                            GError      **error);
 FLATPAK_EXTERN FlatpakInstallation *flatpak_installation_new_system (GCancellable *cancellable,
                                                                      GError      **error);
 FLATPAK_EXTERN FlatpakInstallation *flatpak_installation_new_user (GCancellable *cancellable,

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -84,6 +84,9 @@ FLATPAK_EXTERN GPtrArray *flatpak_get_system_installations (GCancellable *cancel
                                                             GError      **error);
 FLATPAK_EXTERN FlatpakInstallation *flatpak_installation_new_system (GCancellable *cancellable,
                                                                      GError      **error);
+FLATPAK_EXTERN FlatpakInstallation *flatpak_installation_new_system_with_id (const char   *id,
+                                                                             GCancellable *cancellable,
+                                                                             GError      **error);
 FLATPAK_EXTERN FlatpakInstallation *flatpak_installation_new_user (GCancellable *cancellable,
                                                                    GError      **error);
 FLATPAK_EXTERN FlatpakInstallation *flatpak_installation_new_for_path (GFile        *path,

--- a/lib/test-lib-installations.c
+++ b/lib/test-lib-installations.c
@@ -1,0 +1,147 @@
+#include "config.h"
+
+#include <flatpak.h>
+#include <glib.h>
+
+static void
+test_get_system_installations (void)
+{
+  g_autoptr (GPtrArray) installs = NULL;
+  g_autoptr(GError) error = NULL;
+  int i;
+
+  installs = flatpak_get_system_installations (NULL, &error);
+  if (installs == NULL)
+    {
+      g_print ("Error getting system installations: %s", error->message);
+      g_assert (FALSE);
+      return;
+    }
+
+  g_print ("\nInstallations found: %d\n", installs->len);
+  for (i = 0; i < installs->len; i++)
+    {
+      FlatpakInstallation *installation = (FlatpakInstallation*) g_ptr_array_index (installs, i);
+      g_autoptr(GFile) installation_path = flatpak_installation_get_path (installation);
+
+      g_autofree char *path = g_file_get_path (installation_path);
+      g_print ("\nInstallation found: %s\n", path);
+    }
+
+  g_assert (TRUE);
+}
+
+static void
+test_new_system_with_id (void)
+{
+  const char *installs[] = { "endless-games", "endless-sdcard", NULL };
+  gboolean all_found = TRUE;
+  int i;
+
+  for (i = 0; installs[i] != NULL; i++)
+    {
+      g_print("Checking %s...\n", installs[i]);
+      g_autoptr (FlatpakInstallation) install = NULL;
+      g_autoptr(GError) error = NULL;
+
+      install = flatpak_installation_new_system_with_id (installs[i], NULL, &error);
+      if (install != NULL)
+        {
+          g_autoptr(GFile) path = flatpak_installation_get_path (install);
+          g_print ("Installation '%s' found. Path: %s\n", installs[i], g_file_get_path (path));
+        }
+      else
+        {
+          g_print ("Could NOT find system installation '%s': %s\n", installs[i], error->message);
+          all_found = FALSE;
+        }
+    }
+
+  g_assert (all_found);
+}
+
+static void
+test_system_installations_extra_data (void)
+{
+  g_autoptr (GPtrArray) installs = NULL;
+  g_autoptr(GError) error = NULL;
+  int i;
+
+  installs = flatpak_get_system_installations (NULL, &error);
+  if (installs == NULL)
+    {
+      g_print ("Error getting system installations: %s", error->message);
+      g_assert (FALSE);
+      return;
+    }
+
+  g_print ("\nInstallations found: %d\n", installs->len);
+  for (i = 0; i < installs->len; i++)
+    {
+      FlatpakInstallation *installation = (FlatpakInstallation*) g_ptr_array_index (installs, i);
+      const char *current_id = flatpak_installation_get_id (installation);
+      const char *current_display_name = flatpak_installation_get_display_name (installation);
+      const gint current_priority = flatpak_installation_get_priority (installation);
+      const FlatpakStorageType current_storage_type = flatpak_installation_get_storage_type (installation);
+
+      g_autoptr(GFile) installation_path = flatpak_installation_get_path (installation);
+
+      g_autofree char *path = g_file_get_path (installation_path);
+      g_print ("\nExtra data for system installation found at %s:\n", path);
+
+      g_print ("\tID: %s\n", current_id);
+      g_print ("\tDisplay name: %s\n", current_display_name);
+      g_print ("\tPriority: %d\n", current_priority);
+      g_print ("\tStorage type: %d\n", current_storage_type);
+
+      if (current_id != NULL)
+        {
+          g_autoptr (FlatpakInstallation) install = NULL;
+          g_print ("\n  Retrieving extra data for ID %s:\n", current_id);
+
+          install = flatpak_installation_new_system_with_id (current_id, NULL, &error);
+          if (install != NULL)
+            {
+              const char *queried_id = flatpak_installation_get_id (install);
+              const char *queried_display_name = flatpak_installation_get_display_name (install);
+              const gint queried_priority = flatpak_installation_get_priority (install);
+              const FlatpakStorageType queried_storage_type = flatpak_installation_get_storage_type (install);
+
+              g_assert_cmpstr(current_id, ==, queried_id);
+              g_assert_cmpstr(current_display_name, ==, queried_display_name);
+              g_assert_cmpint(current_priority, ==, queried_priority);
+              g_assert_cmpint(current_storage_type, ==, queried_storage_type);
+
+              g_print ("\t Installation '%s' found. Details:\n", current_id);
+              g_print ("\t   ID: %s\n", queried_id);
+              g_print ("\t   Display name: %s\n", queried_display_name);
+              g_print ("\t   Priority: %d\n", queried_priority);
+              g_print ("\t   Storage type: %d\n", queried_storage_type);
+            }
+          else
+            {
+              g_print ("Could NOT find system installation '%s': %s\n", current_id, error->message);
+            }
+        }
+
+    }
+
+  g_assert (TRUE);
+}
+
+int
+main (int argc, char *argv[])
+{
+  int res;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/library/get_system_installations", test_get_system_installations);
+  g_test_add_func ("/library/new_system_with_id", test_new_system_with_id);
+  g_test_add_func ("/library/system_installations_extra_data", test_system_installations_extra_data);
+
+  res = g_test_run ();
+
+  return res;
+}
+

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -119,7 +119,7 @@ schedule_idle_callback (void)
 static FlatpakDir *
 dir_get_system (void)
 {
-  FlatpakDir *system = flatpak_dir_get_system ();
+  FlatpakDir *system = flatpak_dir_get_system_default ();
   flatpak_dir_set_no_system_helper (system, TRUE);
   return system;
 }


### PR DESCRIPTION
Add support to define alternative system installations other than the default one (`/var/lib/flatpak`) plus additional handling for the CLI commands and extra public API in libflatpak.

As an initial attempt to solve this need, the current implementation expects keyfiles dropped under `FLATPAK_CONFIGDIR/installations.d/` whose contents state the installation name (as the group's name) and the path to such installation, and where the name of the file itself encodes the order those files would be loaded. For instance, this is what I can see in my system now, for testing purposes:
```
$ ls /etc/flatpak/installations.d/
02endless-sdcard.install  03endless-games.install

$ cat /etc/flatpak/installations.d/02endless-sdcard.install
[installation "endless-sdcard"]
path=/var/endless-extra/flatpak/SDCard

$ cat /etc/flatpak/installations.d/03endless-games.install 
[installation "endless-games"]
path=/var/endless-extra/flatpak/games
```
(Note that we could decide to add more information to the key files as we need (e.g. priorities, display names...) but for now I'd rather keep it simple so that we can start the discussion)

With that in mind, the current PR adds the required internal APIs to allow naming installations (done via an extra NAME property for FlatpakDir for now), and retrieving system installations on an individual basis (either by name or the default one) as well as a list with all of them, that will be used both by the CLI commands and the public API.

In particular for the CLI commands, I added an extra `--installation=<name>` parameter now that works similar to `--system`, allowing to specify bowth write operations (e.g. `install`) should be performed as well as to refine the results of a query (e.g. `list`) when needed. Additionally, the `flatpak run` comand has been adapted so that a reference is searched across all the configured system installations, so that we can run an app against a runtime where the two of them are installed in different locations (e.g. application on separate internal media + runtime on `/var/lib/flatpak`). 

Last, the last commit is not really meant to be included in this PR for now as it's written for local testing, but I'd expect to evolve it in something upstreamable if this gets accepted, so that we can test the new public API without relaying on external utilities.

https://github.com/flatpak/flatpak/issues/137