### PR TITLE
app/build-export: Fix gcc warning about too many arguments for printf

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -757,7 +757,7 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
                             "Arch: %s\n"
                             "Branch: %s\n"
                             "Built with: "PACKAGE_STRING"\n",
-                            id, arch, branch, NULL);
+                            id, arch, branch);
 
   full_branch = g_strconcat ((opt_runtime || is_runtime) ? "runtime/" : "app/", id, "/", arch, "/", branch, NULL);
 


### PR DESCRIPTION
Drop the spurious final argument.

Signed-off-by: Philip Withnall <withnall@endlessm.com>