### PR TITLE
Depend on json-glib 1.2 for json_to_string()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,7 @@ PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
 
 PKG_CHECK_MODULES(FUSE, [fuse])
 
-PKG_CHECK_MODULES(JSON, [json-glib-1.0])
+PKG_CHECK_MODULES(JSON, [json-glib-1.0 >= 1.2])
 
 AC_ARG_ENABLE([seccomp],
               AC_HELP_STRING([--disable-seccomp],


### PR DESCRIPTION
Also, json_node_ref().

See https://copr-be.cloud.fedoraproject.org/results/amigadave/flatpak-epel7/epel-7-x86_64/00498852-flatpak/build.log.gz for a build failure.