### PR TITLE
User wide cache dir

### DIFF
--- a/builder/builder-context.c
+++ b/builder/builder-context.c
@@ -49,6 +49,7 @@ struct BuilderContext
   GFile          *download_dir;
   GPtrArray      *sources_dirs;
   GFile          *state_dir;
+  GFile          *user_state_dir;
   GFile          *build_dir;
   GFile          *cache_dir;
   GFile          *checksums_dir;
@@ -94,6 +95,7 @@ builder_context_finalize (GObject *object)
   BuilderContext *self = (BuilderContext *) object;
 
   g_clear_object (&self->state_dir);
+  g_clear_object (&self->user_state_dir);
   g_clear_object (&self->download_dir);
   g_clear_object (&self->build_dir);
   g_clear_object (&self->cache_dir);
@@ -166,6 +168,7 @@ static void
 builder_context_constructed (GObject *object)
 {
   BuilderContext *self = BUILDER_CONTEXT (object);
+  g_autoptr(GFile) user_cache_dir = g_file_new_for_path (g_get_user_cache_dir ());
 
   self->state_dir = g_file_get_child (self->run_dir, ".flatpak-builder");
   self->download_dir = g_file_get_child (self->state_dir, "downloads");
@@ -173,6 +176,7 @@ builder_context_constructed (GObject *object)
   self->cache_dir = g_file_get_child (self->state_dir, "cache");
   self->checksums_dir = g_file_get_child (self->state_dir, "checksums");
   self->ccache_dir = g_file_get_child (self->state_dir, "ccache");
+  self->user_state_dir = g_file_get_child (user_cache_dir, "flatpak-builder");
 }
 
 static void
@@ -235,6 +239,12 @@ GFile *
 builder_context_get_state_dir (BuilderContext *self)
 {
   return self->state_dir;
+}
+
+GFile *
+builder_context_get_user_state_dir (BuilderContext *self)
+{
+  return self->user_state_dir;
 }
 
 GFile *

--- a/builder/builder-context.c
+++ b/builder/builder-context.c
@@ -171,12 +171,12 @@ builder_context_constructed (GObject *object)
   g_autoptr(GFile) user_cache_dir = g_file_new_for_path (g_get_user_cache_dir ());
 
   self->state_dir = g_file_get_child (self->run_dir, ".flatpak-builder");
-  self->download_dir = g_file_get_child (self->state_dir, "downloads");
   self->build_dir = g_file_get_child (self->state_dir, "build");
   self->cache_dir = g_file_get_child (self->state_dir, "cache");
   self->checksums_dir = g_file_get_child (self->state_dir, "checksums");
   self->ccache_dir = g_file_get_child (self->state_dir, "ccache");
   self->user_state_dir = g_file_get_child (user_cache_dir, "flatpak-builder");
+  self->download_dir = g_file_get_child (self->user_state_dir, "downloads");
 }
 
 static void

--- a/builder/builder-context.h
+++ b/builder/builder-context.h
@@ -42,6 +42,7 @@ GFile *         builder_context_get_base_dir (BuilderContext *self);
 void            builder_context_set_base_dir (BuilderContext *self,
                                               GFile          *base_dir);
 GFile *         builder_context_get_state_dir (BuilderContext *self);
+GFile *         builder_context_get_user_state_dir (BuilderContext *self);
 GFile *         builder_context_get_cache_dir (BuilderContext *self);
 GFile *         builder_context_get_build_dir (BuilderContext *self);
 GFile *         builder_context_allocate_build_subdir (BuilderContext *self,

--- a/builder/builder-git.c
+++ b/builder/builder-git.c
@@ -57,7 +57,7 @@ git_get_mirror_dir (const char     *url_or_path,
   g_autofree char *filename = NULL;
   g_autofree char *git_dir_path = NULL;
 
-  git_dir = g_file_get_child (builder_context_get_state_dir (context),
+  git_dir = g_file_get_child (builder_context_get_user_state_dir (context),
                               "git");
 
   git_dir_path = g_file_get_path (git_dir);

--- a/builder/builder-source-bzr.c
+++ b/builder/builder-source-bzr.c
@@ -137,7 +137,7 @@ get_mirror_dir (BuilderSourceBzr *self, BuilderContext *context)
   g_autofree char *filename = NULL;
   g_autofree char *bzr_dir_path = NULL;
 
-  bzr_dir = g_file_get_child (builder_context_get_state_dir (context),
+  bzr_dir = g_file_get_child (builder_context_get_user_state_dir (context),
                               "bzr");
 
   bzr_dir_path = g_file_get_path (bzr_dir);


### PR DESCRIPTION
When building multiple apps each from their own folders, we get a `.flatpak-builder/` directory in each of those.

Some of the stuff in there can be shared, like all the downloaded sources. This branch moves these to `${XDG_CACHE_HOME}/flatpak-builder/`.

I'm not sure about the other things in the `.flatpak-builder/` state dir, though:

* `build/` seems inherently tied to the application/sdk being built (race-conditions between two apps trying to build the same module in `foo-N/` at the same time?)
* `cache/` could be shared I guess, since it's already effectively shared between all the apps being built from the same folder (e.g in gnome-apps-nightly), but I don't know OSTree enough to know whether that might be problematic
* could `ccache/` be shared? I don't see it causing any problem, but maybe I'm missing something
* if I understood `checksums/` correctly then it should remain in the build-specific state dir, as it allows a run of `flatpak-builder` to know whether the manifest has changed since the last run
* I know nothing of `rofiles/` so I didn't touch it

In any case, even just sharing the tarballs, git and hg clones can be interesting, to avoid downloading the same sources again and again when building multiple apps requiring the same deps.