### PR TITLE
Use ld.so.cache instead of LD_LIBRARY_PATH in the common case

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -369,11 +369,11 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   flatpak_context_allow_host_fs (app_context);
   flatpak_context_merge (app_context, arg_context);
 
-  envp = flatpak_run_get_minimal_env (TRUE);
+  envp = flatpak_run_get_minimal_env (TRUE, FALSE);
   envp = flatpak_run_apply_env_vars (envp, app_context);
 
   if (!custom_usr && !(is_extension && !is_app_extension) &&
-      !flatpak_run_add_extension_args (argv_array, &envp, runtime_metakey, runtime_ref, &runtime_extensions, cancellable, error))
+      !flatpak_run_add_extension_args (argv_array, NULL, &envp, runtime_metakey, runtime_ref, FALSE, &runtime_extensions, cancellable, error))
     return FALSE;
 
   if (!flatpak_run_add_app_info_args (argv_array,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4960,7 +4960,7 @@ apply_extra_data (FlatpakDir          *self,
 
   app_context = flatpak_context_new ();
 
-  envp = flatpak_run_get_minimal_env (FALSE);
+  envp = flatpak_run_get_minimal_env (FALSE, FALSE);
   if (!flatpak_run_add_environment_args (argv_array, fd_array, &envp, NULL,
                                          FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY |
                                          FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY |

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -159,10 +159,12 @@ FlatpakExports *flatpak_exports_from_context (FlatpakContext *context,
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakExports, flatpak_exports_free);
 
 gboolean  flatpak_run_add_extension_args (GPtrArray    *argv_array,
+                                          GArray       *fd_array,
                                           char       ***envp_p,
                                           GKeyFile     *metakey,
                                           const char   *full_ref,
-					  char        **extensions_out,
+                                          gboolean      use_ld_so_cache,
+                                          char        **extensions_out,
                                           GCancellable *cancellable,
                                           GError      **error);
 gboolean flatpak_run_add_environment_args (GPtrArray      *argv_array,
@@ -176,8 +178,8 @@ gboolean flatpak_run_add_environment_args (GPtrArray      *argv_array,
                                            FlatpakExports **exports_out,
                                            GCancellable *cancellable,
                                            GError      **error);
-char **  flatpak_run_get_minimal_env (gboolean devel);
-char **  flatpak_run_apply_env_default (char **envp);
+char **  flatpak_run_get_minimal_env (gboolean devel, gboolean use_ld_so_cache);
+char **  flatpak_run_apply_env_default (char **envp, gboolean use_ld_so_cache);
 char **  flatpak_run_apply_env_appid (char **envp,
                                       GFile *app_dir);
 char **  flatpak_run_apply_env_vars (char          **envp,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -286,6 +286,10 @@ flatpak_auto_lock_helper (GMutex *mutex)
   return mutex;
 }
 
+gboolean
+flatpak_switch_symlink_and_remove (const char *symlink_path,
+                                   const char *target,
+                                   GError **error);
 gint flatpak_mkstempat (int    dir_fd,
                         gchar *tmpl,
                         int    flags,

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -25,6 +25,7 @@ mkdir -p ${DIR}/usr/bin
 mkdir -p ${DIR}/usr/lib
 ln -s ../lib ${DIR}/usr/lib64
 ln -s ../lib ${DIR}/usr/lib32
+cp `which ldconfig` ${DIR}/usr/bin
 T=`mktemp`
 for i in $@; do
     I=`which $i`


### PR DESCRIPTION
This is an alternative pull request, based on the original in https://github.com/flatpak/flatpak/pull/1048