### PR TITLE
Fix segfault on flatpak update

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9780,7 +9780,7 @@ get_locale_subpaths_from_accounts_dbus (GDBusProxy *proxy)
 {
   const char *accounts_bus_name = "org.freedesktop.Accounts";
   const char *accounts_interface_name = "org.freedesktop.Accounts.User";
-  char **object_path;
+  char **object_path = NULL;
   GList *langs = NULL;
   GList *l = NULL;
   g_autoptr(GString) langs_cache = g_string_new (NULL);


### PR DESCRIPTION
When ret is NULL object_path is filled with garbage and causes a
segfault g_dbus_proxy_new_for_bus_sync.

```

Thread 1 "flatpak" received signal SIGSEGV, Segmentation fault.
0x00007ffff5c03221 in __strlen_avx2 () from /usr/lib/libc.so.6
(gdb) bt full
#0  0x00007ffff5c03221 in __strlen_avx2 () at /usr/lib/libc.so.6
#1  0x00007ffff678b6ff in g_variant_is_object_path (string=string@entry=0x1000000001 <error: Cannot access memory at address 0x1000000001>) at gvariant.c:1382
#2  0x00007ffff6d484b1 in g_dbus_proxy_new_for_bus_sync (bus_type=bus_type@entry=G_BUS_TYPE_SYSTEM, flags=flags@entry=G_DBUS_PROXY_FLAGS_NONE, info=info@entry=0x0, name=name@entry=0x5555555d3846 "org.freedesktop.Accounts", object_path=0x1000000001 <error: Cannot access memory at address 0x1000000001>, interface_name=interface_name@entry=0x5555555d3892 "org.freedesktop.Accounts.User", cancellable=0x0, error=0x0) at gdbusproxy.c:2249
        _g_boolean_var_ = <optimized out>
        initable = <optimized out>
        __func__ = "g_dbus_proxy_new_for_bus_sync"
#3  0x00005555555a19dd in get_locale_subpaths_from_accounts_dbus (proxy=0x555555823da0 [GDBusProxy])
    at common/flatpak-dir.c:9811
        accounts_proxy = 0x0
        value = 0x0
        accounts_interface_name = 0x5555555d3892 "org.freedesktop.Accounts.User"
        object_path = 0x7fffe8001ce0
        subpaths = 0x7fffe8635fa0
        accounts_bus_name = 0x5555555d3846 "org.freedesktop.Accounts"
        langs_cache = 0x7fffe8001d80
        use_full_language = 0
        ret = 0x0
        langs = 0x0
        l = 0x0
        i = <optimized out>
        config = <optimized out>
        subpaths = <optimized out>
#4  0x00005555555a19dd in flatpak_dir_get_locale_subpaths (self=self@entry=0x555555807640 [FlatpakDir])
    at common/flatpak-dir.c:9895
        config = <optimized out>
        subpaths = <optimized out>
#5  0x00005555555a1f08 in add_related (self=self@entry=0x555555807640 [FlatpakDir], related=related@entry=0x7fffe8632880, extension=extension@entry=0x55555585610a "org.gnome.Platform.Locale", extension_collection_id=extension_collection_id@entry=0x0, extension_ref=extension_ref@entry=0x555555858cd0 "runtime/org.gnome.Platform.Locale/x86_64/3.24", checksum=0x555555857680 "62f4855714f03b7de3278a66a972e890f377456107ea61cc30d44818b861907b", no_autodownload=0, download_if=0x0, autodelete=1) at common/flatpak-dir.c:9435
        current_subpaths = <optimized out>
        deploy_data = 0x7fffe8750830
        old_subpaths = <optimized out>
        subpaths = 0x7fffe8001ce0
        i = <optimized out>
        rel = <optimized out>
        download = <optimized out>
        delete = <optimized out>
        ref_parts = <optimized out>
#6  0x00005555555a241b in flatpak_dir_find_remote_related (self=0x555555807640 [FlatpakDir], ref=ref@entry=0x55555580f090 "runtime/org.gnome.Platform/x86_64/3.24", remote_name=remote_name@entry=0x5555558558a0 "gnome", cancellable=cancellable@entry=0x0, error=error@entry=0x7fffffffc310) at common/flatpak-dir.c:9560
        branch = <optimized out>
        autodelete = 1
        extension_ref = 0x555555858cd0 "runtime/org.gnome.Platform.Locale/x86_64/3.24"
        checksum = 0x555555857680 "62f4855714f03b7de3278a66a972e890f377456107ea61cc30d44818b861907b"
        version = 0x0
        subdirectories = 0
        no_autodownload = 0
        download_if = 0x0
        extension_collection_id = 0x0
        extension = 0x55555585610a "org.gnome.Platform.Locale"
        groups = 0x555555826d30
        summary = 0x55555581f380
        metadata = 0x5555558545b0 "[Runtime]\nname=org.gnome.Platform\nruntime=org.gnome.Platform/x86_64/3.24\nsdk=org.gnome.Sdk/x86_64/3.24\n\n[Extension org.freedesktop.Platform.GL]\ndirectory=lib/GL\nno-autodownload=true\nsubdirectories=tru"...
        metakey = 0x555555816540
        i = <optimized out>
        parts = <optimized out>
        related = 0x7fffe8632880
        url = 0x55555583b820 "http://sdk.gnome.org/repo/"
        collection_id = 0x0
#7  0x000055555556cf1d in add_related (self=self@entry=0x55555582da30, remote=0x5555558558a0 "gnome", ref=ref@entry=0x55555580f090 "runtime/org.gnome.Platform/x86_64/3.24", error=0x7fffffffc588) at app/flatpak-transaction.c:337
        related = 0x0
        local_error = 0x0
        i = <optimized out>
---Type <return> to continue, or q <return> to quit---
#8  0x000055555556d29b in add_deps (remote=<optimized out>, error=0x7fffffffc588, ref=0x0, metakey=<optimized out>, self=0x55555582da30) at app/flatpak-transaction.c:439
        runtime_ref = <optimized out>
        full_runtime_ref = 0x55555580f090 "runtime/org.gnome.Platform/x86_64/3.24"
        runtime_remote = 0x5555558558a0 "gnome"
        pref = <optimized out>
        origin = 0x555555829990 "com.spotify.Client-1-origin"
```