### PR TITLE
Add commit and extension info to .flatpak-info

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -70,6 +70,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
 {
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(FlatpakDeploy) runtime_deploy = NULL;
+  g_autoptr(GVariant) runtime_deploy_data = NULL;
   g_autoptr(FlatpakDeploy) extensionof_deploy = NULL;
   g_autoptr(GFile) var = NULL;
   g_autoptr(GFile) usr = NULL;
@@ -205,6 +206,10 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
     {
       runtime_deploy = flatpak_find_deploy_for_ref (runtime_ref, cancellable, error);
       if (runtime_deploy == NULL)
+        return FALSE;
+
+      runtime_deploy_data = flatpak_deploy_get_deploy_data (runtime_deploy, cancellable, error);
+      if (runtime_deploy_data == NULL)
         return FALSE;
 
       runtime_metakey = flatpak_deploy_get_metadata (runtime_deploy);
@@ -365,8 +370,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
 
   if (!flatpak_run_add_app_info_args (argv_array,
                                       NULL,
-                                      app_files,
-                                      runtime_files,
+                                      app_files, NULL,
+                                      runtime_files, runtime_deploy_data,
                                       id, NULL,
                                       runtime_ref,
                                       app_context,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -176,6 +176,12 @@ guint64             flatpak_deploy_data_get_installed_size (GVariant *deploy_dat
 const char *        flatpak_deploy_data_get_alt_id (GVariant *deploy_data);
 
 GFile *        flatpak_deploy_get_dir (FlatpakDeploy *deploy);
+GVariant *     flatpak_load_deploy_data (GFile *deploy_dir,
+                                         GCancellable *cancellable,
+                                         GError      **error);
+GVariant *     flatpak_deploy_get_deploy_data (FlatpakDeploy *deploy,
+                                               GCancellable *cancellable,
+                                               GError      **error);
 GFile *        flatpak_deploy_get_files (FlatpakDeploy *deploy);
 FlatpakContext *flatpak_deploy_get_overrides (FlatpakDeploy *deploy);
 GKeyFile *     flatpak_deploy_get_metadata (FlatpakDeploy *deploy);

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -51,10 +51,12 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
 #define FLATPAK_METADATA_KEY_APP_PATH "app-path"
 #define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
+#define FLATPAK_METADATA_KEY_APP_EXTENSIONS "app-extensions"
 #define FLATPAK_METADATA_KEY_BRANCH "branch"
 #define FLATPAK_METADATA_KEY_FLATPAK_VERSION "flatpak-version"
 #define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
 #define FLATPAK_METADATA_KEY_RUNTIME_COMMIT "runtime-commit"
+#define FLATPAK_METADATA_KEY_RUNTIME_EXTENSIONS "runtime-extensions"
 #define FLATPAK_METADATA_KEY_SESSION_BUS_PROXY "session-bus-proxy"
 #define FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY "system-bus-proxy"
 
@@ -160,6 +162,7 @@ gboolean  flatpak_run_add_extension_args (GPtrArray    *argv_array,
                                           char       ***envp_p,
                                           GKeyFile     *metakey,
                                           const char   *full_ref,
+					  char        **extensions_out,
                                           GCancellable *cancellable,
                                           GError      **error);
 gboolean flatpak_run_add_environment_args (GPtrArray      *argv_array,
@@ -199,8 +202,10 @@ gboolean flatpak_run_add_app_info_args (GPtrArray      *argv_array,
                                         GArray         *fd_array,
                                         GFile          *app_files,
                                         GVariant       *app_deploy_data,
+					const char     *app_extensions,
                                         GFile          *runtime_files,
                                         GVariant       *runtime_deploy_data,
+					const char     *runtime_extensions,
                                         const char     *app_id,
                                         const char     *app_branch,
                                         const char     *runtime_ref,

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -50,9 +50,11 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 
 #define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
 #define FLATPAK_METADATA_KEY_APP_PATH "app-path"
+#define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
 #define FLATPAK_METADATA_KEY_BRANCH "branch"
 #define FLATPAK_METADATA_KEY_FLATPAK_VERSION "flatpak-version"
 #define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
+#define FLATPAK_METADATA_KEY_RUNTIME_COMMIT "runtime-commit"
 #define FLATPAK_METADATA_KEY_SESSION_BUS_PROXY "session-bus-proxy"
 #define FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY "system-bus-proxy"
 
@@ -196,7 +198,9 @@ gboolean flatpak_run_setup_base_argv (GPtrArray      *argv_array,
 gboolean flatpak_run_add_app_info_args (GPtrArray      *argv_array,
                                         GArray         *fd_array,
                                         GFile          *app_files,
+                                        GVariant       *app_deploy_data,
                                         GFile          *runtime_files,
+                                        GVariant       *runtime_deploy_data,
                                         const char     *app_id,
                                         const char     *app_branch,
                                         const char     *runtime_ref,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -386,6 +386,7 @@ typedef struct
 {
   char *id;
   char *installed_id;
+  char *commit;
   char *ref;
   char *directory;
   char *files_path;


### PR DESCRIPTION
This makes it possible for the app to get information about the exact environment it is running in. This can be useful for e.g. debugging. 

Fixes https://github.com/flatpak/flatpak/issues/502