### PR TITLE
Adjust gdbus-codegen Makefile rules

### DIFF
--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -3,7 +3,7 @@ noinst_LTLIBRARIES += libflatpak-common.la
 dbus_built_sources = common/flatpak-dbus.c common/flatpak-dbus.h
 systemd_dbus_built_sources = common/flatpak-systemd-dbus.c common/flatpak-systemd-dbus.h
 
-common/flatpak-dbus.c: data/org.freedesktop.Flatpak.xml
+common/flatpak-dbus.c: data/org.freedesktop.Flatpak.xml Makefile
 	mkdir -p $(builddir)/common
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.Flatpak.	\
@@ -12,7 +12,7 @@ common/flatpak-dbus.c: data/org.freedesktop.Flatpak.xml
 		$(srcdir)/data/org.freedesktop.Flatpak.xml	\
 		$(NULL)
 
-common/flatpak-systemd-dbus.c: data/org.freedesktop.systemd1.xml
+common/flatpak-systemd-dbus.c: data/org.freedesktop.systemd1.xml Makefile
 	mkdir -p $(builddir)/common
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.systemd1.	\

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -3,7 +3,7 @@ noinst_LTLIBRARIES += libflatpak-common.la
 dbus_built_sources = common/flatpak-dbus.c common/flatpak-dbus.h
 systemd_dbus_built_sources = common/flatpak-systemd-dbus.c common/flatpak-systemd-dbus.h
 
-$(dbus_built_sources) : data/org.freedesktop.Flatpak.xml
+common/flatpak-dbus.c: data/org.freedesktop.Flatpak.xml
 	mkdir -p $(builddir)/common
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.Flatpak.	\
@@ -12,7 +12,7 @@ $(dbus_built_sources) : data/org.freedesktop.Flatpak.xml
 		$(srcdir)/data/org.freedesktop.Flatpak.xml	\
 		$(NULL)
 
-$(systemd_dbus_built_sources) : data/org.freedesktop.systemd1.xml
+common/flatpak-systemd-dbus.c: data/org.freedesktop.systemd1.xml
 	mkdir -p $(builddir)/common
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.systemd1.	\
@@ -20,6 +20,9 @@ $(systemd_dbus_built_sources) : data/org.freedesktop.systemd1.xml
 		--generate-c-code $(builddir)/common/flatpak-systemd-dbus	\
 		$(srcdir)/data/org.freedesktop.systemd1.xml	\
 		$(NULL)
+
+common/%-dbus.h: common/%-dbus.c
+	@true # Built as a side-effect of the rules for the .c
 
 nodist_libflatpak_common_la_SOURCES = \
 	$(dbus_built_sources)		\

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -5,7 +5,7 @@ libexec_PROGRAMS += \
 xdp_dbus_built_sources = document-portal/xdp-dbus.c document-portal/xdp-dbus.h
 BUILT_SOURCES += $(xdp_dbus_built_sources)
 
-document-portal/xdp-dbus.c: data/org.freedesktop.portal.Documents.xml
+document-portal/xdp-dbus.c: data/org.freedesktop.portal.Documents.xml Makefile
 	mkdir -p $(builddir)/document-portal
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.portal.	\

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -5,7 +5,7 @@ libexec_PROGRAMS += \
 xdp_dbus_built_sources = document-portal/xdp-dbus.c document-portal/xdp-dbus.h
 BUILT_SOURCES += $(xdp_dbus_built_sources)
 
-$(xdp_dbus_built_sources) : data/org.freedesktop.portal.Documents.xml
+document-portal/xdp-dbus.c: data/org.freedesktop.portal.Documents.xml
 	mkdir -p $(builddir)/document-portal
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.portal.	\
@@ -15,6 +15,9 @@ $(xdp_dbus_built_sources) : data/org.freedesktop.portal.Documents.xml
                 --annotate "org.freedesktop.portal.Documents.AddFull()" org.gtk.GDBus.C.UnixFD "yes" \
 		$(srcdir)/data/org.freedesktop.portal.Documents.xml	\
 		$(NULL)
+
+document-portal/%-dbus.h: document-portal/%-dbus.c
+	@true # Built as a side-effect of the rules for the .c
 
 service_in_files += document-portal/xdg-document-portal.service.in
 systemduserunit_DATA += document-portal/xdg-document-portal.service

--- a/permission-store/Makefile.am.inc
+++ b/permission-store/Makefile.am.inc
@@ -12,7 +12,7 @@ nodist_xdg_permission_store_SOURCES = permission-store/permission-store-dbus.c p
 BUILT_SOURCES += $(nodist_xdg_permission_store_SOURCES)
 CLEANFILES += $(nodist_xdg_permission_store_SOURCES)
 
-$(nodist_xdg_permission_store_SOURCES) : data/org.freedesktop.impl.portal.PermissionStore.xml
+permission-store/permission-store-dbus.c: data/org.freedesktop.impl.portal.PermissionStore.xml
 	mkdir -p $(builddir)/permission-store
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.impl.portal.	\
@@ -20,6 +20,9 @@ $(nodist_xdg_permission_store_SOURCES) : data/org.freedesktop.impl.portal.Permis
 		--generate-c-code $(builddir)/permission-store/permission-store-dbus	\
 		$(srcdir)/data/org.freedesktop.impl.portal.PermissionStore.xml	\
 		$(NULL)
+
+permission-store/%-dbus.h: permission-store/%-dbus.c
+	@true # Built as a side-effect of the rules for the .c
 
 # also used by the document portal
 ps_dbus_built_sources = $(nodist_xdg_permission_store_SOURCES)

--- a/permission-store/Makefile.am.inc
+++ b/permission-store/Makefile.am.inc
@@ -12,7 +12,7 @@ nodist_xdg_permission_store_SOURCES = permission-store/permission-store-dbus.c p
 BUILT_SOURCES += $(nodist_xdg_permission_store_SOURCES)
 CLEANFILES += $(nodist_xdg_permission_store_SOURCES)
 
-permission-store/permission-store-dbus.c: data/org.freedesktop.impl.portal.PermissionStore.xml
+permission-store/permission-store-dbus.c: data/org.freedesktop.impl.portal.PermissionStore.xml Makefile
 	mkdir -p $(builddir)/permission-store
 	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
 		--interface-prefix org.freedesktop.impl.portal.	\


### PR DESCRIPTION
* build: Only run each instance of gdbus-codegen once
    
    A rule of the form
    
        foo.c foo.h: foo.in
            some-generator --output=foo foo.in
    
    is essentially equivalent to writing the same rule once for each target:
    
        foo.c: foo.in
            some-generator --output=foo foo.in
        foo.h: foo.in
            some-generator --output=foo foo.in
    
    In a parallel build, this can result in some-generator being run more
    than once with the same inputs and outputs, leading to unpredictable
    results if the outputs are overwritten in-place by two parallel copies
    (particularly if the generator does not use the standard atomic-writing
    trick of writing out a temporary file and renaming it over the top of
    the intended name, which gdbus-codegen does not).
    
    gdbus-codegen happens to write the .h file before the .c file, so
    use the real build rules to generate the .c file, and consider the
    .h file to be a side-effect.

* build: Re-run gdbus-codegen if the Makefile changes
    
    Changes to the Makefile could include changes to the options passed
    to gdbus-codegen, which would invalidate the output.
    
    