### PR TITLE
Get language list from AccountsService's dbus

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9663,6 +9663,130 @@ flatpak_dir_find_local_related (FlatpakDir *self,
   return g_steal_pointer (&related);
 }
 
+static GDBusProxy *
+get_accounts_dbus_proxy (void)
+{
+  GDBusConnection *conn = NULL;
+  GDBusProxy *proxy = NULL;
+
+  const char *accounts_bus_name = "org.freedesktop.Accounts";
+  const char *accounts_object_path = "/org/freedesktop/Accounts";
+  const char *accounts_interface_name = accounts_bus_name;
+
+  conn = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);
+  proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
+                                         G_DBUS_PROXY_FLAGS_NONE,
+                                         NULL,
+                                         accounts_bus_name,
+                                         accounts_object_path,
+                                         accounts_interface_name,
+                                         NULL,
+                                         NULL);
+  g_object_unref (conn);
+
+  return proxy;
+}
+
+static char **
+get_locale_subpaths_from_accounts_dbus (GDBusProxy *proxy)
+{
+  const char *accounts_bus_name = "org.freedesktop.Accounts";
+  const char *accounts_interface_name = "org.freedesktop.Accounts.User";
+  char **object_path;
+  GList *langs = NULL;
+  GList *l = NULL;
+  GPtrArray *subpaths = g_ptr_array_new ();
+  int i;
+
+  GVariant *ret;
+  ret = g_dbus_proxy_call_sync (G_DBUS_PROXY (proxy),
+                                "ListCachedUsers",
+                                g_variant_new ("()"),
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                NULL);
+  if (ret != NULL)
+    {
+      g_variant_get (ret,
+                     "(^ao)",
+                     &object_path);
+      g_variant_unref (ret);
+    }
+
+  if (object_path != NULL)
+    {
+      for (i = 0; object_path[i] != NULL; i++)
+        {
+          GDBusProxy *accounts_proxy = NULL;
+          GVariant *value = NULL;
+          gsize size;
+          char *lang;
+
+          accounts_proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
+                                                          G_DBUS_PROXY_FLAGS_NONE,
+                                                          NULL,
+                                                          accounts_bus_name,
+                                                          object_path[i],
+                                                          accounts_interface_name,
+                                                          NULL,
+                                                          NULL);
+
+          value = g_dbus_proxy_get_cached_property (accounts_proxy, "Language");
+          if (value != NULL)
+            {
+              size = g_variant_get_size (value);
+              lang = g_strdup (g_variant_get_string (value, &size));
+              langs = g_list_append (langs, lang);
+
+              g_variant_unref (value);
+              g_object_unref (accounts_proxy);
+            }
+        }
+  }
+
+  l = langs;
+  while (l != NULL)
+    {
+      g_autofree char *dir = g_strconcat ("/", l->data, NULL);
+      char *c;
+
+      c = strchr (dir, '@');
+      if (c != NULL)
+        *c = 0;
+      c = strchr (dir, '_');
+      if (c != NULL)
+        *c = 0;
+      c = strchr (dir, '.');
+      if (c != NULL)
+        *c = 0;
+
+      if (strcmp (dir, "/C") == 0)
+        continue;
+
+      g_ptr_array_add (subpaths, g_steal_pointer (&dir));
+      l = l->next;
+    }
+
+  if (langs == NULL)
+    {
+      return NULL;
+    }
+
+  l = langs;
+  while (l != NULL)
+    {
+      if (l->data != NULL)
+        g_free (l->data);
+      l = l->next;
+    }
+  g_list_free (langs);
+
+  g_ptr_array_add (subpaths, NULL);
+
+  return (char **)g_ptr_array_free (subpaths, FALSE);
+}
+
 char **
 flatpak_dir_get_locale_subpaths (FlatpakDir *self)
 {
@@ -9677,7 +9801,19 @@ flatpak_dir_get_locale_subpaths (FlatpakDir *self)
       if (flatpak_dir_is_user (self))
         subpaths = flatpak_get_current_locale_subpaths ();
       else
-        subpaths = g_new0 (char *, 1);
+        {
+          GDBusProxy *proxy = get_accounts_dbus_proxy ();
+          if (proxy)
+            {
+              subpaths = get_locale_subpaths_from_accounts_dbus (proxy);
+              g_object_unref (proxy);
+
+              if (!subpaths)
+                subpaths = g_new0 (char *, 1);
+            }
+          else
+            subpaths = g_new0 (char *, 1);
+        }
     }
 
   return subpaths;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9695,6 +9695,7 @@ get_locale_subpaths_from_accounts_dbus (GDBusProxy *proxy)
   char **object_path;
   GList *langs = NULL;
   GList *l = NULL;
+  GString *langs_cache = g_string_new(NULL);
   GPtrArray *subpaths = g_ptr_array_new ();
   int i;
 
@@ -9764,7 +9765,18 @@ get_locale_subpaths_from_accounts_dbus (GDBusProxy *proxy)
       if (strcmp (dir, "/C") == 0)
         continue;
 
-      g_ptr_array_add (subpaths, g_steal_pointer (&dir));
+      /* handle language == "" */
+      if (strcmp (dir, "/") == 0)
+        continue;
+
+      /* filter duplicate language */
+      if (g_strrstr (langs_cache->str, dir) == NULL)
+        {
+          g_string_append (langs_cache, dir);
+          g_string_append_c (langs_cache, ':');
+          g_ptr_array_add (subpaths, g_steal_pointer (&dir));
+        }
+
       l = l->next;
     }
 
@@ -9781,6 +9793,8 @@ get_locale_subpaths_from_accounts_dbus (GDBusProxy *proxy)
       l = l->next;
     }
   g_list_free (langs);
+
+  g_string_free(langs_cache, TRUE);
 
   g_ptr_array_add (subpaths, NULL);
 


### PR DESCRIPTION
Fixes issue #950

When xa.languages is not set in repo config, system installs will
get language list from AccountsService's dbus.