### PR TITLE
Add bits to document the multiple installations feature

### DIFF
--- a/doc/flatpak-info.xml
+++ b/doc/flatpak-info.xml
@@ -45,8 +45,8 @@
         </para>
         <para>
             By default, both per-user and system-wide installations
-            are queried. Use the --user or --system options to change
-            this.
+            are queried. Use the --user, --system or --installation
+            options to change this.
         </para>
         <para>
             By default this queries the installed apps and runtimes, but you can
@@ -82,7 +82,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Query system-wide installations.
+                    Query the default system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Query a system-wide installation by <arg choice="plain">NAME</arg> among
+                    those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -98,8 +98,8 @@
             default, but you can manually change with make-current.
         </para>
         <para>
-            Unless overridden with the --user option, this command creates a
-            system-wide installation.
+            Unless overridden with the --user or the --installation option, this command installs
+            the application or runtime in the default system-wide installation.
         </para>
 
     </refsect1>
@@ -149,7 +149,7 @@
                 <term><option>--user</option></term>
 
                 <listitem><para>
-                    Create a per-user installation.
+                    Install the application or runtime in a per-user installation.
                 </para></listitem>
             </varlistentry>
 
@@ -157,7 +157,19 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Create a system-wide installation.
+                    Install the application or runtime in the default system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Install the application or runtime in a system-wide installation
+                    specified by <arg choice="plain">NAME</arg> among those defined in
+                    <filename>/etc/flatpak/installations.d</filename>. Using
+                    <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 
@@ -256,7 +268,10 @@
         <title>Examples</title>
 
         <para>
-            <command>$ flatpak -install gnome org.gnome.gedit2</command>
+            <command>$ flatpak install gnome org.gnome.gedit2</command>
+        </para>
+        <para>
+            <command>$ flatpak --installation=default install gnome org.gnome.gedit2</command>
         </para>
         <para>
             <command>$ flatpak --user install gnome org.gnome.gedit//3.22</command>

--- a/doc/flatpak-list.xml
+++ b/doc/flatpak-list.xml
@@ -43,8 +43,8 @@
         </para>
         <para>
             By default, both per-user and system-wide installations
-            are shown. Use the --user or --system options to change
-            this.
+            are shown. Use the --user, --installation or --system
+            options to change this.
         </para>
         <para>
             By default this lists the installed apps, but you can
@@ -80,7 +80,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    List system-wide installations.
+                    List the default system-wide installations.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    List a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-make-current.xml
+++ b/doc/flatpak-make-current.xml
@@ -50,8 +50,8 @@
             command is often not needed.
         </para>
         <para>
-            Unless overridden with the --user option, this command creates a
-            system-wide installation.
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
         </para>
 
     </refsect1>
@@ -75,7 +75,7 @@
                 <term><option>--user</option></term>
 
                 <listitem><para>
-                    Create a per-user installation.
+                    Update a per-user installation.
                 </para></listitem>
             </varlistentry>
 
@@ -83,7 +83,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Create a system-wide installation.
+                    Update the default system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -44,10 +44,14 @@
             to grant a sandboxed application more or less resources than it requested.
         </para>
         <para>
-          By default the application gets access to the resources it
-          requested when it is started. But the user can override it
-          on a particular instance by specifying extra arguments to
-          flatpak run, or every time by using flatpak override.
+            By default the application gets access to the resources it
+            requested when it is started. But the user can override it
+            on a particular instance by specifying extra arguments to
+            flatpak run, or every time by using flatpak override.
+        </para>
+        <para>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
         </para>
 
     </refsect1>
@@ -64,6 +68,33 @@
 
                 <listitem><para>
                     Show help options and exit.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--user</option></term>
+
+                <listitem><para>
+                    Update a per-user installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--system</option></term>
+
+                <listitem><para>
+                    Update the default system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-add.xml
+++ b/doc/flatpak-remote-add.xml
@@ -59,8 +59,8 @@
             such as the gpg key for the repo.
         </para>
         <para>
-            Unless overridden with the --user option, this command changes
-            the system-wide configuration.
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
         </para>
 
     </refsect1>
@@ -101,7 +101,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Modify the system-wide configuration.
+                    Modify the default system-wide configuration.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Modify a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-delete.xml
+++ b/doc/flatpak-remote-delete.xml
@@ -44,8 +44,8 @@
             <arg choice="plain">NAME</arg> is the name of an existing remote.
         </para>
         <para>
-            Unless overridden with the --user option, this command changes
-            the system-wide configuration.
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
         </para>
 
     </refsect1>
@@ -77,7 +77,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Modify the system-wide configuration.
+                    Modify the default system-wide configuration.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Modify a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-list.xml
+++ b/doc/flatpak-remote-list.xml
@@ -43,8 +43,8 @@
         </para>
         <para>
             By default, both per-user and system-wide installations
-            are shown. Use the --user or --system options to change
-            this.
+            are shown. Use the --user, --system or --installation
+            options to change this.
         </para>
 
     </refsect1>
@@ -76,7 +76,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Show the system-wide configuration.
+                    Show the default system-wide configuration.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Show a system-wide installation by <arg choice="plain">NAME</arg> among
+                    those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -45,8 +45,8 @@
             You can find all configured remote repositories with flatpak remote-list.
         </para>
         <para>
-            Unless overridden with the --user option, this command uses
-            the system-wide configuration.
+            Unless overridden with the --user or --installation options, this command
+            uses the default system-wide configuration.
         </para>
 
     </refsect1>
@@ -78,7 +78,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Use the system-wide configuration.
+                    Use the default system-wide configuration.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Use a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -44,8 +44,8 @@
             <arg choice="plain">NAME</arg> is the name for the remote.
         </para>
         <para>
-            Unless overridden with the --user option, this command changes
-            the system-wide configuration.
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
         </para>
 
     </refsect1>
@@ -77,7 +77,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Modify the system-wide configuration.
+                    Modify the default system-wide configuration.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Modify a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-uninstall.xml
+++ b/doc/flatpak-uninstall.xml
@@ -69,8 +69,8 @@
             also purges the data directory for the application.
         </para>
         <para>
-            Unless overridden with the --user option, this command updates
-            a system-wide installation.
+            Unless overridden with the --user or the --installation option, this command updates
+            the default system-wide installation.
         </para>
 
     </refsect1>
@@ -103,7 +103,7 @@
                 <term><option>--user</option></term>
 
                 <listitem><para>
-                    Remove a per-user installation.
+                    Updates a per-user installation.
                 </para></listitem>
             </varlistentry>
 
@@ -111,7 +111,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Remove a system-wide installation.
+                    Updates the default system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-update.xml
+++ b/doc/flatpak-update.xml
@@ -70,8 +70,8 @@
             version, with the --commit option.
         </para>
         <para>
-            Unless overridden with the --user option, this command updates
-            a system-wide installation.
+            Unless overridden with the --user or the --installation option, this command updates
+            the default system-wide installation.
         </para>
 
     </refsect1>
@@ -103,7 +103,18 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Update a system-wide installation.
+                    Update the default system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
+                    among those defined in <filename>/etc/flatpak/installations.d</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -64,6 +64,17 @@
         </para>
 
         <para>
+            In addition to the system-wide installation in <filename>$prefix/var/lib/flatpak/</filename>,
+            which is always considered the default one unless overridden, more
+            system-wide installations can be defined via configuration files
+            <filename>/etc/flatpak/installations.d</filename>, which must define
+            at least the id of the installation and the absolute path to it.
+            Other optional parameters like <arg choice="plain">DisplayName</arg>,
+            <arg choice="plain">Priority</arg> or <arg choice="plain">StorageType</arg>
+            are also supported.
+        </para>
+
+        <para>
             flatpak uses OSTree to distribute and deploy data. The repositories
             it uses are OSTree repositories and can be manipulated with the
             <command>ostree</command> utility. Installed runtimes and


### PR DESCRIPTION
Documented the --installation parameter for all the CLI commands
that accept it, and added a small generic description in the main
flatpak document.