### PR TITLE
run: Use libglnx more (O_TMPFILE, glnx_loop_write())

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1905,9 +1905,9 @@ add_args_data_fd (GPtrArray *argv_array,
                   int fd,
                   const char *path_optional)
 {
-  g_autofree char *fd_str = NULL;
+  g_return_if_fail (fd_array);
 
-  fd_str = g_strdup_printf ("%d", fd);
+  g_autofree char *fd_str = g_strdup_printf ("%d", fd);
   if (fd_array)
     g_array_append_val (fd_array, fd);
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1905,8 +1905,6 @@ add_args_data_fd (GPtrArray *argv_array,
                   int fd,
                   const char *path_optional)
 {
-  g_return_if_fail (fd_array);
-
   g_autofree char *fd_str = g_strdup_printf ("%d", fd);
   if (fd_array)
     g_array_append_val (fd_array, fd);


### PR DESCRIPTION
In general libglnx has expanded a lot to have a good set of low-level wrappers
for things like writing a buffer to a fd.  Also, we should use `O_TMPFILE`
if available - I think the code reduction speaks for itself here.

Writing this patch as a result of looking at what fds flatpak injects.

However, *really* we want to use sealed memfds.  I'll likely copy the
systemd wrappers for that into libglnx too.

Also, it took me a while to figure out the reason the `--args` code
worked before was because we were leaking the fd.