### PR TITLE
build: Add -std=gnu99 to libglnx CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,7 @@ libglnx_srcpath := $(srcdir)/libglnx
 libglnx_cflags := \
 	$(BASE_CFLAGS) \
 	"-I$(libglnx_srcpath)" \
+	-std=gnu99 \
 	$(HIDDEN_VISIBILITY_CFLAGS) \
 	$(NULL)
 libglnx_libs := $(BASE_LIBS)


### PR DESCRIPTION
It uses inline for loop initialisers, which are a C99 feature. Set
-std=gnu99 like ostree.git does for its libglnx submodule.

Based on a patch by Georges Basile Stavracas Neto
<georges.stavracas@gmail.com>.

Signed-off-by: Philip Withnall <withnall@endlessm.com>