### PR TITLE
Update the flatpak-build-export docs

### DIFF
--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -64,7 +64,7 @@
             in the commit, anything else is ignored.
         </para>
         <para>
-            The repo-update command should be used to update repository
+            The build-update-repo command should be used to update repository
             metadata whenever application builds are added to a repository.
         </para>
     </refsect1>


### PR DESCRIPTION
The repo-update command was renamed to build-update-repo.