### PR TITLE
Minor cleanup in dbus-proxy

### DIFF
--- a/dbus-proxy/dbus-proxy.c
+++ b/dbus-proxy/dbus-proxy.c
@@ -30,10 +30,10 @@
 
 #include "flatpak-proxy.h"
 
-GList *proxies;
-int sync_fd = -1;
+static GList *proxies;
+static int sync_fd = -1;
 
-int
+static int
 parse_generic_args (int n_args, const char *args[])
 {
   if (g_str_has_prefix (args[0], "--fd="))
@@ -59,7 +59,7 @@ parse_generic_args (int n_args, const char *args[])
     }
 }
 
-int
+static int
 start_proxy (int n_args, const char *args[])
 {
   g_autoptr(FlatpakProxy) proxy = NULL;

--- a/dbus-proxy/flatpak-proxy.c
+++ b/dbus-proxy/flatpak-proxy.c
@@ -487,7 +487,6 @@ flatpak_proxy_finalize (GObject *object)
   if (g_socket_service_is_active (G_SOCKET_SERVICE (proxy)))
     unlink (proxy->socket_path);
 
-  g_clear_pointer (&proxy->dbus_address, g_free);
   g_assert (proxy->clients == NULL);
 
   g_hash_table_destroy (proxy->policy);

--- a/dbus-proxy/flatpak-proxy.c
+++ b/dbus-proxy/flatpak-proxy.c
@@ -170,9 +170,6 @@
 
 typedef struct FlatpakProxyClient FlatpakProxyClient;
 
-FlatpakPolicy flatpak_proxy_get_policy (FlatpakProxy *proxy,
-                                        const char   *name);
-
 /* We start looking ignoring the first cr-lf
    since there is no previous line initially */
 #define AUTH_END_INIT_OFFSET 2
@@ -439,7 +436,7 @@ flatpak_proxy_get_wildcard_policy (FlatpakProxy *proxy,
   return wildcard_policy;
 }
 
-FlatpakPolicy
+static FlatpakPolicy
 flatpak_proxy_get_policy (FlatpakProxy *proxy,
                           const char   *name)
 {


### PR DESCRIPTION
*   dbus-proxy: Don't clear dbus_address twice
    
    It's sufficient to g_free it, which we do further down finalize().
    This is not a double-free, because we used g_clear_pointer(),
    but it's redundant.
    
*    dbus-proxy: Make miscellaneous globals static
