### PR TITLE
builder: add cmake-ninja support

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -359,7 +359,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>buildsystem</option> (string)</term>
-                    <listitem><para>Build system to use: autotools, cmake, meson</para></listitem>
+                    <listitem><para>Build system to use: autotools, cmake, cmake-ninja, meson</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>builddir</option> (boolean)</term>


### PR DESCRIPTION
Please don't yell too much at me, I didn't touch C in ages. Note that for some reason it currently doesn't work as expected, CMake returns `CMake Error: Could not create named generator 'Ninja'` or `CMake Error: Could not create named generator 'Unix Makefiles'`. I looked at debug log and ran exactly the same command:

```flatpak build --nofilesystem=host --filesystem=/home/bp/dev/flatpak-ppsspp/.flatpak-builder/build/ppsspp-12 --bind-mount=/run/build/ppsspp=/home/bp/dev/flatpak-ppsspp/.flatpak-builder/build/ppsspp-12 --build-dir=/run/build/ppsspp --bind-mount=/run/ccache=/home/bp/dev/flatpak-ppsspp/.flatpak-builder/ccache --env=PATH=/run/ccache/bin:/app/bin:/usr/bin --env=CCACHE_DIR=/run/ccache /home/bp/dev/flatpak-ppsspp/builddir cmake -DCMAKE_INSTALL_PREFIX:PATH='/app' -G'Unix Makefiles' .```

…which works just fine. I would appreciate some help with that.