### PR TITLE
builder: Use build-args during cleanup

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -89,6 +89,7 @@ dist_installed_test_data = \
 	tests/org.test.Hello.png \
 	tests/package_version.txt \
 	tests/test.json \
+	tests/test-runtime.json \
 	tests/module1.json \
 	tests/data1 \
 	tests/data1.patch \

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_without_user_xattrs
 
-echo "1..3"
+echo "1..4"
 
 setup_repo
 install_repo
@@ -38,6 +38,7 @@ cd $TEST_DATA_DIR/
 cp -a $(dirname $0)/test-configure .
 echo "version1" > app-data
 cp $(dirname $0)/test.json .
+cp $(dirname $0)/test-runtime.json .
 cp $(dirname $0)/0001-Add-test-logo.patch .
 mkdir include1
 cp $(dirname $0)/module1.json include1/
@@ -88,3 +89,10 @@ run --command=cat org.test.Hello2 /app/share/app-data > app_data_2
 assert_file_has_content app_data_2 version2
 
 echo "ok update"
+
+# The build-args of --help should prevent the faulty cleanup and
+# platform-cleanup commands from executing
+${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean runtimedir \
+    test-runtime.json
+
+echo "ok runtime build cleanup with build-args"

--- a/tests/test-runtime.json
+++ b/tests/test-runtime.json
@@ -1,0 +1,19 @@
+{
+    "build-runtime": true,
+    "id": "org.test.Hello.Sdk",
+    "id-platform": "org.test.Hello.Platform",
+    "runtime": "org.test.Platform",
+    "sdk": "org.test.Sdk",
+    "tags": ["test"],
+    "cleanup-commands": [ "fdghksdfjhsdfkg" ],
+    "cleanup-platform-commands": [ "sdjfgkafyewgdbvhsail" ],
+    "build-options": {
+        "build-args": ["--help"]
+    },
+
+    "modules": [
+        {
+            "name": "empty"
+        }
+    ]
+}


### PR DESCRIPTION
Any build-args specified in the manifest should be used during the
cleanup and platform-cleanup stages. This is because if you are using
QEMU to build for another architecture, for example, you need to pass
--bind-mount in the build-args, and the bind mount also needs to be
present while running cleanup commands.