### PR TITLE
flatpak-session-helper.c: Make failure of TIOCSCTTY a g_debug()

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -152,8 +152,8 @@ child_setup_func (gpointer user_data)
           if (fd_map[i].from == data->tty)
             {
               if (ioctl (fd_map[i].final, TIOCSCTTY, 0) == -1)
-                g_warning ("ioctl(%d, TIOCSCTTY, 0) failed: %s",
-                           fd_map[i].final, strerror (errno));
+                g_debug ("ioctl(%d, TIOCSCTTY, 0) failed: %s",
+                         fd_map[i].final, strerror (errno));
               break;
             }
         }


### PR DESCRIPTION
Just because stdout/stderr happen to be going to a terminal doesn't
necessarily mean that we want the command launched by HostCommand
to take ownership of the terminal - in the case where 'flatpak run'
is launched from a terminal, stderr will typically be left pointing
to the terminal for any command. In that case the terminal already
has a controlling process, and TIOCSCTTY will fail; avoid scary
messages by making the failure only a g_debug()