### PR TITLE
Improve and simplify profile snippet

### DIFF
--- a/profile/flatpak.sh.in
+++ b/profile/flatpak.sh.in
@@ -1,11 +1,7 @@
 # @sysconfdir@/profile.d/flatpak.sh - set XDG_DATA_DIRS
 
-flatpak_dirs=$HOME/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/
-
-if [ -z "${XDG_DATA_DIRS}" ]; then
-    XDG_DATA_DIRS="$flatpak_dirs:/usr/local/share/:/usr/share/"
-elif [ "${XDG_DATA_DIRS#*flatpak}" == ${XDG_DATA_DIRS} ]; then
-    XDG_DATA_DIRS="$XDG_DATA_DIRS:$flatpak_dirs"
+if [ "${XDG_DATA_DIRS#*flatpak}" = "${XDG_DATA_DIRS}" ]; then
+    XDG_DATA_DIRS="${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak/exports/share:@localstatedir@/lib/flatpak/exports/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 fi
 
 export XDG_DATA_DIRS


### PR DESCRIPTION
Avoid setting a temporary variable flatpak_dirs which, while not
exported to the environment, would still be defined as a
shell "parameter" (variable) in the login shell itself.

Consistently put the Flatpak directories before other XDG_DATA_DIRS,
rather than putting them last if XDG_DATA_DIRS happens to be already
set.

Expand XDG_DATA_HOME if necessary, rather than assuming it will
always be ~/.local/share.

I don't know exactly which shells source profile.d, but it's possible
that one of them might only implement POSIX test syntax, so prefer
[ x = y ] over [ x == y ].

Fix some insufficient quoting that could have gone wrong if
XDG_DATA_DIRS somehow contained spaces.

Signed-off-by: Simon McVittie <smcv@debian.org>

---

This is based on the assumption that consistently prepending is the desired behaviour. If there's a reason why it isn't, reinstating the `[ -z ]` doesn't particularly increase complexity.