### PR TITLE
Add missing flatpak_remote_get_remote_type() implementation

### DIFF
--- a/lib/flatpak-remote.c
+++ b/lib/flatpak-remote.c
@@ -171,6 +171,14 @@ flatpak_remote_class_init (FlatpakRemoteClass *klass)
   object_class->set_property = flatpak_remote_set_property;
   object_class->finalize = flatpak_remote_finalize;
 
+  /**
+   * FlatpakRemote:name:
+   *
+   * Name of the remote, as used in configuration files and when interfacing
+   * with OSTree. This is typically human readable, but could be generated, and
+   * must conform to ostree_validate_remote_name(). It should typically not be
+   * presented in the UI.
+   */
   g_object_class_install_property (object_class,
                                    PROP_NAME,
                                    g_param_spec_string ("name",
@@ -179,6 +187,17 @@ flatpak_remote_class_init (FlatpakRemoteClass *klass)
                                                         NULL,
                                                         G_PARAM_READWRITE));
 
+  /**
+   * FlatpakRemote:type:
+   *
+   * The type of the remote: whether it comes from static configuration files
+   * (@FLATPAK_REMOTE_TYPE_STATIC) or has been dynamically found from the local
+   * network or a mounted USB drive (@FLATPAK_REMOTE_TYPE_LAN,
+   * @FLATPAK_REMOTE_TYPE_USB). Dynamic remotes may be added and removed over
+   * time.
+   *
+   * Since: 0.9.8
+   */
   g_object_class_install_property (object_class,
                                    PROP_TYPE,
                                    g_param_spec_enum ("type",

--- a/lib/flatpak-remote.c
+++ b/lib/flatpak-remote.c
@@ -839,3 +839,22 @@ flatpak_remote_commit (FlatpakRemote   *self,
 
   return flatpak_dir_modify_remote (dir, priv->name, config, priv->local_gpg_key, cancellable, error);
 }
+
+/**
+ * flatpak_remote_get_remote_type:
+ * @self: a #FlatpakRemote
+ *
+ * Get the value of #FlatpakRemote:type.
+ *
+ * Returns: the type of remote this is
+ * Since: 0.9.8
+ */
+FlatpakRemoteType
+flatpak_remote_get_remote_type (FlatpakRemote *self)
+{
+  FlatpakRemotePrivate *priv = flatpak_remote_get_instance_private (self);
+
+  g_return_val_if_fail (FLATPAK_IS_REMOTE (self), FLATPAK_REMOTE_TYPE_STATIC);
+
+  return priv->type;
+}

--- a/lib/test-lib.c
+++ b/lib/test-lib.c
@@ -363,8 +363,9 @@ main (int argc, char *argv[])
       collection_id = flatpak_remote_get_collection_id (remote);
 #endif  /* !FLATPAK_ENABLE_P2P */
 
-      g_print ("\nRemote: %s %d %s %s %s %s %d %d %s\n",
+      g_print ("\nRemote: %s %u %d %s %s %s %s %d %d %s\n",
                flatpak_remote_get_name (remote),
+               flatpak_remote_get_remote_type (remote),
                flatpak_remote_get_prio (remote),
                flatpak_remote_get_url (remote),
                collection_id,

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -250,6 +250,7 @@ test_remote_by_name (void)
   g_assert_cmpstr (flatpak_remote_get_name (remote), ==, repo_name);
   g_assert_cmpstr (flatpak_remote_get_url (remote), ==, repo_url);
   g_assert_cmpstr (flatpak_remote_get_title (remote), ==, NULL);
+  g_assert_cmpint (flatpak_remote_get_remote_type (remote), ==, FLATPAK_REMOTE_TYPE_STATIC);
   g_assert_false (flatpak_remote_get_noenumerate (remote));
   g_assert_false (flatpak_remote_get_disabled (remote));
   g_assert_true (flatpak_remote_get_gpg_verify (remote));


### PR DESCRIPTION
This was declared in the header for the P2P stuff, but the definition got lost somewhere. Oops.

People can currently work around this by using`g_object_get()` with the `type` property.