### PR TITLE
Fix uninitialized variable read if stdout is not a tty

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6252,8 +6252,9 @@ flatpak_terminal_progress_cb (const char *status,
   if (!term->inited)
     {
       struct winsize w;
-      ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-      term->n_columns = w.ws_col;
+      term->n_columns = 80;
+      if (ioctl (STDOUT_FILENO, TIOCGWINSZ, &w) == 0)
+        term->n_columns = w.ws_col;
       term->last_width = 0;
       term->inited = 1;
     }


### PR DESCRIPTION
This showed up when running the tests in valgrind, where
ioctl (STDOUT_FILENO, TIOCGWINSZ) fails. We fall back to 80 chars
in this case.