### PR TITLE
 run: Use memfd_create() for data passed to bwrap

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ EXTRA_DIST += $(service_in_files)
 
 FLATPAK_BINDIR=$(bindir)
 
+ACLOCAL_AMFLAGS = -I m4 -I libglnx ${ACLOCAL_FLAGS}
 AM_CPPFLAGS =							\
 	-DFLATPAK_BINDIR=\"$(FLATPAK_BINDIR)\"			\
 	-DFLATPAK_SYSTEMDIR=\"$(SYSTEM_INSTALL_DIR)\"		\

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1914,8 +1914,7 @@ buffer_to_sealed_memfd_or_tmpfile (GLnxTmpfile *tmpf,
   else
     {
       /* We use an anonymous fd (i.e. O_EXCL) since we don't want
-       * the target container to potentially be able to re-link it.  A
-       * good next step here would be to use memfd_create() and seal.
+       * the target container to potentially be able to re-link it.
        */
       if (!G_IN_SET (errno, ENOSYS, EOPNOTSUPP))
         return glnx_throw_errno_prefix (error, "memfd_create");

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,7 @@ else
 fi
 
 AC_CHECK_FUNCS(fdwalk)
+LIBGLNX_CONFIGURE
 
 AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
 AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])


### PR DESCRIPTION
Followup to the previous commit to use `O_TMPFILE`, for
the cases here what we really want is to use sealed memfds.  This
ensures the container can't mutate the data we pass.

Now, the args fd I was looking at turned out to be a bwrap bug,
but this is a good example of the mitigation:

```
$ flatpak run --command="/bin/sh"  org.test.Hello
ls -al /proc/$$/fd
total 0
dr-x------. 2 1000 1000  0 Oct  1 16:43 .
dr-xr-xr-x. 9 1000 1000  0 Oct  1 16:43 ..
lrwx------. 1 1000 1000 64 Oct  1 16:43 0 -> /dev/pts/2
lrwx------. 1 1000 1000 64 Oct  1 16:43 1 -> /dev/pts/2
lrwx------. 1 1000 1000 64 Oct  1 16:43 2 -> /dev/pts/2
lrwx------. 1 1000 1000 64 Oct  1 16:43 255 -> /dev/pts/2
lrwx------. 1 1000 1000 64 Oct  1 16:43 9 -> /memfd:bwrap-args (deleted)
org.test.Hello$ echo foo > /proc/self/fd/9
sh: /proc/self/fd/9: Operation not permitted
```