### PR TITLE
Add pipewire to --socket option

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -80,6 +80,7 @@ typedef enum {
   FLATPAK_CONTEXT_SOCKET_PULSEAUDIO  = 1 << 2,
   FLATPAK_CONTEXT_SOCKET_SESSION_BUS = 1 << 3,
   FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS  = 1 << 4,
+  FLATPAK_CONTEXT_SOCKET_PIPEWIRE    = 1 << 5,
 } FlatpakContextSockets;
 
 /* Same order as enum */
@@ -89,6 +90,7 @@ const char *flatpak_context_sockets[] = {
   "pulseaudio",
   "session-bus",
   "system-bus",
+  "pipewire",
   NULL
 };
 
@@ -2068,6 +2070,20 @@ flatpak_run_add_pulseaudio_args (GPtrArray *argv_array,
 }
 
 static void
+flatpak_run_add_pipewire_args (GPtrArray *argv_array,
+                                 char    ***envp_p)
+{
+
+  g_autofree char *pipewire_socket = g_build_filename (g_get_user_runtime_dir (), "pipewire-0", NULL);
+  if (g_file_test (pipewire_socket, G_FILE_TEST_EXISTS))
+    {
+      add_args (argv_array,
+                "--bind", pipewire_socket, pipewire_socket,
+                NULL);
+    }
+}
+
+static void
 flatpak_run_add_journal_args (GPtrArray *argv_array)
 {
   g_autofree char *journal_socket_socket = g_strdup ("/run/systemd/journal/socket");
@@ -3059,6 +3075,13 @@ flatpak_run_add_environment_args (GPtrArray      *argv_array,
       g_debug ("Allowing pulseaudio access");
       flatpak_run_add_pulseaudio_args (argv_array, fd_array, envp_p);
     }
+
+  if (context->sockets & FLATPAK_CONTEXT_SOCKET_PIPEWIRE)
+    {
+      g_debug ("Allowing pipewire access");
+      flatpak_run_add_pipewire_args (argv_array, envp_p);
+    }
+
 
   unrestricted_session_bus = (context->sockets & FLATPAK_CONTEXT_SOCKET_SESSION_BUS) != 0;
   if (unrestricted_session_bus)

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -122,7 +122,7 @@
                 <listitem><para>
                     Expose a well known socket to the application. This updates
                     the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, pipewire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -133,7 +133,7 @@
                 <listitem><para>
                     Don't expose a well known socket to the application. This updates
                     the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, pipewire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -140,7 +140,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, pipewire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -151,7 +151,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, pipewire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -128,7 +128,7 @@
                     <term><option>sockets</option> (list)</term>
                     <listitem><para>
                         List of well-known sockets to make available in the sandbox.
-                        Possible sockets: x11, wayland, pulseaudio, session-bus, system-bus.
+                        Possible sockets: x11, wayland, pulseaudio, session-bus, system-bus, pipewire.
                         When making a socket available, flatpak also sets
                         well-known environment variables like DISPLAY or
                         DBUS_SYSTEM_BUS_ADDRESS to let the application

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -126,7 +126,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, piperwire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -137,7 +137,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, pipewire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -181,7 +181,7 @@
                 <listitem><para>
                     Expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, pipewire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -192,7 +192,7 @@
                 <listitem><para>
                     Don't expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus, pipewire.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
Like pulse and wayland, this enables the pipewire socket through flatpak.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>