### PR TITLE
builder: Add buildsystem option and meson support

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -355,7 +355,11 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>cmake</option> (boolean)</term>
-                    <listitem><para>Use cmake instead of configure</para></listitem>
+                    <listitem><para>Use cmake instead of configure (deprecated: use buildsystem instead)</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>buildsystem</option> (string)</term>
+                    <listitem><para>Build system to use: autotools, cmake, meson</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>builddir</option> (boolean)</term>


### PR DESCRIPTION
An example project I tested against can be found here: https://github.com/TingPing/flatpak-meson-test/blob/master/org.gnome.Twitch.json

Specifically:
```json
{
  "name": "gnome-twitch",
  "buildsystem": "meson",
  "builddir": true,
  "sources": [{
    "type": "git",
    "url": "https://github.com/vinszent/gnome-twitch.git"
  }]
}
```

To really be useful this depends upon the Sdks adding `ninja` and `meson`.

Closes #400