### PR TITLE
Remove cache directory when install runs out of disk

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2453,6 +2453,7 @@ flatpak_dir_pull (FlatpakDir          *self,
   g_auto(GLnxConsoleRef) console = { 0, };
   g_autoptr(OstreeAsyncProgress) console_progress = NULL;
   g_autoptr(GPtrArray) subdirs_arg = NULL;
+  g_autoptr(GError) my_error = NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -2526,9 +2527,16 @@ flatpak_dir_pull (FlatpakDir          *self,
                           subdirs_arg ? (const char **)subdirs_arg->pdata : NULL,
                           ref, rev, flatpak_flags, flags,
                           progress,
-                          cancellable, error))
+                          cancellable, &my_error))
     {
+
+      /* Ensure that cache directory gets cleaned on OOD */
+      if (g_error_matches (my_error, G_IO_ERROR, G_FILE_ERROR_NOSPC))
+        flatpak_rm_rf (ostree_repo_get_path (repo), cancellable, NULL);
+
+      g_propagate_error (error, g_steal_pointer (&my_error));
       g_prefix_error (error, _("While pulling %s from remote %s: "), ref, repository);
+
       goto out;
     }
 
@@ -2656,6 +2664,7 @@ flatpak_dir_pull_untrusted_local (FlatpakDir          *self,
   g_autoptr(GVariant) extra_data_sources = NULL;
   g_autoptr(GPtrArray) subdirs_arg = NULL;
   gboolean ret = FALSE;
+  g_autoptr(GError) my_error = NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -2755,9 +2764,16 @@ flatpak_dir_pull_untrusted_local (FlatpakDir          *self,
   if (!repo_pull_one_untrusted (self->repo, remote_name, url,
                                 subdirs_arg ? (const char **)subdirs_arg->pdata : NULL,
                                 ref, checksum, progress,
-                                cancellable, error))
+                                cancellable, &my_error))
     {
+
+      /* Ensure that cache directory gets cleaned on OOD */
+      if (g_error_matches (my_error, G_IO_ERROR, G_FILE_ERROR_NOSPC))
+        flatpak_rm_rf (ostree_repo_get_path (self->repo), cancellable, NULL);
+
+      g_propagate_error (error, g_steal_pointer (&my_error));
       g_prefix_error (error, _("While pulling %s from remote %s: "), ref, remote_name);
+
       goto out;
     }
 
@@ -4995,6 +5011,7 @@ flatpak_dir_install (FlatpakDir          *self,
       gboolean gpg_verify_summary;
       gboolean gpg_verify;
       gboolean is_oci;
+      g_autoptr(GError) my_error = NULL;
 
       system_helper = flatpak_dir_get_system_helper (self);
       g_assert (system_helper != NULL);
@@ -5088,8 +5105,17 @@ flatpak_dir_install (FlatpakDir          *self,
                                                    (const char * const *) subpaths,
                                                    installation ? installation : "",
                                                    cancellable,
-                                                   error))
+                                                   &my_error)) {
+
+        /* Ensure that we clean cache directory on OOD */
+        if (g_error_matches (my_error, G_IO_ERROR, G_FILE_ERROR_NOSPC))
+          (void) glnx_shutil_rm_rf_at (AT_FDCWD, child_repo_path, NULL, NULL);
+
+        g_propagate_error (error, g_steal_pointer (&my_error));
+
         return FALSE;
+      }
+
 
       if (child_repo_path)
         (void) glnx_shutil_rm_rf_at (AT_FDCWD, child_repo_path, NULL, NULL);


### PR DESCRIPTION
When any of the pull or deploy processes during a flatpak install
hits a ENOSPC situation, the created temporary files at
~/.local/share/flatpak/system-cache were not deleted leaving
the disk full.

https://github.com/flatpak/flatpak/issues/528