### PR TITLE
system-helper: Do not ask for password when removing apps/runtimes

### DIFF
--- a/system-helper/org.freedesktop.Flatpak.rules.in
+++ b/system-helper/org.freedesktop.Flatpak.rules.in
@@ -1,6 +1,8 @@
 polkit.addRule(function(action, subject) {
     if ((action.id == "org.freedesktop.Flatpak.app-install" ||
-         action.id == "org.freedesktop.Flatpak.runtime-install") &&
+         action.id == "org.freedesktop.Flatpak.runtime-install"||
+         action.id == "org.freedesktop.Flatpak.app-uninstall" ||
+         action.id == "org.freedesktop.Flatpak.runtime-uninstall") &&
         subject.active == true && subject.local == true &&
         subject.isInGroup("@privileged_group@")) {
             return polkit.Result.YES;


### PR DESCRIPTION
As it's already done for installing an app or runtime, we shouldn't ask
privileged users to authenticate in order to remove them.