### PR TITLE
Peer to peer and unsigned summary file support

### DIFF
--- a/app/flatpak-builtins-add-remote.c
+++ b/app/flatpak-builtins-add-remote.c
@@ -118,6 +118,7 @@ get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *change
   if (opt_collection_id)
     {
       g_key_file_set_string (config, group, "collection-id", opt_collection_id);
+      g_key_file_set_boolean (config, group, "gpg-verify-summary", FALSE);
       *changed = TRUE;
     }
 

--- a/app/flatpak-builtins-add-remote.c
+++ b/app/flatpak-builtins-add-remote.c
@@ -330,6 +330,10 @@ flatpak_builtin_add_remote (int argc, char **argv,
   if (opt_collection_id != NULL &&
       !ostree_validate_collection_id (opt_collection_id, &local_error))
     return flatpak_fail (error, _("‘%s’ is not a valid collection ID: %s"), opt_collection_id, local_error->message);
+
+  if (opt_collection_id != NULL &&
+      (opt_no_gpg_verify || opt_gpg_import == NULL || opt_gpg_import[0] == NULL))
+    return flatpak_fail (error, _("GPG verification is required if collections are enabled"));
 #endif  /* FLATPAK_ENABLE_P2P */
 
   remote_name = argv[1];

--- a/app/flatpak-builtins-build-bundle.c
+++ b/app/flatpak-builtins-build-bundle.c
@@ -126,6 +126,7 @@ build_bundle (OstreeRepo *repo, GFile *file,
   g_autoptr(GBytes) gpg_data = NULL;
   g_autoptr(GVariant) params = NULL;
   g_autoptr(GVariant) metadata = NULL;
+  const char *collection_id;
 
   if (!ostree_repo_resolve_rev (repo, full_branch, FALSE, &commit_checksum, error))
     return FALSE;
@@ -230,6 +231,14 @@ build_bundle (OstreeRepo *repo, GFile *file,
 
   if (opt_runtime_repo)
     g_variant_builder_add (&metadata_builder, "{sv}", "runtime-repo", g_variant_new_string (opt_runtime_repo));
+
+#ifdef FLATPAK_ENABLE_P2P
+  collection_id = ostree_repo_get_collection_id (repo);
+#else  /* if !FLATPAK_ENABLE_P2P */
+  collection_id = NULL;
+#endif  /* !FLATPAK_ENABLE_P2P */
+  g_variant_builder_add (&metadata_builder, "{sv}", "collection-id",
+                         g_variant_new_string (collection_id ? collection_id : ""));
 
   if (opt_gpg_file != NULL)
     {

--- a/app/flatpak-builtins-build-import-bundle.c
+++ b/app/flatpak-builtins-build-import-bundle.c
@@ -134,10 +134,12 @@ import_bundle (OstreeRepo *repo, GFile *file,
   g_autofree char *to_checksum = NULL;
   const char *ref;
 
+  /* Don’t need to check the collection ID of the bundle here;
+   * flatpak_pull_from_bundle() does that. */
   metadata = flatpak_bundle_load (file, &to_checksum,
                                   &bundle_ref,
                                   NULL, NULL, NULL,
-                                  NULL, NULL, error);
+                                  NULL, NULL, NULL, error);
   if (metadata == NULL)
     return NULL;
 

--- a/app/flatpak-builtins-repo-update.c
+++ b/app/flatpak-builtins-repo-update.c
@@ -36,6 +36,7 @@
 static char *opt_title;
 static char *opt_redirect_url;
 static char *opt_default_branch;
+static char *opt_collection_id = NULL;
 static char **opt_gpg_import;
 static char *opt_generate_delta_from;
 static char *opt_generate_delta_to;
@@ -50,6 +51,9 @@ static GOptionEntry options[] = {
   { "redirect-url", 0, 0, G_OPTION_ARG_STRING, &opt_redirect_url, N_("Redirect this repo to a new URL"), N_("URL") },
   { "title", 0, 0, G_OPTION_ARG_STRING, &opt_title, N_("A nice name to use for this repository"), N_("TITLE") },
   { "default-branch", 0, 0, G_OPTION_ARG_STRING, &opt_default_branch, N_("Default branch to use for this repository"), N_("BRANCH") },
+#ifdef FLATPAK_ENABLE_P2P
+  { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id, N_("Collection ID"), N_("COLLECTION-ID") },
+#endif  /* FLATPAK_ENABLE_P2P */
   { "gpg-import", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_gpg_import, N_("Import new default GPG public key from FILE"), N_("FILE") },
   { "gpg-sign", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_gpg_key_ids, N_("GPG Key ID to sign the summary with"), N_("KEY-ID") },
   { "gpg-homedir", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_homedir, N_("GPG Homedir to use when looking for keyrings"), N_("HOMEDIR") },
@@ -433,6 +437,10 @@ flatpak_builtin_build_update_repo (int argc, char **argv,
 
   if (opt_default_branch &&
       !flatpak_repo_set_default_branch (repo, opt_default_branch[0] ? opt_default_branch : NULL, error))
+    return FALSE;
+
+  if (opt_collection_id &&
+      !flatpak_repo_set_collection_id (repo, opt_collection_id[0] ? opt_collection_id : NULL, error))
     return FALSE;
 
   if (opt_gpg_import)

--- a/app/flatpak-builtins-repo-update.c
+++ b/app/flatpak-builtins-repo-update.c
@@ -37,6 +37,7 @@ static char *opt_title;
 static char *opt_redirect_url;
 static char *opt_default_branch;
 static char *opt_collection_id = NULL;
+static gboolean opt_deploy_collection_id = FALSE;
 static char **opt_gpg_import;
 static char *opt_generate_delta_from;
 static char *opt_generate_delta_to;
@@ -53,6 +54,7 @@ static GOptionEntry options[] = {
   { "default-branch", 0, 0, G_OPTION_ARG_STRING, &opt_default_branch, N_("Default branch to use for this repository"), N_("BRANCH") },
 #ifdef FLATPAK_ENABLE_P2P
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id, N_("Collection ID"), N_("COLLECTION-ID") },
+  { "deploy-collection-id", 0, 0, G_OPTION_ARG_NONE, &opt_deploy_collection_id, N_("Permanently deploy collection ID to client remote configurations"), NULL },
 #endif  /* FLATPAK_ENABLE_P2P */
   { "gpg-import", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_gpg_import, N_("Import new default GPG public key from FILE"), N_("FILE") },
   { "gpg-sign", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_gpg_key_ids, N_("GPG Key ID to sign the summary with"), N_("KEY-ID") },
@@ -441,6 +443,10 @@ flatpak_builtin_build_update_repo (int argc, char **argv,
 
   if (opt_collection_id &&
       !flatpak_repo_set_collection_id (repo, opt_collection_id[0] ? opt_collection_id : NULL, error))
+    return FALSE;
+
+  if (opt_deploy_collection_id &&
+      !flatpak_repo_set_deploy_collection_id (repo, TRUE, error))
     return FALSE;
 
   if (opt_gpg_import)

--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -38,12 +38,16 @@ print_info (GVariant *meta)
 {
   g_autoptr(GVariant) cache = NULL;
   const char *title;
+  const char *collection_id;
   const char *default_branch;
   const char *redirect_url;
   g_autoptr(GVariant) gpg_keys = NULL;
 
   if (g_variant_lookup (meta, "xa.title", "&s", &title))
     g_print ("Title: %s\n", title);
+
+  if (g_variant_lookup (meta, "collection-id", "&s", &collection_id))
+    g_print ("Collection ID: %s\n", collection_id);
 
   if (g_variant_lookup (meta, "xa.default-branch", "&s", &default_branch))
     g_print ("Default branch: %s\n", default_branch);

--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -41,6 +41,7 @@ print_info (GVariant *meta)
   const char *collection_id;
   const char *default_branch;
   const char *redirect_url;
+  const char *redirect_collection_id;
   g_autoptr(GVariant) gpg_keys = NULL;
 
   if (g_variant_lookup (meta, "xa.title", "&s", &title))
@@ -54,6 +55,9 @@ print_info (GVariant *meta)
 
   if (g_variant_lookup (meta, "xa.redirect-url", "&s", &redirect_url))
     g_print ("Redirect URL: %s\n", redirect_url);
+
+  if (g_variant_lookup (meta, "xa.collection-id", "&s", &redirect_collection_id))
+    g_print ("Redirect collection ID: %s\n", redirect_collection_id);
 
   if ((gpg_keys = g_variant_lookup_value (meta, "xa.gpg-keys", G_VARIANT_TYPE_BYTESTRING)) != NULL)
     {

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -715,10 +715,13 @@ flatpak_transaction_run (FlatpakTransaction *self,
         }
       else if (kind == FLATPAK_TRANSACTION_OP_KIND_UPDATE)
         {
+          g_auto(OstreeRepoFinderResultv) check_results = NULL;
+
           opname = _("update");
           g_autofree char *target_commit = flatpak_dir_check_for_update (self->dir, op->ref, op->remote, op->commit,
                                                                          (const char **)op->subpaths,
                                                                          self->no_pull,
+                                                                         &check_results,
                                                                          cancellable, &local_error);
           if (target_commit != NULL)
             {
@@ -730,6 +733,7 @@ flatpak_transaction_run (FlatpakTransaction *self,
                                         self->no_static_deltas,
                                         op->commit != NULL, /* Allow downgrade if we specify commit */
                                         op->ref, op->remote, target_commit,
+                                        (const OstreeRepoFinderResult * const *) check_results,
                                         (const char **)op->subpaths,
                                         progress,
                                         cancellable, &local_error);

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -57,6 +57,7 @@ struct BuilderManifest
   char           *id;
   char           *id_platform;
   char           *branch;
+  char           *collection_id;
   char           *type;
   char           *runtime;
   char           *runtime_commit;
@@ -147,6 +148,7 @@ enum {
   PROP_COPY_ICON,
   PROP_DESKTOP_FILE_NAME_PREFIX,
   PROP_DESKTOP_FILE_NAME_SUFFIX,
+  PROP_COLLECTION_ID,
   LAST_PROP
 };
 
@@ -157,6 +159,7 @@ builder_manifest_finalize (GObject *object)
 
   g_free (self->id);
   g_free (self->branch);
+  g_free (self->collection_id);
   g_free (self->runtime);
   g_free (self->runtime_commit);
   g_free (self->runtime_version);
@@ -399,6 +402,10 @@ builder_manifest_get_property (GObject    *object,
       g_value_set_string (value, self->desktop_file_name_suffix);
       break;
 
+    case PROP_COLLECTION_ID:
+      g_value_set_string (value, self->collection_id);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -612,6 +619,11 @@ builder_manifest_set_property (GObject      *object,
     case PROP_DESKTOP_FILE_NAME_SUFFIX:
       g_free (self->desktop_file_name_suffix);
       self->desktop_file_name_suffix = g_value_dup_string (value);
+      break;
+
+    case PROP_COLLECTION_ID:
+      g_free (self->collection_id);
+      self->collection_id = g_value_dup_string (value);
       break;
 
     default:
@@ -900,6 +912,13 @@ builder_manifest_class_init (BuilderManifestClass *klass)
                                                         "",
                                                         NULL,
                                                         G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_COLLECTION_ID,
+                                   g_param_spec_string ("collection-id",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
 }
 
 static void
@@ -1124,6 +1143,20 @@ builder_manifest_set_default_branch (BuilderManifest *self,
 {
   if (self->branch == NULL)
     self->branch = g_strdup (default_branch);
+}
+
+const char *
+builder_manifest_get_collection_id (BuilderManifest *self)
+{
+  return self->collection_id;
+}
+
+void
+builder_manifest_set_default_collection_id (BuilderManifest *self,
+                                            const char      *default_collection_id)
+{
+  if (self->collection_id == NULL)
+    self->collection_id = g_strdup (default_collection_id);
 }
 
 static const char *

--- a/builder/builder-manifest.h
+++ b/builder/builder-manifest.h
@@ -59,6 +59,9 @@ GList *         builder_manifest_get_modules (BuilderManifest *self);
 const char *    builder_manifest_get_branch (BuilderManifest *self);
 void            builder_manifest_set_default_branch (BuilderManifest *self,
                                                      const char *default_branch);
+const char *    builder_manifest_get_collection_id (BuilderManifest *self);
+void            builder_manifest_set_default_collection_id (BuilderManifest *self,
+                                                            const char      *default_collection_id);
 
 gboolean        builder_manifest_start (BuilderManifest *self,
                                         gboolean         allow_missing_runtimes,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5934,8 +5934,8 @@ flatpak_dir_check_for_update (FlatpakDir          *self,
       return NULL;
     }
 
-  if (!repo_get_remote_collection_id (self->repo, remote_name, &collection_id, NULL))
-    g_clear_pointer (&collection_id, g_free);
+  if (!repo_get_remote_collection_id (self->repo, remote_name, &collection_id, error))
+    return NULL;
 
   if (no_pull)
     {
@@ -6099,8 +6099,8 @@ flatpak_dir_update (FlatpakDir          *self,
                                                       &gpg_verify_summary, error))
         return FALSE;
 
-      if (!repo_get_remote_collection_id (self->repo, remote_name, &collection_id, NULL))
-        collection_id = NULL;
+      if (!repo_get_remote_collection_id (self->repo, remote_name, &collection_id, error))
+        return FALSE;
 
       if (!ostree_repo_remote_get_gpg_verify (self->repo, remote_name,
                                               &gpg_verify, error))

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5479,6 +5479,10 @@ flatpak_dir_install (FlatpakDir          *self,
 
           /* Don’t resolve a rev or OstreeRepoFinderResult set early; the pull
            * code will do this. */
+          /* FIXME: Ideally we could merge these two flatpak_dir_pull() calls
+           * so @ref and  %OSTREE_REPO_METADATA_REF are resolved atomically.
+           * However, pulling them separately is no worse than the old code path
+           * where the summary and ref were pulled separately. */
           if (!flatpak_dir_pull (self, remote_name, ref, NULL, NULL, subpaths,
                                  child_repo,
                                  flatpak_flags,
@@ -6079,6 +6083,10 @@ flatpak_dir_update (FlatpakDir          *self,
                                                  cancellable, error))
             return FALSE;
 
+          /* FIXME: Ideally we could merge these two flatpak_dir_pull() calls
+           * so @ref and  %OSTREE_REPO_METADATA_REF are resolved atomically.
+           * However, pulling them separately is no worse than the old code path
+           * where the summary and ref were pulled separately. */
           flatpak_flags |= FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA;
           if (!flatpak_dir_pull (self, remote_name, ref, commit, results, subpaths,
                                  child_repo,
@@ -6812,6 +6820,7 @@ flatpak_dir_get_unmaintained_extension_dir_if_exists (FlatpakDir *self,
 
 G_LOCK_DEFINE_STATIC (cache);
 
+/* FIXME: Move all this caching into libostree. */
 static void
 cached_summary_free (CachedSummary *summary)
 {
@@ -7154,6 +7163,8 @@ flatpak_dir_remote_has_ref (FlatpakDir   *self,
 
 /* This duplicates ostree_repo_list_refs so it can use flatpak_dir_remote_fetch_summary
    and get caching */
+/* FIXME: For command line completion support for collection–refs over P2P,
+ * we need a version of ostree_repo_list_collection_refs(). */
 static gboolean
 flatpak_dir_remote_list_refs (FlatpakDir       *self,
                               const char       *remote_name,
@@ -7356,6 +7367,8 @@ find_matching_ref (GHashTable *refs,
   return NULL;
 }
 
+/* FIXME: For command line completion support for collection–refs over P2P,
+ * we need a version which works with collections. */
 char **
 flatpak_dir_find_remote_refs (FlatpakDir   *self,
                              const char   *remote,
@@ -7385,6 +7398,8 @@ flatpak_dir_find_remote_refs (FlatpakDir   *self,
   return (char **)g_ptr_array_free (matched_refs, FALSE);
 }
 
+/* FIXME: For command line completion support for collection–refs over P2P,
+ * we need a version which works with collections. */
 char *
 flatpak_dir_find_remote_ref (FlatpakDir   *self,
                              const char   *remote,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7775,6 +7775,19 @@ get_group (const char *remote_name)
 }
 
 char *
+flatpak_dir_get_remote_collection_id (FlatpakDir *self,
+                                      const char *remote_name)
+{
+  GKeyFile *config = ostree_repo_get_config (self->repo);
+  g_autofree char *group = get_group (remote_name);
+
+  if (config)
+    return g_key_file_get_string (config, group, "collection-id", NULL);
+
+  return NULL;
+}
+
+char *
 flatpak_dir_get_remote_title (FlatpakDir *self,
                               const char *remote_name)
 {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9138,15 +9138,15 @@ flatpak_dir_update_remote_configuration (FlatpakDir   *self,
     return flatpak_dir_update_remote_configuration_for_repo_metadata (self, remote, summary, FALSE, NULL, cancellable, error);
 }
 
-static gboolean
-flatpak_dir_parse_repo_metadata_for_ref (FlatpakDir    *self,
-                                         const char    *remote_name,
-                                         const char    *ref,
-                                         guint64       *download_size,
-                                         guint64       *installed_size,
-                                         char         **metadata,
-                                         GCancellable  *cancellable,
-                                         GError       **error)
+gboolean
+flatpak_dir_fetch_ref_cache (FlatpakDir   *self,
+                             const char   *remote_name,
+                             const char   *ref,
+                             guint64      *download_size,
+                             guint64      *installed_size,
+                             char        **metadata,
+                             GCancellable *cancellable,
+                             GError      **error)
 {
   g_autoptr(GVariant) cache_v = NULL;
   g_autoptr(GVariant) cache = NULL;
@@ -9195,22 +9195,6 @@ flatpak_dir_parse_repo_metadata_for_ref (FlatpakDir    *self,
     g_variant_get_child (res, 2, "s", metadata);
 
   return TRUE;
-}
-
-gboolean
-flatpak_dir_fetch_ref_cache (FlatpakDir   *self,
-                             const char   *remote_name,
-                             const char   *ref,
-                             guint64      *download_size,
-                             guint64      *installed_size,
-                             char        **metadata,
-                             GCancellable *cancellable,
-                             GError      **error)
-{
-  return flatpak_dir_parse_repo_metadata_for_ref (self, remote_name, ref,
-                                                  download_size, installed_size,
-                                                  metadata,
-                                                  cancellable, error);
 }
 
 void
@@ -9354,9 +9338,9 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
   if (summary == NULL)
     return NULL;
 
-  if (flatpak_dir_parse_repo_metadata_for_ref (self, remote_name, ref,
-                                               NULL, NULL, &metadata,
-                                               NULL, NULL) &&
+  if (flatpak_dir_fetch_ref_cache (self, remote_name, ref,
+                                   NULL, NULL, &metadata,
+                                   NULL, NULL) &&
       g_key_file_load_from_data (metakey, metadata, -1, 0, NULL))
     {
       g_auto(GStrv) groups = NULL;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2839,7 +2839,8 @@ flatpak_dir_pull (FlatpakDir          *self,
             rev = g_hash_table_lookup (results[i]->ref_to_checksum, &collection_ref);
 
           if (rev == NULL)
-            return flatpak_fail (error, "No such ref '%s' in remote %s", ref, repository);
+            return flatpak_fail (error, "No such ref (%s, %s) in remote %s or elsewhere",
+                                 collection_ref.collection_id, collection_ref.ref_name, repository);
         }
       else
 #endif  /* FLATPAK_ENABLE_P2P */
@@ -4839,7 +4840,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
 
   if (checksum_or_latest == NULL)
     {
-      g_debug ("No checksum specified, getting tip of %s", ref);
+      g_debug ("No checksum specified, getting tip of %s from origin %s", ref, origin);
 
       resolved_ref = flatpak_dir_read_latest (self, origin, ref, NULL, cancellable, error);
       if (resolved_ref == NULL)
@@ -5980,7 +5981,8 @@ flatpak_dir_check_for_update (FlatpakDir          *self,
 
       if (latest_rev == NULL)
         {
-          flatpak_fail (error, "No such ref '%s' in remote %s", ref, remote_name);
+          flatpak_fail (error, "No such ref (%s, %s) in remote %s or elsewhere",
+                        collection_ref.collection_id, collection_ref.ref_name, remote_name);
           return NULL;
         }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8746,6 +8746,15 @@ flatpak_dir_fetch_remote_repo_metadata (FlatpakDir    *self,
 {
 #ifdef FLATPAK_ENABLE_P2P
   FlatpakPullFlags flatpak_flags;
+  gboolean gpg_verify;
+
+  /* We can only fetch metadata if we’re going to verify it with GPG. */
+  if (!ostree_repo_remote_get_gpg_verify (self->repo, remote_name,
+                                          &gpg_verify, error))
+    return FALSE;
+
+  if (!gpg_verify)
+    return flatpak_fail (error, "Can't pull from untrusted non-gpg verified remote");
 
   flatpak_flags = FLATPAK_PULL_FLAGS_DOWNLOAD_EXTRA_DATA;
   flatpak_flags |= FLATPAK_PULL_FLAGS_NO_STATIC_DELTAS;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1867,11 +1867,14 @@ repo_get_remote_collection_id (OstreeRepo  *repo,
                                GError     **error)
 {
 #ifdef FLATPAK_ENABLE_P2P
-  if (!ostree_repo_get_remote_option (repo, remote_name, "collection-id",
-                                      NULL, collection_id_out, error))
-    return FALSE;
-  if (collection_id_out != NULL && *collection_id_out != NULL && **collection_id_out == '\0')
-    g_clear_pointer (collection_id_out, g_free);
+  if (collection_id_out != NULL)
+    {
+      if (!ostree_repo_get_remote_option (repo, remote_name, "collection-id",
+                                          NULL, collection_id_out, error))
+        return FALSE;
+      if (*collection_id_out != NULL && **collection_id_out == '\0')
+        g_clear_pointer (collection_id_out, g_free);
+    }
 #else  /* if !FLATPAK_ENABLE_P2P */
   if (collection_id_out != NULL)
     *collection_id_out = NULL;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8616,15 +8616,6 @@ flatpak_dir_fetch_remote_default_branch (FlatpakDir   *self,
   return g_steal_pointer (&default_branch);
 }
 
-GVariant *
-flatpak_dir_fetch_remote_summary (FlatpakDir    *self,
-                                  const char    *remote,
-                                  GCancellable  *cancellable,
-                                  GError       **error)
-{
-  return fetch_remote_summary_file (self, remote, NULL, cancellable, error);
-}
-
 gboolean
 flatpak_dir_fetch_remote_repo_metadata (FlatpakDir    *self,
                                         const char    *remote_name,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -47,6 +47,10 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_REF_NAME_KEY "Name"
 #define FLATPAK_REF_BRANCH_KEY "Branch"
 
+#ifdef FLATPAK_ENABLE_P2P
+#define FLATPAK_REF_COLLECTION_ID_KEY "CollectionID"
+#endif  /* FLATPAK_ENABLE_P2P */
+
 #define FLATPAK_REPO_GROUP "Flatpak Repo"
 #define FLATPAK_REPO_VERSION_KEY "Version"
 #define FLATPAK_REPO_URL_KEY "Url"
@@ -54,6 +58,10 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_REPO_DEFAULT_BRANCH_KEY "DefaultBranch"
 #define FLATPAK_REPO_GPGKEY_KEY "GPGKey"
 #define FLATPAK_REPO_NODEPS_KEY "NoDeps"
+
+#ifdef FLATPAK_ENABLE_P2P
+#define FLATPAK_REPO_COLLECTION_ID_KEY "CollectionID"
+#endif  /* FLATPAK_ENABLE_P2P */
 
 #define FLATPAK_DEFAULT_UPDATE_FREQUENCY 100
 #define FLATPAK_CLI_UPDATE_FREQUENCY 300
@@ -486,6 +494,7 @@ char      *flatpak_dir_create_origin_remote (FlatpakDir   *self,
                                              const char   *title,
                                              const char   *main_ref,
                                              GBytes       *gpg_data,
+                                             const char   *collection_id,
                                              GCancellable *cancellable,
                                              GError      **error);
 gboolean   flatpak_dir_create_remote_for_ref_file (FlatpakDir   *self,
@@ -502,7 +511,8 @@ GKeyFile * flatpak_dir_parse_repofile (FlatpakDir   *self,
                                        GError      **error);
 
 char      *flatpak_dir_find_remote_by_uri (FlatpakDir   *self,
-                                           const char   *uri);
+                                           const char   *uri,
+                                           const char   *collection_id);
 char     **flatpak_dir_list_remotes (FlatpakDir   *self,
                                      GCancellable *cancellable,
                                      GError      **error);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -555,6 +555,10 @@ GVariant *flatpak_dir_fetch_remote_summary (FlatpakDir   *self,
                                             const char   *remote,
                                             GCancellable *cancellable,
                                             GError      **error);
+gboolean flatpak_dir_fetch_remote_repo_metadata (FlatpakDir    *self,
+                                                 const char    *remote_name,
+                                                 GCancellable  *cancellable,
+                                                 GError       **error);
 char *   flatpak_dir_fetch_remote_title (FlatpakDir   *self,
                                          const char   *remote,
                                          GCancellable *cancellable,
@@ -574,6 +578,13 @@ gboolean flatpak_dir_update_remote_configuration_for_summary (FlatpakDir   *self
                                                               gboolean     *has_changed_out,
                                                               GCancellable *cancellable,
                                                               GError      **error);
+gboolean flatpak_dir_update_remote_configuration_for_repo_metadata (FlatpakDir    *self,
+                                                                    const char    *remote,
+                                                                    GVariant      *summary,
+                                                                    gboolean       dry_run,
+                                                                    gboolean      *has_changed_out,
+                                                                    GCancellable  *cancellable,
+                                                                    GError       **error);
 gboolean flatpak_dir_fetch_ref_cache (FlatpakDir   *self,
                                       const char   *remote_name,
                                       const char   *ref,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -120,6 +120,17 @@ typedef enum {
 
 GQuark       flatpak_dir_error_quark (void);
 
+#ifndef FLATPAK_ENABLE_P2P
+/* Rather than putting #ifdefs around all the function arguments for result sets,
+ * define away OstreeRepoFinderResult if we’re compiling without P2P support.
+ * The surrounding code should always pass in NULL if P2P support is disabled. */
+typedef void OstreeRepoFinderResult;
+typedef void** OstreeRepoFinderResultv;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderResult, void)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (OstreeRepoFinderResultv, void, NULL)
+#endif  /* !FLATPAK_ENABLE_P2P */
+
 /**
  * FLATPAK_DEPLOY_DATA_GVARIANT_FORMAT:
  *
@@ -292,6 +303,7 @@ gboolean    flatpak_dir_pull (FlatpakDir          *self,
                               const char          *repository,
                               const char          *ref,
                               const char          *opt_rev,
+                              const OstreeRepoFinderResult * const *results,
                               const char         **subpaths,
                               OstreeRepo          *repo,
                               FlatpakPullFlags     flatpak_flags,
@@ -402,6 +414,7 @@ char * flatpak_dir_check_for_update (FlatpakDir          *self,
                                      const char          *checksum_or_latest,
                                      const char         **opt_subpaths,
                                      gboolean             no_pull,
+                                     OstreeRepoFinderResult ***out_results,
                                      GCancellable        *cancellable,
                                      GError             **error);
 gboolean   flatpak_dir_update (FlatpakDir          *self,
@@ -412,6 +425,7 @@ gboolean   flatpak_dir_update (FlatpakDir          *self,
                                const char          *ref,
                                const char          *remote_name,
                                const char          *checksum_or_latest,
+                               const OstreeRepoFinderResult * const *results,
                                const char         **opt_subpaths,
                                OstreeAsyncProgress *progress,
                                GCancellable        *cancellable,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -68,6 +68,7 @@ GType flatpak_deploy_get_type (void);
 
 typedef struct
 {
+  char           *collection_id;  /* (nullable) */
   char           *ref;
   char           *commit;
   char          **subpaths;

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -551,10 +551,6 @@ gboolean   flatpak_dir_list_remote_refs (FlatpakDir   *self,
                                          GHashTable  **refs,
                                          GCancellable *cancellable,
                                          GError      **error);
-GVariant *flatpak_dir_fetch_remote_summary (FlatpakDir   *self,
-                                            const char   *remote,
-                                            GCancellable *cancellable,
-                                            GError      **error);
 gboolean flatpak_dir_fetch_remote_repo_metadata (FlatpakDir    *self,
                                                  const char    *remote_name,
                                                  GCancellable  *cancellable,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -533,6 +533,8 @@ gboolean   flatpak_dir_remove_remote (FlatpakDir   *self,
                                       GError      **error);
 char      *flatpak_dir_get_remote_title (FlatpakDir *self,
                                          const char *remote_name);
+char      *flatpak_dir_get_remote_collection_id (FlatpakDir *self,
+                                                 const char *remote_name);
 char      *flatpak_dir_get_remote_main_ref (FlatpakDir *self,
                                             const char *remote_name);
 gboolean   flatpak_dir_get_remote_oci (FlatpakDir *self,

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -74,6 +74,10 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_VERSION "version"
 #define FLATPAK_METADATA_KEY_VERSIONS "versions"
 
+#ifdef FLATPAK_ENABLE_P2P
+#define FLATPAK_METADATA_KEY_COLLECTION_ID "collection-id"
+#endif  /* FLATPAK_ENABLE_P2P */
+
 #define FLATPAK_METADATA_GROUP_EXTRA_DATA "Extra Data"
 #define FLATPAK_METADATA_KEY_EXTRA_DATA_CHECKSUM "checksum"
 #define FLATPAK_METADATA_KEY_EXTRA_DATA_INSTALLED_SIZE "installed-size"

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2728,6 +2728,18 @@ flatpak_repo_set_redirect_url (OstreeRepo *repo,
 }
 
 gboolean
+flatpak_repo_set_deploy_collection_id (OstreeRepo  *repo,
+                                       gboolean     deploy_collection_id,
+                                       GError     **error)
+{
+  g_autoptr(GKeyFile) config = NULL;
+
+  config = ostree_repo_copy_config (repo);
+  g_key_file_set_boolean (config, "flatpak", "deploy-collection-id", deploy_collection_id);
+  return ostree_repo_write_config (repo, config, error);
+}
+
+gboolean
 flatpak_repo_set_gpg_keys (OstreeRepo *repo,
                            GBytes *bytes,
                            GError    **error)
@@ -3093,7 +3105,14 @@ populate_commit_data_cache (GVariant   *metadata,
  * If the repo has a collection ID set, additionally store the metadata on a
  * contentless commit in a well-known branch, which is the preferred way of
  * broadcasting per-repo metadata (putting it in the summary file is deprecated,
- * but kept for backwards compatibility). */
+ * but kept for backwards compatibility).
+ *
+ * Note that there are two keys for the collection ID: collection-id, and
+ * xa.collection-id. If a client does not currently have a collection ID configured
+ * for this remote, it will *only* update its configuration from xa.collection-id.
+ * This allows phased deployment of collection-based repositories. Clients will
+ * only update their configuration from an unset to a set collection ID once
+ * (otherwise the security properties of collection IDs are broken). */
 gboolean
 flatpak_repo_update (OstreeRepo   *repo,
                      const char  **gpg_key_ids,
@@ -3119,6 +3138,7 @@ flatpak_repo_update (OstreeRepo   *repo,
   const char *collection_id;
   g_autofree char *old_ostree_metadata_checksum = NULL;
   g_autoptr(GVariant) old_ostree_metadata_v = NULL;
+  gboolean deploy_collection_id = FALSE;
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
 
@@ -3130,6 +3150,7 @@ flatpak_repo_update (OstreeRepo   *repo,
       default_branch = g_key_file_get_string (config, "flatpak", "default-branch", NULL);
       gpg_keys = g_key_file_get_string (config, "flatpak", "gpg-keys", NULL);
       redirect_url = g_key_file_get_string (config, "flatpak", "redirect-url", NULL);
+      deploy_collection_id = g_key_file_get_boolean (config, "flatpak", "deploy-collection-id", NULL);
     }
 
 #ifdef FLATPAK_ENABLE_P2P
@@ -3149,6 +3170,12 @@ flatpak_repo_update (OstreeRepo   *repo,
   if (default_branch)
     g_variant_builder_add (&builder, "{sv}", "xa.default-branch",
                            g_variant_new_string (default_branch));
+
+  if (deploy_collection_id && collection_id != NULL)
+    g_variant_builder_add (&builder, "{sv}", "xa.collection-id",
+                           g_variant_new_string (collection_id));
+  else if (deploy_collection_id)
+    g_debug ("Ignoring deploy-collection-id=true because no collection ID is set.");
 
   if (gpg_keys)
     {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3226,6 +3226,12 @@ flatpak_repo_update (OstreeRepo   *repo,
                              rev_data->metadata_contents);
     }
 
+  /* Note: xa.cache doesn’t need to support collection IDs for the refs listed
+   * in it, because the xa.cache metadata is stored on the ostree-metadata ref,
+   * which is itself strongly bound to a collection ID — so that collection ID
+   * is bound to all the refs in xa.cache. If a client is using the xa.cache
+   * data from a summary file (rather than an ostree-metadata branch), they are
+   * too old to care about collection IDs anyway. */
   g_variant_builder_add (&builder, "{sv}", "xa.cache",
                          g_variant_new_variant (g_variant_builder_end (&ref_data_builder)));
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2717,6 +2717,25 @@ flatpak_repo_set_default_branch (OstreeRepo *repo,
   return TRUE;
 }
 
+gboolean
+flatpak_repo_set_collection_id (OstreeRepo  *repo,
+                                const char  *collection_id,
+                                GError     **error)
+{
+#ifdef FLATPAK_ENABLE_P2P
+  g_autoptr(GKeyFile) config = NULL;
+
+  config = ostree_repo_copy_config (repo);
+  if (!ostree_repo_set_collection_id (repo, collection_id, error))
+    return FALSE;
+
+  if (!ostree_repo_write_config (repo, config, error))
+    return FALSE;
+#endif  /* FLATPAK_ENABLE_P2P */
+
+  return TRUE;
+}
+
 GVariant *
 flatpak_commit_get_extra_data_sources (GVariant *commitv,
                                        GError      **error)

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4863,6 +4863,8 @@ flatpak_pull_from_oci (OstreeRepo   *repo,
   else
     full_ref = g_strdup (ref);
 
+  /* Don’t need to set the collection ID here, since the ref is bound to a
+   * collection via its remote. */
   ostree_repo_transaction_set_ref (repo, NULL, full_ref, commit_checksum);
 
   if (!ostree_repo_commit_transaction (repo, NULL, cancellable, error))

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -341,6 +341,7 @@ GVariant * flatpak_bundle_load (GFile   *file,
                                 char   **app_metadata,
                                 guint64 *installed_size,
                                 GBytes **gpg_keys,
+                                char   **collection_id,
                                 GError **error);
 
 gboolean flatpak_pull_from_bundle (OstreeRepo   *repo,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -298,6 +298,9 @@ gboolean flatpak_repo_set_redirect_url (OstreeRepo *repo,
 gboolean flatpak_repo_set_default_branch (OstreeRepo *repo,
                                           const char *branch,
                                           GError    **error);
+gboolean flatpak_repo_set_collection_id (OstreeRepo  *repo,
+                                         const char  *collection_id,
+                                         GError     **error);
 gboolean flatpak_repo_set_gpg_keys (OstreeRepo *repo,
                                     GBytes *bytes,
                                     GError    **error);

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -128,12 +128,14 @@ gboolean flatpak_variant_bsearch_str (GVariant   *array,
                                       int        *out_pos);
 GVariant *flatpak_repo_load_summary (OstreeRepo *repo,
                                      GError **error);
-char **  flatpak_summary_match_subrefs (GVariant *summary,
+char **  flatpak_summary_match_subrefs (GVariant   *summary,
+                                        const char *collection_id,
                                         const char *ref);
-gboolean flatpak_summary_lookup_ref (GVariant   *summary,
-                                     const char *ref,
-                                     char      **out_checksum,
-                                     GVariant **out_variant);
+gboolean flatpak_summary_lookup_ref (GVariant    *summary,
+                                     const char  *collection_id,
+                                     const char  *ref,
+                                     char       **out_checksum,
+                                     GVariant   **out_variant);
 
 gboolean flatpak_has_name_prefix (const char *string,
                                   const char *name);

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -303,6 +303,9 @@ gboolean flatpak_repo_set_default_branch (OstreeRepo *repo,
 gboolean flatpak_repo_set_collection_id (OstreeRepo  *repo,
                                          const char  *collection_id,
                                          GError     **error);
+gboolean flatpak_repo_set_deploy_collection_id (OstreeRepo  *repo,
+                                                gboolean     deploy_collection_id,
+                                                GError     **error);
 gboolean flatpak_repo_set_gpg_keys (OstreeRepo *repo,
                                     GBytes *bytes,
                                     GError    **error);

--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,28 @@ AC_ARG_ENABLE(sudo,
               [SUDO_BIN="sudo"], [SUDO_BIN=""])
 AC_SUBST([SUDO_BIN])
 
+# Do we enable building peer to peer support using libostree’s experimental (non-stable) API?
+# If so, OSTREE_ENABLE_EXPERIMENTAL_API needs to be #defined before ostree.h is
+# included.
+AC_ARG_ENABLE([p2p],
+  [AS_HELP_STRING([--enable-p2p],
+                  [Enable unstable peer to peer support [default=no]])],,
+  [enable_p2p=no])
+AS_IF([test x$enable_p2p = xyes],[
+  PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
+
+  ostree_features=$($PKG_CONFIG --variable=features ostree-1)
+  AS_CASE(["$ostree_features"],
+          [*experimental*],[have_ostree_experimental=yes])
+
+  AS_IF([test "x$have_ostree_experimental" != "xyes"],
+        [AC_MSG_ERROR([Experimental API not found in ostree-1, which is needed for --enable-p2p. OSTree must be compiled with --enable-experimental-api.])])
+
+  AC_DEFINE([OSTREE_ENABLE_EXPERIMENTAL_API],[1],[Define if libostree experimental API should be enabled])
+  AC_DEFINE([FLATPAK_ENABLE_P2P],[1],[Define if peer to peer support should be enabled])
+])
+AM_CONDITIONAL([ENABLE_P2P],[test x$enable_p2p = xyes])
+
 dnl ************************
 dnl *** check for libelf ***
 dnl ************************
@@ -464,4 +486,5 @@ echo "          Use sandboxed triggers: $enable_sandboxed_triggers"
 echo "          Use seccomp:            $enable_seccomp"
 echo "          Privileged group:       $PRIVILEGED_GROUP"
 echo "          Privilege mode:         $with_priv_mode"
+echo "          Peer to peer support:   $enable_p2p"
 echo ""

--- a/doc/flatpak-build-bundle.xml
+++ b/doc/flatpak-build-bundle.xml
@@ -48,6 +48,11 @@
             in the repository at <arg choice="plain">LOCATION</arg>. If
             a <arg choice="plain">BRANCH</arg> is specified, this branch of
             the application is used.
+            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+            The collection ID set on the repository at
+            <arg choice="plain">LOCATION</arg> (if set) will be used for the
+            bundle.
+            -->
         </para>
         <para>
             The format of the bundle file is that of an ostree static delta

--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -46,6 +46,11 @@
             contents (and most of the metadata) taken from another
             branch, either from another repo, or from another branch in
             the same repository.
+            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+            The collection ID set on
+            <arg choice="plain">DST-REPO</arg> (if set) will be used for the
+            newly created commits.
+            -->
         </para>
         <para>
             This command is very useful when you want to maintain a branch

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -63,6 +63,16 @@
             subdirectories and the <filename>metadata</filename> file are included
             in the commit, anything else is ignored.
         </para>
+        <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+        <para>
+            When exporting a flatpak to be published to the internet,
+            <option>-FIXME-collection-id=COLLECTION-ID</option> should be specified
+            as a globally unique reverse DNS value to identify the collection of
+            flatpaks this will be added to. Setting a globally unique collection
+            ID allows the apps in the repository to be shared over peer to peer
+            systems without needing further configuration.
+        </para>
+        -->
         <para>
             The build-update-repo command should be used to update repository
             metadata whenever application builds are added to a repository.
@@ -101,6 +111,21 @@
                     Full description for the commit message.
                 </para></listitem>
             </varlistentry>
+
+            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+            <varlistentry>
+                <term><option>-FIXME-collection-id=COLLECTION-ID</option></term>
+
+                <listitem><para>
+                    Set as the collection ID of the repository. Setting a globally
+                    unique collection ID allows the apps in the repository to be shared over
+                    peer to peer systems without needing further configuration.
+                    If exporting to an existing repository, the collection ID
+                    must match the existing configured collection ID for that
+                    repository.
+                </para></listitem>
+            </varlistentry>
+            -->
 
             <varlistentry>
                 <term><option>--arch=ARCH</option></term>

--- a/doc/flatpak-build-update-repo.xml
+++ b/doc/flatpak-build-update-repo.xml
@@ -102,6 +102,21 @@
                 </para></listitem>
             </varlistentry>
 
+            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+            <varlistentry>
+                <term><option>-FIXME-collection-id=COLLECTION-ID</option></term>
+
+                <listitem><para>
+                    The globally unique identifier of the remote repository, to
+                    allow mirrors to be grouped. This must be set to a globally
+                    unique reverse DNS string if the repository is to be made
+                    publicly available. If a collection ID is already set on an
+                    existing repository, this will update it. If not specified,
+                    the existing collection ID will be left unchanged.
+                </para></listitem>
+            </varlistentry>
+            -->
+
             <varlistentry>
                 <term><option>--gpg-sign=KEYID</option></term>
 

--- a/doc/flatpak-build-update-repo.xml
+++ b/doc/flatpak-build-update-repo.xml
@@ -115,6 +115,19 @@
                     the existing collection ID will be left unchanged.
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>-FIXME-deploy-collection-id</option></term>
+
+                <listitem><para>
+                    Deploy the collection ID (set using <option>-FIXME-collection-id</option>
+                    in the static remote configuration for all clients. This is
+                    irrevocable once published in a repository. Use it to decide
+                    when to roll out a collection ID to users of an existing repository.
+                    If constructing a new repository which has a collection ID,
+                    you should typically always pass this option.
+                </para></listitem>
+            </varlistentry>
             -->
 
             <varlistentry>

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -99,6 +99,16 @@
             new commits added, or the first module where some changes to the <arg choice="plain">MANIFEST</arg> file caused
             the build environment to change. This makes flatpak-builder very efficient for incremental builds.
         </para>
+        <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+        <para>
+            When building a flatpak to be published to the internet,
+            <option>-FIXME-collection-id=COLLECTION-ID</option> should be specified
+            as a globally unique reverse DNS value to identify the collection of
+            flatpaks this will be added to. Setting a globally unique collection
+            ID allows the apps in the repository to be shared over peer to peer
+            systems without needing further configuration.
+        </para>
+        -->
     </refsect1>
 
     <refsect1>
@@ -313,6 +323,21 @@
                     Used when exporting the build results.
                 </para></listitem>
             </varlistentry>
+
+            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+            <varlistentry>
+                <term><option>-FIXME-collection-id=COLLECTION-ID</option></term>
+
+                <listitem><para>
+                    Set as the collection ID of the repository. Setting a globally
+                    unique collection ID allows the apps in the repository to be shared over
+                    peer to peer systems without needing further configuration.
+                    If building in an existing repository, the collection ID
+                    must match the existing configured collection ID for that
+                    repository.
+                </para></listitem>
+            </varlistentry>
+            -->
 
             <varlistentry>
                 <term><option>--gpg-sign=KEYID</option></term>

--- a/doc/flatpak-flatpakref.xml
+++ b/doc/flatpak-flatpakref.xml
@@ -107,6 +107,13 @@
                     <term><option>Homepage</option> (string)</term>
                     <listitem><para>The url of a webpage describing the application or runtime.</para></listitem>
                 </varlistentry>
+                <!--
+                FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
+                <varlistentry>
+                    <term><option>CollectionID</option> (string)</term>
+                    <listitem><para>The collection ID of the remote, if it has one. This uniquely identifies the collection of apps in the remote, to allow peer to peer redistribution.</para></listitem>
+                </varlistentry>
+                -->
 
                 <varlistentry>
                     <term><option>IsRuntime</option> (boolean)</term>

--- a/doc/flatpak-flatpakrepo.xml
+++ b/doc/flatpak-flatpakrepo.xml
@@ -103,6 +103,13 @@
                     <term><option>Homepage</option> (string)</term>
                     <listitem><para>The url of a webpage describing the remote.</para></listitem>
                 </varlistentry>
+                <!--
+                FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
+                <varlistentry>
+                    <term><option>CollectionID</option> (string)</term>
+                    <listitem><para>The collection ID of the remote, if it has one. This uniquely identifies the collection of apps in the remote, to allow peer to peer redistribution.</para></listitem>
+                </varlistentry>
+                -->
             </variablelist>
         </refsect2>
     </refsect1>
@@ -114,6 +121,10 @@
 Title=GEdit
 Url=http://sdk.gnome.org/repo-apps/
 GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
+<!--
+FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
+CollectionID=org.gnome.Apps
+-->
 </programlisting>
     </refsect1>
 

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -60,6 +60,18 @@
                     <term><option>branch</option> (string)</term>
                     <listitem><para>The branch of the application, defaults to master.</para></listitem>
                 </varlistentry>
+                <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+                <varlistentry>
+                    <term><option>collection-id</option> (string)</term>
+                    <listitem><para>The collection ID of the repository,
+                    defaults to being unset. Setting a globally
+                    unique collection ID allows the apps in the repository to be shared over
+                    peer to peer systems without needing further configuration.
+                    If building in an existing repository, the collection ID
+                    must match the existing configured collection ID for that
+                    repository.</para></listitem>
+                </varlistentry>
+                -->
                 <varlistentry>
                     <term><option>runtime</option> (string)</term>
                     <listitem><para>The name of the runtime that the application uses.</para></listitem>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -430,6 +430,18 @@
                         point when deleting a 'related' application or runtime.
                     </para></listitem>
                 </varlistentry>
+                <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+                <varlistentry>
+                    <term><option>collection-id</option> (string)</term>
+                    <listitem><para>
+                        The ID of the collection that this extension point belongs to. If this
+                        is unspecified, it defaults to the collection ID of the application
+                        or runtime that the extension point is for.
+                        Currently, extension points must be in the same collection as the
+                        application or runtime that they are for.
+                    </para></listitem>
+                </varlistentry>
+                -->
             </variablelist>
         </refsect2>
         <refsect2>

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -187,6 +187,19 @@
                 </para></listitem>
             </varlistentry>
 
+            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+            <varlistentry>
+                <term><option>-FIXME-collection-id=COLLECTION-ID</option></term>
+
+                <listitem><para>
+                    The globally unique identifier of the remote repository, to
+                    allow mirrors to be grouped. This must only be set to the
+                    collection ID provided by the remote, and must not be set if the
+                    remote does not provide an collection ID.
+                </para></listitem>
+            </varlistentry>
+            -->
+
             <varlistentry>
                 <term><option>--url=URL</option></term>
 

--- a/doc/flatpak-remote.xml
+++ b/doc/flatpak-remote.xml
@@ -78,7 +78,13 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>gpg-verify-summary</option> (boolean)</term>
-                    <listitem><para>Whether to use GPG verification for the summary of this remote.</para></listitem>
+                    <listitem>
+                        <para>Whether to use GPG verification for the summary of this remote.</para>
+                        <!--
+                        FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
+                        <para>This is ignored if <option>collection-id</option> is set, as refs are verified in commit metadata in that case. Enabling <option>gpg-verify-summary</option> would break peer to peer distribution of refs.</para>
+                        -->
+                    </listitem>
                 </varlistentry>
                 <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
                 <varlistentry>
@@ -142,6 +148,11 @@
 [remote "gnome-nightly-apps"]
 gpg-verify=true
 gpg-verify-summary=true
+<!--
+FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
+gpg-verify-summary=false
+collection-id=org.gnome.Apps.Nightly
+-->
 url=https://sdk.gnome.org/nightly/repo-apps/
 xa.title=GNOME Applications
 </programlisting>

--- a/doc/flatpak-remote.xml
+++ b/doc/flatpak-remote.xml
@@ -80,6 +80,12 @@
                     <term><option>gpg-verify-summary</option> (boolean)</term>
                     <listitem><para>Whether to use GPG verification for the summary of this remote.</para></listitem>
                 </varlistentry>
+                <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+                <varlistentry>
+                    <term><option>collection-id</option> (string)</term>
+                    <listitem><para>The globally unique identifier for the upstream collection repository, to allow mirrors to be grouped.</para></listitem>
+                </varlistentry>
+                -->
             </variablelist>
             <para>
                 All flatpak-specific keys have a xa. prefix:

--- a/lib/flatpak-bundle-ref.c
+++ b/lib/flatpak-bundle-ref.c
@@ -286,9 +286,10 @@ flatpak_bundle_ref_new (GFile   *file,
   g_autoptr(GVariant) icon_64 = NULL;
   g_autoptr(GVariant) icon_128 = NULL;
   guint64 installed_size;
+  g_autofree char *collection_id = NULL;
 
   metadata = flatpak_bundle_load (file, &commit, &full_ref, &origin, &runtime_repo, &metadata_contents, &installed_size,
-                                  NULL, error);
+                                  NULL, &collection_id, error);
   if (metadata == NULL)
     return NULL;
 
@@ -306,6 +307,9 @@ flatpak_bundle_ref_new (GFile   *file,
                       "branch", parts[3],
                       "commit", commit,
                       "file", file,
+#ifdef FLATPAK_ENABLE_P2P
+                      "collection-id", collection_id,
+#endif  /* FLATPAK_ENABLE_P2P */
                       NULL);
   priv = flatpak_bundle_ref_get_instance_private (ref);
 

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1355,6 +1355,7 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
   g_autofree char *remote_name = NULL;
   FlatpakInstalledRef *result = NULL;
   g_autofree char *target_commit = NULL;
+  g_auto(OstreeRepoFinderResultv) check_results = NULL;
 
   ref = flatpak_compose_ref (kind == FLATPAK_REF_KIND_APP, name, branch, arch, error);
   if (ref == NULL)
@@ -1376,6 +1377,7 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
   target_commit = flatpak_dir_check_for_update (dir, ref, remote_name, NULL,
                                                 (const char **)subpaths,
                                                 (flags & FLATPAK_UPDATE_FLAGS_NO_PULL) != 0,
+                                                &check_results,
                                                 cancellable, error);
   if (target_commit == NULL)
     return NULL;
@@ -1399,7 +1401,9 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
                            (flags & FLATPAK_UPDATE_FLAGS_NO_DEPLOY) != 0,
                            (flags & FLATPAK_UPDATE_FLAGS_NO_STATIC_DELTAS) != 0,
                            FALSE,
-                           ref, remote_name, target_commit, (const char **)subpaths,
+                           ref, remote_name, target_commit,
+                           (const OstreeRepoFinderResult * const *) check_results,
+                           (const char **)subpaths,
                            ostree_progress, cancellable, error))
     goto out;
 

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1944,7 +1944,7 @@ flatpak_installation_list_remote_related_refs_sync (FlatpakInstallation *self,
       FlatpakRelated *rel = g_ptr_array_index (related, i);
       FlatpakRelatedRef *ref;
 
-      ref = flatpak_related_ref_new (rel->ref, rel->commit,
+      ref = flatpak_related_ref_new (rel->collection_id, rel->ref, rel->commit,
                                      rel->subpaths, rel->download, rel->delete);
 
       if (ref)
@@ -2000,7 +2000,7 @@ flatpak_installation_list_installed_related_refs_sync (FlatpakInstallation *self
       FlatpakRelated *rel = g_ptr_array_index (related, i);
       FlatpakRelatedRef *ref;
 
-      ref = flatpak_related_ref_new (rel->ref, rel->commit,
+      ref = flatpak_related_ref_new (rel->collection_id, rel->ref, rel->commit,
                                      rel->subpaths, rel->download, rel->delete);
 
       if (ref)

--- a/lib/flatpak-ref.c
+++ b/lib/flatpak-ref.c
@@ -54,6 +54,7 @@ struct _FlatpakRefPrivate
   char          *branch;
   char          *commit;
   FlatpakRefKind kind;
+  char          *collection_id;
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (FlatpakRef, flatpak_ref, G_TYPE_OBJECT)
@@ -65,7 +66,8 @@ enum {
   PROP_ARCH,
   PROP_BRANCH,
   PROP_COMMIT,
-  PROP_KIND
+  PROP_KIND,
+  PROP_COLLECTION_ID,
 };
 
 static void
@@ -117,6 +119,11 @@ flatpak_ref_set_property (GObject      *object,
       priv->kind = g_value_get_enum (value);
       break;
 
+    case PROP_COLLECTION_ID:
+      g_clear_pointer (&priv->collection_id, g_free);
+      priv->collection_id = g_value_dup_string (value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -152,6 +159,10 @@ flatpak_ref_get_property (GObject    *object,
 
     case PROP_KIND:
       g_value_set_enum (value, priv->kind);
+      break;
+
+    case PROP_COLLECTION_ID:
+      g_value_set_string (value, priv->collection_id);
       break;
 
     default:
@@ -205,6 +216,16 @@ flatpak_ref_class_init (FlatpakRefClass *klass)
                                                       FLATPAK_TYPE_REF_KIND,
                                                       FLATPAK_REF_KIND_APP,
                                                       G_PARAM_READWRITE));
+
+#ifdef FLATPAK_ENABLE_P2P
+  g_object_class_install_property (object_class,
+                                   PROP_COLLECTION_ID,
+                                   g_param_spec_string ("collection-id",
+                                                        "Collection ID",
+                                                        "The collection ID",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+#endif  /* FLATPAK_ENABLE_P2P */
 }
 
 static void
@@ -361,3 +382,21 @@ flatpak_ref_parse (const char *ref, GError **error)
                                     "branch", parts[3],
                                     NULL));
 }
+
+#ifdef FLATPAK_ENABLE_P2P
+/**
+ * flatpak_ref_get_collection_id:
+ * @self: a #FlatpakRef
+ *
+ * Gets the collection ID of the ref.
+ *
+ * Returns: (transfer none): the collection ID
+ */
+const char *
+flatpak_ref_get_collection_id (FlatpakRef *self)
+{
+  FlatpakRefPrivate *priv = flatpak_ref_get_instance_private (self);
+
+  return priv->collection_id;
+}
+#endif  /* FLATPAK_ENABLE_P2P */

--- a/lib/flatpak-ref.c
+++ b/lib/flatpak-ref.c
@@ -216,8 +216,6 @@ flatpak_ref_class_init (FlatpakRefClass *klass)
                                                       FLATPAK_TYPE_REF_KIND,
                                                       FLATPAK_REF_KIND_APP,
                                                       G_PARAM_READWRITE));
-
-#ifdef FLATPAK_ENABLE_P2P
   g_object_class_install_property (object_class,
                                    PROP_COLLECTION_ID,
                                    g_param_spec_string ("collection-id",
@@ -225,7 +223,6 @@ flatpak_ref_class_init (FlatpakRefClass *klass)
                                                         "The collection ID",
                                                         NULL,
                                                         G_PARAM_READWRITE));
-#endif  /* FLATPAK_ENABLE_P2P */
 }
 
 static void
@@ -383,7 +380,6 @@ flatpak_ref_parse (const char *ref, GError **error)
                                     NULL));
 }
 
-#ifdef FLATPAK_ENABLE_P2P
 /**
  * flatpak_ref_get_collection_id:
  * @self: a #FlatpakRef
@@ -399,4 +395,3 @@ flatpak_ref_get_collection_id (FlatpakRef *self)
 
   return priv->collection_id;
 }
-#endif  /* FLATPAK_ENABLE_P2P */

--- a/lib/flatpak-ref.h
+++ b/lib/flatpak-ref.h
@@ -71,4 +71,8 @@ FLATPAK_EXTERN char *        flatpak_ref_format_ref (FlatpakRef *self);
 FLATPAK_EXTERN FlatpakRef *   flatpak_ref_parse (const char *ref,
                                                  GError    **error);
 
+#ifdef FLATPAK_ENABLE_P2P
+FLATPAK_EXTERN const char *   flatpak_ref_get_collection_id (FlatpakRef *self);
+#endif  /* FLATPAK_ENABLE_P2P */
+
 #endif /* __FLATPAK_REF_H__ */

--- a/lib/flatpak-ref.h
+++ b/lib/flatpak-ref.h
@@ -70,9 +70,6 @@ FLATPAK_EXTERN FlatpakRefKind flatpak_ref_get_kind (FlatpakRef *self);
 FLATPAK_EXTERN char *        flatpak_ref_format_ref (FlatpakRef *self);
 FLATPAK_EXTERN FlatpakRef *   flatpak_ref_parse (const char *ref,
                                                  GError    **error);
-
-#ifdef FLATPAK_ENABLE_P2P
 FLATPAK_EXTERN const char *   flatpak_ref_get_collection_id (FlatpakRef *self);
-#endif  /* FLATPAK_ENABLE_P2P */
 
 #endif /* __FLATPAK_REF_H__ */

--- a/lib/flatpak-related-ref-private.h
+++ b/lib/flatpak-related-ref-private.h
@@ -28,7 +28,8 @@
 #include <flatpak-related-ref.h>
 #include <flatpak-dir.h>
 
-FlatpakRelatedRef *flatpak_related_ref_new (const char  *full_ref,
+FlatpakRelatedRef *flatpak_related_ref_new (const char  *collection_id,
+                                            const char  *full_ref,
                                             const char  *commit,
                                             char       **subpaths,
                                             gboolean     download,

--- a/lib/flatpak-related-ref.c
+++ b/lib/flatpak-related-ref.c
@@ -221,7 +221,8 @@ flatpak_related_ref_get_subpaths (FlatpakRelatedRef *self)
 
 
 FlatpakRelatedRef *
-flatpak_related_ref_new (const char  *full_ref,
+flatpak_related_ref_new (const char  *collection_id,
+                         const char  *full_ref,
                          const char  *commit,
                          char       **subpaths,
                          gboolean     download,
@@ -250,6 +251,9 @@ flatpak_related_ref_new (const char  *full_ref,
                       "subpaths", subpaths,
                       "should-download", download,
                       "should-delete", delete,
+#ifdef FLATPAK_ENABLE_P2P
+                      "collection-id", collection_id,
+#endif  /* FLATPAK_ENABLE_P2P */
                       NULL);
 
   return ref;

--- a/lib/flatpak-remote-private.h
+++ b/lib/flatpak-remote-private.h
@@ -32,6 +32,12 @@
 FlatpakRemote *flatpak_remote_new_with_dir (const char *name,
                                             FlatpakDir *dir);
 
+#ifdef FLATPAK_ENABLE_P2P
+FlatpakRemote *flatpak_remote_new_from_ostree (OstreeRemote     *remote,
+                                               OstreeRepoFinder *repo_finder,
+                                               FlatpakDir       *dir);
+#endif  /* FLATPAK_ENABLE_P2P */
+
 gboolean flatpak_remote_commit (FlatpakRemote   *self,
                                 FlatpakDir      *dir,
                                 GCancellable    *cancellable,

--- a/lib/flatpak-remote.c
+++ b/lib/flatpak-remote.c
@@ -32,33 +32,6 @@
 #include <ostree-repo-finder-avahi.h>
 #endif  /* FLATPAK_ENABLE_P2P */
 
-#ifndef FLATPAK_ENABLE_P2P
-/* Avoid too many #ifdefs by redefining this enum when compiling without P2P support. */
-typedef enum {
-  FLATPAK_REMOTE_TYPE_STATIC = 0,
-} FlatpakRemoteType;
-#else  /* if FLATPAK_ENABLE_P2P */
-GType
-flatpak_remote_type_get_type (void)
-{
-  static volatile gsize g_define_type_id__volatile = 0;
-
-  if (g_once_init_enter (&g_define_type_id__volatile))
-    {
-      static const GEnumValue values[] = {
-        { FLATPAK_REMOTE_TYPE_STATIC, "FLATPAK_REMOTE_TYPE_STATIC", "static" },
-        { FLATPAK_REMOTE_TYPE_USB, "FLATPAK_REMOTE_TYPE_USB", "usb" },
-        { FLATPAK_REMOTE_TYPE_LAN, "FLATPAK_REMOTE_TYPE_LAN", "lan" },
-        { 0, NULL, NULL }
-      };
-      GType g_define_type_id = g_enum_register_static (g_intern_static_string ("FlatpakRemoteType"), values);
-      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
-    }
-
-  return g_define_type_id__volatile;
-}
-#endif  /* FLATPAK_ENABLE_P2P */
-
 /**
  * SECTION:flatpak-remote
  * @Short_description: Remote repository
@@ -206,8 +179,6 @@ flatpak_remote_class_init (FlatpakRemoteClass *klass)
                                                         NULL,
                                                         G_PARAM_READWRITE));
 
-#ifdef FLATPAK_ENABLE_P2P
-#ifndef __GI_SCANNER__
   g_object_class_install_property (object_class,
                                    PROP_TYPE,
                                    g_param_spec_enum ("type",
@@ -216,8 +187,6 @@ flatpak_remote_class_init (FlatpakRemoteClass *klass)
                                                       FLATPAK_TYPE_REMOTE_TYPE,
                                                       FLATPAK_REMOTE_TYPE_STATIC,
                                                       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
-#endif  /* !__GI_SCANNER__ */
-#endif  /* FLATPAK_ENABLE_P2P */
 }
 
 static void
@@ -346,7 +315,6 @@ flatpak_remote_set_url (FlatpakRemote *self,
   priv->local_url_set = TRUE;
 }
 
-#ifdef FLATPAK_ENABLE_P2P
 /**
  * flatpak_remote_get_collection_id:
  * @self: a #FlatpakRemote
@@ -358,6 +326,7 @@ flatpak_remote_set_url (FlatpakRemote *self,
 char *
 flatpak_remote_get_collection_id (FlatpakRemote *self)
 {
+#ifdef FLATPAK_ENABLE_P2P
   FlatpakRemotePrivate *priv = flatpak_remote_get_instance_private (self);
 
   if (priv->local_collection_id_set)
@@ -365,6 +334,7 @@ flatpak_remote_get_collection_id (FlatpakRemote *self)
 
   if (priv->dir)
     return flatpak_dir_get_remote_collection_id (priv->dir, priv->name);
+#endif  /** FLATPAK_ENABLE_P2P */
 
   return NULL;
 }
@@ -384,6 +354,7 @@ void
 flatpak_remote_set_collection_id (FlatpakRemote *self,
                                   const char    *collection_id)
 {
+#ifdef FLATPAK_ENABLE_P2P
   FlatpakRemotePrivate *priv = flatpak_remote_get_instance_private (self);
 
   if (collection_id != NULL && *collection_id == '\0')
@@ -392,8 +363,8 @@ flatpak_remote_set_collection_id (FlatpakRemote *self,
   g_free (priv->local_collection_id);
   priv->local_collection_id = g_strdup (collection_id);
   priv->local_collection_id_set = TRUE;
-}
 #endif  /* FLATPAK_ENABLE_P2P */
+}
 
 /**
  * flatpak_remote_get_title:

--- a/lib/flatpak-remote.c
+++ b/lib/flatpak-remote.c
@@ -37,6 +37,26 @@
 typedef enum {
   FLATPAK_REMOTE_TYPE_STATIC = 0,
 } FlatpakRemoteType;
+#else  /* if FLATPAK_ENABLE_P2P */
+GType
+flatpak_remote_type_get_type (void)
+{
+  static volatile gsize g_define_type_id__volatile = 0;
+
+  if (g_once_init_enter (&g_define_type_id__volatile))
+    {
+      static const GEnumValue values[] = {
+        { FLATPAK_REMOTE_TYPE_STATIC, "FLATPAK_REMOTE_TYPE_STATIC", "static" },
+        { FLATPAK_REMOTE_TYPE_USB, "FLATPAK_REMOTE_TYPE_USB", "usb" },
+        { FLATPAK_REMOTE_TYPE_LAN, "FLATPAK_REMOTE_TYPE_LAN", "lan" },
+        { 0, NULL, NULL }
+      };
+      GType g_define_type_id = g_enum_register_static (g_intern_static_string ("FlatpakRemoteType"), values);
+      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
+    }
+
+  return g_define_type_id__volatile;
+}
 #endif  /* FLATPAK_ENABLE_P2P */
 
 /**

--- a/lib/flatpak-remote.c
+++ b/lib/flatpak-remote.c
@@ -372,7 +372,7 @@ flatpak_remote_get_collection_id (FlatpakRemote *self)
 /**
  * flatpak_remote_set_collection_id:
  * @self: a #FlatpakRemote
- * @collection_id: The new collection ID
+ * @collection_id: (nullable): The new collection ID, or %NULL to unset
  *
  * Sets the repository collection ID of this remote.
  *
@@ -385,6 +385,9 @@ flatpak_remote_set_collection_id (FlatpakRemote *self,
                                   const char    *collection_id)
 {
   FlatpakRemotePrivate *priv = flatpak_remote_get_instance_private (self);
+
+  if (collection_id != NULL && *collection_id == '\0')
+    collection_id = NULL;
 
   g_free (priv->local_collection_id);
   priv->local_collection_id = g_strdup (collection_id);
@@ -813,7 +816,12 @@ flatpak_remote_commit (FlatpakRemote   *self,
     g_key_file_set_string (config, group, "url", priv->local_url);
 
   if (priv->local_collection_id_set)
-    g_key_file_set_string (config, group, "collection-id", priv->local_collection_id);
+    {
+      if (priv->local_collection_id != NULL)
+        g_key_file_set_string (config, group, "collection-id", priv->local_collection_id);
+      else
+        g_key_file_remove_key (config, group, "collection-id", NULL);
+    }
 
   if (priv->local_title_set)
     g_key_file_set_string (config, group, "xa.title", priv->local_title);

--- a/lib/flatpak-remote.h
+++ b/lib/flatpak-remote.h
@@ -25,6 +25,15 @@
 #ifndef __FLATPAK_REMOTE_H__
 #define __FLATPAK_REMOTE_H__
 
+#ifdef FLATPAK_ENABLE_P2P
+typedef enum
+{
+  FLATPAK_REMOTE_TYPE_STATIC,  /*< skip >*/
+  FLATPAK_REMOTE_TYPE_USB,  /*< skip >*/
+  FLATPAK_REMOTE_TYPE_LAN,  /*< skip >*/
+} FlatpakRemoteType;
+#endif  /* FLATPAK_ENABLE_P2P */
+
 typedef struct _FlatpakRemote FlatpakRemote;
 
 #include <gio/gio.h>
@@ -84,6 +93,9 @@ FLATPAK_EXTERN int           flatpak_remote_get_prio (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_prio (FlatpakRemote *self,
                                                       int            prio);
 
+#ifdef FLATPAK_ENABLE_P2P
+FLATPAK_EXTERN FlatpakRemoteType flatpak_remote_get_remote_type (FlatpakRemote *self);
+#endif  /* FLATPAK_ENABLE_P2P */
 
 
 #endif /* __FLATPAK_REMOTE_H__ */

--- a/lib/flatpak-remote.h
+++ b/lib/flatpak-remote.h
@@ -25,19 +25,12 @@
 #ifndef __FLATPAK_REMOTE_H__
 #define __FLATPAK_REMOTE_H__
 
-#ifdef FLATPAK_ENABLE_P2P
-#ifndef __GTK_DOC_IGNORE__
-typedef enum  /*< skip >*/
+typedef enum
 {
-  FLATPAK_REMOTE_TYPE_STATIC,  /*< skip >*/
-  FLATPAK_REMOTE_TYPE_USB,  /*< skip >*/
-  FLATPAK_REMOTE_TYPE_LAN,  /*< skip >*/
+  FLATPAK_REMOTE_TYPE_STATIC,
+  FLATPAK_REMOTE_TYPE_USB,
+  FLATPAK_REMOTE_TYPE_LAN,
 } FlatpakRemoteType;
-
-FLATPAK_EXTERN GType flatpak_remote_type_get_type (void);
-#define FLATPAK_TYPE_REMOTE_TYPE flatpak_remote_type_get_type ()
-#endif  /* !__GTK_DOC_IGNORE__ */
-#endif  /* FLATPAK_ENABLE_P2P */
 
 typedef struct _FlatpakRemote FlatpakRemote;
 
@@ -74,11 +67,9 @@ FLATPAK_EXTERN GFile *       flatpak_remote_get_appstream_timestamp (FlatpakRemo
 FLATPAK_EXTERN char *        flatpak_remote_get_url (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_url (FlatpakRemote *self,
                                                      const char    *url);
-#ifdef FLATPAK_ENABLE_P2P
 FLATPAK_EXTERN char *        flatpak_remote_get_collection_id (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_collection_id (FlatpakRemote *self,
                                                                const char    *collection_id);
-#endif  /* FLATPAK_ENABLE_P2P */
 FLATPAK_EXTERN char *        flatpak_remote_get_title (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_title (FlatpakRemote *self,
                                                        const char    *title);
@@ -103,9 +94,7 @@ FLATPAK_EXTERN int           flatpak_remote_get_prio (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_prio (FlatpakRemote *self,
                                                       int            prio);
 
-#ifdef FLATPAK_ENABLE_P2P
 FLATPAK_EXTERN FlatpakRemoteType flatpak_remote_get_remote_type (FlatpakRemote *self);
-#endif  /* FLATPAK_ENABLE_P2P */
 
 
 #endif /* __FLATPAK_REMOTE_H__ */

--- a/lib/flatpak-remote.h
+++ b/lib/flatpak-remote.h
@@ -74,6 +74,11 @@ FLATPAK_EXTERN GFile *       flatpak_remote_get_appstream_timestamp (FlatpakRemo
 FLATPAK_EXTERN char *        flatpak_remote_get_url (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_url (FlatpakRemote *self,
                                                      const char    *url);
+#ifdef FLATPAK_ENABLE_P2P
+FLATPAK_EXTERN char *        flatpak_remote_get_collection_id (FlatpakRemote *self);
+FLATPAK_EXTERN void          flatpak_remote_set_collection_id (FlatpakRemote *self,
+                                                               const char    *collection_id);
+#endif  /* FLATPAK_ENABLE_P2P */
 FLATPAK_EXTERN char *        flatpak_remote_get_title (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_title (FlatpakRemote *self,
                                                        const char    *title);

--- a/lib/flatpak-remote.h
+++ b/lib/flatpak-remote.h
@@ -26,12 +26,17 @@
 #define __FLATPAK_REMOTE_H__
 
 #ifdef FLATPAK_ENABLE_P2P
-typedef enum
+#ifndef __GTK_DOC_IGNORE__
+typedef enum  /*< skip >*/
 {
   FLATPAK_REMOTE_TYPE_STATIC,  /*< skip >*/
   FLATPAK_REMOTE_TYPE_USB,  /*< skip >*/
   FLATPAK_REMOTE_TYPE_LAN,  /*< skip >*/
 } FlatpakRemoteType;
+
+FLATPAK_EXTERN GType flatpak_remote_type_get_type (void);
+#define FLATPAK_TYPE_REMOTE_TYPE flatpak_remote_type_get_type ()
+#endif  /* !__GTK_DOC_IGNORE__ */
 #endif  /* FLATPAK_ENABLE_P2P */
 
 typedef struct _FlatpakRemote FlatpakRemote;

--- a/lib/test-lib.c
+++ b/lib/test-lib.c
@@ -357,10 +357,17 @@ main (int argc, char *argv[])
     {
       FlatpakRemote *remote = g_ptr_array_index (remotes, i);
       g_autoptr(GPtrArray) refs = NULL;
-      g_print ("\nRemote: %s %d %s %s %s %d %d %s\n",
+      const char *collection_id = NULL;
+
+#ifdef FLATPAK_ENABLE_P2P
+      collection_id = flatpak_remote_get_collection_id (remote);
+#endif  /* !FLATPAK_ENABLE_P2P */
+
+      g_print ("\nRemote: %s %d %s %s %s %s %d %d %s\n",
                flatpak_remote_get_name (remote),
                flatpak_remote_get_prio (remote),
                flatpak_remote_get_url (remote),
+               collection_id,
                flatpak_remote_get_title (remote),
                flatpak_remote_get_default_branch (remote),
                flatpak_remote_get_gpg_verify (remote),

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -319,7 +319,7 @@ handle_deploy (FlatpakSystemHelper   *object,
       main_context = g_main_context_new ();
       g_main_context_push_thread_default (main_context);
 
-      if (!flatpak_dir_pull (system, arg_origin, arg_ref, NULL, (const char **)arg_subpaths, NULL,
+      if (!flatpak_dir_pull (system, arg_origin, arg_ref, NULL, NULL, (const char **)arg_subpaths, NULL,
                              FLATPAK_PULL_FLAGS_NONE, OSTREE_REPO_PULL_FLAGS_UNTRUSTED, NULL,
                              NULL, &error))
         {

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -528,13 +528,13 @@ handle_uninstall (FlatpakSystemHelper *object,
 
   if (!flatpak_dir_ensure_repo (system, NULL, &error))
     {
-      g_dbus_method_invocation_return_gerror  (invocation, error);
+      g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
 
   if (!flatpak_dir_uninstall (system, arg_ref, arg_flags, NULL, &error))
     {
-      g_dbus_method_invocation_return_gerror  (invocation, error);
+      g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
 
@@ -581,7 +581,7 @@ handle_install_bundle (FlatpakSystemHelper   *object,
 
   if (!flatpak_dir_install_bundle (system, path, arg_remote, &ref, NULL, &error))
     {
-      g_dbus_method_invocation_return_gerror  (invocation, error);
+      g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
 
@@ -640,7 +640,7 @@ handle_configure_remote (FlatpakSystemHelper *object,
 
   if (!flatpak_dir_ensure_repo (system, NULL, &error))
     {
-      g_dbus_method_invocation_return_gerror  (invocation, error);
+      g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
 
@@ -655,7 +655,7 @@ handle_configure_remote (FlatpakSystemHelper *object,
       if (!flatpak_dir_modify_remote (system, arg_remote, config,
                                       gpg_data, NULL, &error))
         {
-          g_dbus_method_invocation_return_gerror  (invocation, error);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return TRUE;
         }
     }
@@ -667,7 +667,7 @@ handle_configure_remote (FlatpakSystemHelper *object,
                                       arg_remote,
                                       NULL, &error))
         {
-          g_dbus_method_invocation_return_gerror  (invocation, error);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return TRUE;
         }
     }
@@ -723,7 +723,7 @@ handle_update_remote (FlatpakSystemHelper *object,
 
   if (!flatpak_dir_ensure_repo (system, NULL, &error))
     {
-      g_dbus_method_invocation_return_gerror  (invocation, error);
+      g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
 
@@ -740,7 +740,7 @@ handle_update_remote (FlatpakSystemHelper *object,
 
   if (!g_file_get_contents (arg_summary_path, &summary_data, &summary_size, &error))
     {
-      g_dbus_method_invocation_return_gerror  (invocation, error);
+      g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
   summary_bytes = g_bytes_new_take (summary_data, summary_size);
@@ -749,7 +749,7 @@ handle_update_remote (FlatpakSystemHelper *object,
     {
       if (!g_file_get_contents (arg_summary_sig_path, &summary_sig_data, &summary_sig_size, &error))
         {
-          g_dbus_method_invocation_return_gerror  (invocation, error);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return TRUE;
         }
       summary_sig_bytes = g_bytes_new_take (summary_sig_data, summary_sig_size);
@@ -762,7 +762,7 @@ handle_update_remote (FlatpakSystemHelper *object,
       if (gpg_result == NULL ||
           !ostree_gpg_verify_result_require_valid_signature (gpg_result, &error))
         {
-          g_dbus_method_invocation_return_gerror  (invocation, error);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return TRUE;
         }
 
@@ -771,7 +771,7 @@ handle_update_remote (FlatpakSystemHelper *object,
       if (!flatpak_dir_update_remote_configuration_for_summary (system, arg_remote, summary,
                                                                 FALSE, NULL, NULL, &error))
         {
-          g_dbus_method_invocation_return_gerror  (invocation, error);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return TRUE;
         }
     }
@@ -780,7 +780,7 @@ handle_update_remote (FlatpakSystemHelper *object,
       if (!flatpak_dir_update_remote_configuration_for_repo_metadata (system, arg_remote, summary,
                                                                       FALSE, NULL, NULL, &error))
         {
-          g_dbus_method_invocation_return_gerror  (invocation, error);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return TRUE;
         }
     }

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -139,6 +139,7 @@ dist_test_scripts = \
 	tests/test-builder.sh \
 	tests/test-builder-python.sh \
 	tests/test-oci.sh \
+	tests/test-unsigned-summaries.sh \
 	$(NULL)
 
 test_programs = testdb test-doc-portal testlibrary

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -140,6 +140,7 @@ dist_test_scripts = \
 	tests/test-builder-python.sh \
 	tests/test-oci.sh \
 	tests/test-unsigned-summaries.sh \
+	tests/test-update-remote-configuration.sh \
 	$(NULL)
 
 test_programs = testdb test-doc-portal testlibrary

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -1,4 +1,4 @@
-TESTS_ENVIRONMENT += FLATPAK_TESTS_DEBUG=1 \
+AM_TESTS_ENVIRONMENT = FLATPAK_TESTS_DEBUG=1 \
 	FLATPAK_TRIGGERSDIR=$$(cd $(top_srcdir) && pwd)/triggers \
 	FLATPAK_DBUSPROXY=$$(cd $(top_builddir) && pwd)/flatpak-dbus-proxy \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
@@ -7,9 +7,9 @@ TESTS_ENVIRONMENT += FLATPAK_TESTS_DEBUG=1 \
 	$(NULL)
 
 if WITH_SYSTEM_BWRAP
-TESTS_ENVIRONMENT += FLATPAK_BWRAP=$(BWRAP)
+AM_TESTS_ENVIRONMENT += FLATPAK_BWRAP=$(BWRAP)
 else
-TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
+AM_TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
 endif
 
 testdb_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -132,6 +132,8 @@ dist_test_scripts = \
 	tests/test-run-deltas.sh \
 	tests/test-run-system-deltas.sh \
 	tests/test-repo.sh \
+	tests/test-repo-collections.sh \
+	tests/test-repo-collections-server-only.sh \
 	tests/test-repo-system.sh \
 	tests/test-extensions.sh \
 	tests/test-bundle.sh \

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -284,6 +284,13 @@ skip_without_python2 () {
     fi
 }
 
+skip_without_p2p () {
+    if ! ${FLATPAK} remote-add --help | grep -q -e '--collection-id'; then
+        echo "1..0 # SKIP this test requires peer to peer support (--enable-p2p)"
+        exit 0
+    fi
+}
+
 
 sed s#@testdir@#${test_builddir}# ${test_srcdir}/session.conf.in > session.conf
 dbus-daemon --fork --config-file=session.conf --print-address=3 --print-pid=4 \

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -194,42 +194,93 @@ export FL_GPGARGS2="--gpg-homedir=${FL_GPG_HOMEDIR2} --gpg-sign=${FL_GPG_ID2}"
 export FL_GPG_BASE64="mQENBFbPBvoBCADWbz5O+XzuyN+dDExK81pci+gIzBNWB+7SsN0EgoJppKgwBCX+Bd6ERe9Yz0nJbJB/tjazRp7MnnoPnh6fXnhIbHA766/Eciy4sL5X8laqDmWmROCqCe79QZH/w6vYTKsDmoLQrw9eKRP1ilCvECNGcVdhIyfTDlNrU//uy5U4h2PVUz1/Al87lvaJnrj5423m5GnX+qpEG8mmpmcw52lvXNPuC95ykylPQJjI0WnOuaTcxzRhm5eHPkqKQ+nPIS+66iw1SFdobYuye/vg/rDiyp8uyQkh7FWXnzHxz4J8ovesnrCM7pKI4VEHCnZ4/sj2v9E3l0wJlqZxLTULaV3lABEBAAG0D1hkZy1hcHAgdGVzdGluZ4kBOAQTAQIAIgUCVs8G+gIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQE4sx4HsJYf2DiAf7BQ8anU3CgYpJjuO2rT8jQPO0jGRCNaPyaeAcBx8IjFkjf8daKMPCAt6gQioEpC8OhDig86Bl5piYOB7L7JSB53mgUrADJXhgC/dG4soCt7/U4wW30MseXdlXSOqHGApblF/bIs4B30OBGReBj3DcWIqyb48GraSKlPlaCpkZFySNEAcGUCeCqbbygxCQAM8MDq9FgVRk5oVrE/nAUm6oScEBhseoB7+CaHaRTmLoe/SBs0z2AJ7alIH1Sv4X3mQXpfsAIcWf3Zu2MZydF/Vuh8vTMROwPYtOVEtGxZvEBN3h5uc88dHSk928maqsop9T6oEwM43mBKCOu1gdAOw4OLkBDQRWzwb6AQgAx/XuEaQvdI3J2YYmOE6RY0jJZXLauXH46cJR4q70mlDev/OqYKTSLlo4q06D4ozCwzTYflppDak7kmjWMN224/u1koqFOtF76LsglAeLaQmweWmX0ecbPrzFYaX30kaQAqQ9Wk0PRe0+arRzWDWfUv3qX3y1decKUrBCuEC6WvVVwooWs+zX0cUBS8CROhazTjvXFAz36mhK0u+B3WCBlK+T2tIPOjLjlYgzYARw+X7/J6B3C798r2Hw/yXqCDcKLrq7WWUB33kv3buuG2G6LUamctdD8IsTBxi+nIjAvQITFqq4cPbbXAJGaAnWGuLOddQ9e/GhCOI4JjopRnnjOwARAQABiQEfBBgBAgAJBQJWzwb6AhsMAAoJEBOLMeB7CWH9TC8H/A6oreCxeiL8DPOWN29OaQ5sEw7Dg7bnLSZLu8aREgwfCiFSv0numOABjn/G89Y5M6NiEXFZZhUa+SXOALiBLUy98O84lyp9hlP9qGbWRgBXwe5vOAJERqtoUwR5bygpAw5Nc4y3wddPC4vH7upJ8ftU/eEFtPdI0cKrrAZDFdhXFp3RxdCC6fD62wbofE0mo1Ea1iD3xqVh2t7jfWN1RhMV308htHRGkkmWcEbbvHqugwL6dWZEvQmLYi6/7tQyA1KdG4AZksBP/MBi3t2hthRqQx1v52JwdCaZNuItuEe5rWXhfvoGxPoqYZt9ZPjna6yJfcfJwPbMfjNwX2LR4p4="
 export FL_GPG_BASE642="mQENBFkSyx4BCACq/8XFcF+NTpJKfoo8F6YyR8RQXww6kCV47zN78Dt7aCh43WSYLRUBRt1tW5MRT8R60pwCsGvKnFiNS2Vqe4T1IW4mDnFMZIZJXdNVwKUqVBPL/jzkIDnQ9NXtuPNH0qET6VhYnb9aykLo/MiBmx6q+4MvYd/qwiN8kstRifRIxjjZx6wsg+muY6yx9fZKxlgvhc3nsrl3oyDo7/+V+b3heYLtMCQFwlHRKz3Yf2X9H0aUSbDYcgTy6w3q94HVNCpJSqeiR+kBG175BQYKR2l7WYdaVPFf5LMEvAJh0SGnqu77X+8TYYRQiiBB5fYjGOeHfOh6uH5GAJRQymVIJwy/ABEBAAG0KkZsYXRwYWsgKFRlc3Qga2V5IDIpIDxmbGF0cGFrQGZsYXRwYWsub3JnPokBOAQTAQIAIgUCWRLLHgIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQdZ9f0LIxTvyeUQf/euAZpipXBkGWxeW4G10r1QRi2tZAWNeLpy8SB17eo9E6yB61SdH80jALborVs/plnZzKcFf+nLvjCn51FLMh6QPL3S+079WHsed//qtUWfbJ85hLevfCMTZMLktUmqwwUh238WW/gKtbUjYOqr1IZSMBoMiQtc0iOVBP7HUdhYigxTKvs/MBEGHANeQkY07ZnX9oFXElOo+EIPAHScwEOSwEVrXUVHpQODzIfjOoPUHWAZtM1yJT+iWmVHe4HtU8CyBnPyUcnTmTWKr92QmgfWkb1T7ugT5gXt/6ZlYAaZGnr9yNuSk3MMhDMOyldtJBM5Zl8eScE9KBf7pRJoxnMLkBDQRZEsseAQgAvA29IyiJpB+jUHj3MOyVyTBOmvLme+0Ndhpt/mTh+swchJUvzb0IzQS9Le5yVAvn+ppAtDCMb+bV4Xh5zrbiH0Hu0qwK4Qk+KcIKRE8ImDiUM8NFE2SZoomZSsgZ1NBWbAdEyVpkBfrt3Dd8FssMrwPF6kqo02TZr7Pxng+BEHUZT6jPCxueqyXyv2cLbQMe1H0U7klsxPmnnIYUqdwOmPxUspVEYP9oJb5y123mx0yj5JuYdZMjWbP3cRLox1RKIlFWgQqOn2yJiEoWzpqdbtb7sE3ggnbZKJED0ZxUZIakjnyMhX+GAEA8ZMZ6+HfDt1iHV8qHcYiLW5A3AQTxZwARAQABiQEfBBgBAgAJBQJZEsseAhsMAAoJEHWfX9CyMU78Ns4IAJRQ5UJ9KkeZClHm1EjYlgsAq1UJr9wgbyBFKTEkGZ/CAvVmgg+BUXcN/SPAkELbEAOJZTyv8C5cuJC49iFHOxUbRZXZ5eN2SvhZzl+5gep2uHwVLdqRIxFDTHbLWnmtHxPeU7IRA9u86q3wV1N0pD7kreNN7BWKY3/tI33hY2/XVVFy0MN5sutPn+lVK66MqAHqtode5xqqz9Z8LmS7LlqokQkAytcGd6Xqsx99NTk8kk3bnk9HWsAvDO8tRZroeseKeRNmbhGvCNUxPSB6bpYBJLvQtjA9ZVv6sNm0E+SuiXKizZkBGO5AH50pDoy0+MCGoOhwwXeY5+1kZAOzkMI="
 
-setup_repo () {
+setup_repo_no_add () {
     REPONAME=${1:-test}
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.Platform bash ls cat echo readlink > /dev/null
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} > /dev/null
-    update_repo $REPONAME
+    if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+        COLLECTION_ID=${2:-org.test.Collection.${REPONAME}}
+    else
+        COLLECTION_ID=
+    fi
+
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.Platform "${COLLECTION_ID}" bash ls cat echo readlink > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "${COLLECTION_ID}" > /dev/null
+    update_repo $REPONAME "${COLLECTION_ID}"
     if [ $REPONAME == "test" ]; then
         $(dirname $0)/test-webserver.sh repos
         FLATPAK_HTTP_PID=$(cat httpd-pid)
         mv httpd-port httpd-port-main
     fi
+}
+
+setup_repo () {
+    REPONAME=${1:-test}
+    COLLECTION_ID=${2:-org.test.Collection.${REPONAME}}
+
+    setup_repo_no_add "$@"
+
     port=$(cat httpd-port-main)
-    flatpak remote-add ${U} --gpg-import=${GPGPUBKEY:-${FL_GPG_HOMEDIR}/pubring.gpg} ${REPONAME}-repo "http://127.0.0.1:${port}/$REPONAME"
+    if [ x${GPGPUBKEY:-${FL_GPG_HOMEDIR}/pubring.gpg} != x ]; then
+        import_args=--gpg-import=${GPGPUBKEY:-${FL_GPG_HOMEDIR}/pubring.gpg}
+    else
+        import_args=
+    fi
+    if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] ; then
+        collection_args=--collection-id=${COLLECTION_ID}
+    else
+        collection_args=
+    fi
+
+    flatpak remote-add ${U} ${collection_args} ${import_args} ${REPONAME}-repo "http://127.0.0.1:${port}/$REPONAME"
 }
 
 update_repo () {
     REPONAME=${1:-test}
-    ${FLATPAK} build-update-repo ${GPGARGS:-${FL_GPGARGS}} ${UPDATE_REPO_ARGS-} repos/${REPONAME}
+    COLLECTION_ID=${2:-org.test.Collection.${REPONAME}}
+
+    if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+        collection_args=--collection-id=${COLLECTION_ID}
+    else
+        collection_args=
+    fi
+
+    ${FLATPAK} build-update-repo ${collection_args} ${GPGARGS:-${FL_GPGARGS}} ${UPDATE_REPO_ARGS-} repos/${REPONAME}
 }
 
 make_updated_app () {
     REPONAME=${1:-test}
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} ${2:-UPDATED} > /dev/null
-    update_repo $REPONAME
+    if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+        COLLECTION_ID=${2:-org.test.Collection.${REPONAME}}
+    else
+        COLLECTION_ID=""
+    fi
+
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "${COLLECTION_ID}" ${3:-UPDATED} > /dev/null
+    update_repo $REPONAME "${COLLECTION_ID}"
 }
 
 setup_sdk_repo () {
     REPONAME=${1:-test}
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.Sdk bash ls cat echo readlink make mkdir cp touch > /dev/null
-    update_repo $REPONAME
+    if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+        COLLECTION_ID=${2:-org.test.Collection.${REPONAME}}
+    else
+        COLLECTION_ID=""
+    fi
+
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.Sdk "${COLLECTION_ID}" bash ls cat echo readlink make mkdir cp touch > /dev/null
+    update_repo $REPONAME "${COLLECTION_ID}"
 }
 
 setup_python2_repo () {
     REPONAME=${1:-test}
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.PythonPlatform bash python2 ls cat echo rm readlink > /dev/null
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.PythonSdk python2 bash ls cat echo rm readlink make mkdir cp touch > /dev/null
-    update_repo $REPONAME
+    if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+        COLLECTION_ID=${2:-org.test.Collection.${REPONAME}}
+    else
+        COLLECTION_ID=""
+    fi
+
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.PythonPlatform "${COLLECTION_ID}" bash python2 ls cat echo rm readlink > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.PythonSdk "${COLLECTION_ID}" python2 bash ls cat echo rm readlink make mkdir cp touch > /dev/null
+    update_repo $REPONAME "${COLLECTION_ID}"
 }
 
 install_repo () {

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -6,6 +6,8 @@ DIR=`mktemp -d`
 
 REPONAME=$1
 shift
+COLLECTION_ID=$1
+shift
 
 EXTRA="${1-}"
 
@@ -63,7 +65,13 @@ gzip -c > ${DIR}/files/share/app-info/xmls/org.test.Hello.xml.gz <<EOF
 EOF
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/app-info/icons/flatpak/64x64/
 
+if [ x$COLLECTION_ID != x ]; then
+    collection_args=--collection-id=${COLLECTION_ID}
+else
+    collection_args=
+fi
+
 flatpak build-finish --command=hello.sh ${DIR}
 mkdir -p repos
-flatpak build-export ${GPGARGS-} repos/${REPONAME} ${DIR}
+flatpak build-export ${collection_args} ${GPGARGS-} repos/${REPONAME} ${DIR}
 rm -rf ${DIR}

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -8,6 +8,8 @@ REPONAME=$1
 shift
 ID=$1
 shift
+COLLECTION_ID=$1
+shift
 
 mkdir ${DIR}/files
 mkdir ${DIR}/usr
@@ -65,6 +67,12 @@ done
 mkdir -p ${DIR}/usr/lib/locale/
 cp -r /usr/lib/locale/C.* ${DIR}/usr/lib/locale/en_US
 
+if [ x$COLLECTION_ID != x ]; then
+    collection_args=--collection-id=${COLLECTION_ID}
+else
+    collection_args=
+fi
+
 mkdir -p repos
-flatpak build-export --runtime ${GPGARGS-} repos/${REPONAME} ${DIR}
+flatpak build-export ${collection_args} --runtime ${GPGARGS-} repos/${REPONAME} ${DIR}
 rm -rf ${DIR}

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -148,7 +148,7 @@ assert_file_has_content hello_out '^Hello world, from a sandboxUPDATED$'
 
 echo "ok update"
 
-make_updated_app test UPDATED2
+make_updated_app test org.test.Collection.test UPDATED2
 
 ${FLATPAK} build-bundle repos/test --repo-url=file://`pwd`/repos/test --gpg-keys=${FL_GPG_HOMEDIR}/pubring.gpg bundles/hello2.flatpak org.test.Hello
 assert_has_file bundles/hello2.flatpak

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -90,8 +90,8 @@ EOF
 
 mkdir -p repos
 ostree init --repo=repos/test --mode=archive-z2
-. $(dirname $0)/make-test-runtime.sh test org.test.Platform bash ls cat echo readlink > /dev/null
-. $(dirname $0)/make-test-app.sh test > /dev/null
+. $(dirname $0)/make-test-runtime.sh test org.test.Platform "" bash ls cat echo readlink > /dev/null
+. $(dirname $0)/make-test-app.sh test "" > /dev/null
 
 # Modify platform metadata
 ostree checkout -U --repo=repos/test runtime/org.test.Platform/${ARCH}/master platform

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -76,7 +76,7 @@ echo "ok update oci"
 
 flatpak uninstall  ${U} org.test.Hello
 
-make_updated_app test HTTP
+make_updated_app test org.test.Collection.test HTTP
 ${FLATPAK} build-bundle --oci $FL_GPGARGS repos/test oci/registry org.test.Hello
 
 $(dirname $0)/test-webserver.sh `pwd`/oci
@@ -91,7 +91,7 @@ assert_file_has_content hello_out '^Hello world, from a sandboxHTTP$'
 
 echo "ok install oci http"
 
-make_updated_app test UPDATEDHTTP
+make_updated_app test org.test.Collection.test UPDATEDHTTP
 ${FLATPAK} build-bundle --oci $FL_GPGARGS repos/test oci/registry org.test.Hello
 
 ${FLATPAK} update ${U} org.test.Hello

--- a/tests/test-repo-collections-server-only.sh
+++ b/tests/test-repo-collections-server-only.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright © 2017 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+export USE_COLLECTIONS_IN_SERVER=yes
+export USE_COLLECTIONS_IN_CLIENT=no
+
+. $(dirname $0)/test-repo.sh

--- a/tests/test-repo-collections.sh
+++ b/tests/test-repo-collections.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright © 2017 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+export USE_COLLECTIONS_IN_SERVER=yes
+export USE_COLLECTIONS_IN_CLIENT=yes
+
+. $(dirname $0)/test-repo.sh

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,18 +24,35 @@ set -euo pipefail
 skip_without_bwrap
 skip_without_user_xattrs
 
+if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+    skip_without_p2p
+fi
+
 echo "1..6"
 
 #Regular repo
 setup_repo
 
-#unsigned repo
-GPGPUBKEY="" GPG_ARGS="" setup_repo test-no-gpg
+# Unsigned repo (not supported with collections; client-side use of collections requires GPG)
+if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] ; then
+    if GPGPUBKEY=" " GPGARGS=" " setup_repo test-no-gpg org.test.Collection.NoGpg; then
+        assert_not_reached "Should fail remote-add due to missing GPG key"
+    fi
+elif [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+    # Set a collection ID and GPG on the server, but not in the client configuration
+    setup_repo_no_add test-no-gpg org.test.Collection.NoGpg
+    port=$(cat httpd-port-main)
+    flatpak remote-add ${U} --no-gpg-verify test-no-gpg-repo "http://127.0.0.1:${port}/test-no-gpg"
+else
+    GPGPUBKEY="" GPGARGS="" setup_repo test-no-gpg
+fi
 
 #alternative gpg key repo
-GPGPUBKEY="${FL_GPG_HOMEDIR2}/pubring.gpg" GPGARGS="${FL_GPGARGS2}" setup_repo test-gpg2
+GPGPUBKEY="${FL_GPG_HOMEDIR2}/pubring.gpg" GPGARGS="${FL_GPGARGS2}" setup_repo test-gpg2 org.test.Collection.Gpg2
 
 #remote with missing GPG key
+# Don’t use --collection-id= here, or the collections code will grab the appropriate
+# GPG key from one of the previously-configured remotes with the same collection ID.
 port=$(cat httpd-port-main)
 if flatpak remote-add ${U} test-missing-gpg-repo "http://127.0.0.1:${port}/test"; then
     assert_not_reached "Should fail metadata-update due to missing gpg key"
@@ -47,10 +64,14 @@ if flatpak remote-add ${U} --gpg-import=${FL_GPG_HOMEDIR2}/pubring.gpg test-wron
     assert_not_reached "Should fail metadata-update due to wrong gpg key"
 fi
 
-install_repo test-no-gpg
-echo "ok install without gpg key"
+if [ x${USE_COLLECTIONS_IN_CLIENT-} != xyes ] ; then
+    install_repo test-no-gpg
+    echo "ok install without gpg key"
 
-${FLATPAK} ${U} uninstall org.test.Platform org.test.Hello
+    ${FLATPAK} ${U} uninstall org.test.Platform org.test.Hello
+else
+    echo "ok install without gpg key # skip not supported for collections"
+fi
 
 install_repo test-gpg2
 echo "ok with alternative gpg key"
@@ -95,16 +116,17 @@ assert_file_has_content repo-info "new-title"
 echo "ok update metadata"
 
 port=$(cat httpd-port-main)
-UPDATE_REPO_ARGS="--redirect-url=http://127.0.0.1:${port}/test-gpg2 --gpg-import=${FL_GPG_HOMEDIR2}/pubring.gpg" update_repo
+UPDATE_REPO_ARGS="--redirect-url=http://127.0.0.1:${port}/test-gpg3 --gpg-import=${FL_GPG_HOMEDIR2}/pubring.gpg" update_repo
+GPGPUBKEY="${FL_GPG_HOMEDIR2}/pubring.gpg" GPGARGS="${FL_GPGARGS2}" setup_repo_no_add test-gpg3 org.test.Collection.test
 
 ${FLATPAK} ${U} update org.test.Platform
-${FLATPAK} ${U} remotes -d | grep ^test-repo > repo-info
 # Ensure we have the new uri
-assert_file_has_content repo-info "/test-gpg2"
+${FLATPAK} ${U} remotes -d | grep ^test-repo > repo-info
+assert_file_has_content repo-info "/test-gpg3"
 
 # Make sure we also get new installs from the new repo
-GPGARGS="${FL_GPGARGS2}" make_updated_app test-gpg2
-update_repo test-gpg2
+GPGARGS="${FL_GPGARGS2}" make_updated_app test-gpg3 org.test.Collection.test
+update_repo test-gpg3 org.test.Collection.test
 
 ${FLATPAK} ${U} install test-repo org.test.Hello
 assert_file_has_content $FL_DIR/app/org.test.Hello/$ARCH/master/active/files/bin/hello.sh UPDATED

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+# Copyright © 2017 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Authors:
+#  - Philip Withnall <withnall@endlessm.com>
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+skip_without_user_xattrs
+skip_without_p2p
+
+echo "1..7"
+
+# Configure a repository and set up a collection ID for it. Check that setting
+# the collection ID in the remote config disables summary signature checking.
+setup_repo
+install_repo
+
+echo -e "[core]\ncollection-id=org.test.Collection" >> repos/test/config
+${FLATPAK} remote-modify ${U} test-repo --collection-id org.test.Collection
+
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=false$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=true$'
+assert_file_has_content ${FL_DIR}/repo/config '^collection-id=org.test.Collection$'
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify=true$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify=false$'
+
+echo "ok 1 repo config with collections"
+
+# Test that building an app with a collection ID set produces the right
+# metadata in the resulting repository.
+DIR=$(mktemp -d)
+${FLATPAK} build-init ${DIR} org.test.App org.test.Platform org.test.Platform
+mkdir -p ${DIR}/files/a
+echo "a" > ${DIR}/files/a/data
+${FLATPAK} build-finish ${DIR} --socket=x11 --share=network --command=true
+${FLATPAK} build-export ${FL_GPGARGS} --update-appstream repos/test --collection-id org.test.Collection ${DIR} master
+update_repo
+
+ostree --repo=repos/test refs > refs
+assert_file_has_content refs "^app/org.test.App/$ARCH/master$"
+assert_file_has_content refs '^ostree-metadata$'
+assert_file_has_content refs "^appstream/${ARCH}$"
+ostree --repo=repos/test refs --collections > refs-collections
+assert_file_has_content refs-collections "^(org.test.Collection, app/org.test.App/$ARCH/master)$"
+assert_file_has_content refs-collections '^(org.test.Collection, ostree-metadata)$'
+assert_file_has_content refs-collections "^(org.test.Collection, appstream/${ARCH})$"
+assert_has_file repos/test/summary.sig
+ostree --repo=repos/test summary --view > summary
+assert_file_has_content summary '^Collection ID (ostree.summary.collection-id): org.test.Collection$'
+assert_file_has_content summary '^xa.cache: '
+ostree --repo=repos/test show --raw ostree-metadata > metadata
+assert_file_has_content metadata "'xa.cache': "
+assert_file_has_content metadata "'ostree.collection-binding': <'org.test.Collection'>"
+assert_file_has_content metadata "'ostree.ref-binding': <\['ostree-metadata'\]>"
+
+echo "ok 2 create app with collections"
+
+# Try installing the app.
+${FLATPAK} ${U} install test-repo org.test.App master
+${FLATPAK} ${U} uninstall org.test.App
+
+echo "ok 3 install app with collections"
+
+# Regenerate the summary so it doesn’t contain xa.cache and is unsigned; try installing again.
+ostree --repo=repos/test summary --update
+assert_not_has_file repos/test/summary.sig
+ostree --repo=repos/test summary --view > summary
+assert_file_has_content summary '^Collection ID (ostree.summary.collection-id): org.test.Collection$'
+assert_not_file_has_content summary '^xa.cache: '
+
+${FLATPAK} ${U} install test-repo org.test.App master
+${FLATPAK} ${U} uninstall org.test.App
+
+echo "ok 4 install app with collections from unsigned summary"
+
+# Try installing it from a flatpakref file. Don’t uninstall afterwards because
+# we need it for the next test.
+cat << EOF > org.test.App.flatpakref
+[Flatpak Ref]
+Title=Test App
+Name=org.test.App
+Branch=master
+Url=http://127.0.0.1:$(cat httpd-port-main)/test
+IsRuntime=False
+GPGKey=${FL_GPG_BASE64}
+#RuntimeRepo=http://127.0.0.1:$(cat httpd-port-main)/test
+CollectionID=org.test.Collection
+EOF
+
+${FLATPAK} ${U} install --from ./org.test.App.flatpakref
+${FLATPAK} ${U} uninstall org.test.App
+
+echo "ok 5 install app with collections from flatpakref"
+
+# Update the repo metadata and check that it changes in the ostree-metadata branch
+# and the summary file.
+${FLATPAK} build-update-repo ${FL_GPGARGS} --title "New title" repos/test
+
+assert_has_file repos/test/summary.sig
+ostree --repo=repos/test summary --view > summary
+assert_file_has_content summary '^Collection ID (ostree.summary.collection-id): org.test.Collection$'
+assert_file_has_content summary '^xa.title: '
+ostree --repo=repos/test show --raw ostree-metadata > metadata
+assert_file_has_content metadata "'xa.title': "
+assert_file_has_content metadata "'ostree.collection-binding': <'org.test.Collection'>"
+assert_file_has_content metadata "'ostree.ref-binding': <\['ostree-metadata'\]>"
+
+echo "ok 6 update repo metadata"
+
+# Try to update the app, which should pull the updated repository metadata as a
+# side effect. Before doing that, drop xa.title from the summary to check that
+# it’s actually coming from ostree-metadata.
+ostree --repo=repos/test summary --update
+assert_not_has_file repos/test/summary.sig
+ostree --repo=repos/test summary --view > summary
+assert_not_file_has_content summary '^xa.title: '
+
+#${FLATPAK} ${U} update org.test.App
+${FLATPAK} ${U} install test-repo org.test.App master
+assert_file_has_content ${FL_DIR}/repo/config '^xa.title=New title$'
+# TODO: More
+
+echo "ok 7 pull updated repo metadata"

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Copyright © 2017 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Authors:
+#  - Philip Withnall <withnall@endlessm.com>
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+skip_without_user_xattrs
+skip_without_p2p
+
+echo "1..3"
+
+# Configure a repository without a collection ID and pull it locally.
+setup_repo
+install_repo
+
+DIR=$(mktemp -d)
+${FLATPAK} build-init ${DIR} org.test.App org.test.Platform org.test.Platform
+mkdir -p ${DIR}/files/a
+echo "a" > ${DIR}/files/a/data
+${FLATPAK} build-finish ${DIR} --socket=x11 --share=network --command=true
+${FLATPAK} build-export ${FL_GPGARGS} --update-appstream repos/test ${DIR} master
+update_repo
+
+${FLATPAK} ${U} install test-repo org.test.App master
+
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=true$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=false$'
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify=true$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify=false$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^collection-id='
+
+# Change its configuration to include a collection ID, update the repository,
+# but don’t mark the collection ID as to be deployed yet. Ensure it doesn’t
+# appear in the client’s configuration.
+echo -e "[core]\ncollection-id=org.test.Collection" >> repos/test/config
+${FLATPAK} build-export ${FL_GPGARGS} --update-appstream repos/test --collection-id org.test.Collection ${DIR} master
+UPDATE_REPO_ARGS="--collection-id=org.test.Collection" update_repo
+
+${FLATPAK} ${U} update org.test.App master
+
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=true$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=false$'
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify=true$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify=false$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^collection-id='
+
+echo "ok 1 update repo config without deploying collection ID"
+
+# Now mark the collection ID as to be deployed. The client configuration should
+# be updated.
+UPDATE_REPO_ARGS="--collection-id=org.test.Collection --deploy-collection-id" update_repo
+${FLATPAK} ${U} update org.test.App master
+
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=false$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=true$'
+assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify=true$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify=false$'
+assert_file_has_content ${FL_DIR}/repo/config '^collection-id=org.test.Collection$'
+
+echo "ok 2 update repo config to deploy collection ID"
+
+# Try updating the collection ID to some other non-empty value on the server.
+# The client should ignore the update (otherwise we have a security vulnerability).
+# We have to manually add refs under the old collection ID so the client can pull
+# using its old collection ID.
+#UPDATE_REPO_ARGS="--collection-id=net.malicious.NewCollection --deploy-collection-id" update_repo
+#for ref in app/org.test.App/x86_64/master app/org.test.Hello/x86_64/master appstream/x86_64 ostree-metadata runtime/org.test.Platform/x86_64/master; do
+#  ostree --repo=repos/test refs --collections --create=org.test.Collection:$ref $ref
+#done
+ostree --repo=repos/test summary --update --add-metadata="xa.collection-id='net.malicious.NewCollection'"
+${FLATPAK} ${U} update org.test.App master
+
+assert_file_has_content ${FL_DIR}/repo/config '^collection-id=org.test.Collection$'
+assert_not_file_has_content ${FL_DIR}/repo/config '^collection-id=net.malicious.NewCollection$'
+
+echo "ok 3 update repo config to with different collection ID"

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -202,6 +202,9 @@ test_ref (void)
   g_assert_cmpstr (flatpak_ref_get_name (ref), ==, "org.flatpak.Hello");
   g_assert_cmpstr (flatpak_ref_get_arch (ref), ==, "x86_64");
   g_assert_cmpstr (flatpak_ref_get_branch (ref), ==, "master");
+#ifdef FLATPAK_ENABLE_P2P
+  g_assert_null (flatpak_ref_get_collection_id (ref));
+#endif  /* FLATPAK_ENABLE_P2P */
 
   formatted = flatpak_ref_format_ref (ref);
   g_assert_cmpstr (formatted, ==, valid);
@@ -407,6 +410,9 @@ test_install_launch_uninstall (void)
   g_assert_cmpstr (flatpak_ref_get_arch (FLATPAK_REF (ref)), ==, flatpak_get_default_arch ());
   g_assert_cmpstr (flatpak_ref_get_branch (FLATPAK_REF (ref)), ==, "master");
   g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (ref)), ==, FLATPAK_REF_KIND_RUNTIME);
+#ifdef FLATPAK_ENABLE_P2P
+  g_assert_null (flatpak_ref_get_collection_id (FLATPAK_REF (ref)));
+#endif  /* FLATPAK_ENABLE_P2P */
 
   g_assert_cmpuint (flatpak_installed_ref_get_installed_size (ref), >, 0);
 
@@ -452,6 +458,9 @@ test_install_launch_uninstall (void)
   g_assert_cmpstr (flatpak_ref_get_arch (FLATPAK_REF (ref)), ==, flatpak_get_default_arch ());
   g_assert_cmpstr (flatpak_ref_get_branch (FLATPAK_REF (ref)), ==, "master");
   g_assert_cmpint (flatpak_ref_get_kind (FLATPAK_REF (ref)), ==, FLATPAK_REF_KIND_APP);
+#ifdef FLATPAK_ENABLE_P2P
+  g_assert_null (flatpak_ref_get_collection_id (FLATPAK_REF (ref)));
+#endif  /* FLATPAK_ENABLE_P2P */
 
   g_assert_cmpuint (flatpak_installed_ref_get_installed_size (ref), >, 0);
   g_assert_true (flatpak_installed_ref_get_is_current (ref));

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -12,6 +12,9 @@ static char *flatpak_installationsdir;
 static char *gpg_homedir;
 static char *gpg_args;
 static char *repo_url;
+#ifdef FLATPAK_ENABLE_P2P
+static char *repo_collection_id;
+#endif  /* FLATPAK_ENABLE_P2P */
 int httpd_pid = -1;
 
 static const char *gpg_id = "7B0961FD";
@@ -251,6 +254,10 @@ test_remote_by_name (void)
   g_assert_false (flatpak_remote_get_disabled (remote));
   g_assert_true (flatpak_remote_get_gpg_verify (remote));
   g_assert_cmpint (flatpak_remote_get_prio (remote), ==, 1);
+
+#ifdef FLATPAK_ENABLE_P2P
+  g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, repo_collection_id);
+#endif  /* FLATPAK_ENABLE_P2P */
 }
 
 static void
@@ -266,6 +273,12 @@ test_remote (void)
 
   remote = flatpak_installation_get_remote_by_name (inst, repo_name, NULL, &error);
   g_assert_no_error (error);
+
+#ifdef FLATPAK_ENABLE_P2P
+  g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, NULL);
+  flatpak_remote_set_collection_id (remote, "org.example.CollectionID");
+  g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, "org.example.CollectionID");
+#endif  /* FLATPAK_ENABLE_P2P */
 
   g_assert_cmpstr (flatpak_remote_get_title (remote), ==, NULL);
   flatpak_remote_set_title (remote, "Test Repo");

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -414,7 +414,7 @@ test_install_launch_uninstall (void)
   g_assert (FLATPAK_IS_INSTALLED_REF (ref));
   g_assert_cmpint (progress_count, >, 0);
 
-  timeout_id = g_timeout_add (1000, timeout_cb, &timeout_reached);
+  timeout_id = g_timeout_add (20000, timeout_cb, &timeout_reached);
   while (!timeout_reached && changed_count == 0)
     g_main_context_iteration (NULL, TRUE);
   g_source_remove (timeout_id);
@@ -464,7 +464,7 @@ test_install_launch_uninstall (void)
   g_assert (FLATPAK_IS_INSTALLED_REF (ref));
   g_assert_cmpint (progress_count, >, 0);
 
-  timeout_id = g_timeout_add (1000, timeout_cb, &timeout_reached);
+  timeout_id = g_timeout_add (20000, timeout_cb, &timeout_reached);
   while (!timeout_reached && changed_count == 0)
     g_main_context_iteration (NULL, TRUE);
   g_source_remove (timeout_id);

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -371,6 +371,8 @@ test_install_launch_uninstall (void)
     {
       gint exit_code = 0;
       char *argv[] = { (char *)bwrap, "--ro-bind", "/", "/", "/bin/true", NULL };
+      g_autofree char *argv_str = g_strjoinv (" ", argv);
+      g_test_message ("Spawning %s", argv_str);
       g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL, &exit_code, &error);
       g_assert_no_error (error);
       if (exit_code != 0)
@@ -562,6 +564,7 @@ make_test_runtime (void)
   char *argv[] = {
     NULL, "test", "org.test.Platform", "", "bash", "ls", "cat", "echo", "readlink", NULL
   };
+  g_autofree char *argv_str = NULL;
   GSpawnFlags flags = G_SPAWN_DEFAULT;
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-runtime.sh", NULL);
@@ -575,6 +578,8 @@ make_test_runtime (void)
   else
     flags |= G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL;
 
+  argv_str = g_strjoinv (" ", argv);
+  g_test_message ("Spawning %s", argv_str);
   g_spawn_sync (NULL, (char **)argv, NULL, flags, NULL, NULL, NULL, NULL, &status, &error);
   g_assert_no_error (error);
   g_assert_cmpint (status, ==, 0);
@@ -587,6 +592,7 @@ make_test_app (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *arg0 = NULL;
   char *argv[] = { NULL, "test", "", NULL };
+  g_autofree char *argv_str = NULL;
   GSpawnFlags flags = G_SPAWN_DEFAULT;
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
@@ -600,6 +606,8 @@ make_test_app (void)
   else
     flags |= G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL;
 
+  argv_str = g_strjoinv (" ", argv);
+  g_test_message ("Spawning %s", argv_str);
   g_spawn_sync (NULL, (char **)argv, NULL, flags, NULL, NULL, NULL, NULL, &status, &error);
   g_assert_no_error (error);
   g_assert_cmpint (status, ==, 0);
@@ -611,6 +619,7 @@ update_repo (void)
   int status;
   g_autoptr(GError) error = NULL;
   char *argv[] = { "flatpak", "build-update-repo", "--gpg-homedir=", "--gpg-sign=", "repos/test", NULL };
+  g_autofree char *argv_str = NULL;
   GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
   g_auto(GStrv) gpgargs = NULL;
 
@@ -626,6 +635,8 @@ update_repo (void)
   else
     flags |= G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL;
 
+  argv_str = g_strjoinv (" ", argv);
+  g_test_message ("Spawning %s", argv_str);
   g_spawn_sync (NULL, (char **)argv, NULL, flags, NULL, NULL, NULL, NULL, &status, &error);
   g_assert_no_error (error);
   g_assert_cmpint (status, ==, 0);
@@ -638,6 +649,7 @@ launch_httpd (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *path = g_test_build_filename (G_TEST_DIST, "test-webserver.sh", NULL);
   char *argv[] = {path , "repos", NULL };
+  g_autofree char *argv_str = NULL;
   GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
 
   if (g_test_verbose ())
@@ -648,6 +660,8 @@ launch_httpd (void)
   else
     flags |= G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL;
 
+  argv_str = g_strjoinv (" ", argv);
+  g_test_message ("Spawning %s", argv_str);
   g_spawn_sync (NULL, (char **)argv, NULL, flags, NULL, NULL, NULL, NULL, &status, &error);
   g_assert_no_error (error);
   g_assert_cmpint (status, ==, 0);
@@ -659,6 +673,7 @@ add_remote (void)
   int status;
   g_autoptr(GError) error = NULL;
   char *argv[] = { "flatpak", "remote-add", "--user", "--gpg-import=", "name", "url", NULL };
+  g_autofree char *argv_str = NULL;
   g_autofree char *gpgimport = NULL;
   g_autofree char *port = NULL;
   g_autofree char *pid = NULL;
@@ -693,6 +708,8 @@ add_remote (void)
   else
     flags |= G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL;
 
+  argv_str = g_strjoinv (" ", argv);
+  g_test_message ("Spawning %s", argv_str);
   g_spawn_sync (NULL, (char **)argv, NULL, flags, NULL, NULL, NULL, NULL, &status, &error);
   g_assert_no_error (error);
   g_assert_cmpint (status, ==, 0);
@@ -866,6 +883,7 @@ global_teardown (void)
   int status;
   g_autoptr (GError) error = NULL;
   char *argv[] = { "gpg-connect-agent", "--homedir", "<placeholder>", "killagent", "/bye", NULL };
+  g_autofree char *argv_str = NULL;
   GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
 
   if (g_getenv ("SKIP_TEARDOWN"))
@@ -885,6 +903,9 @@ global_teardown (void)
 
   if (httpd_pid != -1)
     kill (httpd_pid, SIGKILL);
+
+  argv_str = g_strjoinv (" ", argv);
+  g_test_message ("Spawning %s", argv_str);
 
   /* mostly ignore failure here */
   if (!g_spawn_sync (NULL, (char **)argv, NULL, flags, NULL, NULL, NULL, NULL, &status, &error) ||

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -278,6 +278,9 @@ test_remote (void)
   g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, NULL);
   flatpak_remote_set_collection_id (remote, "org.example.CollectionID");
   g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, "org.example.CollectionID");
+  /* Don’t leave the collection ID set since the repos aren’t configured with one. */
+  flatpak_remote_set_collection_id (remote, NULL);
+  g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, NULL);
 #endif  /* FLATPAK_ENABLE_P2P */
 
   g_assert_cmpstr (flatpak_remote_get_title (remote), ==, NULL);
@@ -552,7 +555,7 @@ make_test_runtime (void)
   g_autoptr(GError) error = NULL;
   g_autofree char *arg0 = NULL;
   char *argv[] = {
-    NULL, "test", "org.test.Platform", "bash", "ls", "cat", "echo", "readlink", NULL
+    NULL, "test", "org.test.Platform", "", "bash", "ls", "cat", "echo", "readlink", NULL
   };
   GSpawnFlags flags = G_SPAWN_DEFAULT;
 
@@ -578,7 +581,7 @@ make_test_app (void)
   int status;
   g_autoptr(GError) error = NULL;
   g_autofree char *arg0 = NULL;
-  char *argv[] = { NULL, "test", NULL };
+  char *argv[] = { NULL, "test", "", NULL };
   GSpawnFlags flags = G_SPAWN_DEFAULT;
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);


### PR DESCRIPTION
Here’s my branch which adds support for installing/updating apps/runtimes from LAN/USB, including the necessary support for unsigned summary files and the `ostree-metadata` branch (see https://github.com/ostreedev/ostree/issues/983).

It adds a new `--enable-p2p` option to hide the new functionality behind, but most of the commits have not been updated to actually conditionalise their changes on that option yet. Thus this branch is ready for initial review, but should not be merged yet. I’ll update it soon to add the `#ifdef`s, but they shouldn’t impact the overall behaviour or structure of the branch much.

There are also a bunch of `TODO` comments in the final commit which indicate the things I still need to check or implement (they will mostly be corner cases or upstreaming things to libostree; see below).

It adds a couple of new tests, but there are bound to be quite a few corner cases which I haven’t handled yet. I plan to test it for a while with `--enable-p2p` before we consider dropping the option.