### PR TITLE
Use ostree's BARE_USER_ONLY flag

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4496,13 +4496,9 @@ flatpak_dir_create_system_child_repo (FlatpakDir   *self,
   repo_dir_config = g_file_get_child (repo_dir, "config");
   if (!g_file_query_exists (repo_dir_config, NULL))
     {
-#if OSTREE_CHECK_VERSION(2017, 3)
-      OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER_ONLY;
-#else
-      OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER;
-#endif
+      OstreeRepoMode parent_mode = ostree_repo_get_mode (self->repo);
 
-      if (!ostree_repo_create (new_repo, mode, NULL, error))
+      if (!ostree_repo_create (new_repo, parent_mode, NULL, error))
         return NULL;
     }
   else

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1398,9 +1398,13 @@ flatpak_dir_ensure_repo (FlatpakDir   *self,
 
       if (!g_file_query_exists (repodir, cancellable))
         {
-          if (!ostree_repo_create (repo,
-                                   OSTREE_REPO_MODE_BARE_USER,
-                                   cancellable, error))
+#if OSTREE_CHECK_VERSION(2017, 3)
+          OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER_ONLY;
+#else
+          OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER;
+#endif
+
+          if (!ostree_repo_create (repo, mode, cancellable, error))
             {
               flatpak_rm_rf (repodir, cancellable, NULL);
               goto out;
@@ -4492,9 +4496,13 @@ flatpak_dir_create_system_child_repo (FlatpakDir   *self,
   repo_dir_config = g_file_get_child (repo_dir, "config");
   if (!g_file_query_exists (repo_dir_config, NULL))
     {
-      if (!ostree_repo_create (new_repo,
-                               OSTREE_REPO_MODE_BARE_USER,
-                               NULL, error))
+#if OSTREE_CHECK_VERSION(2017, 3)
+      OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER_ONLY;
+#else
+      OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER;
+#endif
+
+      if (!ostree_repo_create (new_repo, mode, NULL, error))
         return NULL;
     }
   else

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1398,10 +1398,15 @@ flatpak_dir_ensure_repo (FlatpakDir   *self,
 
       if (!g_file_query_exists (repodir, cancellable))
         {
-#if OSTREE_CHECK_VERSION(2017, 3)
-          OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER_ONLY;
-#else
           OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER;
+
+#if OSTREE_CHECK_VERSION(2017, 3)
+          {
+            const char *mode_env = g_getenv ("FLATPAK_OSTREE_REPO_MODE");
+
+            if (g_strcmp0 (mode_env, "user-only") == 0)
+              mode = OSTREE_REPO_MODE_BARE_USER_ONLY;
+          }
 #endif
 
           if (!ostree_repo_create (repo, mode, cancellable, error))


### PR DESCRIPTION
Now that Ostree has a 'bare user only' mode for repositories, we should
use it.

This allows installing Flatpak run times inside different Docker layers.

Original patch by: Alexander Larsson <alexl@redhat.com>
Tested-by: Emmanuele Bassi <ebassi@gmail.com>