### PR TITLE
libglnx: Bump to latest master, use new file copy API

### DIFF
--- a/builder/builder-post-process.c
+++ b/builder/builder-post-process.c
@@ -228,8 +228,8 @@ fixup_python_time_stamp (const char *path,
                                       error))
     return FALSE;
 
-  if (!flatpak_copy_bytes (fd, write_fd, error))
-    return FALSE;
+  if (glnx_regfile_copy_bytes (fd, write_fd, (off_t)-1, TRUE) < 0)
+    return glnx_throw_errno_prefix (error, "copyfile");
 
   /* Change to mtime 0 which is what ostree uses for checkouts */
   buffer[4] = OSTREE_TIMESTAMP;

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -784,8 +784,8 @@ flatpak_oci_registry_mirror_blob (FlatpakOciRegistry    *self,
       if (src_fd == -1)
         return FALSE;
 
-      if (!flatpak_copy_bytes (src_fd, fd, error))
-        return FALSE;
+      if (glnx_regfile_copy_bytes (src_fd, fd, (off_t)-1, TRUE) < 0)
+        return glnx_throw_errno_prefix (error, "copyfile");
     }
   else
     {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2164,44 +2164,6 @@ flatpak_openat_noatime (int            dfd,
     }
 }
 
-#define COPY_BUFFER_SIZE (16*1024)
-gboolean
-flatpak_copy_bytes (int fdf,
-                    int fdt,
-                    GError **error)
-{
-  char buf[COPY_BUFFER_SIZE];
-  int r;
-
-  g_return_val_if_fail (fdf >= 0, FALSE);
-  g_return_val_if_fail (fdt >= 0, FALSE);
-
-  for (;;)
-    {
-      size_t m = COPY_BUFFER_SIZE;
-      ssize_t n;
-
-      n = read (fdf, buf, m);
-      if (n < 0)
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
-      if (n == 0) /* EOF */
-        break;
-
-      r = glnx_loop_write (fdt, buf, (size_t) n);
-      if (r < 0)
-        {
-          errno = r;
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
-    }
-
-  return TRUE;
-}
-
 gboolean
 flatpak_cp_a (GFile         *src,
               GFile         *dest,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -414,10 +414,6 @@ gboolean flatpak_openat_noatime (int            dfd,
                                  GCancellable  *cancellable,
                                  GError       **error);
 
-gboolean flatpak_copy_bytes (int fdf,
-                             int fdt,
-                             GError **error);
-
 typedef enum {
   FLATPAK_CP_FLAGS_NONE = 0,
   FLATPAK_CP_FLAGS_MERGE = 1<<0,


### PR DESCRIPTION
The new `glnx_regfile_copy_bytes()` is better than the previous
`flatpak_copy_bytes()` in that it will use reflink/sendfile if available.

More information in https://github.com/GNOME/libglnx/commit/3a4d0f4684f4653338c4756c8a1abfc6b5738467