### PR TITLE
configure: Look for the libdwarf headers also in /usr/include/libdwarf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,7 +247,7 @@ provided, or it will be searched for in includedir])])],
             [with_dwarf_header=yes])
 
 AS_IF([test "x$with_dwarf_header" = "xyes"],
-      [CPPFLAGS="$CPPFLAGS -I$(eval echo \"$includedir\")/libdwarf"
+      [CPPFLAGS="$CPPFLAGS -I$(eval echo \"$includedir\")/libdwarf -I/usr/include/libdwarf"
        AC_CHECK_HEADER([dwarf.h])
        AS_IF([test "x$ac_cv_header_dwarf_h" != "xyes"],
              [AC_MSG_ERROR([dwarf.h is required but was not found; locate it using --with-dwarf-header=/path/containing/header])])],


### PR DESCRIPTION
Before this change, configure script looked for them only in $includedir, which doesn't work well with jhbuild.

Fixes #471