### PR TITLE
Clarify building subfolder projects from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ desktop applications on Linux.
 See http://flatpak.org/ for more information.
 
 Read documentation for the flatpak [commandline tools](http://flatpak.github.io/flatpak/flatpak-docs.html) and for the libflatpak [library API](http://flatpak.github.io/flatpak/reference/html/index.html).
+
+If you're going to build Flatpak from this source repo, the recommended way to build the subfolder projects (currently they are `bubblewrap` and `libglnx`) is just to build Flatpak itself.  The Flatpak build will automatically build the subfolder projects, whereas building them separately first can cause problems.  
+
+You can download the source for Flatpak and for the subfolder projects in one go by using:  
+`git clone --recursive` (followed by the Flatpak source repo's Git clone URL).  


### PR DESCRIPTION
This README.md update should prevent the user error that caused https://github.com/projectatomic/bubblewrap/issues/139 