### PR TITLE
scripts: Fix flatpak-bisect log

### DIFF
--- a/scripts/flatpak-bisect
+++ b/scripts/flatpak-bisect
@@ -177,7 +177,7 @@ class Bisector():
         if pager:
             stdout = subprocess.PIPE
         else:
-            stdout = subprocess.STDOUT
+            stdout = None
         p = subprocess.Popen(cmd, stdout=stdout)
         if pager:
             ps = subprocess.check_call((pager), stdin=p.stdout)


### PR DESCRIPTION
The script was using stdout=subprocess.STDOUT but the Popen
documentation does not mention this as a valid value.

An exception was being thrown when running flatpak-bisect <name> log:
OSError: [Errno 9] Bad file descriptor