### PR TITLE
(WIP) Use fd.o #100344 to do D-Bus via a special server per container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ lib/flatpak-enum-types.c
 lib/flatpak-enum-types.h
 test-libflatpak
 Flatpak-1.0.*
+/common/flatpak-containers1-dbus.[ch]
 /doc/reference/gtkdoc-check.log
 /doc/reference/gtkdoc-check.test
 /doc/reference/gtkdoc-check.trs

--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -409,7 +409,7 @@ update_metadata (GFile *base, FlatpakContext *arg_context, gboolean is_runtime, 
   if (!flatpak_context_load_metadata (app_context, keyfile, error))
     goto out;
   flatpak_context_merge (app_context, arg_context);
-  flatpak_context_save_metadata (app_context, FALSE, keyfile);
+  flatpak_context_save_metadata (app_context, FALSE, keyfile, NULL);
 
   for (i = 0; opt_extra_data != NULL && opt_extra_data[i] != NULL; i++)
     {

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -417,6 +417,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                       runtime_ref,
                                       app_context,
                                       &app_info_path,
+                                      NULL,
                                       error))
     return FALSE;
 

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -122,6 +122,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   g_autofree char *app_info_path = NULL;
   g_autofree char *runtime_extensions = NULL;
   g_autoptr(GFile) app_id_dir = NULL;
+  g_autoptr(GVariant) metadata_dict = NULL;
 
   context = g_option_context_new (_("DIRECTORY [COMMAND [args...]] - Build in directory"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
@@ -417,12 +418,14 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                       runtime_ref,
                                       app_context,
                                       &app_info_path,
-                                      NULL,
+                                      &metadata_dict,
                                       error))
     return FALSE;
 
   if (!flatpak_run_add_environment_args (bwrap, app_info_path, run_flags, id,
-                                         app_context, app_id_dir, NULL, cancellable, error))
+                                         app_context, app_id_dir,
+                                         metadata_dict, NULL, cancellable,
+                                         error))
     return FALSE;
 
   for (i = 0; opt_bind_mounts != NULL && opt_bind_mounts[i] != NULL; i++)

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -303,7 +303,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
           if (opt_show_permissions)
             {
               keyfile = g_key_file_new ();
-              flatpak_context_save_metadata (context, TRUE, keyfile);
+              flatpak_context_save_metadata (context, TRUE, keyfile, NULL);
               contents = g_key_file_to_data (keyfile, NULL, error);
               if (contents == NULL)
                 return FALSE;

--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -93,7 +93,7 @@ flatpak_builtin_override (int argc, char **argv, GCancellable *cancellable, GErr
 
   flatpak_context_merge (overrides, arg_context);
 
-  flatpak_context_save_metadata (overrides, FALSE, metakey);
+  flatpak_context_save_metadata (overrides, FALSE, metakey, NULL);
 
   if (!flatpak_save_override_keyfile (metakey, app, flatpak_dir_is_user (dir), error))
     return FALSE;

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -30,6 +30,15 @@ common/flatpak-systemd-dbus.c: data/org.freedesktop.systemd1.xml Makefile
 		$(srcdir)/data/org.freedesktop.systemd1.xml	\
 		$(NULL)
 
+common/flatpak-containers1-dbus.c: data/org.freedesktop.DBus.Containers1.xml Makefile
+	mkdir -p $(builddir)/common
+	$(AM_V_GEN) $(GDBUS_CODEGEN)				\
+		--interface-prefix org.freedesktop.DBus.	\
+		--c-namespace FpDBus				\
+		--generate-c-code $(builddir)/common/flatpak-containers1-dbus	\
+		$(srcdir)/data/org.freedesktop.DBus.Containers1.xml	\
+		$(NULL)
+
 common/%-dbus.h: common/%-dbus.c
 	@true # Built as a side-effect of the rules for the .c
 
@@ -37,6 +46,8 @@ nodist_libflatpak_common_la_SOURCES = \
 	$(dbus_built_sources)		\
 	$(systemd_dbus_built_sources)	\
 	$(xdp_dbus_built_sources) \
+	common/flatpak-containers1-dbus.c \
+	common/flatpak-containers1-dbus.h \
 	$(NULL)
 
 BUILT_SOURCES += $(nodist_libflatpak_common_la_SOURCES)

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1396,12 +1396,14 @@ flatpak_context_load_metadata (FlatpakContext *context,
  * FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
  * FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY and
  * FLATPAK_METADATA_GROUP_ENVIRONMENT groups, and all groups starting
- * with FLATPAK_METADATA_GROUP_PREFIX_POLICY, into metakey
+ * with FLATPAK_METADATA_GROUP_PREFIX_POLICY, into metakey and optionally
+ * also into @dict.
  */
 void
 flatpak_context_save_metadata (FlatpakContext *context,
                                gboolean        flatten,
-                               GKeyFile       *metakey)
+                               GKeyFile       *metakey,
+                               GVariantDict   *dict)
 {
   g_auto(GStrv) shared = NULL;
   g_auto(GStrv) sockets = NULL;
@@ -1418,6 +1420,11 @@ flatpak_context_save_metadata (FlatpakContext *context,
   FlatpakContextFeatures features_mask = context->features;
   FlatpakContextFeatures features_valid = context->features;
   g_auto(GStrv) groups = NULL;
+  GVariantDict context_dict;
+  g_auto(GVariantBuilder) session_builder = {};
+  g_auto(GVariantBuilder) system_builder = {};
+  g_auto(GVariantBuilder) environment_builder = {};
+  g_autoptr(GHashTable) policy_builders = NULL;
   int i;
 
   if (flatten)
@@ -1445,8 +1452,15 @@ flatpak_context_save_metadata (FlatpakContext *context,
   devices = flatpak_context_devices_to_string (devices_mask, devices_valid);
   features = flatpak_context_features_to_string (features_mask, features_valid);
 
+  /* FIXME: At the moment context is an a{sv}. At the moment it could be
+   * an a{sas}, but do we want to keep the ability to add values that are
+   * not string lists? */
+  g_variant_dict_init (&context_dict, NULL);
+
   if (shared[0] != NULL)
     {
+      g_variant_dict_insert (&context_dict, FLATPAK_METADATA_KEY_SHARED,
+                             "^as", shared);
       g_key_file_set_string_list (metakey,
                                   FLATPAK_METADATA_GROUP_CONTEXT,
                                   FLATPAK_METADATA_KEY_SHARED,
@@ -1462,6 +1476,8 @@ flatpak_context_save_metadata (FlatpakContext *context,
 
   if (sockets[0] != NULL)
     {
+      g_variant_dict_insert (&context_dict, FLATPAK_METADATA_KEY_SOCKETS,
+                             "^as", sockets);
       g_key_file_set_string_list (metakey,
                                   FLATPAK_METADATA_GROUP_CONTEXT,
                                   FLATPAK_METADATA_KEY_SOCKETS,
@@ -1477,6 +1493,8 @@ flatpak_context_save_metadata (FlatpakContext *context,
 
   if (devices[0] != NULL)
     {
+      g_variant_dict_insert (&context_dict, FLATPAK_METADATA_KEY_DEVICES,
+                             "^as", devices);
       g_key_file_set_string_list (metakey,
                                   FLATPAK_METADATA_GROUP_CONTEXT,
                                   FLATPAK_METADATA_KEY_DEVICES,
@@ -1492,6 +1510,8 @@ flatpak_context_save_metadata (FlatpakContext *context,
 
   if (features[0] != NULL)
     {
+      g_variant_dict_insert (&context_dict, FLATPAK_METADATA_KEY_FEATURES,
+                             "^as", features);
       g_key_file_set_string_list (metakey,
                                   FLATPAK_METADATA_GROUP_CONTEXT,
                                   FLATPAK_METADATA_KEY_FEATURES,
@@ -1524,10 +1544,16 @@ flatpak_context_save_metadata (FlatpakContext *context,
             g_ptr_array_add (array, g_strconcat ("!", key, NULL));
         }
 
+      /* FIXME: Can we assume all the items are valid UTF-8? If not, we will
+       * have to escape or otherwise mangle them somehow, for both the
+       * GVariant and the GKeyFile */
       g_key_file_set_string_list (metakey,
                                   FLATPAK_METADATA_GROUP_CONTEXT,
                                   FLATPAK_METADATA_KEY_FILESYSTEMS,
                                   (const char * const *) array->pdata, array->len);
+      g_ptr_array_add (array, NULL);
+      g_variant_dict_insert (&context_dict, FLATPAK_METADATA_KEY_FILESYSTEMS,
+                             "^as", array->pdata);
     }
   else
     {
@@ -1541,6 +1567,9 @@ flatpak_context_save_metadata (FlatpakContext *context,
     {
       g_autofree char **keys = (char **) g_hash_table_get_keys_as_array (context->persistent, NULL);
 
+      /* FIXME: Can we assume all the items are valid UTF-8? */
+      g_variant_dict_insert (&context_dict, FLATPAK_METADATA_KEY_PERSISTENT,
+                             "^as", keys);
       g_key_file_set_string_list (metakey,
                                   FLATPAK_METADATA_GROUP_CONTEXT,
                                   FLATPAK_METADATA_KEY_PERSISTENT,
@@ -1554,16 +1583,41 @@ flatpak_context_save_metadata (FlatpakContext *context,
                              NULL);
     }
 
+  if (dict != NULL)
+    g_variant_dict_insert_value (dict, FLATPAK_METADATA_GROUP_CONTEXT,
+                                 g_variant_dict_end (&context_dict));
+
+  g_variant_builder_init (&session_builder, G_VARIANT_TYPE ("a{ss}"));
+
   g_key_file_remove_group (metakey, FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY, NULL);
   g_hash_table_iter_init (&iter, context->session_bus_policy);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
       FlatpakPolicy policy = GPOINTER_TO_INT (value);
       if (policy > 0)
-        g_key_file_set_string (metakey,
-                               FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
-                               (char *) key, flatpak_policy_to_string (policy));
+        {
+          const char *s = flatpak_policy_to_string (policy);
+
+          g_variant_builder_add (&session_builder, "{ss}", key, s);
+          g_key_file_set_string (metakey,
+                                 FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                                 (char *) key, s);
+        }
     }
+
+  if (dict != NULL)
+    {
+      g_autoptr(GVariant) session_built = g_variant_ref_sink (g_variant_builder_end (&session_builder));
+
+      if (g_variant_n_children (session_built) > 0)
+        g_variant_dict_insert_value (dict,
+                                     FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                                     session_built);
+      else
+        g_variant_dict_remove (dict, FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY);
+    }
+
+  g_variant_builder_init (&system_builder, G_VARIANT_TYPE ("a{ss}"));
 
   g_key_file_remove_group (metakey, FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY, NULL);
   g_hash_table_iter_init (&iter, context->system_bus_policy);
@@ -1571,20 +1625,56 @@ flatpak_context_save_metadata (FlatpakContext *context,
     {
       FlatpakPolicy policy = GPOINTER_TO_INT (value);
       if (policy > 0)
-        g_key_file_set_string (metakey,
-                               FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
-                               (char *) key, flatpak_policy_to_string (policy));
+        {
+          const char *s = flatpak_policy_to_string (policy);
+
+          g_variant_builder_add (&system_builder, "{ss}", key, s);
+          g_key_file_set_string (metakey,
+                                 FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                                 (char *) key, s);
+        }
     }
+
+  if (dict != NULL)
+    {
+      g_autoptr(GVariant) system_built = g_variant_ref_sink (g_variant_builder_end (&system_builder));
+
+      if (g_variant_n_children (system_built) > 0)
+        g_variant_dict_insert_value (dict,
+                                     FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                                     system_built);
+      else
+        g_variant_dict_remove (dict, FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY);
+    }
+
+  g_variant_builder_init (&environment_builder, G_VARIANT_TYPE ("a{ss}"));
 
   g_key_file_remove_group (metakey, FLATPAK_METADATA_GROUP_ENVIRONMENT, NULL);
   g_hash_table_iter_init (&iter, context->env_vars);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
+      /* FIXME: Can we assume all the items are valid UTF-8? */
+      g_variant_builder_add (&environment_builder, "{ss}", key, value);
       g_key_file_set_string (metakey,
                              FLATPAK_METADATA_GROUP_ENVIRONMENT,
                              (char *) key, (char *) value);
     }
 
+  if (dict != NULL)
+    {
+      g_autoptr(GVariant) env_built = g_variant_ref_sink (g_variant_builder_end (&environment_builder));
+
+      if (g_variant_n_children (env_built) > 0)
+        g_variant_dict_insert_value (dict,
+                                     FLATPAK_METADATA_GROUP_ENVIRONMENT,
+                                     env_built);
+      else
+        g_variant_dict_remove (dict, FLATPAK_METADATA_GROUP_ENVIRONMENT);
+    }
+
+  policy_builders = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                           g_free,
+                                          (GDestroyNotify) g_variant_builder_unref);
 
   groups = g_key_file_get_groups (metakey, NULL);
   for (i = 0; groups[i] != NULL; i++)
@@ -1603,6 +1693,7 @@ flatpak_context_save_metadata (FlatpakContext *context,
       const char **policy_values = (const char **)value;
       g_autoptr(GPtrArray) new = g_ptr_array_new ();
 
+      /* FIXME: Can we guarantee that all the policy values are UTF-8? */
       for (i = 0; policy_values[i] != NULL; i++)
         {
           const char *policy_value = policy_values[i];
@@ -1613,11 +1704,52 @@ flatpak_context_save_metadata (FlatpakContext *context,
 
       if (new->len > 0)
         {
+          GVariantBuilder *subsystem_builder;
+
           group = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_POLICY,
                                parts[0], NULL);
           g_key_file_set_string_list (metakey, group, parts[1],
                                       (const char * const*)new->pdata,
                                       new->len);
+
+          /* So that we can use pdata as a GStrv, below */
+          g_ptr_array_add (new, NULL);
+
+          subsystem_builder = g_hash_table_lookup (policy_builders, parts[0]);
+
+          if (subsystem_builder == NULL)
+            {
+              subsystem_builder = g_variant_builder_new (G_VARIANT_TYPE ("{sas}"));
+              /* transfer ownership of subsystem_builder to the hash table */
+              g_hash_table_insert (policy_builders, g_strdup (parts[0]),
+                                   subsystem_builder);
+            }
+
+          g_variant_builder_add (subsystem_builder, "{s^as}", parts[1],
+                                 new->pdata);
+        }
+    }
+
+  if (dict != NULL)
+    {
+      if (g_hash_table_size (policy_builders) > 0)
+        {
+          GVariantBuilder policies;
+
+          g_variant_builder_init (&policies, G_VARIANT_TYPE ("a{sa{sas}}"));
+
+          g_hash_table_iter_init (&iter, policy_builders);
+          while (g_hash_table_iter_next (&iter, &key, &value))
+            g_variant_builder_add (&policies, "{s@a{sas}}", key,
+                                   g_variant_builder_end (value));
+
+          g_variant_dict_insert_value (dict,
+                                       FLATPAK_METADATA_VARIANT_KEY_POLICIES,
+                                       g_variant_builder_end (&policies));
+        }
+      else
+        {
+          g_variant_dict_remove (dict, FLATPAK_METADATA_VARIANT_KEY_POLICIES);
         }
     }
 }

--- a/common/flatpak-context.h
+++ b/common/flatpak-context.h
@@ -88,7 +88,8 @@ gboolean       flatpak_context_load_metadata (FlatpakContext *context,
                                               GError        **error);
 void           flatpak_context_save_metadata (FlatpakContext *context,
                                               gboolean        flatten,
-                                              GKeyFile       *metakey);
+                                              GKeyFile       *metakey,
+                                              GVariantDict   *dict);
 void           flatpak_context_allow_host_fs (FlatpakContext *context);
 void           flatpak_context_set_session_bus_policy (FlatpakContext *context,
                                                        const char     *name,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5315,7 +5315,8 @@ apply_extra_data (FlatpakDir          *self,
                                          FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY |
                                          FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY,
                                          id,
-                                         app_context, NULL, NULL, cancellable, error))
+                                         app_context, NULL, NULL, NULL,
+                                         cancellable, error))
     return FALSE;
 
   g_ptr_array_add (bwrap->argv, g_strdup ("/app/bin/apply_extra"));

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1507,7 +1507,7 @@ flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
     g_key_file_set_boolean (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
                             FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY, TRUE);
 
-  flatpak_context_save_metadata (final_app_context, TRUE, keyfile);
+  flatpak_context_save_metadata (final_app_context, TRUE, keyfile, NULL);
 
   if (!g_key_file_save_to_file (keyfile, tmp_path, error))
     return FALSE;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -64,6 +64,7 @@ add_dbus_proxy_args (GPtrArray *argv_array,
                      GPtrArray *a11y_dbus_proxy_argv,
                      gboolean   enable_a11y_logging,
                      int        sync_fds[2],
+                     const char *app_id,
                      const char *app_info_path,
                      GError   **error);
 
@@ -963,7 +964,7 @@ flatpak_run_add_environment_args (FlatpakBwrap   *bwrap,
                             session_bus_proxy_argv, (flags & FLATPAK_RUN_FLAG_LOG_SESSION_BUS) != 0,
                             system_bus_proxy_argv, (flags & FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS) != 0,
                             a11y_bus_proxy_argv, (flags & FLATPAK_RUN_FLAG_LOG_A11Y_BUS) != 0,
-                            sync_fds, app_info_path, error))
+                            sync_fds, app_id, app_info_path, error))
     return FALSE;
 
   if (sync_fds[1] != -1)
@@ -1858,6 +1859,7 @@ add_dbus_proxy_args (GPtrArray *argv_array,
                      GPtrArray *a11y_dbus_proxy_argv,
                      gboolean   enable_a11y_logging,
                      int        sync_fds[2],
+                     const char *app_id,
                      const char *app_info_path,
                      GError   **error)
 {
@@ -1895,6 +1897,7 @@ add_dbus_proxy_args (GPtrArray *argv_array,
   dbus_proxy_argv = g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (dbus_proxy_argv, g_strdup (proxy));
   g_ptr_array_add (dbus_proxy_argv, g_strdup_printf ("--fd=%d", sync_fds[1]));
+  g_ptr_array_add (dbus_proxy_argv, g_strdup_printf ("--app-id=%s", app_id));
 
   append_proxy_args (dbus_proxy_argv, session_dbus_proxy_argv, enable_session_logging);
   append_proxy_args (dbus_proxy_argv, system_dbus_proxy_argv, enable_system_logging);

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -184,6 +184,7 @@ gboolean flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
                                         const char     *runtime_ref,
                                         FlatpakContext *final_app_context,
                                         char          **app_info_path_out,
+                                        GVariant      **metadata_dict_out,
                                         GError        **error);
 
 gboolean flatpak_run_app (const char     *app_ref,

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -149,6 +149,7 @@ gboolean flatpak_run_add_environment_args (FlatpakBwrap   *bwrap,
                                            const char     *app_id,
                                            FlatpakContext *context,
                                            GFile          *app_id_dir,
+                                           GVariant       *metadata_dict,
                                            FlatpakExports **exports_out,
                                            GCancellable *cancellable,
                                            GError      **error);

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -33,6 +33,8 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 
 /* See flatpak-metadata(5) */
 
+/* When serialized into GVariant, [Application] turns into an a{sv} value with
+ * {'Application', <{'command': <'...'>, 'tags': <['awesome']>, ...}>} */
 #define FLATPAK_METADATA_GROUP_APPLICATION "Application"
 #define FLATPAK_METADATA_GROUP_RUNTIME "Runtime"
 #define FLATPAK_METADATA_KEY_COMMAND "command"
@@ -42,6 +44,8 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_SDK "sdk"
 #define FLATPAK_METADATA_KEY_TAGS "tags"
 
+/* When serialized into GVariant, [Context] turns into an a{sv} entry with
+ * {'Context', <{'shared': <['network, 'ipc']>, ...}>} */
 #define FLATPAK_METADATA_GROUP_CONTEXT "Context"
 #define FLATPAK_METADATA_KEY_SHARED "shared"
 #define FLATPAK_METADATA_KEY_SOCKETS "sockets"
@@ -50,6 +54,8 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_DEVICES "devices"
 #define FLATPAK_METADATA_KEY_FEATURES "features"
 
+/* When serialized into GVariant, [Instance] turns into an a{sv} entry with
+ * {'Instance', <{'app-path': <'/...'>, 'session-bus-proxy': <true>, ...}>} */
 #define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
 #define FLATPAK_METADATA_KEY_APP_PATH "app-path"
 #define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
@@ -62,11 +68,25 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_SESSION_BUS_PROXY "session-bus-proxy"
 #define FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY "system-bus-proxy"
 
+/* When serialized into GVariant, [Session Bus Policy] com.example.Foo=talk ...
+ * turns into an a{sv} entry with
+ * {'Session Bus Policy', <{'com.example.Foo': 'talk', ...}>}.
+ * [System Bus Policy] is encoded the same way. */
 #define FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY "Session Bus Policy"
 #define FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY "System Bus Policy"
-#define FLATPAK_METADATA_GROUP_PREFIX_POLICY "Policy "
+
+/* When serialized into GVariant, [Environment] FOO_DEBUG=all ...
+ * turns into an a{sv} entry {'Environment', <{'FOO_DEBUG': 'all', ...}>}. */
 #define FLATPAK_METADATA_GROUP_ENVIRONMENT "Environment"
 
+/* When serialized into GVariant, [Policy foo] Bar=baz;bar; turns into
+ * {'Policies', {'foo': {'Bar': ['baz', 'bar']}}}. Note that this is not
+ * a 1:1 mapping of the GKeyFile encoding because GVariant and D-Bus support
+ * nested data structures. */
+#define FLATPAK_METADATA_GROUP_PREFIX_POLICY "Policy "
+#define FLATPAK_METADATA_VARIANT_KEY_POLICIES "Policies"
+
+/* Not serialized in flatpak_context_save_metadata() */
 #define FLATPAK_METADATA_GROUP_PREFIX_EXTENSION "Extension "
 #define FLATPAK_METADATA_KEY_ADD_LD_PATH "add-ld-path"
 #define FLATPAK_METADATA_KEY_AUTODELETE "autodelete"
@@ -85,6 +105,7 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_COLLECTION_ID "collection-id"
 #endif  /* FLATPAK_ENABLE_P2P */
 
+/* Not serialized in flatpak_context_save_metadata() */
 #define FLATPAK_METADATA_GROUP_EXTRA_DATA "Extra Data"
 #define FLATPAK_METADATA_KEY_EXTRA_DATA_CHECKSUM "checksum"
 #define FLATPAK_METADATA_KEY_EXTRA_DATA_INSTALLED_SIZE "installed-size"
@@ -93,10 +114,10 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_EXTRA_DATA_URI "uri"
 #define FLATPAK_METADATA_KEY_NO_RUNTIME "NoRuntime"
 
+/* Not serialized in flatpak_context_save_metadata() */
 #define FLATPAK_METADATA_GROUP_EXTENSION_OF "ExtensionOf"
 #define FLATPAK_METADATA_KEY_PRIORITY "priority"
 #define FLATPAK_METADATA_KEY_REF "ref"
-
 
 typedef enum {
   FLATPAK_RUN_FLAG_DEVEL              = (1 << 0),

--- a/data/org.freedesktop.DBus.Containers1.xml
+++ b/data/org.freedesktop.DBus.Containers1.xml
@@ -1,0 +1,44 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.DBus.Containers1">
+    <method name="AddServer">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="a{sv}"/>
+      <arg direction="in" type="a{sv}"/>
+      <arg direction="out" type="o"/>
+      <arg direction="out" type="ay"/>
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="StopInstance">
+      <arg direction="in" type="o"/>
+    </method>
+    <method name="StopListening">
+      <arg direction="in" type="o"/>
+    </method>
+    <method name="GetConnectionInstance">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="o"/>
+      <arg direction="out" type="a{sv}"/>
+      <arg direction="out" type="s"/>
+      <arg direction="out" type="s"/>
+      <arg direction="out" type="a{sv}"/>
+    </method>
+    <method name="GetInstanceInfo">
+      <arg direction="in" type="o"/>
+      <arg direction="out" type="a{sv}"/>
+      <arg direction="out" type="s"/>
+      <arg direction="out" type="s"/>
+      <arg direction="out" type="a{sv}"/>
+    </method>
+    <method name="RequestHeader">
+    </method>
+    <property name="SupportedArguments" type="as" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+    </property>
+    <signal name="InstanceRemoved">
+      <arg type="o" name="path"/>
+    </signal>
+  </interface>
+</node>

--- a/dbus-proxy/Makefile.am.inc
+++ b/dbus-proxy/Makefile.am.inc
@@ -8,5 +8,17 @@ flatpak_dbus_proxy_SOURCES = \
 	dbus-proxy/dbus-proxy.c		\
 	$(NULL)
 
-flatpak_dbus_proxy_LDADD = $(AM_LDADD) $(BASE_LIBS) libglnx.la
-flatpak_dbus_proxy_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) -I$(srcdir)/dbus-proxy
+flatpak_dbus_proxy_LDADD = \
+	libglnx.la \
+	libflatpak-common.la \
+	$(AM_LDADD) \
+	$(BASE_LIBS) \
+	$(NULL)
+flatpak_dbus_proxy_CFLAGS = \
+	-I$(srcdir)/dbus-proxy \
+	$(AM_CFLAGS) \
+	$(BASE_CFLAGS) \
+	$(OSTREE_CFLAGS) \
+	$(SOUP_CFLAGS) \
+	$(JSON_CFLAGS) \
+	$(NULL)

--- a/dbus-proxy/dbus-proxy.c
+++ b/dbus-proxy/dbus-proxy.c
@@ -247,7 +247,7 @@ start_proxy (int n_args, const char *args[])
       n++;
     }
 
-  if (!flatpak_proxy_start (proxy, &error))
+  if (!flatpak_proxy_start (proxy, metadata, &error))
     {
       g_printerr ("Failed to start proxy for %s: %s\n", bus_address, error->message);
       return -1;

--- a/dbus-proxy/flatpak-proxy.c
+++ b/dbus-proxy/flatpak-proxy.c
@@ -35,6 +35,9 @@
  * when we depend on GLib >= 2.50 */
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FpDBusContainers1, g_object_unref)
 
+/* TODO: Remove this when supported by GLib */
+#define DBUS_HEADER_FIELD_CONTAINER_INSTANCE 10
+
 /**
  *
  * |--------------------------------------------------|
@@ -1233,6 +1236,12 @@ parse_header (Buffer *buffer, guint32 serial_offset, guint32 reply_serial_offset
 
           header->unix_fds = read_uint32 (header, &buffer->data[offset]);
           offset += 4;
+          break;
+
+        case DBUS_HEADER_FIELD_CONTAINER_INSTANCE:
+          if (strcmp (signature, "o") != 0 ||
+              get_string (buffer, header, &offset, end_offset) == NULL)
+            return NULL;
           break;
 
         default:

--- a/dbus-proxy/flatpak-proxy.c
+++ b/dbus-proxy/flatpak-proxy.c
@@ -288,6 +288,7 @@ struct FlatpakProxy
   GList         *clients;
   char          *socket_path;
   char          *dbus_address;
+  char          *app_id;
 
   gboolean       filter;
   gboolean       sloppy_names;
@@ -307,7 +308,8 @@ enum {
   PROP_0,
 
   PROP_DBUS_ADDRESS,
-  PROP_SOCKET_PATH
+  PROP_SOCKET_PATH,
+  PROP_APP_ID
 };
 
 #define FLATPAK_TYPE_PROXY flatpak_proxy_get_type ()
@@ -592,6 +594,7 @@ flatpak_proxy_finalize (GObject *object)
 
   g_free (proxy->socket_path);
   g_free (proxy->dbus_address);
+  g_free (proxy->app_id);
 
   G_OBJECT_CLASS (flatpak_proxy_parent_class)->finalize (object);
 }
@@ -612,6 +615,10 @@ flatpak_proxy_set_property (GObject      *object,
 
     case PROP_SOCKET_PATH:
       proxy->socket_path = g_value_dup_string (value);
+      break;
+
+    case PROP_APP_ID:
+      proxy->app_id = g_value_dup_string (value);
       break;
 
     default:
@@ -636,6 +643,10 @@ flatpak_proxy_get_property (GObject    *object,
 
     case PROP_SOCKET_PATH:
       g_value_set_string (value, proxy->socket_path);
+      break;
+
+    case PROP_APP_ID:
+      g_value_set_string (value, proxy->app_id);
       break;
 
     default:
@@ -2618,16 +2629,28 @@ flatpak_proxy_class_init (FlatpakProxyClass *klass)
                                                         "",
                                                         NULL,
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property (object_class,
+                                   PROP_APP_ID,
+                                   g_param_spec_string ("app-id",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
 }
 
 FlatpakProxy *
 flatpak_proxy_new (const char *dbus_address,
-                   const char *socket_path)
+                   const char *socket_path,
+                   const char *app_id)
 {
   FlatpakProxy *proxy;
 
-  proxy = g_object_new (FLATPAK_TYPE_PROXY, "dbus-address", dbus_address, "socket-path", socket_path, NULL);
+  proxy = g_object_new (FLATPAK_TYPE_PROXY,
+                        "dbus-address", dbus_address,
+                        "socket-path", socket_path,
+                        "app-id", app_id,
+                        NULL);
   return proxy;
 }
 

--- a/dbus-proxy/flatpak-proxy.h
+++ b/dbus-proxy/flatpak-proxy.h
@@ -61,6 +61,7 @@ void         flatpak_proxy_add_filter (FlatpakProxy *proxy,
                                        const char   *name,
                                        const char   *rule);
 gboolean     flatpak_proxy_start (FlatpakProxy *proxy,
+                                  GVariant     *metadata,
                                   GError      **error);
 void         flatpak_proxy_stop (FlatpakProxy *proxy);
 

--- a/dbus-proxy/flatpak-proxy.h
+++ b/dbus-proxy/flatpak-proxy.h
@@ -43,7 +43,8 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakProxy, g_object_unref)
 GType flatpak_proxy_get_type (void);
 
 FlatpakProxy *flatpak_proxy_new (const char *dbus_address,
-                                 const char *socket_path);
+                                 const char *socket_path,
+                                 const char *app_id);
 void         flatpak_proxy_set_log_messages (FlatpakProxy *proxy,
                                              gboolean      log);
 void         flatpak_proxy_set_filter (FlatpakProxy *proxy,

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -118,6 +118,15 @@
                     </para></listitem>
                 </varlistentry>
             </variablelist>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is represented by an entry where
+              the name is the same as the group's name
+              (<literal>Application</literal> or <literal>Runtime</literal>),
+              and the value is a string/variant dictionary (type
+              <literal>a{sv}</literal>) with the same keys and values as
+              the group.
+            </para>
         </refsect2>
         <refsect2>
             <title>[Context]</title>
@@ -450,6 +459,13 @@
                     </para></listitem>
                 </varlistentry>
             </variablelist>
+            <para>
+              When app instance metadata is made available as a D-Bus data
+              structure, this group is represented by an entry where
+              the name is <literal>Instance</literal> and the value is a
+              string/variant dictionary (type <literal>a{sv}</literal>)
+              with the same keys and values as the group.
+            </para>
         </refsect2>
         <refsect2>
             <title>[Session Bus Policy]</title>
@@ -696,6 +712,10 @@
                 </varlistentry>
                 -->
             </variablelist>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is not represented.
+            </para>
         </refsect2>
         <refsect2>
             <title>[ExtensionOf]</title>
@@ -719,6 +739,10 @@
                     </para></listitem>
                 </varlistentry>
             </variablelist>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is not represented.
+            </para>
         </refsect2>
         <refsect2>
             <title>[Extra Data]</title>
@@ -766,6 +790,10 @@
                     </para></listitem>
                 </varlistentry>
             </variablelist>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is not represented.
+            </para>
         </refsect2>
         <refsect2>
           <title>[Policy SUBSYSTEM]</title>
@@ -815,7 +843,46 @@ subdirectories=true
 
 [Extension org.gnome.Calculator.Debug]
 directory=lib/debug
+
+[Policy acme-security]
+Allow=coyote;dynamite;
+Deny=roadrunner;
 </programlisting>
+
+        <para>
+          That example could be represented D-Bus as a binary message
+          body item corresponding to this piece of GVariant text format:
+        </para>
+
+<programlisting>
+{
+  'Application': @a{sv} {
+    'name': &lt;'org.gnome.Calculator'&gt;,
+    'runtime': &lt;'org.gnome.Platform/x86_64/3.20'&gt;,
+    'sdk': &lt;'org.gnome.Sdk/x86_64/3.20'&gt;,
+    'command': &lt;'gnome-calculator'&gt;,
+  },
+  'Context': @a{sv} {
+    'shared': &lt;['network', 'ipc']&gt;,
+    'sockets': &lt;['x11', 'wayland']&gt;,
+    'filesystems': &lt;['xdg-run/dconf', '~/.config/dconf:ro']&gt;,
+    'session-bus-proxy': &lt;true&gt;,
+  },
+  'Session Bus Policy': @a{ss} {
+    'ca.desrt.dconf': 'talk',
+  },
+  'Environment': @a{ss} {
+    'DCONF_USER_CONFIG_DIR': '.config/dconf',
+  },
+  'Policies': @a{sa{sas}} {
+    'acme-security': {
+      'Allow': ['coyote', 'dynamite'],
+      'Deny': ['roadrunner'],
+    },
+  },
+}
+</programlisting>
+
     </refsect1>
 
     <refsect1>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -379,6 +379,13 @@
                     </para></listitem>
                 </varlistentry>
             </variablelist>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is represented by an entry where
+              the name is <literal>Context</literal> and the value is a
+              string/variant dictionary (type <literal>a{sv}</literal>)
+              with the same keys and values as the group.
+            </para>
         </refsect2>
         <refsect2>
             <title>[Instance]</title>
@@ -508,6 +515,13 @@
                     </para></listitem>
                 </varlistentry>
             </variablelist>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is represented by an entry where
+              the name is <literal>Session Bus Policy</literal> and the value
+              is a string/string dictionary (type <literal>a{ss}</literal>)
+              with the same keys and values as the group.
+            </para>
         </refsect2>
         <refsect2>
             <title>[System Bus Policy]</title>
@@ -521,6 +535,12 @@
                 Entries in this group have the same form as for the [Session Bus Policy] group.
                 However, the app has no permissions by default.
             </para>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is represented by an entry where
+              the name is <literal>System Bus Policy</literal> and the value
+              is in the same format as for Session Bus Policy.
+            </para>
         </refsect2>
         <refsect2>
             <title>[Environment]</title>
@@ -532,6 +552,14 @@
                 Entries in this group have the form <option>VAR=VALUE</option>
                 where <option>VAR</option> is the name of an environment variable
                 to set.
+            </para>
+            <para>
+              When app metadata is made available as a D-Bus data
+              structure, this group is represented by an entry where
+              the name is <literal>Environment</literal> and the value
+              is a string/string dictionary (type <literal>a{ss}</literal>)
+              with environment variable names as keys and environment
+              variable values as values.
             </para>
         </refsect2>
         <refsect2>
@@ -748,6 +776,15 @@
             to the value. They are not otherwise parsed by Flatpak.
             Available since 0.6.13.
             <!-- TODO: More information would be nice -->
+          </para>
+          <para>
+            When app metadata is made available as a D-Bus data
+            structure, all groups of this form are represented as a
+            single top-level entry named <literal>Policies</literal>.
+            The corresponding value is a dictionary keyed by strings,
+            which are subsystem names. Values in that dictionary are
+            themselves dictionaries, with subsystem-defined string keys
+            and arrays of strings as values.
           </para>
         </refsect2>
     </refsect1>


### PR DESCRIPTION
Reading through `/proc/$pid/root` like Flatpak does has an inherent race condition: if the process exits at exactly the wrong time, and the process ID space (which is only 15 bits) wraps around such that an uncontained or differently-contained process gets the same process ID allocated for it, then the portal would see the differently-contained process's identity instead. Flatpak is effectively trusting its dbus-proxy not to exit at a sufficiently inconvenient time.

It would also be nice if the need for the proxy could eventually go away entirely, with access to D-Bus mediated by the dbus-daemon itself: https://bugs.freedesktop.org/show_bug.cgi?id=100344

This is going to take more work on both the Flatpak and D-Bus sides, but I wanted to put up a branch with the first thing that actually works so that I have some sort of a milestone :-)