### PR TITLE
doc: Include all man pages in html

### DIFF
--- a/doc/flatpak-docs.xml.in
+++ b/doc/flatpak-docs.xml.in
@@ -13,38 +13,48 @@
         Flatpak comes with a rich commandline interface.
       </para>
     </partintro>
-    <xi:include href="@srcdir@/flatpak-install.xml"/>
-    <xi:include href="@srcdir@/flatpak-update.xml"/>
-    <xi:include href="@srcdir@/flatpak-uninstall.xml"/>
-    <xi:include href="@srcdir@/flatpak-list.xml"/>
-    <xi:include href="@srcdir@/flatpak-info.xml"/>
-    <xi:include href="@srcdir@/flatpak-run.xml"/>
-    <xi:include href="@srcdir@/flatpak-override.xml"/>
-    <xi:include href="@srcdir@/flatpak-make-current.xml"/>
-    <xi:include href="@srcdir@/flatpak-enter.xml"/>
-    <xi:include href="@srcdir@/flatpak-document-export.xml"/>
-    <xi:include href="@srcdir@/flatpak-document-unexport.xml"/>
-    <xi:include href="@srcdir@/flatpak-document-info.xml"/>
-    <xi:include href="@srcdir@/flatpak-document-list.xml"/>
-    <xi:include href="@srcdir@/flatpak-remotes.xml"/>
-    <xi:include href="@srcdir@/flatpak-remote-add.xml"/>
-    <xi:include href="@srcdir@/flatpak-remote-modify.xml"/>
-    <xi:include href="@srcdir@/flatpak-remote-delete.xml"/>
-    <xi:include href="@srcdir@/flatpak-remote-ls.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-init.xml"/>
-    <xi:include href="@srcdir@/flatpak-build.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-finish.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-export.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-bundle.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-import-bundle.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-sign.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-update-repo.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-commit-from.xml"/>
-    <xi:include href="@srcdir@/flatpak-builder.xml"/>
-    <xi:include href="@srcdir@/flatpak-metadata.xml"/>
-    <xi:include href="@srcdir@/flatpak-flatpakrepo.xml"/>
-    <xi:include href="@srcdir@/flatpak-flatpakref.xml"/>
-    <xi:include href="@srcdir@/flatpak-manifest.xml"/>
-    <xi:include href="@srcdir@/flatpak-remote.xml"/>
-    <xi:include href="@srcdir@/flatpak-installation.xml"/>
+    <chapter>
+      <title>Executables</title>
+      <xi:include href="@srcdir@/flatpak.xml"/>
+      <xi:include href="@srcdir@/flatpak-builder.xml"/>
+    </chapter>
+    <chapter>
+      <title>Commands</title>
+      <xi:include href="@srcdir@/flatpak-install.xml"/>
+      <xi:include href="@srcdir@/flatpak-update.xml"/>
+      <xi:include href="@srcdir@/flatpak-uninstall.xml"/>
+      <xi:include href="@srcdir@/flatpak-list.xml"/>
+      <xi:include href="@srcdir@/flatpak-info.xml"/>
+      <xi:include href="@srcdir@/flatpak-run.xml"/>
+      <xi:include href="@srcdir@/flatpak-override.xml"/>
+      <xi:include href="@srcdir@/flatpak-make-current.xml"/>
+      <xi:include href="@srcdir@/flatpak-enter.xml"/>
+      <xi:include href="@srcdir@/flatpak-document-export.xml"/>
+      <xi:include href="@srcdir@/flatpak-document-unexport.xml"/>
+      <xi:include href="@srcdir@/flatpak-document-info.xml"/>
+      <xi:include href="@srcdir@/flatpak-document-list.xml"/>
+      <xi:include href="@srcdir@/flatpak-remotes.xml"/>
+      <xi:include href="@srcdir@/flatpak-remote-add.xml"/>
+      <xi:include href="@srcdir@/flatpak-remote-modify.xml"/>
+      <xi:include href="@srcdir@/flatpak-remote-delete.xml"/>
+      <xi:include href="@srcdir@/flatpak-remote-ls.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-init.xml"/>
+      <xi:include href="@srcdir@/flatpak-build.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-finish.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-export.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-bundle.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-import-bundle.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-sign.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-update-repo.xml"/>
+      <xi:include href="@srcdir@/flatpak-build-commit-from.xml"/>
+    </chapter>
+    <chapter>
+      <title>File Formats</title>
+      <xi:include href="@srcdir@/flatpak-metadata.xml"/>
+      <xi:include href="@srcdir@/flatpak-flatpakrepo.xml"/>
+      <xi:include href="@srcdir@/flatpak-flatpakref.xml"/>
+      <xi:include href="@srcdir@/flatpak-manifest.xml"/>
+      <xi:include href="@srcdir@/flatpak-remote.xml"/>
+      <xi:include href="@srcdir@/flatpak-installation.xml"/>
+    </chapter>
 </reference>

--- a/doc/flatpak-docs.xml.in
+++ b/doc/flatpak-docs.xml.in
@@ -20,6 +20,7 @@
     <xi:include href="@srcdir@/flatpak-info.xml"/>
     <xi:include href="@srcdir@/flatpak-run.xml"/>
     <xi:include href="@srcdir@/flatpak-override.xml"/>
+    <xi:include href="@srcdir@/flatpak-make-current.xml"/>
     <xi:include href="@srcdir@/flatpak-enter.xml"/>
     <xi:include href="@srcdir@/flatpak-document-export.xml"/>
     <xi:include href="@srcdir@/flatpak-document-unexport.xml"/>
@@ -36,11 +37,14 @@
     <xi:include href="@srcdir@/flatpak-build-export.xml"/>
     <xi:include href="@srcdir@/flatpak-build-bundle.xml"/>
     <xi:include href="@srcdir@/flatpak-build-import-bundle.xml"/>
-    <xi:include href="@srcdir@/flatpak-build-update-repo.xml"/>
     <xi:include href="@srcdir@/flatpak-build-sign.xml"/>
+    <xi:include href="@srcdir@/flatpak-build-update-repo.xml"/>
+    <xi:include href="@srcdir@/flatpak-build-commit-from.xml"/>
     <xi:include href="@srcdir@/flatpak-builder.xml"/>
     <xi:include href="@srcdir@/flatpak-metadata.xml"/>
     <xi:include href="@srcdir@/flatpak-flatpakrepo.xml"/>
     <xi:include href="@srcdir@/flatpak-flatpakref.xml"/>
-    <xi:include href="@srcdir@/flatpak-make-current.xml"/>
+    <xi:include href="@srcdir@/flatpak-manifest.xml"/>
+    <xi:include href="@srcdir@/flatpak-remote.xml"/>
+    <xi:include href="@srcdir@/flatpak-installation.xml"/>
 </reference>

--- a/doc/xmlto-config.xsl
+++ b/doc/xmlto-config.xsl
@@ -3,4 +3,7 @@
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 version="1.0">
   <xsl:param name="html.stylesheet" select="'docbook.css'"/>
+  <xsl:param name="citerefentry.link" select="1"/>
+  <xsl:template name="generate.citerefentry.link"><xsl:text>#</xsl:text><xsl:value-of select="refentrytitle"/></xsl:template>
+  <xsl:param name="chapter.autolabel" select="0"></xsl:param>
 </xsl:stylesheet>


### PR DESCRIPTION
We have a docbook file that generates html versions of
the man pages. Keep it updated.