### PR TITLE
Fix compiler warning flags and (accordingly) quite a few compiler warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -100,8 +100,8 @@ if !WITH_SYSTEM_BWRAP
 
 bwrap_PROGRAMS = flatpak-bwrap
 flatpak_bwrap_SOURCES = $(bwrap_SOURCES)
-flatpak_bwrap_CFLAGS = $(bwrap_CFLAGS)
-flatpak_bwrap_LDADD = $(bwrap_LDADD)
+flatpak_bwrap_CFLAGS = $(AM_CFLAGS) $(bwrap_CFLAGS)
+flatpak_bwrap_LDADD = $(AM_LDADD) $(bwrap_LDADD)
 bwrapdir = $(libexecdir)
 include bubblewrap/Makefile-bwrap.am.inc
 

--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -38,6 +38,6 @@ flatpak_SOURCES = \
 	app/flatpak-builtins-document-list.c \
 	$(NULL)
 
-flatpak_LDADD = $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) libglnx.la libflatpak-common.la
-flatpak_CFLAGS = $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) \
+flatpak_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) libglnx.la libflatpak-common.la
+flatpak_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) \
         -DLOCALEDIR=\"$(localedir)\"

--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -199,7 +199,7 @@ commit_filter (OstreeRepo *repo,
   return OSTREE_REPO_COMMIT_FILTER_ALLOW;
 }
 
-gboolean
+static gboolean
 add_file_to_mtree (GFile             *file,
                    const char        *name,
                    OstreeRepo        *repo,

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -54,7 +54,7 @@ looks_like_branch (const char *branch)
   return TRUE;
 }
 
-SoupSession *
+static SoupSession *
 get_soup_session (void)
 {
   static SoupSession *soup_session = NULL;

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -137,7 +137,7 @@ message_handler (const gchar   *log_domain,
     g_printerr ("%s: %s\n", g_get_prgname (), message);
 }
 
-GOptionContext *
+static GOptionContext *
 flatpak_option_context_new_with_commands (FlatpakCommand *commands)
 {
   GOptionContext *context;
@@ -173,7 +173,7 @@ flatpak_option_context_new_with_commands (FlatpakCommand *commands)
   return context;
 }
 
-int
+static int
 flatpak_usage (FlatpakCommand *commands,
                gboolean        is_error)
 {
@@ -292,7 +292,7 @@ usage_error (GOptionContext *context, const char *message, GError **error)
   return FALSE;
 }
 
-FlatpakCommand *
+static FlatpakCommand *
 extract_command (int     *argc,
                  char   **argv,
                  const char **command_name_out)
@@ -340,7 +340,7 @@ extract_command (int     *argc,
 }
 
 
-int
+static int
 flatpak_run (int      argc,
              char   **argv,
              GError **res_error)

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -192,7 +192,7 @@ flatpak_transaction_free (FlatpakTransaction *self)
   g_free (self);
 }
 
-gboolean
+static gboolean
 flatpak_transaction_contains_ref (FlatpakTransaction *self,
                                   const char *ref)
 {
@@ -245,7 +245,7 @@ kind_to_str (FlatpakTransactionOpKind kind)
   return "unknown";
 }
 
-FlatpakTransactionOp *
+static FlatpakTransactionOp *
 flatpak_transaction_add_op (FlatpakTransaction *self,
                             const char *remote,
                             const char *ref,

--- a/builder/Makefile.am.inc
+++ b/builder/Makefile.am.inc
@@ -38,6 +38,6 @@ flatpak_builder_SOURCES = \
 	builder/builder-git.h \
 	$(NULL)
 
-flatpak_builder_LDADD = $(BASE_LIBS) $(OSTREE_LIBS) $(JSON_LIBS) $(SOUP_LIBS) $(LIBELF_LIBS) \
+flatpak_builder_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(JSON_LIBS) $(SOUP_LIBS) $(LIBELF_LIBS) \
 			libglnx.la libflatpak-common.la
-flatpak_builder_CFLAGS = $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(JSON_CFLAGS) $(SOUP_CFLAGS)
+flatpak_builder_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(JSON_CFLAGS) $(SOUP_CFLAGS)

--- a/builder/builder-context.c
+++ b/builder/builder-context.c
@@ -569,7 +569,7 @@ builder_context_set_bundle_sources (BuilderContext *self,
 
 static char *rofiles_unmount_path = NULL;
 
-void
+static void
 rofiles_umount_handler (int signum)
 {
   char *argv[] = { "fusermount", "-u", NULL,

--- a/builder/builder-git.c
+++ b/builder/builder-git.c
@@ -106,7 +106,7 @@ builder_git_get_current_commit (const char     *repo_location,
   return git_get_current_commit (mirror_dir, branch, ensure_commit, context, error);
 }
 
-char *
+static char *
 make_absolute (const char *orig_parent, const char *orig_relpath, GError **error)
 {
   g_autofree char *parent = g_strdup (orig_parent);

--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -135,7 +135,7 @@ message_handler (const gchar   *log_domain,
     g_printerr ("%s: %s\n", g_get_prgname (), message);
 }
 
-int
+static int
 usage (GOptionContext *context, const char *message)
 {
   g_autofree gchar *help = g_option_context_get_help (context, TRUE, NULL);

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -1353,7 +1353,7 @@ builder_manifest_checksum (BuilderManifest *self,
     builder_options_checksum (self->build_options, cache, context);
 }
 
-void
+static void
 builder_manifest_checksum_for_cleanup (BuilderManifest *self,
                                        BuilderCache    *cache,
                                        BuilderContext  *context)
@@ -1378,7 +1378,7 @@ builder_manifest_checksum_for_cleanup (BuilderManifest *self,
     }
 }
 
-void
+static void
 builder_manifest_checksum_for_finish (BuilderManifest *self,
                                       BuilderCache    *cache,
                                       BuilderContext  *context)
@@ -1403,7 +1403,7 @@ builder_manifest_checksum_for_finish (BuilderManifest *self,
     }
 }
 
-void
+static void
 builder_manifest_checksum_for_bundle_sources (BuilderManifest *self,
                                               BuilderCache    *cache,
                                               BuilderContext  *context)
@@ -1412,7 +1412,7 @@ builder_manifest_checksum_for_bundle_sources (BuilderManifest *self,
   builder_cache_checksum_boolean (cache, builder_context_get_bundle_sources (context));
 }
 
-void
+static void
 builder_manifest_checksum_for_platform (BuilderManifest *self,
                                         BuilderCache    *cache,
                                         BuilderContext  *context)

--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -2182,7 +2182,6 @@ builder_manifest_finish (BuilderManifest *self,
           const char *parent_id = NULL;
           const char *parent_version = NULL;
           g_autofree char *base_metadata = NULL;
-          g_auto(GStrv) groups = NULL;
 
           arch_option = g_strdup_printf ("--arch=%s", builder_context_get_arch (context));
 

--- a/builder/builder-options.h
+++ b/builder/builder-options.h
@@ -41,6 +41,8 @@ const char *builder_options_get_cflags (BuilderOptions *self,
                                         BuilderContext *context);
 const char *builder_options_get_cxxflags (BuilderOptions *self,
                                           BuilderContext *context);
+const char *builder_options_get_cppflags (BuilderOptions *self,
+                                          BuilderContext *context);
 const char *builder_options_get_ldflags (BuilderOptions *self,
                                          BuilderContext *context);
 const char *builder_options_get_prefix (BuilderOptions *self,

--- a/builder/builder-source-archive.c
+++ b/builder/builder-source-archive.c
@@ -72,13 +72,13 @@ typedef enum {
   ZIP
 } BuilderArchiveType;
 
-gboolean
+static gboolean
 is_tar (BuilderArchiveType type)
 {
   return (type >= TAR) && (type <= TAR_XZ);
 }
 
-const char *
+static const char *
 tar_decompress_flag (BuilderArchiveType type)
 {
   switch (type)
@@ -389,7 +389,7 @@ unrpm (GFile   *dir,
   return res;
 }
 
-BuilderArchiveType
+static BuilderArchiveType
 get_type (GFile *archivefile)
 {
   g_autofree char *base_name = NULL;

--- a/builder/builder-utils.c
+++ b/builder/builder-utils.c
@@ -63,7 +63,7 @@ builder_uri_to_filename (const char *uri)
   return g_string_free (s, FALSE);
 }
 
-const char *
+static const char *
 inplace_basename (const char *path)
 {
   const char *last_slash;

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -74,4 +74,4 @@ libflatpak_common_la_CFLAGS = \
 	$(INTERNAL_GPGME_CFLAGS) \
 	-I$(srcdir)/dbus-proxy \
 	$(NULL)
-libflatpak_common_la_LIBADD = libglnx.la $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(XAUTH_LIBS) $(LIBSECCOMP_LIBS) $(INTERNAL_GPGME_LIBS)
+libflatpak_common_la_LIBADD = $(AM_LIBADD) libglnx.la $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(XAUTH_LIBS) $(LIBSECCOMP_LIBS) $(INTERNAL_GPGME_LIBS)

--- a/dbus-proxy/Makefile.am.inc
+++ b/dbus-proxy/Makefile.am.inc
@@ -8,5 +8,5 @@ flatpak_dbus_proxy_SOURCES = \
 	dbus-proxy/dbus-proxy.c		\
 	$(NULL)
 
-flatpak_dbus_proxy_LDADD = $(BASE_LIBS) libglnx.la
-flatpak_dbus_proxy_CFLAGS = $(BASE_CFLAGS) -I$(srcdir)/dbus-proxy
+flatpak_dbus_proxy_LDADD = $(AM_LDADD) $(BASE_LIBS) libglnx.la
+flatpak_dbus_proxy_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) -I$(srcdir)/dbus-proxy

--- a/dbus-proxy/flatpak-proxy.c
+++ b/dbus-proxy/flatpak-proxy.c
@@ -401,7 +401,7 @@ flatpak_proxy_client_init (FlatpakProxyClient *client)
   client->unique_id_policy = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 }
 
-FlatpakProxyClient *
+static FlatpakProxyClient *
 flatpak_proxy_client_new (FlatpakProxy *proxy, GSocketConnection *connection)
 {
   FlatpakProxyClient *client;

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -39,5 +39,5 @@ xdg_document_portal_SOURCES = \
 	document-portal/xdp-fuse.c		\
 	$(NULL)
 
-xdg_document_portal_LDADD = $(BASE_LIBS) $(FUSE_LIBS) libflatpak-common.la
-xdg_document_portal_CFLAGS = $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(FUSE_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal -I$(srcdir)/permission-store -I$(builddir)/permission-store -DFLATPAK_COMPILATION
+xdg_document_portal_LDADD = $(AM_LDADD) $(BASE_LIBS) $(FUSE_LIBS) libflatpak-common.la
+xdg_document_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(FUSE_CFLAGS) -I$(srcdir)/document-portal -I$(builddir)/document-portal -I$(srcdir)/permission-store -I$(builddir)/permission-store -DFLATPAK_COMPILATION

--- a/document-portal/xdp-fuse.c
+++ b/document-portal/xdp-fuse.c
@@ -573,7 +573,7 @@ xdp_inode_rename_child (XdpInode   *dir,
 }
 
 /* NULL if removed */
-char *
+static char *
 xdp_inode_get_filename (XdpInode *inode)
 {
   AUTOLOCK (inodes);
@@ -1043,7 +1043,7 @@ xdp_fuse_lookup (fuse_req_t  req,
   fuse_reply_entry (req, &e);
 }
 
-void
+static void
 xdp_fuse_forget (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup)
 {
   g_autoptr(XdpInode) inode = NULL;

--- a/document-portal/xdp-main.c
+++ b/document-portal/xdp-main.c
@@ -274,7 +274,7 @@ portal_delete (GDBusMethodInvocation *invocation,
   g_dbus_method_invocation_return_value (invocation, g_variant_new ("()"));
 }
 
-char *
+static char *
 do_create_doc (struct stat *parent_st_buf, const char *path, gboolean reuse_existing, gboolean persistent)
 {
   g_autoptr(GVariant) data = NULL;

--- a/lib/Makefile.am.inc
+++ b/lib/Makefile.am.inc
@@ -79,12 +79,14 @@ libflatpak_la_CFLAGS = \
 	$(NULL)
 
 libflatpak_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	-version-info $(LT_VERSION_INFO)	\
 	-export-dynamic				\
 	-rpath $(libdir)			\
 	$(NULL)
 
 libflatpak_la_LIBADD = \
+	$(AM_LIBADD) \
         libflatpak-common.la \
 	$(BASE_LIBS)	\
 	$(OSTREE_LIBS)	\
@@ -97,12 +99,14 @@ test_libflatpak_SOURCES = \
 	$(NULL)
 
 test_libflatpak_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
 	-I$(top_srcdir)/lib \
 	-I$(top_builddir)/lib \
 	$(NULL)
 
 test_libflatpak_LDADD = \
+	$(AM_LDADD) \
 	$(BASE_LIBS)	\
         libflatpak.la \
 	$(NULL)

--- a/permission-store/Makefile.am.inc
+++ b/permission-store/Makefile.am.inc
@@ -33,5 +33,5 @@ xdg_permission_store_SOURCES = \
 	permission-store/xdg-permission-store.h	\
 	$(NULL)
 
-xdg_permission_store_LDADD = $(BASE_LIBS) libflatpak-common.la
-xdg_permission_store_CFLAGS = $(BASE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(OSTREE_CFLAGS) $(GSYSTEM_CFLAGS) -I$(srcdir)/permission-store -I$(builddir)/permission-store
+xdg_permission_store_LDADD = $(AM_LDADD) $(BASE_LIBS) libflatpak-common.la
+xdg_permission_store_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(OSTREE_CFLAGS) $(GSYSTEM_CFLAGS) -I$(srcdir)/permission-store -I$(builddir)/permission-store

--- a/session-helper/Makefile.am.inc
+++ b/session-helper/Makefile.am.inc
@@ -12,5 +12,5 @@ flatpak_session_helper_SOURCES = \
 	session-helper/flatpak-session-helper.c	\
 	$(NULL)
 
-flatpak_session_helper_LDADD = $(BASE_LIBS) libflatpak-common.la
-flatpak_session_helper_CFLAGS = $(BASE_CFLAGS) $(SOUP_CFLAGS) $(OSTREE_CFLAGS) $(GSYSTEM_CFLAGS) $(JSON_CFLAGS)
+flatpak_session_helper_LDADD = $(AM_LDADD) $(BASE_LIBS) libflatpak-common.la
+flatpak_session_helper_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(SOUP_CFLAGS) $(OSTREE_CFLAGS) $(GSYSTEM_CFLAGS) $(JSON_CFLAGS)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -12,8 +12,9 @@ else
 TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
 endif
 
-testdb_CFLAGS = $(BASE_CFLAGS)
+testdb_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
 testdb_LDADD = \
+             $(AM_LDADD) \
              $(BASE_LIBS) \
              $(OSTREE_LIBS) \
              libglnx.la \
@@ -21,8 +22,9 @@ testdb_LDADD = \
              $(NULL)
 testdb_SOURCES = tests/testdb.c
 
-test_doc_portal_CFLAGS = $(BASE_CFLAGS)
+test_doc_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
 test_doc_portal_LDADD = \
+             $(AM_LDADD) \
              $(BASE_LIBS) \
              $(OSTREE_LIBS) \
              libglnx.la \
@@ -31,8 +33,9 @@ test_doc_portal_LDADD = \
 test_doc_portal_SOURCES = tests/test-doc-portal.c
 nodist_test_doc_portal_SOURCES = $(xdp_dbus_built_sources)
 
-testlibrary_CFLAGS = $(BASE_CFLAGS)
+testlibrary_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
 testlibrary_LDADD = \
+             $(AM_LDADD) \
              $(BASE_LIBS) \
              libglnx.la \
              libflatpak.la \

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -674,10 +674,6 @@ add_extra_installation (const char *id,
                         const char *storage_type,
                         const char *priority)
 {
-  static const char *base_fmt_string =
-    "[Installation \"%s\"]\n"
-    "Path=%s";
-
   g_autofree char *conffile_path = NULL;
   g_autofree char *contents_string = NULL;
   g_autofree char *path = NULL;
@@ -689,7 +685,10 @@ add_extra_installation (const char *id,
 
   contents_array = g_ptr_array_new_with_free_func ((GDestroyNotify)g_free);
 
-  g_ptr_array_add (contents_array, g_strdup_printf (base_fmt_string, id, path));
+  g_ptr_array_add (contents_array,
+      g_strdup_printf ("[Installation \"%s\"]\n"
+                       "Path=%s",
+                       id, path));
 
   if (display_name != NULL)
     g_ptr_array_add (contents_array, g_strdup_printf ("DisplayName=%s", display_name));


### PR DESCRIPTION
Turns out the warning flags in `$(WARN_CFLAGS)` were being used successfully in very few places in the code base. Fix that, and fix the resulting onslaught of compiler warnings.

This should hopefully get the warnings which people see locally inline with the warnings the CI system enables, so people don’t keep submitting broken-at-the-time-of-submission PRs.