### PR TITLE
[0.8.x] Compatibility with libostree 2017.7

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -61,12 +61,14 @@ static OstreeRepo * flatpak_dir_create_system_child_repo (FlatpakDir   *self,
 static gboolean flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
                                                   const char   *name,
                                                   GBytes      **out_summary,
+                                                  GBytes      **out_summary_sig,
                                                   GCancellable *cancellable,
                                                   GError      **error);
 
 typedef struct
 {
   GBytes *bytes;
+  GBytes *bytes_sig;
   char *remote;
   char *url;
   guint64 time;
@@ -2250,7 +2252,7 @@ flatpak_dir_pull (FlatpakDir          *self,
       g_autoptr(GVariant) summary = NULL;
 
       if (!flatpak_dir_remote_fetch_summary (self, repository,
-                                             &summary_bytes,
+                                             &summary_bytes, NULL,
                                              cancellable, error))
         return FALSE;
 
@@ -4869,7 +4871,7 @@ flatpak_dir_update (FlatpakDir          *self,
             }
         }
       else if (flatpak_dir_remote_fetch_summary (self, remote_name,
-                                                 &summary_bytes,
+                                                 &summary_bytes, NULL,
                                                  cancellable, NULL))
         {
           g_autoptr(GVariant) summary =
@@ -5716,6 +5718,8 @@ static void
 cached_summary_free (CachedSummary *summary)
 {
   g_bytes_unref (summary->bytes);
+  if (summary->bytes_sig)
+    g_bytes_unref (summary->bytes_sig);
   g_free (summary->remote);
   g_free (summary->url);
   g_free (summary);
@@ -5723,24 +5727,29 @@ cached_summary_free (CachedSummary *summary)
 
 static CachedSummary *
 cached_summary_new (GBytes *bytes,
+                    GBytes *bytes_sig,
                     const char *remote,
                     const char *url)
 {
   CachedSummary *summary = g_new0 (CachedSummary, 1);
   summary->bytes = g_bytes_ref (bytes);
+  if (bytes_sig)
+    summary->bytes_sig = g_bytes_ref (bytes_sig);
   summary->url = g_strdup (url);
   summary->remote = g_strdup (remote);
   summary->time = g_get_monotonic_time ();
   return summary;
 }
 
-static GBytes *
+static gboolean
 flatpak_dir_lookup_cached_summary (FlatpakDir  *self,
+                                   GBytes **bytes_out,
+                                   GBytes **bytes_sig_out,
                                    const char  *name,
                                    const char  *url)
 {
   CachedSummary *summary;
-  GBytes *res = NULL;
+  gboolean res = FALSE;
 
   G_LOCK (cache);
 
@@ -5755,7 +5764,15 @@ flatpak_dir_lookup_cached_summary (FlatpakDir  *self,
           strcmp (url, summary->url) == 0)
         {
           g_debug ("Using cached summary for remote %s", name);
-          res = g_bytes_ref (summary->bytes);
+          *bytes_out = g_bytes_ref (summary->bytes);
+          if (bytes_sig_out)
+            {
+              if (summary->bytes_sig)
+                *bytes_sig_out = g_bytes_ref (summary->bytes_sig);
+              else
+                *bytes_sig_out = NULL;
+            }
+          res = TRUE;
         }
     }
 
@@ -5767,6 +5784,7 @@ flatpak_dir_lookup_cached_summary (FlatpakDir  *self,
 static void
 flatpak_dir_cache_summary (FlatpakDir  *self,
                            GBytes      *bytes,
+                           GBytes      *bytes_sig,
                            const char  *name,
                            const char  *url)
 {
@@ -5781,7 +5799,7 @@ flatpak_dir_cache_summary (FlatpakDir  *self,
   /* This was already initialized in the cache-miss lookup */
   g_assert (self->summary_cache != NULL);
 
-  summary = cached_summary_new (bytes, name, url);
+  summary = cached_summary_new (bytes, bytes_sig, name, url);
   g_hash_table_replace (self->summary_cache, summary->remote, summary);
 
   G_UNLOCK (cache);
@@ -5886,6 +5904,7 @@ static gboolean
 flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
                                   const char   *name,
                                   GBytes      **out_summary,
+                                  GBytes      **out_summary_sig,
                                   GCancellable *cancellable,
                                   GError      **error)
 {
@@ -5893,7 +5912,8 @@ flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
   gboolean is_local;
   g_autoptr(GError) local_error = NULL;
   g_autofree char *oci_uri = NULL;
-  GBytes *summary;
+  g_autoptr(GBytes) summary = NULL;
+  g_autoptr(GBytes) summary_sig = NULL;
 
   if (!ostree_repo_remote_get_url (self->repo, name, &url, error))
     return FALSE;
@@ -5903,12 +5923,8 @@ flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
   /* No caching for local files */
   if (!is_local)
     {
-      GBytes *cached_summary = flatpak_dir_lookup_cached_summary (self, name, url);
-      if (cached_summary)
-        {
-          *out_summary = cached_summary;
-          return TRUE;
-        }
+      if (flatpak_dir_lookup_cached_summary (self, out_summary, out_summary_sig, name, url))
+        return TRUE;
     }
 
   /* Seems ostree asserts if this is NULL */
@@ -5928,7 +5944,7 @@ flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
   else
     {
       if (!ostree_repo_remote_fetch_summary (self->repo, name,
-                                             &summary, NULL,
+                                             &summary, &summary_sig,
                                              cancellable,
                                              error))
         return FALSE;
@@ -5939,9 +5955,11 @@ flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
                          "Check the URL passed to remote-add was valid\n", name);
 
   if (!is_local)
-    flatpak_dir_cache_summary (self, summary, name, url);
+    flatpak_dir_cache_summary (self, summary, summary_sig, name, url);
 
-  *out_summary = summary;
+  *out_summary = g_steal_pointer (&summary);
+  if (out_summary_sig)
+    *out_summary_sig = g_steal_pointer (&summary_sig);
 
   return TRUE;
 }
@@ -5956,7 +5974,7 @@ flatpak_dir_remote_has_ref (FlatpakDir   *self,
   g_autoptr(GError) local_error = NULL;
 
   if (!flatpak_dir_remote_fetch_summary (self, remote,
-                                         &summary_bytes,
+                                         &summary_bytes, NULL,
                                          NULL, &local_error))
     {
       g_debug ("Can't get summary for remote %s: %s\n", remote, local_error->message);
@@ -5986,7 +6004,7 @@ flatpak_dir_remote_list_refs (FlatpakDir       *self,
   GVariant *child;
 
   if (!flatpak_dir_remote_fetch_summary (self, remote_name,
-                                         &summary_bytes,
+                                         &summary_bytes, NULL,
                                          cancellable, error))
     return FALSE;
 
@@ -7362,7 +7380,7 @@ fetch_remote_summary_file (FlatpakDir   *self,
     return NULL;
 
   if (!flatpak_dir_remote_fetch_summary (self, remote,
-                                         &summary_bytes,
+                                         &summary_bytes, NULL,
                                          cancellable, error))
     return NULL;
 
@@ -7633,7 +7651,7 @@ flatpak_dir_fetch_ref_cache (FlatpakDir   *self,
     return FALSE;
 
   if (!flatpak_dir_remote_fetch_summary (self, remote_name,
-                                         &summary_bytes,
+                                         &summary_bytes, NULL,
                                          cancellable, error))
     return FALSE;
 
@@ -7776,7 +7794,7 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
     return g_steal_pointer (&related);  /* Empty url, silently disables updates */
 
   if (!flatpak_dir_remote_fetch_summary (self, remote_name,
-                                         &summary_bytes,
+                                         &summary_bytes, NULL,
                                          cancellable, error))
     return NULL;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4509,9 +4509,18 @@ flatpak_dir_install (FlatpakDir          *self,
           /* We're pulling from a remote source, we do the network mirroring pull as a
              user and hand back the resulting data to the system-helper, that trusts us
              due to the GPG signatures in the repo */
+          g_autoptr(GBytes) summary_copy = NULL;
+          g_autoptr(GBytes) summary_sig_copy = NULL;
+          g_autoptr(GFile) summary_file = NULL;
+          g_autoptr(GFile) summary_sig_file = NULL;
 
           child_repo = flatpak_dir_create_system_child_repo (self, &child_repo_lock, error);
           if (child_repo == NULL)
+            return FALSE;
+
+          if (!flatpak_dir_remote_fetch_summary (self, remote_name,
+                                                 &summary_copy, &summary_sig_copy,
+                                                 cancellable, error))
             return FALSE;
 
           if (!flatpak_dir_pull (self, remote_name, ref, NULL, subpaths,
@@ -4519,6 +4528,20 @@ flatpak_dir_install (FlatpakDir          *self,
                                  FLATPAK_PULL_FLAGS_DOWNLOAD_EXTRA_DATA | FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA,
                                  OSTREE_REPO_PULL_FLAGS_MIRROR,
                                  progress, cancellable, error))
+            return FALSE;
+
+          summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
+          if (!g_file_replace_contents (summary_file,
+                                        g_bytes_get_data (summary_copy, NULL),
+                                        g_bytes_get_size (summary_copy),
+                                        NULL, FALSE, 0, NULL, cancellable, NULL))
+            return FALSE;
+
+          summary_sig_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary.sig");
+          if (!g_file_replace_contents (summary_sig_file,
+                                        g_bytes_get_data (summary_sig_copy, NULL),
+                                        g_bytes_get_size (summary_sig_copy),
+                                        NULL, FALSE, 0, NULL, cancellable, NULL))
             return FALSE;
 
           child_repo_path = g_file_get_path (ostree_repo_get_path (child_repo));

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -138,6 +138,14 @@ assert_not_file_has_content () {
     fi
 }
 
+assert_file_has_mode () {
+    mode=$(stat -c '%a' $1)
+    if [ "$mode" != "$2" ]; then
+        echo 1>&2 "File '$1' has wrong mode: expected $2, but got $mode"
+        exit 1
+    fi
+}
+
 assert_not_has_dir () {
     if test -d "$1"; then
 	echo 1>&2 "Directory '$1' exists"; exit 1

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -358,14 +358,15 @@ rm -rf app
 flatpak build-init app org.test.Setuid org.test.Platform org.test.Platform
 mkdir -p app/files/
 touch app/files/exe
-chmod u+s app/files/exe
+chmod 04644 app/files/exe
 flatpak build-finish --command=hello.sh app
 ostree --repo=repos/test commit  ${FL_GPGARGS} --branch=app/org.test.Setuid/$ARCH/master app
 update_repo
 
 if ${FLATPAK} ${U} install test-repo org.test.Setuid &> err2.txt; then
-    assert_not_reached "Should not be able to install with setuid file"
+    assert_file_has_mode "$FL_DIR/app/org.test.Setuid/$ARCH/master/active/files/exe" 644
+else
+    assert_file_has_content err2.txt [Ii]nvalid
 fi
-assert_file_has_content err2.txt [Ii]nvalid
 
 echo "ok no setuid"


### PR DESCRIPTION
I'm not sure whether this is appropriate to merge into a stable-branch, but I'm going to need it as distro patches for as long as I'm shipping flatpak 0.8.x in Debian unstable, so I'd appreciate review even if you subsequently reject the PR.

This branch backports commits from master to fix the incompatibility with libostree 2017.7 discussed in <https://lists.freedesktop.org/archives/flatpak/2017-June/000723.html>.

It also makes the test for avoiding setuid files a little more tolerant: with libostree 2017.7, the setuid file gets its setuid permission masked out before Flatpak's check even sees it, so instead of asserting that the app fails to install, we have to assert that either the app fails to install or the setuid file loses its setuid bit. See the commit message for further details.