### PR TITLE
Improve display of partial extension sizes

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -204,7 +204,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
                g_autofree char *formatted = NULL;
 
                formatted = g_format_size (size);
-               g_print (" %s", formatted);
+               g_print (" %s%s", subpaths && subpaths[0] ? "<" : "", formatted);
              }
 
            if (subpaths)


### PR DESCRIPTION
The installed size in the metadata refers to the full
extension. If we have subpaths, the actual installed
size may be much smaller. Unfortunately, it appears
hard to obtain the actual size, so just hint at this
fact by displaying a '<' before the size.