### PR TITLE
Automatically use a separate builddir with Meson

### DIFF
--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -1401,7 +1401,7 @@ builder_module_build (BuilderModule  *self,
         }
 
       var_require_builddir = strstr (configure_content, "buildapi-variable-require-builddir") != NULL;
-      use_builddir = var_require_builddir || self->builddir;
+      use_builddir = var_require_builddir || self->builddir || meson;
 
       if (use_builddir)
         {


### PR DESCRIPTION
Meson does not support builddir == srcdir, so there is no reason to
require developers to set "builddir" to true in their manifests, when we
can just do the right thing.