### PR TITLE
Handle ostree.ref-binding obsoleting xa.ref

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -276,6 +276,9 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
       /* Copy old metadata */
       g_variant_builder_init (&metadata_builder, G_VARIANT_TYPE ("a{sv}"));
       g_variant_builder_add (&metadata_builder, "{sv}", "xa.ref", g_variant_new_string (dst_ref));
+#if OSTREE_CHECK_VERSION(2017, 9)
+      g_variant_builder_add (&metadata_builder, "{sv}", OSTREE_COMMIT_META_KEY_REF_BINDING, g_variant_new_string (dst_ref));
+#endif
       /* Record the source commit. This is nice to have, but it also
          means the commit-from gets a different commit id, which
          avoids problems with e.g.  sharing .commitmeta files
@@ -291,6 +294,12 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
           if (strcmp (key, "xa.ref") == 0 ||
               strcmp (key, "xa.from_commit") == 0)
             continue;
+
+#if OSTREE_CHECK_VERSION(2017, 9)
+          if (strcmp (key, OSTREE_COMMIT_META_KEY_REF_BINDING) == 0 ||
+              strcmp (key, OSTREE_COMMIT_META_KEY_COLLECTION_BINDING) == 0)
+            continue;
+#endif
 
           g_variant_builder_add_value (&metadata_builder, child);
         }

--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -836,6 +836,13 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
   if (!flatpak_repo_collect_sizes (repo, root, &installed_size, &download_size, cancellable, error))
     goto out;
 
+  /* ostree.ref-binding obsoletes xa.ref, but we write both for now:
+   * https://github.com/ostreedev/ostree/releases/tag/v2017.9
+   */
+
+#if OSTREE_CHECK_VERSION(2017, 9)
+  g_variant_dict_insert_value (&metadata_dict, OSTREE_COMMIT_META_KEY_REF_BINDING, g_variant_new_string (full_branch));
+#endif
   g_variant_dict_insert_value (&metadata_dict, "xa.ref", g_variant_new_string (full_branch));
   g_variant_dict_insert_value (&metadata_dict, "xa.metadata", g_variant_new_string (metadata_contents));
   g_variant_dict_insert_value (&metadata_dict, "xa.installed-size", g_variant_new_uint64 (GUINT64_TO_BE (installed_size)));

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4654,6 +4654,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
         }
     }
 
+  /* Note this is obsoleted by ostree.ref-binding: https://github.com/ostreedev/ostree/releases/tag/v2017.9 */
   g_variant_lookup (commit_metadata, "xa.ref", "s", &xa_ref);
   if (xa_ref != NULL)
     {


### PR DESCRIPTION
More info: <https://github.com/ostreedev/ostree/releases/tag/v2017.9>
<https://mail.gnome.org/archives/ostree-list/2017-May/msg00013.html>

libostree interprets it during pull, which is nicer than what we did before. But
we keep writing/reading `xa.ref` too for compatibility.