### PR TITLE
Tests no longer require user xattrs

### DIFF
--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -1,14 +1,12 @@
 #! /bin/bash
 #
-# Run a test in tap mode, ensuring we have a temporary directory.  We
-# always use /var/tmp because we might want to use user xattrs, which
-# aren't available on tmpfs.
+# Run a test in tap mode, ensuring we have a temporary directory.
 #
 # The test binary is passed as $1
 
 srcd=$(cd $(dirname $1) && pwd)
 bn=$(basename $1)
-tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
+tempdir=$(mktemp -d /tmp/tap-test.XXXXXX)
 touch ${tempdir}/.testtmp
 function cleanup () {
     if test -n "${TEST_SKIP_CLEANUP:-}"; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -72,8 +72,7 @@ fi
 export MALLOC_CHECK_=3
 export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))
 
-# We need this to be in /var/tmp because /tmp has no xattr support
-TEST_DATA_DIR=`mktemp -d /var/tmp/test-flatpak-XXXXXX`
+TEST_DATA_DIR=`mktemp -d /tmp/test-flatpak-XXXXXX`
 mkdir -p ${TEST_DATA_DIR}/home
 mkdir -p ${TEST_DATA_DIR}/runtime
 mkdir -p ${TEST_DATA_DIR}/system

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -308,14 +308,6 @@ run_sh () {
     ${CMD_PREFIX} flatpak run --command=bash ${ARGS-} org.test.Hello -c "$*"
 }
 
-skip_without_user_xattrs () {
-    touch ${TEST_DATA_DIR}/test-xattrs
-    if ! setfattr -n user.testvalue -v somevalue ${TEST_DATA_DIR}/test-xattrs; then
-        echo "1..0 # SKIP this test requires xattr support"
-        exit 0
-    fi
-}
-
 skip_without_bwrap () {
     if [ -z "${FLATPAK_BWRAP:-}" ]; then
         # running installed-tests: assume we know what we're doing

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-skip_without_user_xattrs
 
 echo "1..7"
 

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-skip_without_user_xattrs
 
 echo "1..2"
 

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-skip_without_user_xattrs
 
 echo "1..6"
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-skip_without_user_xattrs
 
 if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
     skip_without_p2p

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-skip_without_user_xattrs
 
 echo "1..12"
 

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -25,7 +25,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-skip_without_user_xattrs
 skip_without_p2p
 
 echo "1..7"

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -25,7 +25,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-skip_without_user_xattrs
 skip_without_p2p
 
 echo "1..3"

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -798,7 +798,7 @@ global_setup (void)
   g_autofree char *datadir = NULL;
   g_autofree char *homedir = NULL;
 
-  testdir = g_strdup ("/var/tmp/flatpak-test-XXXXXX");
+  testdir = g_strdup ("/tmp/flatpak-test-XXXXXX");
   g_mkdtemp (testdir);
   g_test_message ("testdir: %s", testdir);
 


### PR DESCRIPTION
Since Flatpak 0.9.6, the tests do not need user extended attributes any more, so we don't need to skip them when running on a deficient filesystem.

This means there is no longer any reason why we should prefer `/var/tmp` over `/tmp`, so use `/tmp`.