### PR TITLE
common/utils: Fix is_number("") to return FALSE

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5320,6 +5320,9 @@ flatpak_yes_no_prompt (const char *prompt, ...)
 static gboolean
 is_number (const char *s)
 {
+  if (*s == '\0')
+    return FALSE;
+
   while (*s != 0)
     {
       if (!g_ascii_isdigit (*s))


### PR DESCRIPTION
Previously, it was possible to enter ‘ ’ (a space) at a number prompt,
and it would be stripped, passed to is_number() (which would erroneously
return TRUE), then passed to strtol() and the return value used
unconditionally.

Fix that by fixing is_number() to return FALSE for the empty string.

Signed-off-by: Philip Withnall <withnall@endlessm.com>