### PR TITLE
Bump libglnx, and compiler warnings

### DIFF
--- a/app/flatpak-builtins-build-bundle.c
+++ b/app/flatpak-builtins-build-bundle.c
@@ -467,7 +467,7 @@ flatpak_builtin_build_bundle (int argc, char **argv, GCancellable *cancellable, 
         return flatpak_fail (error, _("'%s' is not a valid name: %s"), name, my_error->message);
 
       if (!flatpak_is_valid_branch (branch, &my_error))
-        return flatpak_fail (error, _("'%s' is not a valid branch name: %s"), branch, &my_error);
+        return flatpak_fail (error, _("'%s' is not a valid branch name: %s"), branch, my_error->message);
 
       if (opt_runtime)
         full_branch = flatpak_build_runtime_ref (name, branch, opt_arch);

--- a/builder/builder-utils.c
+++ b/builder/builder-utils.c
@@ -989,7 +989,7 @@ handle_dwarf2_section (DebuginfoData *data, GHashTable *files, GError **error)
     }
   else
     {
-      return flatpak_fail (0, 0, "%s: Wrong ELF data encoding", data->filename);
+      return flatpak_fail (error, "%s: Wrong ELF data encoding", data->filename);
     }
 
   debug_sections = data->debug_sections;

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -285,23 +285,6 @@ flatpak_path_match_prefix (const char *pattern,
   return NULL; /* Should not be reached */
 }
 
-gboolean
-flatpak_fail (GError **error, const char *format, ...)
-{
-  g_autofree char *message = NULL;
-  va_list args;
-
-  va_start (args, format);
-  message = g_strdup_vprintf (format, args);
-  va_end (args);
-
-  g_set_error_literal (error,
-                       G_IO_ERROR, G_IO_ERROR_FAILED,
-                       message);
-
-  return FALSE;
-}
-
 const char *
 flatpak_get_kernel_arch (void)
 {

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -46,9 +46,11 @@ typedef enum {
 #define FLATPAK_VARIANT_DICT_INITIALIZER {{{0,}}}
 #endif
 
-gboolean flatpak_fail (GError    **error,
-                       const char *format,
-                       ...);
+/* https://github.com/GNOME/libglnx/pull/38
+ * Note by using #define rather than wrapping via a static inline, we
+ * don't have to re-define attributes like G_GNUC_PRINTF.
+ */
+#define flatpak_fail glnx_throw
 
 gint flatpak_strcmp0_ptr (gconstpointer a,
                           gconstpointer b);


### PR DESCRIPTION
One benefit here becomes immediately obvious - `flatpak_fail()` was lacking
`G_GNUC_PRINTF` which meant we missed a lot of type checking. Fix up the
callers.