### PR TITLE
Update terminal title with build progress

### DIFF
--- a/builder/builder-module.c
+++ b/builder/builder-module.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <sys/statfs.h>
 
+#include <glib/gi18n.h>
 #include <gio/gio.h>
 #include "libglnx/libglnx.h"
 
@@ -895,6 +896,8 @@ builder_module_download_sources (BuilderModule  *self,
       if (!builder_source_is_enabled (source, context))
         continue;
 
+      builder_set_term_title (_("Downloading %s"), self->name);
+
       if (!builder_source_download (source, update_vcs, context, error))
         {
           g_prefix_error (error, "module %s: ", self->name);
@@ -1265,6 +1268,8 @@ builder_module_build (BuilderModule  *self,
   g_print ("Building module %s in %s\n", self->name, source_dir_path);
   g_print ("========================================================================\n");
 
+  builder_set_term_title (_("Building %s"), self->name);
+
   if (!builder_module_extract_sources (self, source_dir, context, error))
     return FALSE;
 
@@ -1540,6 +1545,8 @@ builder_module_build (BuilderModule  *self,
 
   /* Build and install */
 
+  builder_set_term_title (_("Installing %s"), self->name);
+
   if (meson || cmake_ninja)
     make_cmd = "ninja";
   else if (simple)
@@ -1571,6 +1578,8 @@ builder_module_build (BuilderModule  *self,
     }
 
   /* Post installation scripts */
+
+  builder_set_term_title (_("Post-Install %s"), self->name);
 
   if (builder_context_get_separate_locales (context))
     {
@@ -1617,6 +1626,8 @@ builder_module_build (BuilderModule  *self,
 
   /* Clean up build dir */
 
+  builder_set_term_title (_("Cleanup %s"), self->name);
+
   if (!builder_context_get_keep_build_dirs (context))
     {
       if (!g_file_delete (build_link, NULL, error))
@@ -1648,6 +1659,8 @@ builder_module_update (BuilderModule  *self,
 
       if (!builder_source_is_enabled (source, context))
         continue;
+
+      builder_set_term_title (_("Updating %s"), self->name);
 
       if (!builder_source_update (source, context, error))
         {

--- a/builder/builder-utils.c
+++ b/builder/builder-utils.c
@@ -26,6 +26,7 @@
 #include <gelf.h>
 #include <dwarf.h>
 #include <sys/mman.h>
+#include <sys/uio.h>
 #include <stdio.h>
 
 #include <string.h>
@@ -1704,4 +1705,21 @@ builder_serializable_find_property_with_error (JsonSerializable *serializable,
       !g_str_has_prefix (name, "x-"))
     g_warning ("Unknown property %s for type %s\n", name, g_type_name_from_instance ((GTypeInstance *)serializable));
   return pspec;
+}
+
+void
+builder_set_term_title (const gchar *format,
+                        ...)
+{
+  g_autofree gchar *message = NULL;
+  va_list args;
+
+  if (isatty (STDOUT_FILENO) != 1)
+    return;
+
+  va_start (args, format);
+  message = g_strdup_vprintf (format, args);
+  va_end (args);
+
+  g_print ("\033]2;flatpak-builder: %s\007", message);
 }

--- a/builder/builder-utils.h
+++ b/builder/builder-utils.h
@@ -72,6 +72,9 @@ gboolean builder_download_uri (const char     *url,
 GParamSpec * builder_serializable_find_property_with_error (JsonSerializable *serializable,
                                                             const char       *name);
 
+void builder_set_term_title (const gchar *format,
+                             ...) G_GNUC_PRINTF (1, 2);
+
 G_END_DECLS
 
 #endif /* __BUILDER_UTILS_H__ */


### PR DESCRIPTION
Build systems such as `jhbuild` update the terminal title with some high-level status of the build progress. I suggest that `flatpak-builder` does the same.

Doing so not only updates the user of build progress when their terminal tab is not focused, but it also allows applications scripting flatpak-builder (using a PTY) to pass along status messages to users in their user interface. Doing this traditionally would require parsing all STDOUT content which is laborious, CPU expensive, and prone to breakages.

Another possible way to solve this for application scripting would be to pass in a "control FD". I think this solution is better because it solves to similar use-cases with one design.