### PR TITLE
dir: Report progress more frequently

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1829,6 +1829,9 @@ repo_pull_one_dir (OstreeRepo          *self,
   g_variant_builder_add (&builder, "{s@v}", "override-commit-ids",
                          g_variant_new_variant (g_variant_new_strv ((const char * const *) revs_to_fetch, -1)));
 
+  g_variant_builder_add (&builder, "{s@v}", "update-frequency",
+                         g_variant_new_variant (g_variant_new_uint32 (FLATPAK_DEFAULT_UPDATE_FREQUENCY)));
+
   options = g_variant_ref_sink (g_variant_builder_end (&builder));
 
   remote_and_branch = g_strdup_printf ("%s:%s", remote_name, ref_to_fetch);
@@ -2543,6 +2546,8 @@ repo_pull_one_untrusted (OstreeRepo          *self,
                          g_variant_new_variant (g_variant_new_boolean (TRUE)));
   g_variant_builder_add (&builder, "{s@v}", "inherit-transaction",
                          g_variant_new_variant (g_variant_new_boolean (TRUE)));
+  g_variant_builder_add (&builder, "{s@v}", "update-frequency",
+                         g_variant_new_variant (g_variant_new_uint32 (FLATPAK_DEFAULT_UPDATE_FREQUENCY)));
 
   if (dirs_to_pull)
     {

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -55,6 +55,8 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_REPO_GPGKEY_KEY "GPGKey"
 #define FLATPAK_REPO_NODEPS_KEY "NoDeps"
 
+#define FLATPAK_DEFAULT_UPDATE_FREQUENCY 100
+
 typedef struct
 {
   char           *ref;


### PR DESCRIPTION
Flatpak relies on OSTree to report the progress, and
OSTree's progress report frequency fallbacks to 1 second.

Recently, however, OSTree received support for setting
custom update frequencies. Since it relies on GVariant
options, if the user has an older OSTree, it'll simply
be ignored.

This patch, then, makes Flatpak report progress every
100ms rather than the default value of 1 second.

flatpak/flatpak#609