### PR TITLE
dir: Ensure we return on pull error to avoid error-overwrites

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1798,7 +1798,6 @@ repo_pull_one_dir (OstreeRepo          *self,
   g_autoptr(GVariant) new_commit = NULL;
   const char *refs_to_fetch[2];
   const char *revs_to_fetch[2];
-  gboolean res;
   guint32 update_freq = 0;
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
@@ -1847,8 +1846,9 @@ repo_pull_one_dir (OstreeRepo          *self,
       !ostree_repo_load_commit (self, current_checksum, &old_commit, NULL, error))
     return FALSE;
 
-  res = ostree_repo_pull_with_options (self, remote_name, options,
-                                       progress, cancellable, error);
+  if (!ostree_repo_pull_with_options (self, remote_name, options,
+                                      progress, cancellable, error))
+    return FALSE;
 
   if (old_commit &&
       (flatpak_flags & FLATPAK_PULL_FLAGS_ALLOW_DOWNGRADE) == 0)
@@ -1866,7 +1866,7 @@ repo_pull_one_dir (OstreeRepo          *self,
         return flatpak_fail (error, "Update is older then current version");
     }
 
-  return res;
+  return TRUE;
 }
 
 static void


### PR DESCRIPTION
Looking at the git history, this code originally retried on
some cases for pull, then stopped doing so, then a later commit
added code after it, which made it incorrect.

Just do an early return again and drop the `res` variable.