### PR TITLE
flatpak-enter: warn when not running as root

### DIFF
--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -104,6 +104,10 @@ flatpak_builtin_enter (int           argc,
       return FALSE;
     }
 
+  /* Before further checks, warn if we are not already root */
+  if (geteuid () != 0)
+    g_printerr ("%s\n", _("Not running as root, may be unable to enter namespace"));
+
   pid_s = argv[rest_argv_start];
 
   pid = atoi (pid_s);


### PR DESCRIPTION
Currently, all conceivable configurations and installations of
flatpak require root to perform this operation. That may not be
the case in the future, but until then, we should warn when the
user is not root as the operation will fail.

Fixes https://github.com/flatpak/flatpak/issues/855