### PR TITLE
Don't fail the build if rofiles-fuse is not available

### DIFF
--- a/builder/builder-context.c
+++ b/builder/builder-context.c
@@ -550,7 +550,7 @@ builder_context_enable_rofiles (BuilderContext *self,
 
   if (!self->have_rofiles)
     {
-      g_debug ("rofiles-fuse not available, doing without");
+      g_warning ("rofiles-fuse not available, doing without");
       return TRUE;
     }
 


### PR DESCRIPTION
My understanding is that rofiles-fuse is just an optimization,
and we support building without it anyway (using --disable-rofiles-fuse).

So, instead of failing the build, we can just not use rofiles-fuse
if it is not present on the system, which seems to be the case on
some OSes, we've seen this reported from Debian and Arch.