### PR TITLE
tests: Use a more realistic bwrap invocation to check for support

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -321,7 +321,8 @@ skip_without_bwrap () {
     if [ -z "${FLATPAK_BWRAP:-}" ]; then
         # running installed-tests: assume we know what we're doing
         :
-    elif ! "$FLATPAK_BWRAP" --ro-bind / / /bin/true > bwrap-result 2>&1; then
+    elif ! "$FLATPAK_BWRAP" --unshare-ipc --unshare-net --unshare-pid \
+            --ro-bind / / /bin/true > bwrap-result 2>&1; then
         sed -e 's/^/# /' < bwrap-result
         echo "1..0 # SKIP Cannot run bwrap"
         exit 0

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -377,7 +377,8 @@ test_install_launch_uninstall (void)
   if (bwrap != NULL)
     {
       gint exit_code = 0;
-      char *argv[] = { (char *)bwrap, "--ro-bind", "/", "/", "/bin/true", NULL };
+      char *argv[] = { (char *)bwrap, "--unshare-ipc", "--unshare-net",
+          "--unshare-pid", "--ro-bind", "/", "/", "/bin/true", NULL };
       g_autofree char *argv_str = g_strjoinv (" ", argv);
       g_test_message ("Spawning %s", argv_str);
       g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL, &exit_code, &error);


### PR DESCRIPTION
The kernel used on some autobuilders for the Debian PA-RISC port
can do "bwrap --ro-bind / / /bin/true", but not the bwrap invocations
made during the actual testing, which fail with "Creating new namespace
failed: Invalid argument". Make the trial bwrap invocation more like
what Flatpak actually does, so that these tests will hopefully be
skipped on such kernels.

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876743
Signed-off-by: Simon McVittie <smcv@debian.org>