### PR TITLE
Partially revert #986

### DIFF
--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -1,12 +1,14 @@
 #! /bin/bash
 #
-# Run a test in tap mode, ensuring we have a temporary directory.
+# Run a test in tap mode, ensuring we have a temporary directory.  We
+# always use /var/tmp because we might want to use user xattrs, which
+# aren't available on tmpfs.
 #
 # The test binary is passed as $1
 
 srcd=$(cd $(dirname $1) && pwd)
 bn=$(basename $1)
-tempdir=$(mktemp -d /tmp/tap-test.XXXXXX)
+tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
 touch ${tempdir}/.testtmp
 function cleanup () {
     if test -n "${TEST_SKIP_CLEANUP:-}"; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -309,6 +309,14 @@ run_sh () {
     ${CMD_PREFIX} flatpak run --command=bash ${ARGS-} org.test.Hello -c "$*"
 }
 
+skip_without_user_xattrs () {
+    touch ${TEST_DATA_DIR}/test-xattrs
+    if ! setfattr -n user.testvalue -v somevalue ${TEST_DATA_DIR}/test-xattrs; then
+        echo "1..0 # SKIP this test requires xattr support"
+        exit 0
+    fi
+}
+
 skip_without_bwrap () {
     if [ -z "${FLATPAK_BWRAP:-}" ]; then
         # running installed-tests: assume we know what we're doing

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -77,6 +77,7 @@ mkdir -p ${TEST_DATA_DIR}/home
 mkdir -p ${TEST_DATA_DIR}/runtime
 mkdir -p ${TEST_DATA_DIR}/system
 export FLATPAK_SYSTEM_DIR=${TEST_DATA_DIR}/system
+export FLATPAK_SYSTEM_CACHE_DIR=${TEST_DATA_DIR}/system-cache
 export FLATPAK_SYSTEM_HELPER_ON_SESSION=1
 
 export HOME=${TEST_DATA_DIR}/home

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -72,7 +72,8 @@ fi
 export MALLOC_CHECK_=3
 export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))
 
-TEST_DATA_DIR=`mktemp -d /tmp/test-flatpak-XXXXXX`
+# We need this to be in /var/tmp because /tmp has no xattr support
+TEST_DATA_DIR=`mktemp -d /var/tmp/test-flatpak-XXXXXX`
 mkdir -p ${TEST_DATA_DIR}/home
 mkdir -p ${TEST_DATA_DIR}/runtime
 mkdir -p ${TEST_DATA_DIR}/system

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..7"
 

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..2"
 

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..6"
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
     skip_without_p2p

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..12"
 

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 skip_without_p2p
 
 echo "1..7"

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 skip_without_p2p
 
 echo "1..3"

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -12,6 +12,7 @@
 static char *testdir;
 static char *flatpak_runtimedir;
 static char *flatpak_systemdir;
+static char *flatpak_systemcachedir;
 static char *flatpak_configdir;
 static char *flatpak_installationsdir;
 static char *gpg_homedir;
@@ -831,6 +832,11 @@ global_setup (void)
   g_mkdir_with_parents (flatpak_systemdir, S_IRWXU|S_IRWXG|S_IRWXO);
   g_setenv ("FLATPAK_SYSTEM_DIR", flatpak_systemdir, TRUE);
   g_test_message ("setting FLATPAK_SYSTEM_DIR=%s", flatpak_systemdir);
+
+  flatpak_systemcachedir = g_strconcat (testdir, "/system-cache", NULL);
+  g_mkdir_with_parents (flatpak_systemcachedir, S_IRWXU|S_IRWXG|S_IRWXO);
+  g_setenv ("FLATPAK_SYSTEM_CACHE_DIR", flatpak_systemcachedir, TRUE);
+  g_test_message ("setting FLATPAK_SYSTEM_CACHE_DIR=%s", flatpak_systemcachedir);
 
   flatpak_configdir = g_strconcat (testdir, "/config", NULL);
   g_mkdir_with_parents (flatpak_configdir, S_IRWXU|S_IRWXG|S_IRWXO);

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -799,7 +799,7 @@ global_setup (void)
   g_autofree char *datadir = NULL;
   g_autofree char *homedir = NULL;
 
-  testdir = g_strdup ("/tmp/flatpak-test-XXXXXX");
+  testdir = g_strdup ("/var/tmp/flatpak-test-XXXXXX");
   g_mkdtemp (testdir);
   g_test_message ("testdir: %s", testdir);
 


### PR DESCRIPTION
#986 was a bit over-zealous and only worked because `flatpak_ensure_system_user_cache_dir_location()` is hard-coded to prefer `/var/tmp`, which is typically (although not always) not tmpfs. It appears the per-user system cache directory does need to be bare-user and not bare-user-only (I tried the latter and got test failures).