### PR TITLE
Fix flatpak_summary_match_subrefs

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2587,7 +2587,7 @@ flatpak_summary_match_subrefs (GVariant *summary, const char *ref)
         continue;
 
       /* Must match arch & branch */
-      if (!g_str_has_prefix (cur, ref_prefix))
+      if (!g_str_has_suffix (cur, ref_suffix))
         continue;
 
       id_start = strchr (cur, '/');


### PR DESCRIPTION
We were checking the prefix twice here, instead of
checking prefix and suffix, which was obviously the
intention.

This caused extensions with non-matching architectures
to be reported as related refs.