### PR TITLE
flatpak-system-helper: remove dangling reference to EXTERNAL_INSTALL_DIR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,6 @@ SUBDIRS += po
 %.service: %.service.in config.log
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" \
 		-e "s|\@localstatedir\@|$(localstatedir)|" \
-		-e "s|\@externalinstalldir\@|$(EXTERNAL_INSTALL_DIR)|" \
 		-e "s|\@extraargs\@||" $< > $@
 
 dbus_servicedir = $(DBUS_SERVICE_DIR)

--- a/system-helper/flatpak-system-helper.service.in
+++ b/system-helper/flatpak-system-helper.service.in
@@ -3,6 +3,6 @@ Description=flatpak system helper
 
 [Service]
 BusName=org.freedesktop.Flatpak.SystemHelper
-Environment=XDG_DATA_DIRS=@localstatedir@/lib/flatpak/exports/share/:@externalinstalldir@/exports/share/:/usr/local/share/:/usr/share/
+Environment=XDG_DATA_DIRS=@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/
 ExecStart=@libexecdir@/flatpak-system-helper
 Type=dbus


### PR DESCRIPTION
If EXTERNAL_INSTALL_DIR wasn't defined (which is likely, since nothing
in the build system does), then we would tell the system helper
to search /exports/share, which is not Flatpak's territory
(but is a semi-commonly-used path for site-specific NFS shares,
which might have contents that are inappropriate to search here).

Installations that do define an external installation directory
(Endless OS?) can easily override the Environment to include it
by placing a drop-in in
/etc/systemd/user/flatpak-system-helper.service.d/external.conf
or similar.

---

cc @cosimoc: I assume this was unintended?