### PR TITLE
Allow setting the locale subpaths in repo config

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8860,7 +8860,12 @@ flatpak_dir_get_locale_subpaths (FlatpakDir *self)
     subpaths = g_key_file_get_string_list (config, "core", "xa.languages", NULL, NULL);
 
   if (!subpaths)
-    subpaths = flatpak_get_current_locale_subpaths ();
+    {
+      if (flatpak_dir_is_user (self))
+        subpaths = flatpak_get_current_locale_subpaths ();
+      else
+        subpaths = g_new0 (char *, 1);
+    }
 
   return subpaths;
 }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8581,7 +8581,7 @@ add_related (FlatpakDir *self,
 
   if (g_str_has_suffix (extension, ".Locale"))
     {
-      g_autofree char ** current_subpaths = flatpak_get_current_locale_subpaths ();
+      g_autofree char ** current_subpaths = flatpak_dir_get_locale_subpaths (self);
       for (i = 0; current_subpaths[i] != NULL; i++)
         {
           g_autofree char *subpath = current_subpaths[i];
@@ -8848,4 +8848,19 @@ flatpak_dir_find_local_related (FlatpakDir *self,
     }
 
   return g_steal_pointer (&related);
+}
+
+char **
+flatpak_dir_get_locale_subpaths (FlatpakDir *self)
+{
+  GKeyFile *config = ostree_repo_get_config (self->repo);
+  char **subpaths = NULL;
+
+  if (config)
+    subpaths = g_key_file_get_string_list (config, "core", "xa.languages", NULL, NULL);
+
+  if (!subpaths)
+    subpaths = flatpak_get_current_locale_subpaths ();
+
+  return subpaths;
 }

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -577,4 +577,6 @@ gboolean flatpak_dir_lookup_repo_metadata (FlatpakDir    *self,
                                            const char    *format_string,
                                            ...);
 
+char ** flatpak_dir_get_locale_subpaths (FlatpakDir *self);
+
 #endif /* __FLATPAK_DIR_H__ */


### PR DESCRIPTION
Read an xa.languages key from the [core] section of
the repo config to determine which subpaths to install
for Locales. This lets us maintain a list of system
languages without inventing a new file in /etc, and
will also work for alternative install locations.