### PR TITLE
Add configure options for stateless distros & fix warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -119,7 +119,7 @@ completiondir = $(datadir)/bash-completion/completions
 completion_DATA = completion/flatpak
 EXTRA_DIST += $(completion_DATA)
 
-profiledir = $(sysconfdir)/profile.d
+profiledir = $(PROFILE_DIR)
 profile_DATA = flatpak.sh
 EXTRA_DIST += \
 	profile/flatpak.sh.in \

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -210,7 +210,7 @@ print_table_for_refs (gboolean print_apps, GPtrArray* refs_array, const char *ar
 
               if (strcmp (parts[0], "app") == 0)
                 {
-                  g_autofree char *current;
+                  g_autofree char *current = NULL;
 
                   current = flatpak_dir_current_ref (dir, parts[1], cancellable);
                   if (current && strcmp (ref, current) == 0)

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -174,7 +174,7 @@ flatpak_usage (FlatpakCommand *commands,
                gboolean        is_error)
 {
   GOptionContext *context;
-  g_autofree char *help;
+  g_autofree char *help = NULL;
 
   context = flatpak_option_context_new_with_commands (commands);
 
@@ -344,7 +344,7 @@ flatpak_run (int      argc,
   if (!command->fn)
     {
       GOptionContext *context;
-      g_autofree char *help;
+      g_autofree char *help = NULL;
 
       context = flatpak_option_context_new_with_commands (commands);
 

--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -200,7 +200,7 @@ main (int    argc,
   g_autoptr(GFileEnumerator) dir_enum2 = NULL;
   GFileInfo *next = NULL;
   const char *platform_id = NULL;
-  g_autofree char **orig_argv;
+  g_autofree char **orig_argv = NULL;
   gboolean is_run = FALSE;
   gboolean is_show_deps = FALSE;
   gboolean app_dir_is_empty = FALSE;

--- a/builder/builder-source-bzr.c
+++ b/builder/builder-source-bzr.c
@@ -245,7 +245,7 @@ builder_source_bzr_checksum (BuilderSource  *source,
                              BuilderContext *context)
 {
   BuilderSourceBzr *self = BUILDER_SOURCE_BZR (source);
-  g_autofree char *current_commit;
+  g_autofree char *current_commit = NULL;
 
   g_autoptr(GError) error = NULL;
 

--- a/builder/builder-source.c
+++ b/builder/builder-source.c
@@ -264,7 +264,7 @@ builder_source_extract (BuilderSource  *self,
 {
   BuilderSourceClass *class;
 
-  g_autoptr(GFile) real_dest;
+  g_autoptr(GFile) real_dest = NULL;
 
   class = BUILDER_SOURCE_GET_CLASS (self);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2603,7 +2603,7 @@ flatpak_dir_list_refs (FlatpakDir   *self,
 {
   gboolean ret = FALSE;
 
-  g_autoptr(GFile) base;
+  g_autoptr(GFile) base = NULL;
   g_autoptr(GFileEnumerator) dir_enum = NULL;
   g_autoptr(GFileInfo) child_info = NULL;
   GError *temp_error = NULL;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -563,7 +563,7 @@ get_xdg_dir_from_string (const char *filesystem,
 {
   char *slash;
   const char *rest;
-  g_autofree char *prefix;
+  g_autofree char *prefix = NULL;
   const char *dir = NULL;
   gsize len;
 
@@ -597,7 +597,7 @@ get_xdg_user_dir_from_string (const char  *filesystem,
 {
   char *slash;
   const char *rest;
-  g_autofree char *prefix;
+  g_autofree char *prefix = NULL;
   gsize len;
 
   slash = strchr (filesystem, '/');

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,12 @@ AC_ARG_WITH(dbus_service_dir,
 DBUS_SERVICE_DIR=$with_dbus_service_dir
 AC_SUBST(DBUS_SERVICE_DIR)
 
+AC_ARG_WITH(dbus_config_dir,
+		AS_HELP_STRING([--with-dbus-config-dir=PATH],[choose directory for dbus config files, [default=SYSCONFDIR/dbus-1/system.d]]),
+            with_dbus_config_dir="$withval", with_dbus_config_dir=${sysconfdir}/dbus-1/system.d)
+DBUS_CONFIG_DIR=$with_dbus_config_dir
+AC_SUBST(DBUS_CONFIG_DIR)
+
 AC_ARG_WITH([systemduserunitdir],
             [AS_HELP_STRING([--with-systemduserunitdir=DIR],
                             [Directory for systemd user service files (default=PREFIX/lib/systemd/user)])],

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,12 @@ AC_ARG_WITH(system_fonts_dir,
 SYSTEM_FONTS_DIR=$with_system_fonts_dir
 AC_SUBST(SYSTEM_FONTS_DIR)
 
+AC_ARG_WITH(profile_dir,
+		AS_HELP_STRING([--with-profile-dir=PATH],[choose directory for profile.d files, [default=SYSCONFDIR/profile.d]]),
+            with_profile_dir="$withval", with_profile_dir=${sysconfdir}/profile.d)
+PROFILE_DIR=$with_profile_dir
+AC_SUBST(PROFILE_DIR)
+
 AC_ARG_VAR([BWRAP], [Bubblewrap executable])
 AC_ARG_WITH([system-bubblewrap],
             [AS_HELP_STRING([--with-system-bubblewrap], [Use system bwrap executable [default=check $BWRAP]])],

--- a/permission-store/xdg-permission-store.c
+++ b/permission-store/xdg-permission-store.c
@@ -329,7 +329,7 @@ handle_set (XdgPermissionStore     *object,
   g_variant_iter_init (&iter, app_permissions);
   while ((child = g_variant_iter_next_value (&iter)))
     {
-      g_autoptr(FlatpakDbEntry) old_entry;
+      g_autoptr(FlatpakDbEntry) old_entry = NULL;
       const char *child_app_id;
       g_autofree const char **permissions;
 

--- a/system-helper/Makefile.am.inc
+++ b/system-helper/Makefile.am.inc
@@ -8,7 +8,7 @@ dbussystemservicedir = $(datadir)/dbus-1/system-services
 service_in_files += system-helper/org.freedesktop.Flatpak.SystemHelper.service.in
 dbussystemservice_DATA = system-helper/org.freedesktop.Flatpak.SystemHelper.service
 
-dbusconfdir = ${sysconfdir}/dbus-1/system.d
+dbusconfdir = $(DBUS_CONFIG_DIR)
 dbusconf_DATA = system-helper/org.freedesktop.Flatpak.SystemHelper.conf
 
 service_in_files += system-helper/flatpak-system-helper.service.in

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -663,7 +663,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
 
   if (action)
     {
-      g_autoptr(AutoPolkitAuthorizationResult) result;
+      g_autoptr(AutoPolkitAuthorizationResult) result = NULL;
       g_autoptr(GError) error = NULL;
 
       result = polkit_authority_check_authorization_sync (authority, subject,


### PR DESCRIPTION
 - Add `--with-dbus-config-dir` to override the dbus `system.d` directory for newer dbus versions
 - Add `--with-profile-dir` to support using alternative profile environment directory for vendor files
 - Cleanup some compiler warnings whereby the cleanup variables were not initialised. 