### PR TITLE
dir: Print debug output when opening flatpak dirs

### DIFF
--- a/app/flatpak-builtins-list-remotes.c
+++ b/app/flatpak-builtins-list-remotes.c
@@ -116,6 +116,8 @@ flatpak_builtin_list_remotes (int argc, char **argv, GCancellable *cancellable, 
       FlatpakDir *dir = g_ptr_array_index (dirs, j);
       g_auto(GStrv) remotes = NULL;
 
+      flatpak_log_dir_access (dir);
+
       remotes = flatpak_dir_list_remotes (dir, cancellable, error);
       if (remotes == NULL)
         return FALSE;

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -291,6 +291,7 @@ print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gbo
       g_auto(GStrv) user_runtime = NULL;
 
       user_dir =flatpak_dir_get_user ();
+      flatpak_log_dir_access (user_dir);
       if (!find_refs_for_dir (user_dir, app ? &user_app : NULL, runtime ? &user_runtime : NULL, cancellable, error))
         return FALSE;
       g_ptr_array_add (refs_array, refs_data_new (user_dir, user_app, user_runtime));
@@ -311,6 +312,8 @@ print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gbo
           g_auto(GStrv) apps = NULL;
           g_auto(GStrv) runtimes = NULL;
 
+          flatpak_log_dir_access (dir);
+
           if (!find_refs_for_dir (dir, app ? &apps : NULL, runtime ? &runtimes : NULL, cancellable, error))
             return FALSE;
           g_ptr_array_add (refs_array, refs_data_new (dir, apps, runtimes));
@@ -325,6 +328,7 @@ print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gbo
           g_auto(GStrv) system_runtime = NULL;
 
           system_dir = flatpak_dir_get_system_default ();
+          flatpak_log_dir_access (system_dir);
           if (!find_refs_for_dir (system_dir, app ? &system_app : NULL, runtime ? &system_runtime : NULL, cancellable, error))
             return FALSE;
           g_ptr_array_add (refs_array, refs_data_new (system_dir, system_app, system_runtime));
@@ -345,6 +349,7 @@ print_installed_refs (gboolean app, gboolean runtime, gboolean print_system, gbo
                 continue;
 
               system_dir = flatpak_dir_get_system_by_id (installations[i], cancellable, error);
+              flatpak_log_dir_access (system_dir);
               if (system_dir == NULL)
                 return FALSE;
 

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -219,6 +219,12 @@ flatpak_option_context_parse (GOptionContext     *context,
   if (!g_option_context_parse (context, argc, argv, error))
     return FALSE;
 
+  if (opt_verbose)
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+
+  if (opt_ostree_verbose)
+    g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+
   if (opt_version)
     {
       g_print ("%s\n", PACKAGE_STRING);
@@ -268,13 +274,9 @@ flatpak_option_context_parse (GOptionContext     *context,
       if (!(flags & FLATPAK_BUILTIN_FLAG_NO_REPO) &&
           !flatpak_dir_ensure_repo (dir, cancellable, error))
         return FALSE;
+
+      flatpak_log_dir_access (dir);
     }
-
-  if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
-
-  if (opt_ostree_verbose)
-    g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
 
   if (out_dir)
     *out_dir = g_steal_pointer (&dir);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -1362,6 +1362,7 @@ flatpak_find_deploy_for_ref (const char   *ref,
   g_autoptr(GError) my_error = NULL;
 
   user_dir = flatpak_dir_get_user ();
+  flatpak_log_dir_access (user_dir);
   system_dirs = flatpak_dir_get_system_list (cancellable, error);
   if (system_dirs == NULL)
     return NULL;
@@ -1377,6 +1378,7 @@ flatpak_find_deploy_for_ref (const char   *ref,
         {
           FlatpakDir *system_dir = g_ptr_array_index (system_dirs, i);
 
+          flatpak_log_dir_access (system_dir);
           g_clear_error (&my_error);
           deploy = flatpak_dir_load_deployed (system_dir, ref, NULL, cancellable, &my_error);
         }
@@ -6434,4 +6436,21 @@ flatpak_progress_new (FlatpakProgressCallback progress,
     g_object_set_data (G_OBJECT (ostree_progress), "update-frequency", GUINT_TO_POINTER (FLATPAK_CLI_UPDATE_FREQUENCY));
 
   return ostree_progress;
+}
+
+void
+flatpak_log_dir_access (FlatpakDir *dir)
+{
+  if (dir != NULL)
+    {
+      GFile *dir_path = NULL;
+      g_autofree char *dir_path_str = NULL;
+      g_autofree char *dir_name = NULL;
+
+      dir_path = flatpak_dir_get_path (dir);
+      if (dir_path != NULL)
+        dir_path_str = g_file_get_path (dir_path);
+      dir_name = flatpak_dir_get_name (dir);
+      g_debug ("Opening %s flatpak installation at path %s", dir_name, dir_path_str);
+    }
 }

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -700,4 +700,6 @@ typedef void (*FlatpakProgressCallback)(const char *status,
 OstreeAsyncProgress *flatpak_progress_new (FlatpakProgressCallback progress,
                                            gpointer                progress_data);
 
+void flatpak_log_dir_access (FlatpakDir *dir);
+
 #endif /* __FLATPAK_UTILS_H__ */


### PR DESCRIPTION
It's easy to end up with multiple flatpak installations on a system, and
it's not always clear which one(s) flatpak is using. So this commit adds
some debug output to print the path whenever flatpak opens an
installation directory such as /var/lib/flatpak. This is especially
important for people who build flatpak themselves because if you omit
--prefix=/usr or use --with-system-install-dir your flatpak will look in
non-standard locations like /usr/local/var/lib/flatpak.