### PR TITLE
Allow specifying an ISO-8601 timestamp when using build-export

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -320,7 +320,7 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
     return FALSE;
 
   if (opt_update_appstream &&
-      !flatpak_repo_generate_appstream (dst_repo, (const char **) opt_gpg_key_ids, opt_gpg_homedir, cancellable, error))
+      !flatpak_repo_generate_appstream (dst_repo, (const char **) opt_gpg_key_ids, opt_gpg_homedir, 0, cancellable, error))
     return FALSE;
 
   if (!opt_no_update_summary &&

--- a/app/flatpak-builtins-build-import-bundle.c
+++ b/app/flatpak-builtins-build-import-bundle.c
@@ -198,7 +198,7 @@ flatpak_builtin_build_import (int argc, char **argv, GCancellable *cancellable, 
     }
 
   if (opt_update_appstream &&
-      !flatpak_repo_generate_appstream (repo, (const char **) opt_gpg_key_ids, opt_gpg_homedir, cancellable, error))
+      !flatpak_repo_generate_appstream (repo, (const char **) opt_gpg_key_ids, opt_gpg_homedir, 0, cancellable, error))
     return FALSE;
 
   if (!opt_no_update_summary &&

--- a/app/flatpak-builtins-repo-update.c
+++ b/app/flatpak-builtins-repo-update.c
@@ -384,7 +384,7 @@ flatpak_builtin_build_update_repo (int argc, char **argv,
     return FALSE;
 
   g_print (_("Updating appstream branch\n"));
-  if (!flatpak_repo_generate_appstream (repo, (const char **) opt_gpg_key_ids, opt_gpg_homedir, cancellable, error))
+  if (!flatpak_repo_generate_appstream (repo, (const char **) opt_gpg_key_ids, opt_gpg_homedir, 0, cancellable, error))
     return FALSE;
 
   if (opt_generate_deltas &&

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3481,6 +3481,7 @@ gboolean
 flatpak_repo_generate_appstream (OstreeRepo   *repo,
                                  const char  **gpg_key_ids,
                                  const char   *gpg_homedir,
+                                 guint64       timestamp,
                                  GCancellable *cancellable,
                                  GError      **error)
 {
@@ -3616,10 +3617,22 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
 
       if (!skip_commit)
         {
-          if (!ostree_repo_write_commit (repo, parent, "Update", NULL, NULL,
-                                         OSTREE_REPO_FILE (root),
-                                         &commit_checksum, cancellable, error))
-            goto out;
+          if (timestamp > 0)
+            {
+              if (!ostree_repo_write_commit_with_time (repo, parent, "Update", NULL, NULL,
+                                                       OSTREE_REPO_FILE (root),
+                                                       timestamp,
+                                                       &commit_checksum,
+                                                       cancellable, error))
+                goto out;
+            }
+          else
+            {
+              if (!ostree_repo_write_commit (repo, parent, "Update", NULL, NULL,
+                                             OSTREE_REPO_FILE (root),
+                                             &commit_checksum, cancellable, error))
+                goto out;
+            }
 
           if (gpg_key_ids)
             {

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -556,6 +556,7 @@ GBytes *flatpak_appstream_xml_root_to_data (FlatpakXml *appstream_root,
 gboolean   flatpak_repo_generate_appstream (OstreeRepo   *repo,
                                             const char  **gpg_key_ids,
                                             const char   *gpg_homedir,
+                                            guint64       timestamp,
                                             GCancellable *cancellable,
                                             GError      **error);
 


### PR DESCRIPTION
This allows us to build reproducable repo summaries, for instance in gnome-software self tests.