### PR TITLE
lib: Add methods to clean up refs in local repository

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7020,7 +7020,7 @@ flatpak_dir_remove_ref (FlatpakDir   *self,
                                       error))
     return FALSE;
 
-  return flatpak_dir_prune (self, cancellable, error);
+  return TRUE;
 }
 
 gboolean

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6967,6 +6967,23 @@ flatpak_dir_undeploy_all (FlatpakDir   *self,
   return TRUE;
 }
 
+/**
+ * flatpak_dir_remove_ref:
+ *
+ * @self: a #FlatpakDir
+ * @remote_name: the name of the remote
+ * @ref: the flatpak ref to remove
+ * @cancellable: (nullable) (optional): a #GCancellable
+ * @error: a #GError
+ *
+ * Remove the flatpak ref given by @remote_name:@ref from the underlying
+ * OSTree repo. Attempting to remove a ref that is currently deployed
+ * is an error, you need to uninstall the flatpak first. Note that this does
+ * not remove the objects bound to @ref from the disk, you will need to
+ * call flatpak_dir_prune() to do that.
+ *
+ * Returns: %TRUE if removing the ref succeeded, %FALSE otherwise.
+ */
 gboolean
 flatpak_dir_remove_ref (FlatpakDir   *self,
                         const char   *remote_name,
@@ -8089,20 +8106,19 @@ filter_out_deployed_refs (FlatpakDir *self,
 /**
  * flatpak_dir_cleanup_undeployed_refs:
  *
- * Find all flatpak refs in the local repository which have not been deloyed
+ * @self: a #FlatpakDir
+ * @cancellable: (nullable) (optional): a #GCancellable
+ * @error: a #GError
+ *
+ * Find all flatpak refs in the local repository which have not been deployed
  * in the dir and remove them from the repository. You might want to call this
  * function if you pulled refs into the dir but then decided that you did
  * not want to deploy them for some reason. Note that this does not prune
  * objects bound to the cleaned up refs from the underlying OSTree repository,
- * you should consider using flatpak_dir_prune to do that.
- *
- * @self: a #FlatpakDir
- * @cancellable: (allow-none): a #GCancellable
- * @error: (allow-none): a #GError
+ * you should consider using flatpak_dir_prune() to do that.
  *
  * Since: 0.10.0
- * Returns: (transfer-full): %TRUE if cleaning up the refs suceeded, %FALSE
- *                           otherwise
+ * Returns: %TRUE if cleaning up the refs suceeded, %FALSE otherwise
  */
 gboolean
 flatpak_dir_cleanup_undeployed_refs (FlatpakDir   *self,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8071,11 +8071,10 @@ filter_out_deployed_refs (FlatpakDir *self,
   for (i = 0; i < local_refspecs->len; ++i)
     {
       const gchar *refspec = g_ptr_array_index (local_refspecs, i);
-      g_autofree gchar *remote = NULL;
       g_autofree gchar *ref = NULL;
       g_autoptr(GVariant) deploy_data = NULL;
 
-      if (!ostree_parse_refspec (refspec, &remote, &ref, error))
+      if (!ostree_parse_refspec (refspec, NULL, &ref, error))
         return FALSE;
 
       deploy_data = flatpak_dir_get_deploy_data (self, ref, NULL, NULL);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7092,6 +7092,25 @@ flatpak_dir_prune (FlatpakDir   *self,
   if (error == NULL)
     error = &local_error;
 
+  if (flatpak_dir_use_system_helper (self, NULL))
+    {
+      const char *installation = flatpak_dir_get_id (self);
+      FlatpakSystemHelper *system_helper = flatpak_dir_get_system_helper (self);
+
+      /* If we don't have the system helper, we'll have to try and just remove
+       * the ref as an unprivileged user, which might fail later */
+      if (system_helper)
+        {
+          if (!flatpak_system_helper_call_prune_local_repo_sync (system_helper,
+                                                                 installation ? installation : "",
+                                                                 cancellable,
+                                                                 error))
+            return FALSE;
+        }
+
+      return TRUE;
+    }
+
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     goto out;
 

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -491,6 +491,9 @@ gboolean    flatpak_dir_prune (FlatpakDir   *self,
 gboolean    flatpak_dir_cleanup_removed (FlatpakDir   *self,
                                          GCancellable *cancellable,
                                          GError      **error);
+gboolean    flatpak_dir_cleanup_undeployed_refs (FlatpakDir   *self,
+                                                 GCancellable *cancellable,
+                                                 GError      **error);
 gboolean    flatpak_dir_collect_deployed_refs (FlatpakDir   *self,
                                                const char   *type,
                                                const char   *name_prefix,

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -117,6 +117,10 @@
       <arg type='s' name='installation' direction='in'/>
     </method>
 
+    <method name="PruneLocalRepo">
+      <arg type='s' name='installation' direction='in'/>
+    </method>
+
   </interface>
 
 </node>

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -111,6 +111,12 @@
       <arg type='ay' name='summary_sig_path' direction='in'/>
     </method>
 
+    <method name="RemoveLocalRef">
+      <arg type='s' name='remote' direction='in'/>
+      <arg type='s' name='ref' direction='in'/>
+      <arg type='s' name='installation' direction='in'/>
+    </method>
+
   </interface>
 
 </node>

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2056,7 +2056,9 @@ flatpak_installation_list_installed_related_refs_sync (FlatpakInstallation *self
  * pulled a flatpak ref using flatpak_installation_install_full() and
  * specified %FLATPAK_INSTALL_FLAGS_NO_DEPLOY but then decided not to
  * deploy the ref later on and want to remove the local ref to prevent it
- * from taking up disk space.
+ * from taking up disk space. Note that this will not remove the objects
+ * referred to by @ref from the underlying OSTree repo, you should use
+ * flatpak_installation_prune_local_repo() to do that.
  *
  * Returns: %TRUE on success
  */
@@ -2084,8 +2086,11 @@ flatpak_installation_remove_local_ref_sync (FlatpakInstallation *self,
  * you pulled a flatpak refs using flatpak_installation_install_full() and
  * specified %FLATPAK_INSTALL_FLAGS_NO_DEPLOY but then decided not to
  * deploy the refs later on and want to remove the local refs to prevent them
- * from taking up disk space.
+ * from taking up disk space. Note that this will not remove the objects
+ * referred to by @ref from the underlying OSTree repo, you should use
+ * flatpak_installation_prune_local_repo() to do that.
  *
+ * Since: 0.10.0
  * Returns: %TRUE on success
  */
 gboolean
@@ -2096,4 +2101,25 @@ flatpak_installation_cleanup_local_refs_sync (FlatpakInstallation *self,
   g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
 
   return flatpak_dir_cleanup_undeployed_refs (dir, cancellable, error);
+}
+
+/**
+ * flatpak_installation_prune_local_repo
+ * @self: a #FlatpakInstallation
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Remove all orphaned OSTree objects from the underlying OSTree repo in
+ * @installation.
+ *
+ * Returns: %TRUE on success
+ */
+gboolean
+flatpak_installation_prune_local_repo (FlatpakInstallation *self,
+                                       GCancellable        *cancellable,
+                                       GError             **error)
+{
+  g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
+
+  return flatpak_dir_prune (dir, cancellable, error);
 }

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1933,7 +1933,7 @@ flatpak_installation_create_monitor (FlatpakInstallation *self,
  * flatpak_installation_list_remote_related_refs_sync:
  * @self: a #FlatpakInstallation
  * @remote_name: the name of the remote
- * @ref: the name of the remote
+ * @ref: the ref
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -1990,7 +1990,7 @@ flatpak_installation_list_remote_related_refs_sync (FlatpakInstallation *self,
  * flatpak_installation_list_installed_related_refs_sync:
  * @self: a #FlatpakInstallation
  * @remote_name: the name of the remote
- * @ref: the name of the remote
+ * @ref: the ref
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2041,3 +2041,59 @@ flatpak_installation_list_installed_related_refs_sync (FlatpakInstallation *self
 
   return g_steal_pointer (&refs);
 }
+
+/**
+ * flatpak_installation_remove_local_ref_sync
+ * @self: a #FlatpakInstallation
+ * @remote_name: the name of the remote
+ * @ref: the ref
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Remove the OSTree ref given by @remote_name:@ref from the local flatpak
+ * repository. The next time the underlying OSTree repo is pruned, objects
+ * which were attached to that ref will be removed. This is useful if you
+ * pulled a flatpak ref using flatpak_installation_install_full() and
+ * specified %FLATPAK_INSTALL_FLAGS_NO_DEPLOY but then decided not to
+ * deploy the ref later on and want to remove the local ref to prevent it
+ * from taking up disk space.
+ *
+ * Returns: %TRUE on success
+ */
+gboolean
+flatpak_installation_remove_local_ref_sync (FlatpakInstallation *self,
+                                            const char          *remote_name,
+                                            const char          *ref,
+                                            GCancellable        *cancellable,
+                                            GError             **error)
+{
+  g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
+
+  return flatpak_dir_remove_ref (dir, remote_name, ref, cancellable, error);
+}
+
+/**
+ * flatpak_installation_cleanup_local_refs_sync
+ * @self: a #FlatpakInstallation
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Remove all OSTree refs from the local flatpak repository which are not
+ * in a deployed state. The next time the underlying OSTree repo is pruned,
+ * objects which were attached to that ref will be removed. This is useful if
+ * you pulled a flatpak refs using flatpak_installation_install_full() and
+ * specified %FLATPAK_INSTALL_FLAGS_NO_DEPLOY but then decided not to
+ * deploy the refs later on and want to remove the local refs to prevent them
+ * from taking up disk space.
+ *
+ * Returns: %TRUE on success
+ */
+gboolean
+flatpak_installation_cleanup_local_refs_sync (FlatpakInstallation *self,
+                                              GCancellable        *cancellable,
+                                              GError             **error)
+{
+  g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (self);
+
+  return flatpak_dir_cleanup_undeployed_refs (dir, cancellable, error);
+}

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -309,4 +309,13 @@ FLATPAK_EXTERN GPtrArray    *    flatpak_installation_list_installed_related_ref
                                                                                         GCancellable        *cancellable,
                                                                                         GError             **error);
 
+FLATPAK_EXTERN gboolean          flatpak_installation_remove_local_ref_sync (FlatpakInstallation *self,
+                                                                             const char          *remote_name,
+                                                                             const char          *ref,
+                                                                             GCancellable        *cancellable,
+                                                                             GError              **error);
+FLATPAK_EXTERN gboolean          flatpak_installation_cleanup_local_refs_sync (FlatpakInstallation *self,
+                                                                               GCancellable        *cancellable,
+                                                                               GError              **error);
+
 #endif /* __FLATPAK_INSTALLATION_H__ */

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -317,5 +317,9 @@ FLATPAK_EXTERN gboolean          flatpak_installation_remove_local_ref_sync (Fla
 FLATPAK_EXTERN gboolean          flatpak_installation_cleanup_local_refs_sync (FlatpakInstallation *self,
                                                                                GCancellable        *cancellable,
                                                                                GError              **error);
+FLATPAK_EXTERN gboolean          flatpak_installation_prune_local_repo (FlatpakInstallation *self,
+                                                                        GCancellable        *cancellable,
+                                                                        GError              **error);
+
 
 #endif /* __FLATPAK_INSTALLATION_H__ */

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -834,6 +834,40 @@ handle_remove_local_ref (FlatpakSystemHelper   *object,
 }
 
 static gboolean
+handle_prune_local_repo (FlatpakSystemHelper   *object,
+                         GDBusMethodInvocation *invocation,
+                         const gchar           *arg_installation)
+{
+  g_autoptr(FlatpakDir) system = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_debug ("PruneLocalRepo %s", arg_installation);
+
+  system = dir_get_system (arg_installation, &error);
+  if (system == NULL)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  if (!flatpak_dir_ensure_repo (system, NULL, &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  if (!flatpak_dir_prune (system, NULL, &error))
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  flatpak_system_helper_complete_prune_local_repo (object, invocation);
+
+  return TRUE;
+}
+
+static gboolean
 flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
                                   GDBusMethodInvocation  *invocation,
                                   gpointer                user_data)
@@ -946,7 +980,8 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
 
       polkit_details_insert (details, "remote", remote);
     }
-  else if (g_strcmp0 (method_name, "RemoveLocalRef") == 0)
+  else if (g_strcmp0 (method_name, "RemoveLocalRef") == 0 ||
+           g_strcmp0 (method_name, "PruneLocalRepo") == 0)
     {
       const char *remote;
 
@@ -1012,6 +1047,7 @@ on_bus_acquired (GDBusConnection *connection,
   g_signal_connect (helper, "handle-configure-remote", G_CALLBACK (handle_configure_remote), NULL);
   g_signal_connect (helper, "handle-update-remote", G_CALLBACK (handle_update_remote), NULL);
   g_signal_connect (helper, "handle-remove-local-ref", G_CALLBACK (handle_remove_local_ref), NULL);
+  g_signal_connect (helper, "handle-prune-local-repo", G_CALLBACK (handle_prune_local_repo), NULL);
 
   g_signal_connect (helper, "g-authorize-method",
                     G_CALLBACK (flatpak_authorize_method_handler),

--- a/system-helper/org.freedesktop.Flatpak.policy.in
+++ b/system-helper/org.freedesktop.Flatpak.policy.in
@@ -98,6 +98,21 @@
     </defaults>
   </action>
 
+  <action id="org.freedesktop.Flatpak.modify-repo">
+    <!-- SECURITY:
+          - Normal users do not need authentication to modify the
+            OSTree repository
+     -->
+    <description>Update system repository</description>
+    <message>Authentication is required to update the system repository</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.freedesktop.Flatpak.install-bundle">
     <description>Install bundle</description>
     <message>Authentication is required to install software</message>

--- a/system-helper/org.freedesktop.Flatpak.rules.in
+++ b/system-helper/org.freedesktop.Flatpak.rules.in
@@ -2,7 +2,8 @@ polkit.addRule(function(action, subject) {
     if ((action.id == "org.freedesktop.Flatpak.app-install" ||
          action.id == "org.freedesktop.Flatpak.runtime-install"||
          action.id == "org.freedesktop.Flatpak.app-uninstall" ||
-         action.id == "org.freedesktop.Flatpak.runtime-uninstall") &&
+         action.id == "org.freedesktop.Flatpak.runtime-uninstall" ||
+         action.id == "org.freedesktop.Flatpak.modify-repo") &&
         subject.active == true && subject.local == true &&
         subject.isInGroup("@privileged_group@")) {
             return polkit.Result.YES;


### PR DESCRIPTION
Add flatpak_installation_remove_local_ref_sync to remove a given ref from the local repository if the ref is known and flatpak_installation_cleanup_local_refs_sync to remove all undeployed refs.

This changes also adds a RemoveLocalRef helper method to the system helper, since modifying the system OSTree repo is a privileged operation. Removing a local ref probably does not impose any notable security risks, since the worst that could happen is a DoS where the user would have to download it again. Theoretically, it could be used in an attack where the local refs are removed and refs are re-downloaded from a compromised OSTree remote, but if that occurs there are much bigger problems (the remote owner would have lost control of their keys).

Fixes #1031 