### PR TITLE
add missing '[]' around AC_MSG_ERROR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,7 @@ AS_CASE([$BWRAP],
 if test "x$BWRAP" != xfalse; then
    BWRAP_VERSION=`$BWRAP --version | sed 's,.*\ \([0-9]*\.[0-9]*\.[0-9]*\)$,\1,'`
    AX_COMPARE_VERSION([$SYSTEM_BWRAP_REQS],[gt],[$BWRAP_VERSION],
-         AC_MSG_ERROR([You need at least version $SYSTEM_BWRAP_REQS of bubblewrap to use the system installed version]))
+                      [AC_MSG_ERROR([You need at least version $SYSTEM_BWRAP_REQS of bubblewrap to use the system installed version])])
    AM_CONDITIONAL([WITH_SYSTEM_BWRAP], [true])
 else
    AM_CONDITIONAL([WITH_SYSTEM_BWRAP], [false])
@@ -158,8 +158,8 @@ fi
 
 AC_CHECK_FUNCS(fdwalk)
 
-AC_CHECK_HEADER([sys/xattr.h], [], AC_MSG_ERROR([You must have sys/xattr.h from glibc]))
-AC_CHECK_HEADER([sys/capability.h], have_caps=yes, AC_MSG_ERROR([sys/capability.h header not found]))
+AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
+AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])
 
 AC_SUBST([GLIB_MKENUMS], [`$PKG_CONFIG --variable glib_mkenums glib-2.0`])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])


### PR DESCRIPTION
Without the '[]', if the error sentence contains a comma, it will cause strange output or errors.