### PR TITLE
testlibrary: Call g_assert_no_error first

### DIFF
--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -47,8 +47,8 @@ test_user_installation (void)
   g_autofree char *expected_path = NULL;
 
   inst = flatpak_installation_new_user (NULL, &error);
-  g_assert_nonnull (inst);
   g_assert_no_error (error);
+  g_assert_nonnull (inst);
 
   g_assert_true (flatpak_installation_get_is_user (inst));
 
@@ -67,8 +67,8 @@ test_system_installation (void)
   g_autofree char *path = NULL;
 
   inst = flatpak_installation_new_system (NULL, &error);
-  g_assert_nonnull (inst);
   g_assert_no_error (error);
+  g_assert_nonnull (inst);
 
   g_assert_false (flatpak_installation_get_is_user (inst));
 
@@ -99,8 +99,8 @@ test_multiple_system_installations (void)
   int i;
 
   system_dirs = flatpak_get_system_installations (NULL, &error);
-  g_assert_nonnull (system_dirs);
   g_assert_no_error (error);
+  g_assert_nonnull (system_dirs);
   g_assert_cmpint (system_dirs->len, ==, 4);
 
   for (i = 0; i < system_dirs->len; i++)
@@ -196,8 +196,8 @@ test_ref (void)
 
   valid = "app/org.flatpak.Hello/x86_64/master";
   ref = flatpak_ref_parse (valid, &error);
-  g_assert (FLATPAK_IS_REF (ref));
   g_assert_no_error (error);
+  g_assert (FLATPAK_IS_REF (ref));
   g_assert_cmpint (flatpak_ref_get_kind (ref), ==, FLATPAK_REF_KIND_APP);
   g_assert_cmpstr (flatpak_ref_get_name (ref), ==, "org.flatpak.Hello");
   g_assert_cmpstr (flatpak_ref_get_arch (ref), ==, "x86_64");
@@ -368,9 +368,9 @@ test_install_launch_uninstall (void)
   g_assert_no_error (error);
 
   monitor = flatpak_installation_create_monitor (inst, NULL, &error);
-  g_file_monitor_set_rate_limit (monitor, 100);
-  g_assert (G_IS_FILE_MONITOR (monitor));
   g_assert_no_error (error);
+  g_assert (G_IS_FILE_MONITOR (monitor));
+  g_file_monitor_set_rate_limit (monitor, 100);
 
   loop = g_main_loop_new (NULL, TRUE);
 


### PR DESCRIPTION
Failing tests produce much clearer diagnostics this way round.