### PR TITLE
Add a marker to rewritten desktop files

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3386,6 +3386,9 @@ export_desktop_file (const char   *app,
                                       "X-Flatpak-Tags",
                                       (const char * const *) tags, length);
         }
+
+      /* Add a marker so consumers can easily find out that this launches a sandbox */
+      g_key_file_set_boolean (keyfile, "Desktop Entry", "X-Flatpak", TRUE);
     }
 
   groups = g_key_file_get_groups (keyfile, NULL);


### PR DESCRIPTION
Add X-Flatpak=true to rewritten desktop files.
Desktop files have multiple consumers, and this
makes it easier for them to know what to do.