### PR TITLE
run: Print an error for runtimes that aren't installed

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -165,16 +165,20 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
   if (app_deploy == NULL)
     {
       g_autoptr(FlatpakDeploy) runtime_deploy = NULL;
+      g_autoptr(GError) local_error2 = NULL;
 
       runtime_ref = flatpak_compose_ref (FALSE, id, branch, arch, error);
       if (runtime_ref == NULL)
         return FALSE;
 
-      runtime_deploy = flatpak_find_deploy_for_ref (runtime_ref, cancellable, NULL);
+      runtime_deploy = flatpak_find_deploy_for_ref (runtime_ref, cancellable, &local_error2);
       if (runtime_deploy == NULL)
         {
           /* Report old app-kind error, as its more likely right */
-          g_propagate_error (error, g_steal_pointer (&local_error));
+          if (local_error != NULL)
+            g_propagate_error (error, g_steal_pointer (&local_error));
+          else
+            g_propagate_error (error, g_steal_pointer (&local_error2));
           return FALSE;
         }
       /* Clear app-kind error */


### PR DESCRIPTION
Currently if you pass flatpak-run an app that's not installed it prints
an error message to that effect, but if you pass it a runtime that's not
installed (and use the full ref format, e.g.
runtime/org.gnome.Sdk//master) it prints this message and crashes:
```
(flatpak run:15104): GLib-CRITICAL **: g_propagate_error: assertion 'src != NULL' failed
flatpak:ERROR:app/flatpak-main.c:394:flatpak_run: assertion failed: (success || error)
```
This commit makes flatpak print the appropriate error message, while
still printing an "app not found" error if the user didn't specify
whether the ref is an app or runtime.