### PR TITLE
 Document all metadata groups and keys

### DIFF
--- a/builder/builder-manifest.c
+++ b/builder/builder-manifest.c
@@ -2221,7 +2221,9 @@ builder_manifest_finish (BuilderManifest *self,
 
           for (i = 0; self->inherit_extensions[i] != NULL; i++)
             {
-              g_autofree char *group = g_strdup_printf ("Extension %s", self->inherit_extensions[i]);
+              g_autofree char *group = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION,
+                                                    self->inherit_extensions[i],
+                                                    NULL);
               g_auto(GStrv) keys = NULL;
               int j;
 
@@ -2240,9 +2242,13 @@ builder_manifest_finish (BuilderManifest *self,
                   g_key_file_set_value (keyfile, group, keys[j], value);
                 }
 
-              if (!g_key_file_has_key (keyfile, group, "version", NULL) &&
-                  !g_key_file_has_key (keyfile, group, "versions", NULL))
-                g_key_file_set_value (keyfile, group, "version", parent_version);
+              if (!g_key_file_has_key (keyfile, group,
+                                       FLATPAK_METADATA_KEY_VERSION, NULL) &&
+                  !g_key_file_has_key (keyfile, group,
+                                       FLATPAK_METADATA_KEY_VERSIONS, NULL))
+                g_key_file_set_value (keyfile, group,
+                                      FLATPAK_METADATA_KEY_VERSION,
+                                      parent_version);
             }
 
           if (!g_key_file_save_to_file (keyfile,
@@ -2565,7 +2571,7 @@ builder_manifest_create_platform (BuilderManifest *self,
           g_autoptr(GFile) dest_metadata = g_file_get_child (app_dir, "metadata.platform");
           g_autoptr(GKeyFile) keyfile = g_key_file_new ();
           g_auto(GStrv) groups = NULL;
-          g_autofree char *sdk_group_prefix = g_strdup_printf ("Extension %s.", self->id);
+          g_autofree char *sdk_group_prefix = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION, self->id, NULL);
           int j;
 
           if (!g_key_file_load_from_file (keyfile,
@@ -2577,7 +2583,8 @@ builder_manifest_create_platform (BuilderManifest *self,
               return FALSE;
             }
 
-          g_key_file_set_string (keyfile, "Runtime", "name", self->id_platform);
+          g_key_file_set_string (keyfile, FLATPAK_METADATA_GROUP_RUNTIME,
+                                 FLATPAK_METADATA_KEY_NAME, self->id_platform);
 
           groups = g_key_file_get_groups (keyfile, NULL);
           for (j = 0; groups[j] != NULL; j++)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4307,7 +4307,7 @@ apply_extra_data (FlatpakDir          *self,
   g_autoptr(GArray) fd_array = NULL;
   g_auto(GStrv) envp = NULL;
   int exit_status;
-  const char *group = "Application";
+  const char *group = FLATPAK_METADATA_GROUP_APPLICATION;
   g_autoptr(GError) local_error = NULL;
 
   apply_extra_file = g_file_resolve_relative_path (checkoutdir, "files/bin/apply_extra");
@@ -4323,11 +4323,13 @@ apply_extra_data (FlatpakDir          *self,
   if (!g_key_file_load_from_data (metakey, metadata_contents, metadata_size, 0, error))
     return FALSE;
 
-  id = g_key_file_get_string (metakey, group, "name", &local_error);
+  id = g_key_file_get_string (metakey, group, FLATPAK_METADATA_KEY_NAME,
+                              &local_error);
   if (id == NULL)
     {
-      group = "Runtime";
-      id = g_key_file_get_string (metakey, group, "name", NULL);
+      group = FLATPAK_METADATA_GROUP_RUNTIME;
+      id = g_key_file_get_string (metakey, group, FLATPAK_METADATA_KEY_NAME,
+                                  NULL);
       if (id == NULL)
         {
           g_propagate_error (error, g_steal_pointer (&local_error));
@@ -4336,7 +4338,8 @@ apply_extra_data (FlatpakDir          *self,
       g_clear_error (&local_error);
     }
 
-  runtime = g_key_file_get_string (metakey, group, "runtime", error);
+  runtime = g_key_file_get_string (metakey, group,
+                                   FLATPAK_METADATA_KEY_RUNTIME, error);
   if (runtime == NULL)
     return FALSE;
 
@@ -4346,7 +4349,8 @@ apply_extra_data (FlatpakDir          *self,
   if (runtime_ref_parts == NULL)
     return FALSE;
 
-  if (!g_key_file_get_boolean (metakey, "Extra Data", "NoRuntime", NULL))
+  if (!g_key_file_get_boolean (metakey, FLATPAK_METADATA_GROUP_EXTRA_DATA,
+                               FLATPAK_METADATA_KEY_NO_RUNTIME, NULL))
     {
       runtime_deploy = flatpak_find_deploy_for_ref (runtime_ref, cancellable, error);
       if (runtime_deploy == NULL)
@@ -8649,19 +8653,19 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
         {
           char *extension;
 
-          if (g_str_has_prefix (groups[i], "Extension ") &&
-              *(extension = (groups[i] + strlen ("Extension "))) != 0)
+          if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
+              *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
             {
               g_autofree char *version = g_key_file_get_string (metakey, groups[i],
-                                                                "version", NULL);
+                                                                FLATPAK_METADATA_KEY_VERSION, NULL);
               gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
-                                                                "subdirectories", NULL);
+                                                                FLATPAK_METADATA_KEY_SUBDIRECTORIES, NULL);
               gboolean no_autodownload = g_key_file_get_boolean (metakey, groups[i],
-                                                                 "no-autodownload", NULL);
+                                                                 FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD, NULL);
               g_autofree char *download_if = g_key_file_get_string (metakey, groups[i],
-                                                                    "download-if", NULL);
+                                                                    FLATPAK_METADATA_KEY_DOWNLOAD_IF, NULL);
               gboolean autodelete = g_key_file_get_boolean (metakey, groups[i],
-                                                            "autodelete", NULL);
+                                                            FLATPAK_METADATA_KEY_AUTODELETE, NULL);
               const char *branch;
               g_autofree char *extension_ref = NULL;
               g_autofree char *checksum = NULL;
@@ -8781,19 +8785,19 @@ flatpak_dir_find_local_related (FlatpakDir *self,
         {
           char *extension;
 
-          if (g_str_has_prefix (groups[i], "Extension ") &&
-              *(extension = (groups[i] + strlen ("Extension "))) != 0)
+          if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
+              *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
             {
               g_autofree char *version = g_key_file_get_string (metakey, groups[i],
-                                                                "version", NULL);
+                                                                FLATPAK_METADATA_KEY_VERSION, NULL);
               gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
-                                                                "subdirectories", NULL);
+                                                                FLATPAK_METADATA_KEY_SUBDIRECTORIES, NULL);
               gboolean no_autodownload = g_key_file_get_boolean (metakey, groups[i],
-                                                                 "no-autodownload", NULL);
+                                                                 FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD, NULL);
               g_autofree char *download_if = g_key_file_get_string (metakey, groups[i],
-                                                                    "download-if", NULL);
+                                                                    FLATPAK_METADATA_KEY_DOWNLOAD_IF, NULL);
               gboolean autodelete = g_key_file_get_boolean (metakey, groups[i],
-                                                            "autodelete", NULL);
+                                                            FLATPAK_METADATA_KEY_AUTODELETE, NULL);
               const char *branch;
               g_autofree char *extension_ref = NULL;
               g_autofree char *prefixed_extension_ref = NULL;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3489,30 +3489,37 @@ flatpak_run_add_app_info_args (GPtrArray      *argv_array,
   keyfile = g_key_file_new ();
 
   if (app_files)
-    group = "Application";
+    group = FLATPAK_METADATA_GROUP_APPLICATION;
   else
-    group = "Runtime";
+    group = FLATPAK_METADATA_GROUP_RUNTIME;
 
-  g_key_file_set_string (keyfile, group, "name", app_id);
-  g_key_file_set_string (keyfile, group, "runtime", runtime_ref);
+  g_key_file_set_string (keyfile, group, FLATPAK_METADATA_KEY_NAME, app_id);
+  g_key_file_set_string (keyfile, group, FLATPAK_METADATA_KEY_RUNTIME,
+                         runtime_ref);
 
   if (app_files)
     {
       g_autofree char *app_path = g_file_get_path (app_files);
-      g_key_file_set_string (keyfile, "Instance", "app-path", app_path);
+      g_key_file_set_string (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
+                             FLATPAK_METADATA_KEY_APP_PATH, app_path);
     }
   runtime_path = g_file_get_path (runtime_files);
-  g_key_file_set_string (keyfile, "Instance", "runtime-path", runtime_path);
+  g_key_file_set_string (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
+                         FLATPAK_METADATA_KEY_RUNTIME_PATH, runtime_path);
   if (app_branch != NULL)
-    g_key_file_set_string (keyfile, "Instance", "branch", app_branch);
+    g_key_file_set_string (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
+                           FLATPAK_METADATA_KEY_BRANCH, app_branch);
 
-  g_key_file_set_string (keyfile, "Instance", "flatpak-version", PACKAGE_VERSION);
+  g_key_file_set_string (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
+                         FLATPAK_METADATA_KEY_FLATPAK_VERSION, PACKAGE_VERSION);
 
   if ((final_app_context->sockets & FLATPAK_CONTEXT_SOCKET_SESSION_BUS) == 0)
-    g_key_file_set_boolean (keyfile, "Instance", "session-bus-proxy", TRUE);
+    g_key_file_set_boolean (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
+                            FLATPAK_METADATA_KEY_SESSION_BUS_PROXY, TRUE);
 
   if ((final_app_context->sockets & FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS) == 0)
-    g_key_file_set_boolean (keyfile, "Instance", "system-bus-proxy", TRUE);
+    g_key_file_set_boolean (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
+                            FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY, TRUE);
 
   flatpak_context_save_metadata (final_app_context, TRUE, keyfile);
 
@@ -4614,10 +4621,17 @@ flatpak_run_app (const char     *app_ref,
     }
   else
     {
+      const gchar *key;
+
+      if ((flags & FLATPAK_RUN_FLAG_DEVEL) != 0)
+        key = FLATPAK_METADATA_KEY_SDK;
+      else
+        key = FLATPAK_METADATA_KEY_RUNTIME,
+
       metakey = flatpak_deploy_get_metadata (app_deploy);
-      default_runtime = g_key_file_get_string (metakey, "Application",
-                                               (flags & FLATPAK_RUN_FLAG_DEVEL) != 0 ? "sdk" : "runtime",
-                                               &my_error);
+      default_runtime = g_key_file_get_string (metakey,
+                                               FLATPAK_METADATA_GROUP_APPLICATION,
+                                               key, &my_error);
       if (my_error)
         {
           g_propagate_error (error, g_steal_pointer (&my_error));
@@ -4747,7 +4761,10 @@ flatpak_run_app (const char     *app_ref,
     }
   else if (metakey)
     {
-      default_command = g_key_file_get_string (metakey, "Application", "command", &my_error);
+      default_command = g_key_file_get_string (metakey,
+                                               FLATPAK_METADATA_GROUP_APPLICATION,
+                                               FLATPAK_METADATA_KEY_COMMAND,
+                                               &my_error);
       if (my_error)
         {
           g_propagate_error (error, g_steal_pointer (&my_error));

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1233,7 +1233,15 @@ parse_negated (const char *option, gboolean *negated)
   return option;
 }
 
-/* This is a merge, not a replace */
+/*
+ * Merge the FLATPAK_METADATA_GROUP_CONTEXT,
+ * FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+ * FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY and
+ * FLATPAK_METADATA_GROUP_ENVIRONMENT groups, and all groups starting
+ * with FLATPAK_METADATA_GROUP_PREFIX_POLICY, from metakey into context.
+ *
+ * This is a merge, not a replace!
+ */
 gboolean
 flatpak_context_load_metadata (FlatpakContext *context,
                                GKeyFile       *metakey,
@@ -1444,6 +1452,13 @@ flatpak_context_load_metadata (FlatpakContext *context,
   return TRUE;
 }
 
+/*
+ * Save the FLATPAK_METADATA_GROUP_CONTEXT,
+ * FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+ * FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY and
+ * FLATPAK_METADATA_GROUP_ENVIRONMENT groups, and all groups starting
+ * with FLATPAK_METADATA_GROUP_PREFIX_POLICY, into metakey
+ */
 void
 flatpak_context_save_metadata (FlatpakContext *context,
                                gboolean        flatten,

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -29,17 +29,62 @@
 gboolean flatpak_run_in_transient_unit (const char *app_id,
                                         GError    **error);
 
+/* See flatpak-metadata(5) */
+
+#define FLATPAK_METADATA_GROUP_APPLICATION "Application"
+#define FLATPAK_METADATA_GROUP_RUNTIME "Runtime"
+#define FLATPAK_METADATA_KEY_COMMAND "command"
+#define FLATPAK_METADATA_KEY_NAME "name"
+#define FLATPAK_METADATA_KEY_REQUIRED_FLATPAK "required-flatpak"
+#define FLATPAK_METADATA_KEY_RUNTIME "runtime"
+#define FLATPAK_METADATA_KEY_SDK "sdk"
+#define FLATPAK_METADATA_KEY_TAGS "tags"
+
 #define FLATPAK_METADATA_GROUP_CONTEXT "Context"
-#define FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY "Session Bus Policy"
-#define FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY "System Bus Policy"
-#define FLATPAK_METADATA_GROUP_PREFIX_POLICY "Policy "
-#define FLATPAK_METADATA_GROUP_ENVIRONMENT "Environment"
 #define FLATPAK_METADATA_KEY_SHARED "shared"
 #define FLATPAK_METADATA_KEY_SOCKETS "sockets"
 #define FLATPAK_METADATA_KEY_FILESYSTEMS "filesystems"
 #define FLATPAK_METADATA_KEY_PERSISTENT "persistent"
 #define FLATPAK_METADATA_KEY_DEVICES "devices"
 #define FLATPAK_METADATA_KEY_FEATURES "features"
+
+#define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
+#define FLATPAK_METADATA_KEY_APP_PATH "app-path"
+#define FLATPAK_METADATA_KEY_BRANCH "branch"
+#define FLATPAK_METADATA_KEY_FLATPAK_VERSION "flatpak-version"
+#define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
+#define FLATPAK_METADATA_KEY_SESSION_BUS_PROXY "session-bus-proxy"
+#define FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY "system-bus-proxy"
+
+#define FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY "Session Bus Policy"
+#define FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY "System Bus Policy"
+#define FLATPAK_METADATA_GROUP_PREFIX_POLICY "Policy "
+#define FLATPAK_METADATA_GROUP_ENVIRONMENT "Environment"
+
+#define FLATPAK_METADATA_GROUP_PREFIX_EXTENSION "Extension "
+#define FLATPAK_METADATA_KEY_ADD_LD_PATH "add-ld-path"
+#define FLATPAK_METADATA_KEY_AUTODELETE "autodelete"
+#define FLATPAK_METADATA_KEY_DIRECTORY "directory"
+#define FLATPAK_METADATA_KEY_DOWNLOAD_IF "download-if"
+#define FLATPAK_METADATA_KEY_ENABLE_IF "enable-if"
+#define FLATPAK_METADATA_KEY_MERGE_DIRS "merge-dirs"
+#define FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD "no-autodownload"
+#define FLATPAK_METADATA_KEY_SUBDIRECTORIES "subdirectories"
+#define FLATPAK_METADATA_KEY_SUBDIRECTORY_SUFFIX "subdirectory-suffix"
+#define FLATPAK_METADATA_KEY_VERSION "version"
+#define FLATPAK_METADATA_KEY_VERSIONS "versions"
+
+#define FLATPAK_METADATA_GROUP_EXTRA_DATA "Extra Data"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_CHECKSUM "checksum"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_INSTALLED_SIZE "installed-size"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_NAME "name"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_SIZE "size"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_URI "uri"
+#define FLATPAK_METADATA_KEY_NO_RUNTIME "NoRuntime"
+
+#define FLATPAK_METADATA_GROUP_EXTENSION_OF "ExtensionOf"
+#define FLATPAK_METADATA_KEY_PRIORITY "priority"
+#define FLATPAK_METADATA_KEY_REF "ref"
 
 extern const char *flatpak_context_sockets[];
 extern const char *flatpak_context_devices[];

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -1676,7 +1676,8 @@ parse_app_id_from_fileinfo (int pid)
       if (errno == ENOENT)
         {
           /* No file => on the host */
-          g_key_file_set_string (metadata, "Application", "name", "");
+          g_key_file_set_string (metadata, FLATPAK_METADATA_GROUP_APPLICATION,
+                                 FLATPAK_METADATA_KEY_NAME, "");
           return g_steal_pointer (&metadata);
         }
 
@@ -3351,13 +3352,15 @@ flatpak_appstream_xml_migrate (FlatpakXml *source,
     return FALSE;
 
   if (g_str_has_prefix (ref, "app/"))
-    group = "Application";
+    group = FLATPAK_METADATA_GROUP_APPLICATION;
   else
-    group = "Runtime";
+    group = FLATPAK_METADATA_GROUP_RUNTIME;
 
-  tags = g_key_file_get_string_list (metadata, group, "tags", NULL, NULL);
-  runtime = g_key_file_get_string (metadata, group, "runtime", NULL);
-  sdk = g_key_file_get_string (metadata, group, "sdk", NULL);
+  tags = g_key_file_get_string_list (metadata, group, FLATPAK_METADATA_KEY_TAGS,
+                                     NULL, NULL);
+  runtime = g_key_file_get_string (metadata, group,
+                                   FLATPAK_METADATA_KEY_RUNTIME, NULL);
+  sdk = g_key_file_get_string (metadata, group, FLATPAK_METADATA_KEY_SDK, NULL);
 
   source_components = source->first_child;
   dest_components = dest->first_child;
@@ -3831,7 +3834,10 @@ flatpak_extension_new (const char *id,
       g_autofree char *metadata_path = g_build_filename (ext->files_path, "../metadata", NULL);
 
       if (g_key_file_load_from_file (keyfile, metadata_path, G_KEY_FILE_NONE, NULL))
-        ext->priority = g_key_file_get_integer (keyfile, "ExtensionOf", "priority", NULL);
+        ext->priority = g_key_file_get_integer (keyfile,
+                                                FLATPAK_METADATA_GROUP_EXTENSION_OF,
+                                                FLATPAK_METADATA_KEY_PRIORITY,
+                                                NULL);
     }
 
   return ext;
@@ -3879,11 +3885,21 @@ add_extension (GKeyFile   *metakey,
                GList *res)
 {
   FlatpakExtension *ext;
-  g_autofree char *directory = g_key_file_get_string (metakey, group, "directory", NULL);
-  g_autofree char *add_ld_path = g_key_file_get_string (metakey, group, "add-ld-path", NULL);
-  g_auto(GStrv) merge_dirs = g_key_file_get_string_list (metakey, group, "merge-dirs", NULL, NULL);
-  g_autofree char *enable_if = g_key_file_get_string (metakey, group, "enable-if", NULL);
-  g_autofree char *subdir_suffix = g_key_file_get_string (metakey, group, "subdirectory-suffix", NULL);
+  g_autofree char *directory = g_key_file_get_string (metakey, group,
+                                                      FLATPAK_METADATA_KEY_DIRECTORY,
+                                                      NULL);
+  g_autofree char *add_ld_path = g_key_file_get_string (metakey, group,
+                                                        FLATPAK_METADATA_KEY_ADD_LD_PATH,
+                                                        NULL);
+  g_auto(GStrv) merge_dirs = g_key_file_get_string_list (metakey, group,
+                                                         FLATPAK_METADATA_KEY_MERGE_DIRS,
+                                                         NULL, NULL);
+  g_autofree char *enable_if = g_key_file_get_string (metakey, group,
+                                                      FLATPAK_METADATA_KEY_ENABLE_IF,
+                                                      NULL);
+  g_autofree char *subdir_suffix = g_key_file_get_string (metakey, group,
+                                                          FLATPAK_METADATA_KEY_SUBDIRECTORY_SUFFIX,
+                                                          NULL);
   g_autofree char *ref = NULL;
   gboolean is_unmaintained = FALSE;
   g_autoptr(GFile) files = NULL;
@@ -3910,7 +3926,7 @@ add_extension (GKeyFile   *metakey,
         }
     }
   else if (g_key_file_get_boolean (metakey, group,
-                                   "subdirectories", NULL))
+                                   FLATPAK_METADATA_KEY_SUBDIRECTORIES, NULL))
     {
       g_autofree char *prefix = g_strconcat (extension, ".", NULL);
       g_auto(GStrv) refs = NULL;
@@ -3973,11 +3989,15 @@ flatpak_list_extensions (GKeyFile   *metakey,
     {
       char *extension;
 
-      if (g_str_has_prefix (groups[i], "Extension ") &&
-          *(extension = (groups[i] + strlen ("Extension "))) != 0)
+      if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
+          *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
         {
-          g_autofree char *version = g_key_file_get_string (metakey, groups[i], "version", NULL);
-          g_auto(GStrv) versions = g_key_file_get_string_list (metakey, groups[i], "versions", NULL, NULL);
+          g_autofree char *version = g_key_file_get_string (metakey, groups[i],
+                                                            FLATPAK_METADATA_KEY_VERSION,
+                                                            NULL);
+          g_auto(GStrv) versions = g_key_file_get_string_list (metakey, groups[i],
+                                                               FLATPAK_METADATA_KEY_VERSIONS,
+                                                               NULL, NULL);
           const char *default_branches[] = { default_branch, NULL};
           const char **branches;
 

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -187,6 +187,66 @@
             </variablelist>
         </refsect2>
         <refsect2>
+            <title>[Instance]</title>
+            <para>
+                This group only appears in <filename>/.flatpak-info</filename>
+                for a running app, and not in the metadata files written by
+                application authors. It is filled in by Flatpak itself.
+            </para>
+            <variablelist>
+                <varlistentry>
+                    <term><option>app-path</option> (string)</term>
+                    <listitem><para>
+                        The absolute path on the host system of the app's
+                        app files, as mounted at <filename>/app</filename>
+                        inside the container
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>branch</option> (string)</term>
+                    <listitem><para>
+                        The branch of the app, for example
+                        <literal>stable</literal>
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>flatpak-version</option> (string)</term>
+                    <listitem><para>
+                        The version number of the Flatpak version that ran
+                        this app
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>runtime-path</option> (string)</term>
+                    <listitem><para>
+                        The absolute path on the host system of the app's
+                        runtime files, as mounted at <filename>/usr</filename>
+                        inside the container
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>session-bus-proxy</option> (boolean)</term>
+                    <listitem><para>
+                        True if this app cannot access the D-Bus session bus
+                        directly (either it goes via a proxy, or it cannot
+                        access the session bus at all)
+                        <!-- TODO: Those semantics are weird, are they
+                        intended? -->
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>system-bus-proxy</option> (boolean)</term>
+                    <listitem><para>
+                        True if this app cannot access the D-Bus system bus
+                        directly (either it goes via a proxy, or it cannot
+                        access the system bus at all)
+                        <!-- TODO: Those semantics are weird, are they
+                        intended? -->
+                    </para></listitem>
+                </varlistentry>
+            </variablelist>
+        </refsect2>
+        <refsect2>
             <title>[Session Bus Policy]</title>
             <para>
                 If the <option>sockets</option> key is not allowing full access

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -48,7 +48,10 @@
 
         <para>
             A metadata file describing the effective configuration is available
-            inside the running sandbox at <filename>/run/user/$UID/flatpak-info</filename>.
+            inside the running sandbox at <filename>/.flatpak-info</filename>.
+            For compatibility with older Flatpak versions,
+            <filename>/run/user/$UID/flatpak-info</filename> is a symbolic
+            link to the same file.
         </para>
     </refsect1>
 

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -90,6 +90,21 @@
                     <term><option>command</option> (string)</term>
                     <listitem><para>The command to run. Only relevant for applications.</para></listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term><option>required-flatpak</option> (string)</term>
+                    <listitem><para>
+                        The required version of Flatpak to run this application
+                        or runtime.
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>tags</option> (string list)</term>
+                    <listitem><para>
+                        Tags to include in AppStream XML.
+                        <!-- TODO: what are these tags for? What should they
+                        be? -->
+                    </para></listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
         <refsect2>
@@ -156,6 +171,17 @@
                       in the sandbox a bind mount to "~/.var/app/org.my.App/.myapp",
                       thus allowing an unmodified application to save data in
                       the per-application location.
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>features</option> (list)</term>
+                    <listitem><para>
+                        List of features available or unavailable to the
+                        application, currently from the following list:
+                        devel, multiarch.
+                        A feature can be prefixed with ! to indicate the absence
+                        of that feature, for example !devel if development and
+                        debugging are not allowed.
                     </para></listitem>
                 </varlistentry>
             </variablelist>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -496,6 +496,16 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
+        <refsect2>
+          <title>[Policy SUBSYSTEM]</title>
+          <para>
+            Subsystems can define their own policies to be placed in a group
+            whose name has this form. Their values are treated as lists,
+            in which items can have their meaning negated by prepending !
+            to the value. They are not otherwise parsed by Flatpak.
+            <!-- TODO: More information would be nice -->
+          </para>
+        </refsect2>
     </refsect1>
 
     <refsect1>

--- a/document-portal/xdp-main.c
+++ b/document-portal/xdp-main.c
@@ -422,8 +422,12 @@ validate_fd (int fd,
   /* For apps we translate /app and /usr to the installed locations.
      Also, we need to rewrite to drop the /newroot prefix added by
      bubblewrap for other files to work. */
-  app_path = g_key_file_get_string (app_info, "Instance", "app-path", NULL);
-  runtime_path = g_key_file_get_string (app_info, "Instance", "runtime-path", NULL);
+  app_path = g_key_file_get_string (app_info, FLATPAK_METADATA_GROUP_INSTANCE,
+                                    FLATPAK_METADATA_KEY_APP_PATH, NULL);
+  runtime_path = g_key_file_get_string (app_info,
+                                        FLATPAK_METADATA_GROUP_INSTANCE,
+                                        FLATPAK_METADATA_KEY_RUNTIME_PATH,
+                                        NULL);
   if (app_path != NULL || runtime_path != NULL)
     {
       if (app_path != NULL &&
@@ -824,7 +828,9 @@ got_app_id_cb (GObject      *source_object,
 
   app_info = flatpak_invocation_lookup_app_info_finish (invocation, res, &error);
   if (app_info != NULL)
-    app_id = g_key_file_get_string (app_info, "Application", "name", &error);
+    app_id = g_key_file_get_string (app_info,
+                                    FLATPAK_METADATA_GROUP_APPLICATION,
+                                    FLATPAK_METADATA_KEY_NAME, &error);
 
   if (app_id == NULL)
     g_dbus_method_invocation_return_gerror (invocation, error);


### PR DESCRIPTION
While putting together a serialization for metadata as a GVariant in #890, I did some tidying up of the documentation and `#define`s for flatpak-metadata(5). Is this something people would like merged?

If you prefer the code to use string literals instead of `#define` constants but you do want the flatpak-metadata(5) documentation fixes, everything after the first commit should be cherry-pickable.