### PR TITLE
Add -v -v (or -vv) to mean more verbose

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -33,7 +33,7 @@
 #include "flatpak-builtins.h"
 #include "flatpak-utils.h"
 
-static gboolean opt_verbose;
+static int opt_verbose;
 static gboolean opt_ostree_verbose;
 static gboolean opt_version;
 static gboolean opt_default_arch;
@@ -104,8 +104,19 @@ static FlatpakCommand commands[] = {
   { NULL }
 };
 
+static gboolean
+opt_verbose_cb (const gchar *option_name,
+                const gchar *value,
+                gpointer     data,
+                GError     **error)
+{
+  opt_verbose++;
+  return TRUE;
+}
+
+
 GOptionEntry global_entries[] = {
-  { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, N_("Print debug information during command processing"), NULL },
+  { "verbose", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, &opt_verbose_cb, N_("Print debug information during command processing, -vv for more detail"), NULL },
   { "ostree-verbose", 0, 0, G_OPTION_ARG_NONE, &opt_ostree_verbose, N_("Print OSTree debug information during command processing"), NULL },
   { "help", '?', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, N_("Show help options"), NULL, NULL },
   { NULL }
@@ -224,8 +235,10 @@ flatpak_option_context_parse (GOptionContext     *context,
   /* We never want verbose output in the complete case, that breaks completion */
   if (!is_in_complete)
     {
-      if (opt_verbose)
+      if (opt_verbose > 0)
         g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+      if (opt_verbose > 1)
+        g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG, message_handler, NULL);
 
       if (opt_ostree_verbose)
         g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -42,6 +42,8 @@ static gboolean opt_gl_drivers;
 static gboolean opt_user;
 static char *opt_installation;
 
+static gboolean is_in_complete;
+
 typedef struct
 {
   const char *name;
@@ -219,11 +221,15 @@ flatpak_option_context_parse (GOptionContext     *context,
   if (!g_option_context_parse (context, argc, argv, error))
     return FALSE;
 
-  if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+  /* We never want verbose output in the complete case, that breaks completion */
+  if (!is_in_complete)
+    {
+      if (opt_verbose)
+        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
 
-  if (opt_ostree_verbose)
-    g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+      if (opt_ostree_verbose)
+        g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    }
 
   if (opt_version)
     {
@@ -411,6 +417,8 @@ complete (int    argc,
   FlatpakCommand *command;
   FlatpakCompletion *completion;
   const char *command_name = NULL;
+
+  is_in_complete = TRUE;
 
   completion = flatpak_completion_new (argv[2], argv[3], argv[4]);
   if (completion == NULL)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -5097,6 +5097,8 @@ flatpak_run_app (const char     *app_ref,
   g_autoptr(FlatpakExports) exports = NULL;
   g_auto(GStrv) app_ref_parts = NULL;
   g_autofree char *commandline = NULL;
+  int commandline_2_start;
+  g_autofree char *commandline2 = NULL;
   g_autofree char *doc_mount_path = NULL;
   g_autofree char *app_extensions = NULL;
   g_autofree char *runtime_extensions = NULL;
@@ -5331,6 +5333,8 @@ flatpak_run_app (const char     *app_ref,
                       "--args", arg_fd, NULL);
   }
 
+  commandline_2_start = real_argv_array->len;
+
   g_ptr_array_add (real_argv_array, g_strdup (command));
   if (!add_rest_args (app_ref_parts[1], exports, (flags & FLATPAK_RUN_FLAG_FILE_FORWARDING) != 0,
                       doc_mount_path,
@@ -5338,9 +5342,11 @@ flatpak_run_app (const char     *app_ref,
     return FALSE;
 
   g_ptr_array_add (real_argv_array, NULL);
+  g_ptr_array_add (argv_array, NULL);
 
-  commandline = flatpak_quote_argv ((const char **) real_argv_array->pdata);
-  flatpak_debug2 ("Running '%s'", commandline);
+  commandline = flatpak_quote_argv ((const char **) argv_array->pdata);
+  commandline2 = flatpak_quote_argv (((const char **) real_argv_array->pdata) + commandline_2_start);
+  flatpak_debug2 ("Running '%s %s'", commandline, commandline2);
 
   if ((flags & FLATPAK_RUN_FLAG_BACKGROUND) != 0)
     {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -4138,7 +4138,7 @@ prepend_bwrap_argv_wrapper (GPtrArray *argv,
 
   {
     g_autofree char *commandline = flatpak_quote_argv ((const char **) bwrap_args->pdata);
-    g_debug ("bwrap args '%s'", commandline);
+    flatpak_debug2 ("bwrap args '%s'", commandline);
   }
 
   bwrap_args_data = join_args (bwrap_args, &bwrap_args_len);
@@ -4244,7 +4244,7 @@ add_dbus_proxy_args (GPtrArray *argv_array,
     return FALSE;
 
   commandline = flatpak_quote_argv ((const char **) dbus_proxy_argv->pdata);
-  g_debug ("Running '%s'", commandline);
+  flatpak_debug2 ("Running '%s'", commandline);
 
   spawn_data.sync_fd = sync_fds[1];
   spawn_data.app_info_fd = app_info_fd;
@@ -5010,7 +5010,7 @@ regenerate_ld_cache (GPtrArray      *base_argv_array,
   g_ptr_array_add (argv_array, NULL);
 
   commandline = flatpak_quote_argv ((const char **) argv_array->pdata);
-  g_debug ("Running ldconfig: '%s'", commandline);
+  flatpak_debug2 ("Running: '%s'", commandline);
 
   combined_fd_array = g_array_new (FALSE, TRUE, sizeof (int));
   g_array_append_vals (combined_fd_array, base_fd_array->data, base_fd_array->len);
@@ -5340,7 +5340,7 @@ flatpak_run_app (const char     *app_ref,
   g_ptr_array_add (real_argv_array, NULL);
 
   commandline = flatpak_quote_argv ((const char **) real_argv_array->pdata);
-  g_debug ("Running '%s'", commandline);
+  flatpak_debug2 ("Running '%s'", commandline);
 
   if ((flags & FLATPAK_RUN_FLAG_BACKGROUND) != 0)
     {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -77,6 +77,22 @@ flatpak_error_quark (void)
   return (GQuark) quark_volatile;
 }
 
+void
+flatpak_debug2 (const char *format, ...)
+{
+  va_list var_args;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+  va_start (var_args, format);
+  g_logv (G_LOG_DOMAIN"2",
+          G_LOG_LEVEL_DEBUG,
+          format, var_args);
+  va_end (var_args);
+#pragma GCC diagnostic pop
+
+}
+
 GFile *
 flatpak_file_new_tmp_in (GFile *dir,
                          const char *template,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -61,6 +61,8 @@ typedef void (*FlatpakLoadUriProgress) (guint64 downloaded_bytes,
  */
 #define flatpak_fail glnx_throw
 
+void flatpak_debug2 (const char *format, ...) G_GNUC_PRINTF(1, 2);
+
 gint flatpak_strcmp0_ptr (gconstpointer a,
                           gconstpointer b);
 


### PR DESCRIPTION
Initially this is used to limit the printing of all the bwrap arguments, which is kind of large.

Also contains a fix for -v vs completion, as mentioned in https://github.com/flatpak/flatpak/pull/1067