### PR TITLE
Allow cancelling the downloading process for extra data

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4655,6 +4655,7 @@ typedef struct {
   GString *content;
   char buffer[16*1024];
   FlatpakLoadUriProgress progress;
+  GCancellable *cancellable;
   gpointer user_data;
   guint64 last_progress_time;
 } LoadUriData;
@@ -4720,7 +4721,7 @@ load_uri_read_cb (GObject *source, GAsyncResult *res, gpointer user_data)
     }
 
   g_input_stream_read_async (stream, data->buffer, sizeof (data->buffer),
-                             G_PRIORITY_DEFAULT, NULL,
+                             G_PRIORITY_DEFAULT, data->cancellable,
                              load_uri_read_cb, data);
 }
 
@@ -4764,7 +4765,7 @@ load_uri_callback (GObject *source_object,
     }
 
   g_input_stream_read_async (in, data->buffer, sizeof (data->buffer),
-                             G_PRIORITY_DEFAULT, NULL,
+                             G_PRIORITY_DEFAULT, data->cancellable,
                              load_uri_read_cb, data);
 }
 
@@ -4818,6 +4819,7 @@ flatpak_load_http_uri (SoupSession *soup_session,
   data.loop = loop;
   data.content = content;
   data.progress = progress;
+  data.cancellable = cancellable;
   data.user_data = user_data;
   data.last_progress_time = g_get_monotonic_time ();
 
@@ -4868,6 +4870,7 @@ flatpak_download_http_uri (SoupSession *soup_session,
   data.loop = loop;
   data.out = out;
   data.progress = progress;
+  data.cancellable = cancellable;
   data.user_data = user_data;
   data.last_progress_time = g_get_monotonic_time ();
 


### PR DESCRIPTION
So far, the installation of external apps can only be cancelled
before flatpak starts downloading the extra data, as there's no
cancellable being passed to g_input_stream_read_async().

This fixes that problem, making it possible to cancel installs
from GNOME Software regardless of the installation stage.

Fixes: https://github.com/flatpak/flatpak/issues/559