### PR TITLE
builder: Add a "simple" buildsystem

### DIFF
--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -59,6 +59,7 @@ struct BuilderModule
   char          **cleanup_platform;
   GList          *sources;
   GList          *modules;
+  char          **build_commands;
 };
 
 typedef struct
@@ -92,6 +93,7 @@ enum {
   PROP_CLEANUP_PLATFORM,
   PROP_POST_INSTALL,
   PROP_MODULES,
+  PROP_BUILD_COMMANDS,
   LAST_PROP
 };
 
@@ -114,6 +116,7 @@ builder_module_finalize (GObject *object)
   g_strfreev (self->cleanup);
   g_strfreev (self->cleanup_platform);
   g_list_free_full (self->modules, g_object_unref);
+  g_strfreev (self->build_commands);
 
   if (self->changes)
     g_ptr_array_unref (self->changes);
@@ -205,6 +208,10 @@ builder_module_get_property (GObject    *object,
 
     case PROP_MODULES:
       g_value_set_pointer (value, self->modules);
+      break;
+
+    case PROP_BUILD_COMMANDS:
+      g_value_set_boxed (value, self->build_commands);
       break;
 
     default:
@@ -320,6 +327,12 @@ builder_module_set_property (GObject      *object,
       g_list_free_full (self->modules, g_object_unref);
       /* NOTE: This takes ownership of the list! */
       self->modules = g_value_get_pointer (value);
+      break;
+
+    case PROP_BUILD_COMMANDS:
+      tmp = self->build_commands;
+      self->build_commands = g_strdupv (g_value_get_boxed (value));
+      g_strfreev (tmp);
       break;
 
     default:
@@ -467,6 +480,13 @@ builder_module_class_init (BuilderModuleClass *klass)
                                                          "",
                                                          "",
                                                          G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_BUILD_COMMANDS,
+                                   g_param_spec_boxed ("build-commands",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_STRV,
+                                                       G_PARAM_READWRITE));
 }
 
 static void
@@ -1182,7 +1202,7 @@ builder_module_build (BuilderModule  *self,
   g_autofree char *make_l = NULL;
   const char *make_cmd = NULL;
 
-  gboolean autotools = FALSE, cmake = FALSE, cmake_ninja = FALSE, meson = FALSE;
+  gboolean autotools = FALSE, cmake = FALSE, cmake_ninja = FALSE, meson = FALSE, simple = FALSE;
   g_autoptr(GFile) configure_file = NULL;
   GFile *build_parent_dir = NULL;
   g_autoptr(GFile) build_dir = NULL;
@@ -1298,10 +1318,19 @@ builder_module_build (BuilderModule  *self,
     autotools = TRUE;
   else if (!strcmp (self->buildsystem, "cmake-ninja"))
     cmake_ninja = TRUE;
+  else if (!strcmp (self->buildsystem, "simple"))
+    simple = TRUE;
   else
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "module %s: Invalid buildsystem: \"%s\"",
                    self->name, self->buildsystem);
+      return FALSE;
+    }
+
+  if (simple && !self->build_commands)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "module %s: Buildsystem simple requires specifying \"build-commands\"",
+                   self->name);
       return FALSE;
     }
 
@@ -1343,9 +1372,10 @@ builder_module_build (BuilderModule  *self,
         }
     }
 
-  has_configure = g_file_query_exists (configure_file, NULL);
+  if (!simple)
+    has_configure = g_file_query_exists (configure_file, NULL);
 
-  if (!has_configure && !self->no_autogen)
+  if (!simple && !has_configure && !self->no_autogen)
     {
       const char *autogen_names[] =  {"autogen", "autogen.sh", "bootstrap", NULL};
       g_autofree char *autogen_cmd = NULL;
@@ -1384,7 +1414,7 @@ builder_module_build (BuilderModule  *self,
       has_configure = TRUE;
     }
 
-  if (has_configure)
+  if (!simple && has_configure)
     {
       const char *configure_cmd;
       const char *cmake_generator = NULL;
@@ -1520,18 +1550,31 @@ builder_module_build (BuilderModule  *self,
 
   /* Build and install */
 
-  if (meson || cmake_ninja)
-    make_cmd = "ninja";
+  if (simple)
+    {
+      for (i = 0; self->build_commands[i] != NULL; i++)
+        {
+          g_print ("%s\n", self->build_commands[i]);
+          if (!build (app_dir, self->name, context, source_dir, build_dir_relative, build_args, env, error,
+                      "/bin/sh", "-c", self->build_commands[i], NULL))
+            return FALSE;
+        }
+    }
   else
-    make_cmd = "make";
+    {
+      if (meson || cmake_ninja)
+        make_cmd = "ninja";
+      else
+        make_cmd = "make";
 
-  if (!build (app_dir, self->name, context, source_dir, build_dir_relative, build_args, env, error,
-              make_cmd, make_j ? make_j : skip_arg, make_l ? make_l : skip_arg, strv_arg, self->make_args, NULL))
-    return FALSE;
+      if (!build (app_dir, self->name, context, source_dir, build_dir_relative, build_args, env, error,
+                  make_cmd, make_j ? make_j : skip_arg, make_l ? make_l : skip_arg, strv_arg, self->make_args, NULL))
+        return FALSE;
 
-  if (!build (app_dir, self->name, context, source_dir, build_dir_relative, build_args, env, error,
-              make_cmd, "install", strv_arg, self->make_install_args, NULL))
-    return FALSE;
+      if (!build (app_dir, self->name, context, source_dir, build_dir_relative, build_args, env, error,
+                  make_cmd, "install", strv_arg, self->make_install_args, NULL))
+        return FALSE;
+    }
 
   /* Post installation scripts */
 

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -359,7 +359,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>buildsystem</option> (string)</term>
-                    <listitem><para>Build system to use: autotools, cmake, cmake-ninja, meson</para></listitem>
+                    <listitem><para>Build system to use: autotools, cmake, cmake-ninja, meson, simple</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>builddir</option> (boolean)</term>
@@ -372,6 +372,12 @@
                 <varlistentry>
                     <term><option>build-options</option> (object)</term>
                     <listitem><para>A build options object that can override global options</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>build-commands</option> (array of strings)</term>
+                    <listitem><para>An array of commands to run in order to build and install the module, when using
+                    the "simple" buildsystem.
+                    </para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>post-install</option> (array of strings)</term>


### PR DESCRIPTION
This just runs the specified "build-commands" one after the other, ignoring makefiles, configure scripts, and all the rest.

Relates to #134