### PR TITLE
flatpak-run.c:  valid locations, not types

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -763,7 +763,7 @@ flatpak_context_verify_filesystem (const char *filesystem_and_mode,
     return TRUE;
 
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
-               _("Unknown filesystem location %s, valid types are: host, home, xdg-*[/...], ~/dir, /dir"), filesystem);
+               _("Unknown filesystem location %s, valid locations are: host, home, xdg-*[/...], ~/dir, /dir"), filesystem);
   return FALSE;
 }
 


### PR DESCRIPTION
Some previous g_set_error messages were related to 'unknown type', but this one about 'unknown location'. So it would probably be best to suggest 'valid locations', instead of 'valid types'.