### PR TITLE
flatpak-builder: bundle module sources as runtime

### DIFF
--- a/builder/builder-context.c
+++ b/builder/builder-context.c
@@ -47,6 +47,7 @@ struct BuilderContext
   char           *stop_at;
 
   GFile          *download_dir;
+  GPtrArray      *sources_dirs;
   GFile          *state_dir;
   GFile          *build_dir;
   GFile          *cache_dir;
@@ -107,6 +108,8 @@ builder_context_finalize (GObject *object)
   g_strfreev (self->cleanup);
   g_strfreev (self->cleanup_platform);
   glnx_release_lock_file(&self->rofiles_file_lock);
+
+  g_clear_pointer (&self->sources_dirs, g_ptr_array_unref);
 
   G_OBJECT_CLASS (builder_context_parent_class)->finalize (object);
 }
@@ -246,6 +249,20 @@ GFile *
 builder_context_get_download_dir (BuilderContext *self)
 {
   return self->download_dir;
+}
+
+GPtrArray *
+builder_context_get_sources_dirs (BuilderContext *self)
+{
+  return self->sources_dirs;
+}
+
+void
+builder_context_set_sources_dirs (BuilderContext *self,
+                                  GPtrArray      *sources_dirs)
+{
+  g_clear_pointer (&self->sources_dirs, g_ptr_array_unref);
+  self->sources_dirs = g_ptr_array_ref (sources_dirs);
 }
 
 GFile *

--- a/builder/builder-context.c
+++ b/builder/builder-context.c
@@ -66,6 +66,7 @@ struct BuilderContext
   gboolean        build_runtime;
   gboolean        build_extension;
   gboolean        separate_locales;
+  gboolean        bundle_sources;
   gboolean        sandboxed;
   gboolean        rebuild_on_sdk_change;
   gboolean        use_rofiles;
@@ -507,6 +508,19 @@ builder_context_set_separate_locales (BuilderContext *self,
                                       gboolean        separate_locales)
 {
   self->separate_locales = !!separate_locales;
+}
+
+gboolean
+builder_context_get_bundle_sources (BuilderContext *self)
+{
+  return self->bundle_sources;
+}
+
+void
+builder_context_set_bundle_sources (BuilderContext *self,
+                                    gboolean        bundle_sources)
+{
+  self->bundle_sources = !!bundle_sources;
 }
 
 static char *rofiles_unmount_path = NULL;

--- a/builder/builder-context.h
+++ b/builder/builder-context.h
@@ -49,6 +49,9 @@ GFile *         builder_context_allocate_build_subdir (BuilderContext *self,
                                                        GError **error);
 GFile *         builder_context_get_ccache_dir (BuilderContext *self);
 GFile *         builder_context_get_download_dir (BuilderContext *self);
+GPtrArray *     builder_context_get_sources_dirs (BuilderContext *self);
+void            builder_context_set_sources_dirs (BuilderContext *self,
+                                                  GPtrArray      *sources_dirs);
 SoupSession *   builder_context_get_soup_session (BuilderContext *self);
 const char *    builder_context_get_arch (BuilderContext *self);
 void            builder_context_set_arch (BuilderContext *self,

--- a/builder/builder-context.h
+++ b/builder/builder-context.h
@@ -86,6 +86,9 @@ void            builder_context_set_build_extension (BuilderContext *self,
 gboolean        builder_context_get_separate_locales (BuilderContext *self);
 void            builder_context_set_separate_locales (BuilderContext *self,
                                                       gboolean        separate_locales);
+void            builder_context_set_bundle_sources (BuilderContext *self,
+                                                    gboolean        bundle_sources);
+gboolean        builder_context_get_bundle_sources (BuilderContext *self);
 gboolean        builder_context_get_rebuild_on_sdk_change (BuilderContext *self);
 void            builder_context_set_rebuild_on_sdk_change (BuilderContext *self,
                                                            gboolean        rebuild_on_sdk_change);
@@ -94,7 +97,6 @@ char *          builder_context_get_checksum_for (BuilderContext *self,
 void            builder_context_set_checksum_for (BuilderContext *self,
                                                   const char *name,
                                                   const char *checksum);
-
 
 BuilderContext *builder_context_new (GFile *run_dir,
                                      GFile *app_dir);

--- a/builder/builder-git.c
+++ b/builder/builder-git.c
@@ -225,7 +225,7 @@ git_mirror_submodules (const char     *repo_location,
           if (g_strcmp0 (words[0], "160000") != 0)
             continue;
 
-          if (!builder_git_mirror_repo (absolute_url, update, TRUE, disable_fsck, words[2], context, error))
+          if (!builder_git_mirror_repo (absolute_url, NULL, update, TRUE, disable_fsck, words[2], context, error))
             return FALSE;
         }
     }

--- a/builder/builder-git.h
+++ b/builder/builder-git.h
@@ -26,6 +26,7 @@
 G_BEGIN_DECLS
 
 gboolean builder_git_mirror_repo        (const char      *repo_location,
+                                         const char      *destination_path,
                                          gboolean         update,
                                          gboolean         mirror_submodules,
                                          gboolean         disable_fsck,

--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -79,7 +79,7 @@ static GOptionEntry entries[] = {
   { "disable-updates", 0, 0, G_OPTION_ARG_NONE, &opt_disable_updates, "Only download missing sources, never update to latest vcs version", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Only download sources, don't build", NULL },
   { "bundle-sources", 0, 0, G_OPTION_ARG_NONE, &opt_bundle_sources, "Bundle module sources as runtime", NULL },
-  { "use-sources", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_sources_dirs, "Build the sources specified by SOURCE-DIR, multiple uses of this option possible", "SOURCE-DIR"},
+  { "extra-sources", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_sources_dirs, "Add a directory of sources specified by SOURCE-DIR, multiple uses of this option possible", "SOURCE-DIR"},
   { "build-only", 0, 0, G_OPTION_ARG_NONE, &opt_build_only, "Stop after build, don't run clean and finish phases", NULL },
   { "finish-only", 0, 0, G_OPTION_ARG_NONE, &opt_finish_only, "Only run clean and finish and export phases", NULL },
   { "allow-missing-runtimes", 0, 0, G_OPTION_ARG_NONE, &opt_allow_missing_runtimes, "Don't fail if runtime and sdk missing", NULL },

--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -144,6 +144,42 @@ usage (GOptionContext *context, const char *message)
 static const char skip_arg[] = "skip";
 
 static gboolean
+bundle_manifest (BuilderContext *build_context,
+                 GFile          *manifest_file,
+                 GError        **error)
+{
+  g_autoptr(GFile) sources_dir = NULL;
+  g_autoptr(GFile) destination_file = NULL;
+  g_autofree char *sources_dir_path = NULL;
+  g_autofree char *file_name = NULL;
+  g_autofree char *destination_file_path = NULL;
+  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (build_context));
+
+  sources_dir_path = g_build_filename (app_dir_path,
+                                       "sources",
+                                       NULL);
+  sources_dir = g_file_new_for_path (sources_dir_path);
+  if (!g_file_query_exists (sources_dir, NULL) &&
+      !g_file_make_directory_with_parents (sources_dir, NULL, error))
+    return FALSE;
+
+  file_name = g_file_get_basename (manifest_file);
+  destination_file_path = g_build_filename (sources_dir_path,
+                                            file_name,
+                                            NULL);
+  destination_file = g_file_new_for_path (destination_file_path);
+
+  if (!g_file_copy (manifest_file, destination_file,
+                    G_FILE_COPY_OVERWRITE,
+                    NULL,
+                    NULL, NULL,
+                    error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
 do_export (BuilderContext *build_context,
            GError        **error,
            gboolean        runtime,
@@ -672,6 +708,12 @@ main (int    argc,
         {
           g_autofree char *sources_id = builder_manifest_get_sources_id (manifest);
           g_print ("Exporting %s to repo\n", sources_id);
+
+          if (!bundle_manifest (build_context, manifest_file, &error))
+            {
+              g_printerr ("Can't bundle manifest file '%s' : %s\n", manifest_rel_path, error->message);
+              return 1;
+            }
 
           if (!do_export (build_context, &error, TRUE,
                           "--metadata=metadata.sources",

--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -515,7 +515,6 @@ main (int    argc,
 
   if (!opt_finish_only &&
       !opt_disable_download &&
-      !opt_sources_dirs &&
       !builder_manifest_download (manifest, !opt_disable_updates, opt_build_shell, build_context, &error))
     {
       g_printerr ("Failed to download sources: %s\n", error->message);

--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -676,7 +676,7 @@ main (int    argc,
 
           if (!do_export (build_context, &error, TRUE,
                           "--metadata=metadata.sources",
-                          builder_context_get_build_runtime (build_context) ? "--files=usr/sources" : "--files=sources",
+                          "--files=sources",
                           opt_repo, app_dir_path, builder_manifest_get_branch (manifest, opt_default_branch), NULL))
             {
               g_printerr ("Export failed: %s\n", error->message);

--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -399,6 +399,7 @@ main (int    argc,
       g_autoptr(GFile) build_subdir = NULL;
 
       if (!builder_git_mirror_repo (opt_from_git,
+                                    NULL,
                                     !opt_disable_updates, FALSE, FALSE,
                                     git_branch, build_context, &error))
         {

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -2274,12 +2274,11 @@ builder_manifest_finish (BuilderManifest *self,
             return FALSE;
         }
 
-      if (g_file_query_exists (sources_dir, NULL))
+      if (builder_context_get_bundle_sources (context) && g_file_query_exists (sources_dir, NULL))
         {
           g_autoptr(GFile) metadata_sources_file = NULL;
           g_autofree char *metadata_contents = NULL;
           g_autofree char *sources_id = builder_manifest_get_sources_id (self);
-
           metadata_sources_file = g_file_get_child (app_dir, "metadata.sources");
 
           metadata_contents = g_strdup_printf ("[Runtime]\n"

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -1044,6 +1044,13 @@ builder_manifest_get_debug_id (BuilderManifest *self)
   return g_strdup_printf ("%s.Debug", id);
 }
 
+char *
+builder_manifest_get_sources_id (BuilderManifest *self)
+{
+  g_autofree char *id = make_valid_id_prefix (self->id);
+  return g_strdup_printf ("%s.Sources", id);
+}
+
 const char *
 builder_manifest_get_id_platform (BuilderManifest *self)
 {
@@ -2051,6 +2058,7 @@ builder_manifest_finish (BuilderManifest *self,
 {
   g_autoptr(GFile) manifest_file = NULL;
   g_autoptr(GFile) debuginfo_dir = NULL;
+  g_autoptr(GFile) sources_dir = NULL;
   g_autoptr(GFile) locale_parent_dir = NULL;
   g_autofree char *json = NULL;
   g_autofree char *commandline = NULL;
@@ -2185,11 +2193,13 @@ builder_manifest_finish (BuilderManifest *self,
         {
           debuginfo_dir = g_file_resolve_relative_path (app_dir, "usr/lib/debug");
           locale_parent_dir = g_file_resolve_relative_path (app_dir, "usr/" LOCALES_SEPARATE_DIR);
+          sources_dir = g_file_resolve_relative_path (app_dir, "usr/sources");
         }
       else
         {
           debuginfo_dir = g_file_resolve_relative_path (app_dir, "files/lib/debug");
           locale_parent_dir = g_file_resolve_relative_path (app_dir, "files/" LOCALES_SEPARATE_DIR);
+          sources_dir = g_file_resolve_relative_path (app_dir, "sources");
         }
 
       if (self->separate_locales && g_file_query_exists (locale_parent_dir, NULL))
@@ -2260,6 +2270,21 @@ builder_manifest_finish (BuilderManifest *self,
           metadata_contents = g_strdup_printf ("[Runtime]\n"
                                                "name=%s\n", debug_id);
           if (!g_file_set_contents (flatpak_file_get_path_cached (metadata_debuginfo_file),
+                                    metadata_contents, strlen (metadata_contents), error))
+            return FALSE;
+        }
+
+      if (g_file_query_exists (sources_dir, NULL))
+        {
+          g_autoptr(GFile) metadata_sources_file = NULL;
+          g_autofree char *metadata_contents = NULL;
+          g_autofree char *sources_id = builder_manifest_get_sources_id (self);
+
+          metadata_sources_file = g_file_get_child (app_dir, "metadata.sources");
+
+          metadata_contents = g_strdup_printf ("[Runtime]\n"
+                                               "name=%s\n", sources_id);
+          if (!g_file_set_contents (flatpak_file_get_path_cached (metadata_sources_file),
                                     metadata_contents, strlen (metadata_contents), error))
             return FALSE;
         }

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -2193,14 +2193,13 @@ builder_manifest_finish (BuilderManifest *self,
         {
           debuginfo_dir = g_file_resolve_relative_path (app_dir, "usr/lib/debug");
           locale_parent_dir = g_file_resolve_relative_path (app_dir, "usr/" LOCALES_SEPARATE_DIR);
-          sources_dir = g_file_resolve_relative_path (app_dir, "usr/sources");
         }
       else
         {
           debuginfo_dir = g_file_resolve_relative_path (app_dir, "files/lib/debug");
           locale_parent_dir = g_file_resolve_relative_path (app_dir, "files/" LOCALES_SEPARATE_DIR);
-          sources_dir = g_file_resolve_relative_path (app_dir, "sources");
         }
+      sources_dir = g_file_resolve_relative_path (app_dir, "sources");
 
       if (self->separate_locales && g_file_query_exists (locale_parent_dir, NULL))
         {

--- a/builder/builder-manifest.h
+++ b/builder/builder-manifest.h
@@ -49,6 +49,7 @@ void builder_manifest_set_demarshal_buid_context (BuilderContext *build_context)
 const char *    builder_manifest_get_id (BuilderManifest *self);
 char *          builder_manifest_get_locale_id (BuilderManifest *self);
 char *          builder_manifest_get_debug_id (BuilderManifest *self);
+char *          builder_manifest_get_sources_id (BuilderManifest *self);
 const char *    builder_manifest_get_id_platform (BuilderManifest *self);
 char *          builder_manifest_get_locale_id_platform (BuilderManifest *self);
 BuilderOptions *builder_manifest_get_build_options (BuilderManifest *self);

--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -1184,10 +1184,10 @@ builder_module_build (BuilderModule  *self,
   g_print ("Building module %s in %s\n", self->name, source_dir_path);
   g_print ("========================================================================\n");
 
-  if (!builder_module_extract_sources (self, source_dir, context, error))
+  if (builder_context_get_bundle_sources (context) && !builder_module_bundle_sources (self, context, error))
     return FALSE;
 
-  if (builder_context_get_bundle_sources (context) && !builder_module_bundle_sources (self, context, error))
+  if (!builder_module_extract_sources (self, source_dir, context, error))
     return FALSE;
 
   if (self->subdir != NULL && self->subdir[0] != 0)

--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -1187,7 +1187,7 @@ builder_module_build (BuilderModule  *self,
   if (!builder_module_extract_sources (self, source_dir, context, error))
     return FALSE;
 
-  if (!builder_module_bundle_sources (self, context, error))
+  if (builder_context_get_bundle_sources (context) && !builder_module_bundle_sources (self, context, error))
     return FALSE;
 
   if (self->subdir != NULL && self->subdir[0] != 0)

--- a/builder/builder-module.h
+++ b/builder/builder-module.h
@@ -62,6 +62,9 @@ gboolean builder_module_extract_sources (BuilderModule  *self,
                                          GFile          *dest,
                                          BuilderContext *context,
                                          GError        **error);
+gboolean builder_module_bundle_sources (BuilderModule  *self,
+                                        BuilderContext *context,
+                                        GError        **error);
 gboolean builder_module_ensure_writable (BuilderModule  *self,
                                          BuilderCache   *cache,
                                          BuilderContext *context,

--- a/builder/builder-source-archive.c
+++ b/builder/builder-source-archive.c
@@ -211,6 +211,7 @@ get_uri (BuilderSourceArchive *self,
 static GFile *
 get_download_location (BuilderSourceArchive *self,
                        BuilderContext       *context,
+                       gboolean             *is_local,
                        GError              **error)
 {
   g_autoptr(SoupURI) uri = NULL;
@@ -243,8 +244,10 @@ get_download_location (BuilderSourceArchive *self,
       g_autoptr(GFile) local_download_dir = g_file_get_child (sources_root, "downloads");
       g_autoptr(GFile) local_sha256_dir = g_file_get_child (local_download_dir, self->sha256);
       g_autoptr(GFile) local_file = g_file_get_child (local_sha256_dir, base_name);
-      if (g_file_query_exists (local_file, NULL))
+      if (g_file_query_exists (local_file, NULL)) {
+        *is_local = TRUE;
         return g_steal_pointer (&local_file);
+      }
     }
 
   download_dir = builder_context_get_download_dir (context);
@@ -265,7 +268,7 @@ get_source_file (BuilderSourceArchive *self,
   if (self->url != NULL && self->url[0] != 0)
     {
       *is_local = FALSE;
-      return get_download_location (self, context, error);
+      return get_download_location (self, context, is_local, error);
     }
 
   if (self->path != NULL && self->path[0] != 0)

--- a/builder/builder-source-archive.c
+++ b/builder/builder-source-archive.c
@@ -609,13 +609,14 @@ builder_source_archive_bundle (BuilderSource  *source,
   g_autofree char *download_dir_path = NULL;
   g_autofree char *file_name = NULL;
   g_autofree char *destination_file_path = NULL;
-  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+  g_autofree char *app_dir_path = NULL;
   gboolean is_local;
 
   file = get_source_file (self, context, &is_local, error);
   if (file == NULL)
     return FALSE;
 
+  app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
   download_dir_path = g_build_filename (app_dir_path,
                                         "sources",
                                         "downloads",

--- a/builder/builder-source-bzr.c
+++ b/builder/builder-source-bzr.c
@@ -136,6 +136,19 @@ get_mirror_dir (BuilderSourceBzr *self, BuilderContext *context)
   g_autoptr(GFile) bzr_dir = NULL;
   g_autofree char *filename = NULL;
   g_autofree char *bzr_dir_path = NULL;
+  GPtrArray *sources_dirs = NULL;
+  int i;
+
+  sources_dirs = builder_context_get_sources_dirs (context);
+  for (i = 0; sources_dirs != NULL && i < sources_dirs->len; i++)
+    {
+      GFile* sources_root = g_ptr_array_index (sources_dirs, i);
+      g_autoptr(GFile) local_bzr_dir = g_file_get_child (sources_root, "bzr");
+      g_autofree char *local_filename = builder_uri_to_filename (self->url);
+      g_autoptr(GFile) file = g_file_get_child (local_bzr_dir, local_filename);
+      if (g_file_query_exists (file, NULL))
+        return g_steal_pointer (&file);
+    }
 
   bzr_dir = g_file_get_child (builder_context_get_state_dir (context),
                               "bzr");
@@ -239,6 +252,62 @@ builder_source_bzr_extract (BuilderSource  *source,
   return TRUE;
 }
 
+static gboolean
+builder_source_bzr_bundle (BuilderSource  *source,
+                           BuilderContext *context,
+                           GError        **error)
+{
+  BuilderSourceBzr *self = BUILDER_SOURCE_BZR (source);
+
+  g_autoptr(GFile) sources_dir = NULL;
+  g_autoptr(GFile) dest_dir = NULL;
+  g_autoptr(GFile) dest_dir_tmp = NULL;
+  g_autoptr(GFile) bzr_sources_dir = NULL;
+
+  g_autofree char *sources_dir_path = NULL;
+  g_autofree char *dest_dir_path = NULL;
+  g_autofree char *dest_dir_path_tmp = NULL;
+  g_autofree char *bzr_sources_dir_path = NULL;
+
+  g_autofree char *base_name = NULL;
+  g_autofree char *base_name_tmp = NULL;
+  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+
+  sources_dir = get_mirror_dir (self, context);
+  sources_dir_path = g_file_get_path (sources_dir);
+
+  if (!g_file_query_exists (sources_dir, NULL))
+    return FALSE;
+
+  base_name = g_file_get_basename (sources_dir);
+
+  bzr_sources_dir_path = g_build_filename (app_dir_path,
+                                           "sources",
+                                           "bzr",
+                                           NULL);
+  bzr_sources_dir = g_file_new_for_path (bzr_sources_dir_path);
+  if (!g_file_query_exists (bzr_sources_dir, NULL) &&
+      !g_file_make_directory_with_parents (bzr_sources_dir, NULL, error))
+    return FALSE;
+
+  base_name_tmp = g_strconcat (base_name, ".clone_tmp", NULL);
+  dest_dir_path_tmp = g_build_filename (bzr_sources_dir_path,
+                                        base_name_tmp,
+                                        NULL);
+  dest_dir_tmp = g_file_new_for_path (dest_dir_path_tmp);
+  dest_dir_path = g_build_filename (bzr_sources_dir_path,
+                                    base_name,
+                                    NULL);
+  dest_dir = g_file_new_for_path (dest_dir_path);
+
+  if (!bzr (bzr_sources_dir, NULL, error,
+            "branch", sources_dir_path, base_name_tmp, NULL) ||
+      !g_file_move (dest_dir_tmp, dest_dir, 0, NULL, NULL, NULL, error))
+    return FALSE;
+
+  return TRUE;
+}
+
 static void
 builder_source_bzr_checksum (BuilderSource  *source,
                              BuilderCache   *cache,
@@ -289,6 +358,7 @@ builder_source_bzr_class_init (BuilderSourceBzrClass *klass)
 
   source_class->download = builder_source_bzr_download;
   source_class->extract = builder_source_bzr_extract;
+  source_class->bundle = builder_source_bzr_bundle;
   source_class->update = builder_source_bzr_update;
   source_class->checksum = builder_source_bzr_checksum;
 

--- a/builder/builder-source-bzr.c
+++ b/builder/builder-source-bzr.c
@@ -274,10 +274,11 @@ builder_source_bzr_bundle (BuilderSource  *source,
   g_autofree char *app_dir_path = NULL;
 
   sources_dir = get_mirror_dir (self, context);
-  sources_dir_path = g_file_get_path (sources_dir);
 
-  if (!g_file_query_exists (sources_dir, NULL))
+  if (sources_dir == NULL) {
+    g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Can't locate repo with URL '%s'", self->url);
     return FALSE;
+  }
 
   base_name = g_file_get_basename (sources_dir);
 
@@ -301,6 +302,7 @@ builder_source_bzr_bundle (BuilderSource  *source,
                                     NULL);
   dest_dir = g_file_new_for_path (dest_dir_path);
 
+  sources_dir_path = g_file_get_path (sources_dir);
   if (!bzr (bzr_sources_dir, NULL, error,
             "branch", sources_dir_path, base_name_tmp, NULL) ||
       !g_file_move (dest_dir_tmp, dest_dir, 0, NULL, NULL, NULL, error))

--- a/builder/builder-source-bzr.c
+++ b/builder/builder-source-bzr.c
@@ -271,7 +271,7 @@ builder_source_bzr_bundle (BuilderSource  *source,
 
   g_autofree char *base_name = NULL;
   g_autofree char *base_name_tmp = NULL;
-  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+  g_autofree char *app_dir_path = NULL;
 
   sources_dir = get_mirror_dir (self, context);
   sources_dir_path = g_file_get_path (sources_dir);
@@ -281,6 +281,7 @@ builder_source_bzr_bundle (BuilderSource  *source,
 
   base_name = g_file_get_basename (sources_dir);
 
+  app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
   bzr_sources_dir_path = g_build_filename (app_dir_path,
                                            "sources",
                                            "bzr",

--- a/builder/builder-source-file.c
+++ b/builder/builder-source-file.c
@@ -161,6 +161,7 @@ get_uri (BuilderSourceFile *self,
 static GFile *
 get_download_location (BuilderSourceFile *self,
                        gboolean          *is_inline,
+                       gboolean          *is_local,
                        BuilderContext    *context,
                        GError           **error)
 {
@@ -200,8 +201,10 @@ get_download_location (BuilderSourceFile *self,
       g_autoptr(GFile) local_download_dir = g_file_get_child (sources_root, "downloads");
       g_autoptr(GFile) local_sha256_dir = g_file_get_child (local_download_dir, self->sha256);
       g_autoptr(GFile) local_file = g_file_get_child (local_sha256_dir, base_name);
-      if (g_file_query_exists (local_file, NULL))
+      if (g_file_query_exists (local_file, NULL)) {
+        *is_local = TRUE;
         return g_steal_pointer (&local_file);
+      }
     }
 
   download_dir = builder_context_get_download_dir (context);
@@ -224,7 +227,7 @@ get_source_file (BuilderSourceFile *self,
   if (self->url != NULL && self->url[0] != 0)
     {
       *is_local = FALSE;
-      return get_download_location (self, is_inline, context, error);
+      return get_download_location (self, is_inline, is_local, context, error);
     }
 
   if (self->path != NULL && self->path[0] != 0)

--- a/builder/builder-source-file.c
+++ b/builder/builder-source-file.c
@@ -170,6 +170,8 @@ get_download_location (BuilderSourceFile *self,
   GFile *download_dir = NULL;
   g_autoptr(GFile) sha256_dir = NULL;
   g_autoptr(GFile) file = NULL;
+  GPtrArray *sources_dirs = NULL;
+  int i;
 
   uri = get_uri (self, error);
   if (uri == NULL)
@@ -189,6 +191,17 @@ get_download_location (BuilderSourceFile *self,
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Sha256 not specified");
       return FALSE;
+    }
+
+  sources_dirs = builder_context_get_sources_dirs (context);
+  for (i = 0; sources_dirs != NULL && i < sources_dirs->len; i++)
+    {
+      GFile* sources_root = g_ptr_array_index (sources_dirs, i);
+      g_autoptr(GFile) local_download_dir = g_file_get_child (sources_root, "downloads");
+      g_autoptr(GFile) local_sha256_dir = g_file_get_child (local_download_dir, self->sha256);
+      g_autoptr(GFile) local_file = g_file_get_child (local_sha256_dir, base_name);
+      if (g_file_query_exists (local_file, NULL))
+        return g_steal_pointer (&local_file);
     }
 
   download_dir = builder_context_get_download_dir (context);
@@ -424,6 +437,52 @@ builder_source_file_extract (BuilderSource  *source,
 }
 
 static gboolean
+builder_source_file_bundle (BuilderSource  *source,
+                            BuilderContext *context,
+                            GError        **error)
+{
+  BuilderSourceFile *self = BUILDER_SOURCE_FILE (source);
+
+  g_autoptr(GFile) file = NULL;
+  g_autoptr(GFile) download_dir = NULL;
+  g_autoptr(GFile) destination_file = NULL;
+  g_autofree char *download_dir_path = NULL;
+  g_autofree char *file_name = NULL;
+  g_autofree char *destination_file_path = NULL;
+  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+  gboolean is_local, is_inline;
+
+  file = get_source_file (self, context, &is_local, &is_inline, error);
+  if (file == NULL)
+    return FALSE;
+
+  download_dir_path = g_build_filename (app_dir_path,
+                                        "sources",
+                                        "downloads",
+                                        self->sha256,
+                                        NULL);
+  download_dir = g_file_new_for_path (download_dir_path);
+  if (!g_file_query_exists (download_dir, NULL) &&
+      !g_file_make_directory_with_parents (download_dir, NULL, error))
+    return FALSE;
+
+  file_name = g_file_get_basename (file);
+  destination_file_path = g_build_filename (download_dir_path,
+                                            file_name,
+                                            NULL);
+  destination_file = g_file_new_for_path (destination_file_path);
+
+  if (!g_file_copy (file, destination_file,
+                    G_FILE_COPY_OVERWRITE,
+                    NULL,
+                    NULL, NULL,
+                    error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
 builder_source_file_update (BuilderSource  *source,
                             BuilderContext *context,
                             GError        **error)
@@ -498,6 +557,7 @@ builder_source_file_class_init (BuilderSourceFileClass *klass)
   source_class->show_deps = builder_source_file_show_deps;
   source_class->download = builder_source_file_download;
   source_class->extract = builder_source_file_extract;
+  source_class->bundle = builder_source_file_bundle;
   source_class->update = builder_source_file_update;
   source_class->checksum = builder_source_file_checksum;
 

--- a/builder/builder-source-file.c
+++ b/builder/builder-source-file.c
@@ -452,13 +452,14 @@ builder_source_file_bundle (BuilderSource  *source,
   g_autofree char *download_dir_path = NULL;
   g_autofree char *file_name = NULL;
   g_autofree char *destination_file_path = NULL;
-  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+  g_autofree char *app_dir_path = NULL;
   gboolean is_local, is_inline;
 
   file = get_source_file (self, context, &is_local, &is_inline, error);
   if (file == NULL)
     return FALSE;
 
+  app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
   download_dir_path = g_build_filename (app_dir_path,
                                         "sources",
                                         "downloads",

--- a/builder/builder-source-git.c
+++ b/builder/builder-source-git.c
@@ -255,13 +255,14 @@ builder_source_git_bundle (BuilderSource  *source,
   g_autofree char *location = NULL;
   g_autoptr(GFile) mirror_dir = NULL;
   g_autofree char *mirror_dir_path = NULL;
-  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+  g_autofree char *app_dir_path = NULL;
 
   location = get_url_or_path (self, context, error);
 
   if (location == NULL)
     return FALSE;
 
+  app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
   mirror_dir_path = g_build_filename (app_dir_path,
                                       "sources",
                                       "git",

--- a/builder/builder-source-git.c
+++ b/builder/builder-source-git.c
@@ -206,6 +206,7 @@ builder_source_git_download (BuilderSource  *source,
     return FALSE;
 
   if (!builder_git_mirror_repo (location,
+                                NULL,
                                 update_vcs, TRUE, self->disable_fsckobjects,
                                 get_branch (self),
                                 context,
@@ -274,7 +275,7 @@ builder_source_git_bundle (BuilderSource  *source,
 
   if (!builder_git_mirror_repo (location,
                                 mirror_dir_path,
-                                FALSE, TRUE,
+                                FALSE, TRUE, FALSE,
                                 get_branch (self),
                                 context,
                                 error))

--- a/builder/builder-source-git.c
+++ b/builder/builder-source-git.c
@@ -245,6 +245,43 @@ builder_source_git_extract (BuilderSource  *source,
   return TRUE;
 }
 
+static gboolean
+builder_source_git_bundle (BuilderSource  *source,
+                           BuilderContext *context,
+                           GError        **error)
+{
+  BuilderSourceGit *self = BUILDER_SOURCE_GIT (source);
+
+  g_autofree char *location = NULL;
+  g_autoptr(GFile) mirror_dir = NULL;
+  g_autofree char *mirror_dir_path = NULL;
+  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+
+  location = get_url_or_path (self, context, error);
+
+  if (location == NULL)
+    return FALSE;
+
+  mirror_dir_path = g_build_filename (app_dir_path,
+                                      "sources",
+                                      "git",
+                                      NULL);
+  mirror_dir = g_file_new_for_path (mirror_dir_path);
+  if (!g_file_query_exists (mirror_dir, NULL) &&
+      !g_file_make_directory_with_parents (mirror_dir, NULL, error))
+    return FALSE;
+
+  if (!builder_git_mirror_repo (location,
+                                mirror_dir_path,
+                                FALSE, TRUE,
+                                get_branch (self),
+                                context,
+                                error))
+    return FALSE;
+
+  return TRUE;
+}
+
 static void
 builder_source_git_checksum (BuilderSource  *source,
                              BuilderCache   *cache,
@@ -311,6 +348,7 @@ builder_source_git_class_init (BuilderSourceGitClass *klass)
 
   source_class->download = builder_source_git_download;
   source_class->extract = builder_source_git_extract;
+  source_class->bundle = builder_source_git_bundle;
   source_class->update = builder_source_git_update;
   source_class->checksum = builder_source_git_checksum;
 

--- a/builder/builder-source-patch.c
+++ b/builder/builder-source-patch.c
@@ -286,13 +286,14 @@ builder_source_patch_bundle (BuilderSource  *source,
   g_autofree char *patches_dir_path = NULL;
   g_autofree char *file_name = NULL;
   g_autofree char *destination_file_path = NULL;
-  g_autofree char *app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
+  g_autofree char *app_dir_path = NULL;
 
   src = get_source_file (self, context, error);
 
   if (src == NULL)
     return FALSE;
 
+  app_dir_path = g_file_get_path (builder_context_get_app_dir (context));
   patches_dir_path = g_build_filename (app_dir_path,
                                        "sources",
                                        "patches",

--- a/builder/builder-source-patch.c
+++ b/builder/builder-source-patch.c
@@ -254,6 +254,16 @@ builder_source_patch_extract (BuilderSource  *source,
   return TRUE;
 }
 
+static gboolean
+builder_source_patch_bundle (BuilderSource  *source,
+                             BuilderContext *context,
+                             GError        **error)
+{
+  // the patches are part of the source archives
+  // or repositories, no need to bundle anything here
+  return TRUE;
+}
+
 static void
 builder_source_patch_checksum (BuilderSource  *source,
                                BuilderCache   *cache,
@@ -290,6 +300,7 @@ builder_source_patch_class_init (BuilderSourcePatchClass *klass)
   source_class->show_deps = builder_source_patch_show_deps;
   source_class->download = builder_source_patch_download;
   source_class->extract = builder_source_patch_extract;
+  source_class->bundle = builder_source_patch_bundle;
   source_class->checksum = builder_source_patch_checksum;
 
   g_object_class_install_property (object_class,

--- a/builder/builder-source-script.c
+++ b/builder/builder-source-script.c
@@ -179,8 +179,8 @@ builder_source_script_bundle (BuilderSource  *source,
                               BuilderContext *context,
                               GError        **error)
 {
-  // no need to bundle anything here as this part
-  // can be reconstructed from the manifest
+  /* no need to bundle anything here as this part
+     can be reconstructed from the manifest */
   return TRUE;
 }
 

--- a/builder/builder-source-script.c
+++ b/builder/builder-source-script.c
@@ -174,6 +174,16 @@ builder_source_script_extract (BuilderSource  *source,
   return TRUE;
 }
 
+static gboolean
+builder_source_script_bundle (BuilderSource  *source,
+                              BuilderContext *context,
+                              GError        **error)
+{
+  // no need to bundle anything here as this part
+  // can be reconstructed from the manifest
+  return TRUE;
+}
+
 static void
 builder_source_script_checksum (BuilderSource  *source,
                                 BuilderCache   *cache,
@@ -197,6 +207,7 @@ builder_source_script_class_init (BuilderSourceScriptClass *klass)
 
   source_class->download = builder_source_script_download;
   source_class->extract = builder_source_script_extract;
+  source_class->bundle = builder_source_script_bundle;
   source_class->checksum = builder_source_script_checksum;
 
   g_object_class_install_property (object_class,

--- a/builder/builder-source-shell.c
+++ b/builder/builder-source-shell.c
@@ -183,8 +183,8 @@ builder_source_shell_bundle (BuilderSource  *source,
                              BuilderContext *context,
                              GError        **error)
 {
-  // no need to bundle anything here as this part
-  // can be reconstructed from the manifest
+  /* no need to bundle anything here as this part
+     can be reconstructed from the manifest */
   return TRUE;
 }
 

--- a/builder/builder-source-shell.c
+++ b/builder/builder-source-shell.c
@@ -178,6 +178,16 @@ builder_source_shell_extract (BuilderSource  *source,
   return TRUE;
 }
 
+static gboolean
+builder_source_shell_bundle (BuilderSource  *source,
+                             BuilderContext *context,
+                             GError        **error)
+{
+  // no need to bundle anything here as this part
+  // can be reconstructed from the manifest
+  return TRUE;
+}
+
 static void
 builder_source_shell_checksum (BuilderSource  *source,
                                BuilderCache   *cache,
@@ -200,6 +210,7 @@ builder_source_shell_class_init (BuilderSourceShellClass *klass)
 
   source_class->download = builder_source_shell_download;
   source_class->extract = builder_source_shell_extract;
+  source_class->bundle = builder_source_shell_bundle;
   source_class->checksum = builder_source_shell_checksum;
 
   g_object_class_install_property (object_class,

--- a/builder/builder-source.c
+++ b/builder/builder-source.c
@@ -151,6 +151,16 @@ builder_source_real_extract (BuilderSource  *self,
 }
 
 static gboolean
+builder_source_real_bundle (BuilderSource  *self,
+                            BuilderContext *context,
+                            GError        **error)
+{
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+               "Bundle not implemented for type %s", g_type_name_from_instance ((GTypeInstance *) self));
+  return FALSE;
+}
+
+static gboolean
 builder_source_real_update (BuilderSource  *self,
                             BuilderContext *context,
                             GError        **error)
@@ -170,6 +180,7 @@ builder_source_class_init (BuilderSourceClass *klass)
   klass->show_deps = builder_source_real_show_deps;
   klass->download = builder_source_real_download;
   klass->extract = builder_source_real_extract;
+  klass->bundle = builder_source_real_bundle;
   klass->update = builder_source_real_update;
 
   g_object_class_install_property (object_class,
@@ -320,6 +331,17 @@ builder_source_extract (BuilderSource  *self,
 
 
   return class->extract (self, real_dest, build_options, context, error);
+}
+
+gboolean
+builder_source_bundle (BuilderSource  *self,
+                       BuilderContext *context,
+                       GError        **error)
+{
+  BuilderSourceClass *class;
+  class = BUILDER_SOURCE_GET_CLASS (self);
+
+  return class->bundle (self, context, error);
 }
 
 gboolean

--- a/builder/builder-source.h
+++ b/builder/builder-source.h
@@ -61,6 +61,9 @@ typedef struct
                        BuilderOptions *build_options,
                        BuilderContext *context,
                        GError        **error);
+  gboolean (* bundle)(BuilderSource  *self,
+                      BuilderContext *context,
+                      GError        **error);
   gboolean (* update)(BuilderSource  *self,
                       BuilderContext *context,
                       GError        **error);
@@ -85,6 +88,9 @@ gboolean builder_source_extract (BuilderSource  *self,
                                  BuilderOptions *build_options,
                                  BuilderContext *context,
                                  GError        **error);
+gboolean builder_source_bundle (BuilderSource  *self,
+                                BuilderContext *context,
+                                GError        **error);
 gboolean builder_source_update (BuilderSource  *self,
                                 BuilderContext *context,
                                 GError        **error);


### PR DESCRIPTION
This adds a step to the build process to bundle
the module sources, used for building the flatpak,
as a runtime extension.

The sources can then be installed like the
debug or translation runtime.

This also adds an option to flatpak-builder
for specifying sources directories. One can specify
source dirctories with the use-sources argument. This
will skip the download part of the processing
and will extract the sources from the given sources
directory directly for further processing.

Those source directories do need the same
structure as the ones that flatpak-builder
creates during processing in .flatpak-builder
and which is also used in the exported sources
runtime.