### PR TITLE
Catch some more errors in option parsing

### DIFF
--- a/builder/builder-main.c
+++ b/builder/builder-main.c
@@ -453,6 +453,12 @@ main (int    argc,
   if (is_run && argc == 3)
     return usage (context, "Program to run must be specified");
 
+  if (opt_show_deps && !is_show_deps)
+    return usage (context, "Can't use --show-deps after a non-option");
+
+  if (opt_run && !is_run)
+    return usage (context, "Can't use --run after a non-option");
+
   if (is_show_deps)
     {
       if (!builder_manifest_show_deps (manifest, build_context, &error))


### PR DESCRIPTION
flatpak-builder was running into an assertion when --run was
used after a non-option. Catch this and exit with a clear error
message. Same for --show-deps