### PR TITLE
Fix some test issues

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -79,6 +79,7 @@ dist_installed_test_extra_scripts += \
 	tests/make-test-app.sh \
 	tests/make-test-runtime.sh \
 	tests/make-test-bundles.sh \
+	tests/testpython.py \
 	$(NULL)
 
 dist_installed_test_data = \
@@ -89,7 +90,6 @@ dist_installed_test_data = \
 	tests/session.conf.in \
 	tests/0001-Add-test-logo.patch \
 	tests/org.test.Python.json \
-	tests/testpython.py \
 	tests/importme.py \
 	tests/importme2.py \
 	$(NULL)

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -691,6 +691,7 @@ add_extra_installation (const char *id,
   if (priority != NULL)
     g_ptr_array_add (contents_array, g_strdup_printf ("Priority=%s", priority));
 
+  g_ptr_array_add (contents_array, NULL);
   contents_string = g_strjoinv ("\n", (char**)contents_array->pdata);
 
   conffile_path = g_strconcat (flatpak_installationsdir, "/", id, ".conf", NULL);


### PR DESCRIPTION
* testlibrary crashed because it failed to NULL-terminate a GStrv
* testpython.py was not installed +x, causing a "permission denied" error when running the test that uses it as an installed-test