### PR TITLE
run: Handle non-default WAYLAND_DISPLAY

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1989,8 +1989,16 @@ static void
 flatpak_run_add_wayland_args (GPtrArray *argv_array,
                               char    ***envp_p)
 {
-  g_autofree char *wayland_socket = g_build_filename (g_get_user_runtime_dir (), "wayland-0", NULL);
-  g_autofree char *sandbox_wayland_socket = g_strdup_printf ("/run/user/%d/wayland-0", getuid ());
+  const char *wayland_display;
+  g_autofree char *wayland_socket = NULL;
+  g_autofree char *sandbox_wayland_socket = NULL;
+
+  wayland_display = g_getenv ("WAYLAND_DISPLAY");
+  if (!wayland_display)
+    wayland_display = "wayland-0";
+
+  wayland_socket = g_build_filename (g_get_user_runtime_dir (), wayland_display, NULL);
+  sandbox_wayland_socket = g_strdup_printf ("/run/user/%d/%s", getuid (), wayland_display);
 
   if (g_file_test (wayland_socket, G_FILE_TEST_EXISTS))
     {


### PR DESCRIPTION
WAYLAND_DISPLAY can be other than "wayland-0" for various reasons, such
as using a custom Wayland display server or the session display server
using a custom display name.

Note that for xdg-desktop-portal to support showing portal windows, the
xdg-desktop-portal service MUST use the same WAYLAND_DISPLAY.

---

I needed this to be able to debug a mutter crash where the reproducer was a flatpak app, so that I could make that app use the display server instance I was debugging. There are probably other reasons for WAYLAND_DISPLAY being something other than "wayland-0" where flatpak should till work though.