### PR TITLE
Append flatpak data dirs if XDG_DATA_DIRS is already set

### DIFF
--- a/profile/flatpak.sh.in
+++ b/profile/flatpak.sh.in
@@ -1,4 +1,11 @@
 # @sysconfdir@/profile.d/flatpak.sh - set XDG_DATA_DIRS
 
-XDG_DATA_DIRS="${XDG_DATA_DIRS:-$HOME/.local/share/flatpak/exports/share:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/}"
+flatpak_dirs=$HOME/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/
+
+if [ -z "${XDG_DATA_DIRS}" ]; then
+    XDG_DATA_DIRS="$flatpak_dirs":/usr/local/share/:/usr/share/
+else
+    XDG_DATA_DIRS="$XDG_DATA_DIRS:$flatpak_dirs"
+fi
+
 export XDG_DATA_DIRS

--- a/profile/flatpak.sh.in
+++ b/profile/flatpak.sh.in
@@ -3,7 +3,7 @@
 flatpak_dirs=$HOME/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/
 
 if [ -z "${XDG_DATA_DIRS}" ]; then
-    XDG_DATA_DIRS="$flatpak_dirs":/usr/local/share/:/usr/share/
+    XDG_DATA_DIRS="$flatpak_dirs:/usr/local/share/:/usr/share/"
 else
     XDG_DATA_DIRS="$XDG_DATA_DIRS:$flatpak_dirs"
 fi


### PR DESCRIPTION
Otherwise it will be impossible to run flatpak apps from desktop menus.
This issue can happen if another app (e.g. snapd) wants to add custom
folders to XDG_DATA_DIRS through /etc/profile.d

If XDG_DATA_DIRS is empty or unset, define it as before.

Fixes #606