### PR TITLE
flatpak-dir: Check for variant containing string correctly

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7350,7 +7350,7 @@ flatpak_dir_update_remote_configuration (FlatpakDir   *self,
               g_ptr_array_add (updated_params, g_steal_pointer (&gpg_data_checksum));
             }
           else if (g_strv_contains (supported_params, key) &&
-                   g_variant_get_type_string (value_var))
+                   g_variant_is_of_type (value_var, G_VARIANT_TYPE_STRING))
             {
               const char *value = g_variant_get_string(value_var, NULL);
               if (value != NULL && *value != 0)


### PR DESCRIPTION
g_variant_get_type_string() is like g_dbus_message_get_signature(),
not like G_VALUE_HOLDS_STRING(). Use g_variant_is_of_type() to get
the equivalent of G_VALUE_HOLDS_STRING(). This was correct on master,
but went wrong during backporting to 0.8.x.