### PR TITLE
docs: Remove --version from flatpak-build docs

### DIFF
--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -79,14 +79,6 @@
             </varlistentry>
 
             <varlistentry>
-                <term><option>--version</option></term>
-
-                <listitem><para>
-                    Print version information and exit.
-                </para></listitem>
-            </varlistentry>
-
-            <varlistentry>
                 <term><option>-r</option></term>
                 <term><option>--runtime</option></term>
 


### PR DESCRIPTION
This is not an option in flatpak-build; `flatpak build --version` prints
an unknown option error message.