### PR TITLE
Fix downloading extra data when run from a different thread

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4579,6 +4579,7 @@ flatpak_load_http_uri (SoupSession *soup_session,
                        GError      **error)
 {
   GBytes *bytes = NULL;
+  g_autoptr(GMainContext) context = NULL;
   g_autoptr(SoupRequestHTTP) request = NULL;
   g_autoptr(GMainLoop) loop = NULL;
   g_autoptr(GString) content = g_string_new ("");
@@ -4586,7 +4587,10 @@ flatpak_load_http_uri (SoupSession *soup_session,
 
   g_debug ("Loading %s using libsoup", uri);
 
-  loop = g_main_loop_new (NULL, TRUE);
+  context = g_main_context_new ();
+  g_main_context_push_thread_default (context);
+
+  loop = g_main_loop_new (context, TRUE);
   data.loop = loop;
   data.content = content;
   data.progress = progress;
@@ -4603,6 +4607,7 @@ flatpak_load_http_uri (SoupSession *soup_session,
                            load_uri_callback, &data);
 
   g_main_loop_run (loop);
+  g_main_context_pop_thread_default (context);
 
   if (data.error)
     {
@@ -4627,11 +4632,15 @@ flatpak_download_http_uri (SoupSession *soup_session,
 {
   g_autoptr(SoupRequestHTTP) request = NULL;
   g_autoptr(GMainLoop) loop = NULL;
+  g_autoptr(GMainContext) context = NULL;
   LoadUriData data = { NULL };
 
   g_debug ("Loading %s using libsoup", uri);
 
-  loop = g_main_loop_new (NULL, TRUE);
+  context = g_main_context_new ();
+  g_main_context_push_thread_default (context);
+
+  loop = g_main_loop_new (context, TRUE);
   data.loop = loop;
   data.out = out;
   data.progress = progress;
@@ -4648,6 +4657,7 @@ flatpak_download_http_uri (SoupSession *soup_session,
                            load_uri_callback, &data);
 
   g_main_loop_run (loop);
+  g_main_context_pop_thread_default (context);
 
   if (data.error)
     {


### PR DESCRIPTION
The main loop that is initiated while the extra data is being downloaded
needs a different context to be the thread-default one, otherwise the
operations just hang when running from a different thread.