### PR TITLE
Search also in share/metainfo subdir for appstream metadata

### DIFF
--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -1735,6 +1735,13 @@ builder_manifest_cleanup (BuilderManifest *self,
       appdata_dir = g_file_resolve_relative_path (app_root, "share/appdata");
       appdata_basename = g_strdup_printf ("%s.appdata.xml", self->id);
       appdata_file = g_file_get_child (appdata_dir, appdata_basename);
+      if (!g_file_test (appdata_file, G_FILE_TEST_EXISTS))
+        {
+          g_object_unref (appdata_dir);
+          g_object_unref (appdata_file);
+          appdata_dir = g_file_resolve_relative_path (app_root, "share/metainfo");
+          appdata_file = g_file_get_child (appdata_dir, appdata_basename);
+        }
 
       if (self->rename_appdata_file != NULL)
         {

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -1735,7 +1735,7 @@ builder_manifest_cleanup (BuilderManifest *self,
       appdata_dir = g_file_resolve_relative_path (app_root, "share/appdata");
       appdata_basename = g_strdup_printf ("%s.appdata.xml", self->id);
       appdata_file = g_file_get_child (appdata_dir, appdata_basename);
-      if (!g_file_test (appdata_file, G_FILE_TEST_EXISTS))
+      if (!g_file_query_exists (appdata_file, NULL))
         {
           g_object_unref (appdata_dir);
           g_object_unref (appdata_file);


### PR DESCRIPTION
Should be a fix for https://github.com/flatpak/flatpak/issues/30, at least particularly. I should also fix our problem with KDE apps repository where all KDE apps install appstream metadata file into /app/share/metainfo and flatpak-builder doesn't seem to pickup this location.