### PR TITLE
common/dir: Drop unused variable

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2303,7 +2303,6 @@ flatpak_dir_lookup_repo_metadata (FlatpakDir    *self,
                                   ...)
 {
   va_list args;
-  g_autofree char *collection_id = NULL;
   g_autoptr(GVariant) metadata = NULL;
   g_autoptr(GVariant) value = NULL;
 


### PR DESCRIPTION
This was accidentally introduced in a8ad3927 in advance of the LAN/USB
changes from PR #884 which will actually use it.

Signed-off-by: Philip Withnall <withnall@endlessm.com>