### PR TITLE
Strip some more common environment variables from the host

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3320,6 +3320,13 @@ static const ExportData default_exports[] = {
   {"XDG_DATA_DIRS", "/app/share:/usr/share"},
   {"SHELL", "/bin/sh"},
   {"TMPDIR", NULL}, /* Unset TMPDIR as it may not exist in the sandbox */
+
+  /* Some env vars are common enough and will affect the sandbox badly
+     if set on the host. We clear these always. */
+  {"PYTHONPATH", NULL},
+  {"PERLLIB", NULL},
+  {"PERL5LIB", NULL},
+  {"XCURSOR_PATH", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {


### PR DESCRIPTION
We strip PYTHONPATH, PERLLIB, PERL5LIB and XCURSOR_PATH from the
environment in the sandbox, because these kind of path variables
can badly affect the sandbox (e.g. pulling in host-side code).