### PR TITLE
[WIP] builder: Add finish-options to the flatpak-builder manifest

### DIFF
--- a/builder/Makefile.am.inc
+++ b/builder/Makefile.am.inc
@@ -8,6 +8,8 @@ flatpak_builder_SOURCES = \
 	builder/builder-manifest.h \
 	builder/builder-options.c \
 	builder/builder-options.h \
+	builder/builder-finish-options.c \
+	builder/builder-finish-options.h \
 	builder/builder-module.c \
 	builder/builder-module.h \
 	builder/builder-source.c \

--- a/builder/builder-finish-options.c
+++ b/builder/builder-finish-options.c
@@ -1,0 +1,212 @@
+/* builder-options.c
+ *
+ * Copyright © 2016 Kinvolk GmbH
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Michal Rostecki <michal@kinvolk.io>
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "builder-finish-options.h"
+#include "builder-context.h"
+
+struct BuilderFinishOptions
+{
+  GObject     parent;
+
+  GHashTable *arch;
+};
+
+typedef struct
+{
+  GObjectClass parent_class;
+} BuilderFinishOptionsClass;
+
+static void serializable_iface_init (JsonSerializableIface *serializable_iface);
+
+G_DEFINE_TYPE_WITH_CODE (BuilderFinishOptions, builder_finish_options, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (JSON_TYPE_SERIALIZABLE, serializable_iface_init));
+
+enum {
+  PROP_0,
+  PROP_ARCH,
+  LAST_PROP
+};
+
+static void
+builder_finish_options_finalize (GObject *object)
+{
+  BuilderFinishOptions *self = (BuilderFinishOptions *) object;
+
+  g_hash_table_destroy (self->arch);
+
+  G_OBJECT_CLASS (builder_finish_options_parent_class)->finalize (object);
+}
+
+static void
+builder_finish_options_get_property (GObject    *object,
+		                     guint       prop_id,
+				     GValue     *value,
+				     GParamSpec *pspec)
+{
+  BuilderFinishOptions *self = BUILDER_FINISH_OPTIONS (object);
+
+  switch (prop_id)
+    {
+    case PROP_ARCH:
+      g_value_set_boxed (value, self->arch);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+builder_finish_options_set_property (GObject      *object,
+                             guint         prop_id,
+                             const GValue *value,
+                             GParamSpec   *pspec)
+{
+  BuilderFinishOptions *self = BUILDER_FINISH_OPTIONS (object);
+
+  switch (prop_id)
+    {
+    case PROP_ARCH:
+      g_hash_table_destroy (self->arch);
+      self->arch = g_value_dup_boxed (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+builder_finish_options_class_init (BuilderFinishOptionsClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = builder_finish_options_finalize;
+  object_class->get_property = builder_finish_options_get_property;
+  object_class->set_property = builder_finish_options_set_property;
+
+  g_object_class_install_property (object_class,
+                                   PROP_ARCH,
+                                   g_param_spec_boxed ("arch",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_HASH_TABLE,
+                                                       G_PARAM_READWRITE));
+}
+
+static void
+builder_finish_options_init (BuilderFinishOptions *self)
+{
+  self->arch = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+}
+
+static JsonNode *
+builder_finish_options_serialize_property (JsonSerializable *serializable,
+                                   const gchar *property_name,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  if (strcmp (property_name, "arch") == 0)
+    {
+      BuilderFinishOptions *self = BUILDER_FINISH_OPTIONS (serializable);
+      JsonNode *retval = NULL;
+
+      if (self->arch && g_hash_table_size (self->arch) > 0)
+        {
+          JsonObject *object;
+          GHashTableIter iter;
+	  gpointer key, value;
+
+	  object = json_object_new ();
+
+	  g_hash_table_iter_init (&iter, self->arch);
+
+	  while (g_hash_table_iter_next (&iter, &key, &value))
+            {
+              JsonNode *child = json_gobject_serialize (value);
+              json_object_set_member (object, (char *) key, child);
+	    }
+
+	  retval = json_node_init_object (json_node_alloc (), object);
+	  json_object_unref (object);
+	}
+
+      return retval;
+    }
+
+  return json_serializable_default_serialize_property (serializable,
+                                                       property_name,
+                                                       value,
+                                                       pspec);
+}
+
+static gboolean
+builder_finish_options_deserialize_property (JsonSerializable *serializable,
+                                     const gchar *property_name,
+				     GValue *value,
+				     GParamSpec *pspec,
+				     JsonNode *property_node)
+{
+  if (strcmp (property_name, "arch") == 0)
+    {
+      if (JSON_NODE_TYPE (property_node) == JSON_NODE_NULL)
+        {
+          g_value_set_boxed (value, NULL);
+	  return TRUE;
+	}
+      else if (JSON_NODE_TYPE (property_node) == JSON_NODE_OBJECT)
+	{
+	  JsonObject *object = json_node_get_object (property_node);
+	  g_autoptr(GHashTable) hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+	  g_autoptr(GList) members = NULL;
+
+	  members = json_object_get_members (object);
+
+	  return TRUE;
+	}
+      return FALSE;
+    }
+  return json_serializable_default_deserialize_property (serializable,
+		                                         property_name,
+							 value,
+							 pspec, property_node);
+}
+
+static void
+serializable_iface_init (JsonSerializableIface *serializable_iface)
+{
+  serializable_iface->serialize_property = builder_finish_options_serialize_property;
+  serializable_iface->deserialize_property = builder_finish_options_deserialize_property;
+}
+
+char **
+builder_finish_options_get_finish_args (BuilderFinishOptions *self, BuilderContext *context)
+{
+  char **options = NULL;
+  const char *arch = builder_context_get_arch (context);
+
+  options = g_hash_table_lookup (self->arch, arch);
+
+  return options;
+}

--- a/builder/builder-finish-options.h
+++ b/builder/builder-finish-options.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Kinvolk GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Michal Rostecki <michal@kinvolk.io>
+ */
+
+#ifndef __BUILDER_FINISH_OPTIONS_H__
+#define __BUILDER_FINISH_OPTIONS_H__
+
+#include <json-glib/json-glib.h>
+
+G_BEGIN_DECLS
+
+typedef struct BuilderContext BuilderContext;
+typedef struct BuilderFinishOptions BuilderFinishOptions;
+
+#define BUILDER_TYPE_FINISH_OPTIONS (builder_finish_options_get_type ())
+#define BUILDER_FINISH_OPTIONS(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), BUILDER_TYPE_FINISH_OPTIONS, BuilderFinishOptions))
+#define BUILDER_IS_FINISH_OPTIONS(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), BUILDER_TYPE_FINISH_OPTIONS))
+
+GType builder_finish_options_get_type (void);
+
+char ** builder_finish_options_get_finish_args (BuilderFinishOptions *self,
+                                                BuilderContext *context);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderFinishOptions, g_object_unref)
+
+G_END_DECLS
+
+#endif /* __BUILDER_FINISH_OPTIONS_H__ */

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -37,44 +37,45 @@
 
 struct BuilderManifest
 {
-  GObject         parent;
+  GObject               parent;
 
-  char           *id;
-  char           *id_platform;
-  char           *branch;
-  char           *runtime;
-  char           *runtime_commit;
-  char           *runtime_version;
-  char           *sdk;
-  char           *sdk_commit;
-  char           *var;
-  char           *base;
-  char           *base_commit;
-  char           *base_version;
-  char          **base_extensions;
-  char           *metadata;
-  char           *metadata_platform;
-  gboolean        separate_locales;
-  char          **cleanup;
-  char          **cleanup_commands;
-  char          **cleanup_platform;
-  char          **finish_args;
-  char          **tags;
-  char           *rename_desktop_file;
-  char           *rename_appdata_file;
-  char           *rename_icon;
-  gboolean        copy_icon;
-  char           *desktop_file_name_prefix;
-  char           *desktop_file_name_suffix;
-  gboolean        build_runtime;
-  gboolean        writable_sdk;
-  gboolean        appstream_compose;
-  char          **sdk_extensions;
-  char          **platform_extensions;
-  char           *command;
-  BuilderOptions *build_options;
-  GList          *modules;
-  GList          *expanded_modules;
+  char                 *id;
+  char                 *id_platform;
+  char                 *branch;
+  char                 *runtime;
+  char                 *runtime_commit;
+  char                 *runtime_version;
+  char                 *sdk;
+  char                 *sdk_commit;
+  char                 *var;
+  char                 *base;
+  char                 *base_commit;
+  char                 *base_version;
+  char                **base_extensions;
+  char                 *metadata;
+  char                 *metadata_platform;
+  gboolean              separate_locales;
+  char                **cleanup;
+  char                **cleanup_commands;
+  char                **cleanup_platform;
+  char                **finish_args;
+  BuilderFinishOptions *finish_options;
+  char                **tags;
+  char                 *rename_desktop_file;
+  char                 *rename_appdata_file;
+  char                 *rename_icon;
+  gboolean              copy_icon;
+  char                 *desktop_file_name_prefix;
+  char                 *desktop_file_name_suffix;
+  gboolean              build_runtime;
+  gboolean              writable_sdk;
+  gboolean              appstream_compose;
+  char                **sdk_extensions;
+  char                **platform_extensions;
+  char                 *command;
+  BuilderOptions       *build_options;
+  GList                *modules;
+  GList                *expanded_modules;
 };
 
 typedef struct
@@ -118,6 +119,7 @@ enum {
   PROP_SDK_EXTENSIONS,
   PROP_PLATFORM_EXTENSIONS,
   PROP_FINISH_ARGS,
+  PROP_FINISH_OPTIONS,
   PROP_TAGS,
   PROP_RENAME_DESKTOP_FILE,
   PROP_RENAME_APPDATA_FILE,
@@ -310,6 +312,10 @@ builder_manifest_get_property (GObject    *object,
       g_value_set_boxed (value, self->finish_args);
       break;
 
+    case PROP_FINISH_OPTIONS:
+      g_value_set_object (value, self->finish_options);
+      break;
+
     case PROP_TAGS:
       g_value_set_boxed (value, self->tags);
       break;
@@ -496,6 +502,10 @@ builder_manifest_set_property (GObject      *object,
       tmp = self->finish_args;
       self->finish_args = g_strdupv (g_value_get_boxed (value));
       g_strfreev (tmp);
+      break;
+
+    case PROP_FINISH_OPTIONS:
+      g_set_object (&self->finish_options, g_value_get_object (value));
       break;
 
     case PROP_TAGS:
@@ -735,6 +745,13 @@ builder_manifest_class_init (BuilderManifestClass *klass)
                                                        "",
                                                        G_TYPE_STRV,
                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_FINISH_OPTIONS,
+                                   g_param_spec_object ("finish-options",
+					                "",
+							"",
+							BUILDER_TYPE_FINISH_OPTIONS,
+							G_PARAM_READWRITE));
   g_object_class_install_property (object_class,
                                    PROP_BUILD_RUNTIME,
                                    g_param_spec_boolean ("build-runtime",
@@ -2325,6 +2342,7 @@ builder_manifest_run (BuilderManifest *self,
   g_autofree char *ccache_dir_path = NULL;
   g_auto(GStrv) env = NULL;
   g_auto(GStrv) build_args = NULL;
+  char **arch_finish_args = NULL;
   int i;
 
   if (!flatpak_mkdir_p (builder_context_get_build_dir (context),
@@ -2373,6 +2391,17 @@ builder_manifest_run (BuilderManifest *self,
             g_ptr_array_add (args, g_strdup (arg));
         }
     }
+
+  arch_finish_args = builder_finish_options_get_finish_args (self->finish_options, context);
+  if (arch_finish_args != NULL)
+    {
+      for (i = 0; arch_finish_args[i] != NULL; i++)
+        {
+          const char *arg = arch_finish_args[i];
+	  g_ptr_array_add (args, g_strdup (arg));
+	}
+    }
+
 
   flatpak_context_to_args (arg_context, args);
 

--- a/builder/builder-manifest.h
+++ b/builder/builder-manifest.h
@@ -26,6 +26,7 @@
 #include "flatpak-run.h"
 #include "builder-options.h"
 #include "builder-module.h"
+#include "builder-finish-options.h"
 #include "builder-cache.h"
 
 G_BEGIN_DECLS


### PR DESCRIPTION
finish-options can contain per-architecture finish-args with the following syntax:

```
"finish-options": {
    "arch": {
        "x86_64": [...],
        "i386": [...]
    }
}
```

The main use case is to be able to define different extra data for each architecture, i.e. to fetch different propertiary binaries for different archs.

Fixes #452