### PR TITLE
install: handle arch when installing from a flatpakref

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -354,7 +354,7 @@ install_from (FlatpakDir *dir,
   if (!handle_runtime_repo_deps_from_keyfile (dir, file_data, error))
     return FALSE;
 
-  if (!flatpak_dir_create_remote_for_ref_file (dir, file_data, &remote, &ref, error))
+  if (!flatpak_dir_create_remote_for_ref_file (dir, file_data, opt_arch, &remote, &ref, error))
     return FALSE;
 
   /* Need to pick up the new config, in case it was applied in the system helper. */

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6635,6 +6635,7 @@ parse_ref_file (GBytes *data,
 gboolean
 flatpak_dir_create_remote_for_ref_file (FlatpakDir *self,
                                         GBytes     *data,
+                                        const char *default_arch,
                                         char      **remote_name_out,
                                         char      **ref_out,
                                         GError    **error)
@@ -6652,7 +6653,7 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir *self,
   if (!parse_ref_file (data, &name, &branch, &url, &title, &gpg_data, &is_runtime, error))
     return FALSE;
 
-  ref = flatpak_compose_ref (!is_runtime, name, branch, NULL, error);
+  ref = flatpak_compose_ref (!is_runtime, name, branch, default_arch, error);
   if (ref == NULL)
     return FALSE;
 

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -463,6 +463,7 @@ char      *flatpak_dir_create_origin_remote (FlatpakDir   *self,
                                              GError      **error);
 gboolean   flatpak_dir_create_remote_for_ref_file (FlatpakDir   *self,
                                                    GBytes  *data,
+                                                   const char *default_arch,
                                                    char   **remote_name_out,
                                                    char   **ref_out,
                                                    GError **error);

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1281,7 +1281,7 @@ flatpak_installation_install_ref_file (FlatpakInstallation *self,
   g_autofree char *remote = NULL;
   g_autofree char *ref = NULL;
 
-  if (!flatpak_dir_create_remote_for_ref_file (dir, ref_file_data, &remote, &ref, error))
+  if (!flatpak_dir_create_remote_for_ref_file (dir, ref_file_data, NULL, &remote, &ref, error))
     return NULL;
 
   if (!flatpak_installation_drop_caches (self, cancellable, error))


### PR DESCRIPTION
Before this commit
$ flatpak install --arch someArch --from some.flatpakref
Would completely ignore the arch argument and only install for the
default flatpak architecture. Since flatpakref files don't include
an arch field, there's no reason we can't attempt to install the
arch specified on the command line.

https://github.com/flatpak/flatpak/issues/406