### PR TITLE
Refresh ld.so.cache on applications

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -376,7 +376,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   envp = flatpak_run_apply_env_vars (envp, app_context);
 
   if (!custom_usr && !(is_extension && !is_app_extension) &&
-      !flatpak_run_add_extension_args (argv_array, &envp, runtime_metakey, runtime_ref, cancellable, error))
+      !flatpak_run_add_extension_args (argv_array, NULL, &envp, runtime_metakey, runtime_ref, cancellable, error))
     return FALSE;
 
   if (!flatpak_run_add_environment_args (argv_array, NULL, &envp, app_info_path, run_flags, id,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4829,52 +4829,50 @@ child_setup (gpointer user_data)
     fcntl (g_array_index (fd_array, int, i), F_SETFD, 0);
 }
 
-static GKeyFile*
-get_metakey (GFile         *checkoutdir,
-             GCancellable  *cancellable,
-             GError       **error)
+static gboolean
+apply_extra_data (FlatpakDir          *self,
+                  GFile               *checkoutdir,
+                  GCancellable        *cancellable,
+                  GError             **error)
 {
-  g_autoptr(GKeyFile) metakey = NULL;
   g_autoptr(GFile) metadata = NULL;
   g_autofree char *metadata_contents = NULL;
   gsize metadata_size;
-
-  metadata = g_file_get_child (checkoutdir, "metadata");
-
-  if (!g_file_load_contents (metadata, cancellable, &metadata_contents, &metadata_size, NULL, error))
-    return NULL;
-
-  metakey = g_key_file_new ();
-  if (!g_key_file_load_from_data (metakey, metadata_contents, metadata_size, 0, error)) {
-    g_key_file_free (metakey);
-    return NULL;
-  }
-  return g_steal_pointer (&metakey);
-}
-
-static gboolean
-get_execution_env (FlatpakDir          *self,
-                   GPtrArray           *argv_array,
-                   GArray              *fd_array,
-                   GStrv               *envp,
-                   GFile               *checkoutdir,
-                   GKeyFile            *metakey,
-                   GCancellable        *cancellable,
-                   GError             **error)
-{
+  g_autoptr(GKeyFile) metakey = NULL;
   g_autofree char *id = NULL;
   g_autofree char *runtime = NULL;
   g_autofree char *runtime_ref = NULL;
   g_autoptr(FlatpakDeploy) runtime_deploy = NULL;
+  g_autoptr(GFile) app_files = NULL;
+  g_autoptr(GFile) apply_extra_file = NULL;
+  g_autoptr(GFile) app_export_file = NULL;
+  g_autoptr(GFile) extra_export_file = NULL;
+  g_autoptr(GFile) extra_files = NULL;
   g_autoptr(GFile) runtime_files = NULL;
+  g_autoptr(GPtrArray) argv_array = NULL;
   g_auto(GStrv) runtime_ref_parts = NULL;
   g_autoptr(FlatpakContext) app_context = NULL;
+  g_autoptr(GArray) fd_array = NULL;
+  g_auto(GStrv) envp = NULL;
+  int exit_status;
   const char *group = FLATPAK_METADATA_GROUP_APPLICATION;
   g_autoptr(GError) local_error = NULL;
 
+  apply_extra_file = g_file_resolve_relative_path (checkoutdir, "files/bin/apply_extra");
+  if (!g_file_query_exists (apply_extra_file, cancellable))
+    return TRUE;
+
+  metadata = g_file_get_child (checkoutdir, "metadata");
+
+  if (!g_file_load_contents (metadata, cancellable, &metadata_contents, &metadata_size, NULL, error))
+    return FALSE;
+
+  metakey = g_key_file_new ();
+  if (!g_key_file_load_from_data (metakey, metadata_contents, metadata_size, 0, error))
+    return FALSE;
+
   id = g_key_file_get_string (metakey, group, FLATPAK_METADATA_KEY_NAME,
                               &local_error);
-
   if (id == NULL)
     {
       group = FLATPAK_METADATA_GROUP_RUNTIME;
@@ -4908,11 +4906,27 @@ get_execution_env (FlatpakDir          *self,
       runtime_files = flatpak_deploy_get_files (runtime_deploy);
     }
 
+  app_files = g_file_get_child (checkoutdir, "files");
+  app_export_file = g_file_get_child (checkoutdir, "export");
+  extra_files = g_file_get_child (app_files, "extra");
+  extra_export_file = g_file_get_child (extra_files, "export");
+
+  argv_array = g_ptr_array_new_with_free_func (g_free);
+  fd_array = g_array_new (FALSE, TRUE, sizeof (int));
+  g_array_set_clear_func (fd_array, clear_fd);
+  g_ptr_array_add (argv_array, g_strdup (flatpak_get_bwrap ()));
+
   if (runtime_files)
     add_args (argv_array,
               "--ro-bind", flatpak_file_get_path_cached (runtime_files), "/usr",
             "--lock-file", "/usr/.ref",
               NULL);
+
+  add_args (argv_array,
+            "--ro-bind", flatpak_file_get_path_cached (app_files), "/app",
+            "--bind", flatpak_file_get_path_cached (extra_files), "/app/extra",
+            "--chdir", "/app/extra",
+            NULL);
 
   if (!flatpak_run_setup_base_argv (argv_array, fd_array, runtime_files, NULL, runtime_ref_parts[2],
                                     FLATPAK_RUN_FLAG_NO_SESSION_HELPER,
@@ -4921,138 +4935,14 @@ get_execution_env (FlatpakDir          *self,
 
   app_context = flatpak_context_new ();
 
-  if (!flatpak_run_add_environment_args (argv_array, fd_array, envp, NULL,
+  envp = flatpak_run_get_minimal_env (FALSE);
+  if (!flatpak_run_add_environment_args (argv_array, fd_array, &envp, NULL,
                                          FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY |
                                          FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY |
                                          FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY,
                                          id,
                                          app_context, NULL, NULL, cancellable, error))
     return FALSE;
-
-  return TRUE;
-}
-
-static gboolean
-refresh_ldconfig (FlatpakDir          *self,
-                  GFile               *checkoutdir,
-                  char const          *full_ref,
-                  GCancellable        *cancellable,
-                  GError             **error) {
-  g_autoptr(GPtrArray) argv_array = NULL;
-  g_autoptr(GArray) fd_array = NULL;
-  g_autoptr(GFile) app_files = NULL;
-  g_autoptr(GFile) etc = NULL;
-  g_autoptr(GFile) ld_so_conf_file = NULL;
-  g_autoptr(GKeyFile) metakey = NULL;
-  g_auto(GStrv) envp = NULL;
-  int exit_status;
-
-  ld_so_conf_file = g_file_resolve_relative_path (checkoutdir, "files/etc/ld.so.conf");
-  if (!g_file_query_exists (ld_so_conf_file, cancellable))
-    return TRUE;
-
-  app_files = g_file_get_child (checkoutdir, "files");
-  etc = g_file_get_child (app_files, "etc");
-
-  argv_array = g_ptr_array_new_with_free_func (g_free);
-  g_ptr_array_add (argv_array, g_strdup (flatpak_get_bwrap ()));
-
-  add_args (argv_array,
-            "--ro-bind", flatpak_file_get_path_cached (app_files), "/app",
-            "--bind", flatpak_file_get_path_cached (etc), "/app/etc",
-            NULL);
-
-  envp = flatpak_run_get_minimal_env (FALSE);
-
-  fd_array = g_array_new (FALSE, TRUE, sizeof (int));
-  g_array_set_clear_func (fd_array, clear_fd);
-
-  metakey = get_metakey(checkoutdir, cancellable, error);
-
-  if (!get_execution_env (self, argv_array, fd_array, &envp, checkoutdir, metakey,
-                          cancellable, error)) {
-    return FALSE;
-  }
-
-  if (!flatpak_run_add_extension_args (argv_array, &envp, metakey, full_ref, cancellable, error)) {
-    return FALSE;
-  }
-
-  g_ptr_array_add (argv_array, g_strdup ("/sbin/ldconfig"));
-  g_ptr_array_add (argv_array, g_strdup ("-C"));
-  g_ptr_array_add (argv_array, g_strdup ("/app/etc/ld.so.cache"));
-  g_ptr_array_add (argv_array, g_strdup ("-f"));
-  g_ptr_array_add (argv_array, g_strdup ("/app/etc/ld.so.conf"));
-
-  g_ptr_array_add (argv_array, NULL);
-
-  g_debug ("Running /sbin/ldconfig ");
-
-  if (!g_spawn_sync (NULL,
-                     (char **) argv_array->pdata,
-                     envp,
-                     G_SPAWN_SEARCH_PATH,
-                     child_setup, fd_array,
-                     NULL, NULL,
-                     &exit_status,
-                     error))
-    return FALSE;
-
-  if (exit_status != 0)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   _("apply_extra script failed, exit status %d"), exit_status);
-      return FALSE;
-    }
-
-  return TRUE;
-}
-
-static gboolean
-apply_extra_data (FlatpakDir          *self,
-                  GFile               *checkoutdir,
-                  GCancellable        *cancellable,
-                  GError             **error)
-{
-  g_autoptr(GFile) extra_export_file = NULL;
-  g_autoptr(GPtrArray) argv_array = NULL;
-  g_autoptr(GFile) app_files = NULL;
-  g_autoptr(GFile) extra_files = NULL;
-  g_auto(GStrv) envp = NULL;
-  g_autoptr(GArray) fd_array = NULL;
-  g_autoptr(GFile) app_export_file = NULL;
-  g_autoptr(GFile) apply_extra_file = NULL;
-  g_autoptr(GKeyFile) metakey = NULL;
-  int exit_status;
-
-  apply_extra_file = g_file_resolve_relative_path (checkoutdir, "files/bin/apply_extra");
-  if (!g_file_query_exists (apply_extra_file, cancellable))
-    return TRUE;
-
-  argv_array = g_ptr_array_new_with_free_func (g_free);
-  g_ptr_array_add (argv_array, g_strdup (flatpak_get_bwrap ()));
-
-  app_files = g_file_get_child (checkoutdir, "files");
-  extra_files = g_file_get_child (app_files, "extra");
-  extra_export_file = g_file_get_child (extra_files, "export");
-  app_export_file = g_file_get_child (checkoutdir, "export");
-
-  add_args (argv_array,
-            "--ro-bind", flatpak_file_get_path_cached (app_files), "/app",
-            "--bind", flatpak_file_get_path_cached (extra_files), "/app/extra",
-            "--chdir", "/app/extra",
-            NULL);
-
-  envp = flatpak_run_get_minimal_env (FALSE);
-
-  fd_array = g_array_new (FALSE, TRUE, sizeof (int));
-  g_array_set_clear_func (fd_array, clear_fd);
-
-  metakey = get_metakey(checkoutdir, cancellable, error);
-
-  if (!get_execution_env (self, argv_array, fd_array, &envp, checkoutdir, metakey, cancellable, error)) {
-    return FALSE;
-  }
 
   g_ptr_array_add (argv_array, g_strdup ("/app/bin/apply_extra"));
 
@@ -5086,98 +4976,6 @@ apply_extra_data (FlatpakDir          *self,
                          FLATPAK_CP_FLAGS_MERGE,
                          cancellable, error))
         return FALSE;
-    }
-
-  return TRUE;
-}
-
-static GHashTable *
-flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
-                                    FlatpakKinds kinds,
-                                    GError     **error);
-
-static GPtrArray *
-find_matching_refs (GHashTable *refs,
-                    const char   *opt_name,
-                    const char   *opt_branch,
-                    const char   *opt_arch,
-                    FlatpakKinds  kinds,
-                    GError      **error);
-
-static gboolean
-refresh_ldconfig_on_back_references (FlatpakDir    *self,
-                                     const char    *ref,
-                                     GCancellable  *cancellable,
-                                     GError       **error)
-{
-  size_t i;
-  g_auto(GStrv) deployed_ids = NULL;
-  g_autoptr(GHashTable) local_refs = NULL;
-  g_auto(GStrv) ref_parts = NULL;
-  g_autoptr(GPtrArray) refs_on_arch = NULL;
-
-  ref_parts = g_strsplit (ref, "/", -1);
-  if (strcmp (ref_parts[0], "runtime") == 0)
-    {
-      local_refs = flatpak_dir_get_all_installed_refs(self, FLATPAK_KINDS_APP, error);
-      if (local_refs == NULL)
-        return FALSE;
-
-      refs_on_arch = find_matching_refs (local_refs, NULL, NULL, ref_parts[2], FLATPAK_KINDS_APP, error);
-      if (refs_on_arch == NULL)
-        return FALSE;
-
-      for (i = 0; i < refs_on_arch->len; ++i)
-        {
-          g_auto(GStrv) groups = NULL;
-          char* back_ref;
-          size_t j;
-          gboolean depends = FALSE;
-          gchar* runtime;
-          g_autoptr(GFile) deploy_base = NULL;
-          g_autoptr(GFile) deploy_path = NULL;
-          g_autoptr(GKeyFile) metakey = NULL;
-
-          back_ref = (char*)g_ptr_array_index(refs_on_arch, i);
-
-          deploy_base = flatpak_dir_get_deploy_dir (self, back_ref);
-          deploy_path = g_file_get_child (deploy_base, "active");
-          if (deploy_path == NULL)
-            return FALSE;
-          metakey = get_metakey(deploy_path, cancellable, error);
-          if (metakey == NULL)
-            return FALSE;
-
-          runtime = g_key_file_get_string(metakey, FLATPAK_METADATA_GROUP_APPLICATION, FLATPAK_METADATA_KEY_RUNTIME, NULL);
-          if (runtime != NULL) {
-            if (strcmp(runtime, ref_parts[1]) == 0) {
-              depends = TRUE;
-            }
-          }
-          if (!depends)
-            {
-              groups = g_key_file_get_groups (metakey, NULL);
-              for (j = 0; groups[j] != NULL; j++)
-                {
-                  if (g_str_has_prefix (groups[j], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))
-                    {
-                      char *extension;
-                      extension = groups[j] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION);
-                      if (strcmp (extension, ref_parts[1]) == 0)
-                        {
-                          depends = TRUE;
-                          break ;
-                        }
-                    }
-                }
-            }
-
-          if (depends)
-            {
-              g_debug ("Refreshing ldconfigcache for %s", back_ref);
-              refresh_ldconfig (self, deploy_path, back_ref, cancellable, error);
-            }
-        }
     }
 
   return TRUE;
@@ -5372,9 +5170,6 @@ flatpak_dir_deploy (FlatpakDir          *self,
             }
         }
     }
-
-  if (!refresh_ldconfig (self, checkoutdir, ref, cancellable, error))
-    return FALSE;
 
   /* Extract any extra data */
   extradir = g_file_resolve_relative_path (checkoutdir, "files/extra");
@@ -5584,9 +5379,6 @@ flatpak_dir_deploy (FlatpakDir          *self,
     return FALSE;
 
   if (!flatpak_dir_set_active (self, ref, checkout_basename, cancellable, error))
-    return FALSE;
-
-  if (!refresh_ldconfig_on_back_references (self, ref, cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2296,7 +2296,7 @@ flatpak_run_add_extension_args (GPtrArray    *argv_array,
           g_autofree char *tmp_path = NULL;
           g_autofree char *fd_str = NULL;
           g_autofree char *ld_path = g_build_filename (full_directory, ext->add_ld_path, NULL);
-          g_autofree char *contents = g_strconcat("include ", ld_path, "\n", NULL);
+          g_autofree char *contents = g_strconcat(ld_path, "\n", NULL);
 
           fd = g_file_open_tmp ("flatpak-ld_so_conf-XXXXXX.conf", &tmp_path, NULL);
           if (fd == -1)

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -155,6 +155,7 @@ FlatpakExports *flatpak_exports_from_context (FlatpakContext *context,
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakExports, flatpak_exports_free);
 
 gboolean  flatpak_run_add_extension_args (GPtrArray    *argv_array,
+                                          GArray       *fd_array,
                                           char       ***envp_p,
                                           GKeyFile     *metakey,
                                           const char   *full_ref,


### PR DESCRIPTION
This is a first step into removing the need to set LD_LIBRARY_PATH to /app/lib (or other paths for application requiring more path). ld.so.cache should be faster at runtime (once LD_LIBRARY_PATH is removed). Also LD_LIBRARY_PATH is kind of a hack for development, but this is just an opinion.

ldconfig will be run in two situations: when you deploy an app, or when you deploy a runtime or extension on which an app depends. It will be run only if /app/etc/ld.so.conf exists.

On normal run, /etc/ld.so.conf and /etc/ld.so.cache are bound to /app/etc/ld.so.confg and /app/etc/ld.so.cache respectively if they exist.

This should be backward compatible. There is no need to do anything on the runtimes. Only application which need it need to be modified.

Just add post-install commands in your application json:
  "cp /etc/ld.so.conf /app/etc/ld.so.conf",
  "echo /app/lib >>/app/etc/ld.so.conf",
  "echo /app/some/other/path >>/app/etc/ld.so.conf"

This fixes the problem of priority of libraries in com.valvesoftware.Steam. One of Steam's scripts uses ldconfig to find out what the system library paths are. Unfortunately it cannot find 32bits libraries. So it gets into loading the libstdc++ from steam runtime which is too old for LLVM 5 used by mesa drivers. Note that Steam only reads ld.so.conf. It tells ldconfig to recompute the cache and print it instead of writing it.

For reference Steam was tested with the following paths in ld.so.conf:
/app/lib
/app/lib/32bit/lib
/app/lib/32bit/lib/pulseaudio
