### PR TITLE
Update the support for locale subset

### DIFF
--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -20,6 +20,7 @@ flatpak_SOURCES = \
 	app/flatpak-builtins-uninstall.c \
 	app/flatpak-builtins-list.c \
 	app/flatpak-builtins-info.c \
+	app/flatpak-builtins-config.c \
 	app/flatpak-builtins-run.c \
 	app/flatpak-builtins-enter.c \
 	app/flatpak-builtins-build-init.c \

--- a/app/flatpak-builtins-config.c
+++ b/app/flatpak-builtins-config.c
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <locale.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <glib/gi18n.h>
+
+#include "libglnx/libglnx.h"
+
+#include "flatpak-builtins.h"
+#include "common/flatpak-dir.h"
+
+static gboolean opt_get;
+static gboolean opt_set;
+static gboolean opt_unset;
+static gboolean opt_list;
+
+static GOptionEntry options[] = {
+  { "list", 0, 0, G_OPTION_ARG_NONE, &opt_list, N_("List configuration keys and values"), NULL },
+  { "get", 0, 0, G_OPTION_ARG_NONE, &opt_get, N_("Get configuration for KEY"), NULL },
+  { "set", 0, 0, G_OPTION_ARG_NONE, &opt_set, N_("Set configuration for KEY to VALUE"), NULL },
+  { "unset", 0, 0, G_OPTION_ARG_NONE, &opt_unset, N_("Unset configuration for KEY"), NULL },
+  { NULL }
+};
+
+static char *
+parse_lang (const char *value)
+{
+  if (strcmp (value, "*") == 0 ||
+      strcmp (value, "*all*") == 0)
+    return g_strdup ("");
+  return g_strdup (value);
+}
+
+static char *
+print_lang (const char *value)
+{
+  if (*value == 0)
+    return g_strdup ("*all*");
+  return g_strdup (value);
+}
+
+static char *
+get_lang_default (FlatpakDir *dir)
+{
+  g_auto(GStrv) langs = flatpak_dir_get_default_locale_languages (dir);
+
+  return g_strjoinv (";", langs);
+}
+
+typedef struct {
+  const char *name;
+  const char *ostree_name;
+  char *(*parse)(const char *value);
+  char *(*print)(const char *value);
+  char *(*get_default)(FlatpakDir *dir);
+} ConfigKey;
+
+ConfigKey keys[] = {
+  { "languages", "xa.languages", parse_lang, print_lang, get_lang_default },
+};
+
+static ConfigKey *
+get_config_key (const char *arg, GError **error)
+{
+  int i;
+
+  for (i = 0; i < G_N_ELEMENTS (keys); i++)
+    {
+      if (strcmp (keys[i].name, arg) == 0)
+        return &keys[i];
+    }
+
+  flatpak_fail (error, _("Unknown configure key '%s'"), arg);
+  return NULL;
+}
+
+static char *
+print_config (FlatpakDir *dir, ConfigKey *key)
+{
+  GKeyFile *config = ostree_repo_get_config (flatpak_dir_get_repo (dir));
+  g_autofree char *value = NULL;
+
+  value = g_key_file_get_string (config, "core", key->ostree_name, NULL);
+  if (value == NULL)
+    return g_strdup ("*unset*");
+
+  return key->print (value);
+}
+
+static gboolean
+list_config (int argc, char **argv, FlatpakDir *dir, GCancellable *cancellable, GError **error)
+{
+  int i;
+
+  for (i = 0; i < G_N_ELEMENTS (keys); i++)
+    {
+      const char *key = keys[i].name;
+      g_autofree char *value = print_config (dir, &keys[i]);
+      g_autofree char *default_value = NULL;
+
+      g_print ("%s: %s", key, value);
+
+      if (keys[i].get_default)
+        default_value = keys[i].get_default (dir);
+      if (default_value)
+        {
+          g_autofree char *printed = keys[i].print (default_value);
+          g_print (" (default: %s)", printed);
+        }
+      g_print ("\n");
+    }
+
+  return TRUE;
+}
+
+static gboolean
+get_config (int argc, char **argv, FlatpakDir *dir, GCancellable *cancellable, GError **error)
+{
+  ConfigKey *key;
+  g_autofree char *value = NULL;
+
+  if (argc != 2)
+    return flatpak_fail (error, _("You must specify key"));
+
+  key = get_config_key (argv[1], error);
+  if (key == NULL)
+    return FALSE;
+
+  value = print_config (dir, key);
+  if (value)
+    g_print ("%s\n", value);
+  else
+    g_print ("*unset*\n");
+
+  return TRUE;
+}
+
+static gboolean
+set_config (int argc, char **argv, FlatpakDir *dir, GCancellable *cancellable, GError **error)
+{
+  ConfigKey *key;
+  g_autofree char *parsed = NULL;
+
+  if (argc != 3)
+    return flatpak_fail (error, _("You must specify both key and value"));
+
+  key = get_config_key (argv[1], error);
+  if (key == NULL)
+    return FALSE;
+
+  parsed = key->parse (argv[2]);
+  if (!flatpak_dir_set_config (dir, key->ostree_name, parsed, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
+unset_config (int argc, char **argv, FlatpakDir *dir, GCancellable *cancellable, GError **error)
+{
+  ConfigKey *key;
+
+  if (argc != 2)
+    return flatpak_fail (error, _("You must specify key"));
+
+  key = get_config_key (argv[1], error);
+  if (key == NULL)
+    return FALSE;
+
+  if (!flatpak_dir_set_config (dir, key->ostree_name, argv[2], error))
+    return FALSE;
+
+  return TRUE;
+}
+
+gboolean
+flatpak_builtin_config (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(FlatpakDir) dir = NULL;
+
+  context = g_option_context_new (_("[KEY [VALUE]] - Manage configuration"));
+  g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
+
+  if (!flatpak_option_context_parse (context, options, &argc, &argv, 0, &dir, cancellable, error))
+    return FALSE;
+
+  if (opt_get)
+    return get_config (argc, argv, dir, cancellable, error);
+  else if (opt_set)
+    return set_config (argc, argv, dir, cancellable, error);
+  else if (opt_unset)
+    return unset_config (argc, argv, dir, cancellable, error);
+  else if (opt_list)
+    return list_config (argc, argv, dir, cancellable, error);
+  else
+    return flatpak_fail (error, _("Must specify one on --list, --get, --set or --unset"));
+
+  return TRUE;
+}
+
+gboolean
+flatpak_complete_config (FlatpakCompletion *completion)
+{
+  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(FlatpakDir) dir = NULL;
+
+  context = g_option_context_new ("");
+  if (!flatpak_option_context_parse (context, options, &completion->argc, &completion->argv, 0, &dir, NULL, NULL))
+    return FALSE;
+
+  switch (completion->argc)
+    {
+    case 0:
+    case 1: /* REMOTE */
+      flatpak_complete_options (completion, global_entries);
+      flatpak_complete_options (completion, options);
+      flatpak_complete_options (completion, user_entries);
+
+      if (opt_set || opt_get || opt_unset)
+        {
+          int i;
+          for (i = 0; i < G_N_ELEMENTS (keys); i++)
+            flatpak_complete_word (completion, "%s", keys[i].name);
+        }
+
+      break;
+    }
+
+  return TRUE;
+}

--- a/app/flatpak-builtins.h
+++ b/app/flatpak-builtins.h
@@ -84,6 +84,7 @@ BUILTINPROTO (document_info)
 BUILTINPROTO (document_list)
 BUILTINPROTO (override)
 BUILTINPROTO (repo)
+BUILTINPROTO (config)
 
 #undef BUILTINPROTO
 

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -64,6 +64,7 @@ static FlatpakCommand commands[] = {
   { "uninstall", N_("Uninstall an installed application or runtime"), flatpak_builtin_uninstall, flatpak_complete_uninstall },
   { "list", N_("List installed apps and/or runtimes"), flatpak_builtin_list, flatpak_complete_list },
   { "info", N_("Show info for installed app or runtime"), flatpak_builtin_info, flatpak_complete_info },
+  { "config", N_("Configure flatpak"), flatpak_builtin_config, flatpak_complete_config },
 
    /* translators: please keep the leading newline and space */
   { N_("\n Running applications") },

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -40,6 +40,7 @@ typedef enum {
 struct FlatpakTransactionOp {
   char *remote;
   char *ref;
+  /* NULL means unspecified (normally keep whatever was there before), [] means force everything */
   char **subpaths;
   char *commit;
   GFile *bundle;
@@ -267,13 +268,8 @@ flatpak_transaction_add_op (FlatpakTransaction *self,
   op = g_hash_table_lookup (self->refs, ref);
   if (op != NULL)
     {
-      /* Only override subpaths if already specified,
-         we always want the un-subpathed to win if specified. */
-      if (op->subpaths != NULL && op->subpaths[0] != NULL && subpaths != NULL)
-        {
-          g_strfreev (op->subpaths);
-          op->subpaths = g_strdupv ((char **)subpaths);
-        }
+      g_auto(GStrv) old_subpaths = op->subpaths;
+      op->subpaths = flatpak_subpaths_merge (old_subpaths, (char **)subpaths);
 
       return op;
     }
@@ -676,14 +672,6 @@ flatpak_transaction_run (FlatpakTransaction *self,
 
           if (dir_ref_is_installed (self->dir, op->ref, NULL, &deploy_data))
             {
-              g_autofree const char **current_subpaths = NULL;
-
-              /* When we update a dependency, we always inherit the subpaths
-                 rather than use the default. */
-              g_strfreev (op->subpaths);
-              current_subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
-              op->subpaths = g_strdupv ((char **)current_subpaths);
-
               /* Don't use the remote from related ref on update, always use
                  the current remote. */
               g_free (op->remote);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1643,6 +1643,28 @@ flatpak_dir_ensure_repo (FlatpakDir   *self,
 }
 
 gboolean
+flatpak_dir_set_config (FlatpakDir *self,
+                        const char *key,
+                        const char *value,
+                        GError    **error)
+{
+  GKeyFile *config = ostree_repo_copy_config (self->repo);
+
+  if (value == NULL)
+    g_key_file_remove_key (config, "core", key, NULL);
+  else
+    g_key_file_set_value (config, "core", key, value);
+
+  if (!ostree_repo_write_config (self->repo, config, error))
+    return FALSE;
+
+  if (!ostree_repo_reload_config (self->repo, NULL, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+gboolean
 flatpak_dir_mark_changed (FlatpakDir *self,
                           GError    **error)
 {

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -309,6 +309,10 @@ gboolean    flatpak_dir_recreate_repo (FlatpakDir   *self,
 gboolean    flatpak_dir_ensure_repo (FlatpakDir   *self,
                                      GCancellable *cancellable,
                                      GError      **error);
+gboolean    flatpak_dir_set_config (FlatpakDir *self,
+                                    const char *key,
+                                    const char *value,
+                                    GError    **error);
 gboolean    flatpak_dir_mark_changed (FlatpakDir *self,
                                       GError    **error);
 gboolean    flatpak_dir_remove_appstream (FlatpakDir   *self,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -643,6 +643,8 @@ gboolean flatpak_dir_lookup_repo_metadata (FlatpakDir    *self,
                                            const char    *format_string,
                                            ...);
 
+char ** flatpak_dir_get_default_locale_languages (FlatpakDir *self);
+char ** flatpak_dir_get_locale_languages (FlatpakDir *self);
 char ** flatpak_dir_get_locale_subpaths (FlatpakDir *self);
 
 #endif /* __FLATPAK_DIR_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6218,6 +6218,48 @@ flatpak_completion_free (FlatpakCompletion *completion)
   g_free (completion);
 }
 
+/* In this NULL means don't care about these paths, while
+   an empty array means match anything */
+char **
+flatpak_subpaths_merge (char **subpaths1,
+                        char **subpaths2)
+{
+  GPtrArray *array;
+  int i;
+
+  /* Maybe either (or both) is unspecified */
+  if (subpaths1 == NULL)
+    return g_strdupv (subpaths2);
+  if (subpaths2 == NULL)
+    return g_strdupv (subpaths1);
+
+  /* Check for any "everything" match */
+  if (subpaths1[0] == NULL)
+    return g_strdupv (subpaths1);
+  if (subpaths2[0] == NULL)
+    return g_strdupv (subpaths2);
+
+  /* Combine both */
+  array = g_ptr_array_new ();
+
+  for (i = 0; subpaths1[i] != NULL; i++)
+    {
+      if (!flatpak_g_ptr_array_contains_string (array, subpaths1[i]))
+        g_ptr_array_add (array, g_strdup (subpaths1[i]));
+    }
+
+  for (i = 0; subpaths2[i] != NULL; i++)
+    {
+      if (!flatpak_g_ptr_array_contains_string (array, subpaths2[i]))
+        g_ptr_array_add (array, g_strdup (subpaths2[i]));
+    }
+
+  g_ptr_array_sort (array, flatpak_strcmp0_ptr);
+  g_ptr_array_add (array, NULL);
+
+  return (char **)g_ptr_array_free (array, FALSE);
+}
+
 char *
 flatpak_get_lang_from_locale (const char *locale)
 {

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -87,6 +87,9 @@ gboolean flatpak_extension_matches_reason (const char *extension_id,
 
 const char * flatpak_get_bwrap (void);
 
+char **flatpak_subpaths_merge (char **subpaths1,
+                               char **subpaths2);
+
 char *flatpak_get_lang_from_locale (const char *locale);
 char **flatpak_get_current_locale_langs (void);
 

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -87,7 +87,8 @@ gboolean flatpak_extension_matches_reason (const char *extension_id,
 
 const char * flatpak_get_bwrap (void);
 
-char ** flatpak_get_current_locale_subpaths (void);
+char *flatpak_get_lang_from_locale (const char *locale);
+char **flatpak_get_current_locale_langs (void);
 
 void flatpak_migrate_from_xdg_app (void);
 
@@ -253,6 +254,8 @@ g_key_file_save_to_file (GKeyFile    *key_file,
   return success;
 }
 #endif
+
+gboolean flatpak_g_ptr_array_contains_string (GPtrArray *array, const char *str);
 
 /* Returns the first string in subset that is not in strv */
 static inline const gchar *

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,6 +25,7 @@ man1 = \
 	flatpak-remote-modify.1		\
 	flatpak-remote-ls.1		\
 	flatpak-install.1		\
+	flatpak-config.1		\
 	flatpak-update.1		\
 	flatpak-uninstall.1		\
 	flatpak-list.1			\

--- a/doc/flatpak-config.xml
+++ b/doc/flatpak-config.xml
@@ -1,0 +1,145 @@
+<?xml version='1.0'?> <!--*-nxml-*-->
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
+    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+
+<refentry id="flatpak-config">
+
+    <refentryinfo>
+        <title>flatpak config</title>
+        <productname>flatpak</productname>
+
+        <authorgroup>
+            <author>
+                <contrib>Developer</contrib>
+                <firstname>Alexander</firstname>
+                <surname>Larsson</surname>
+                <email>alexl@redhat.com</email>
+            </author>
+        </authorgroup>
+    </refentryinfo>
+
+    <refmeta>
+        <refentrytitle>flatpak config</refentrytitle>
+        <manvolnum>1</manvolnum>
+    </refmeta>
+
+    <refnamediv>
+        <refname>flatpak-config</refname>
+        <refpurpose>Manage configuration</refpurpose>
+    </refnamediv>
+
+    <refsynopsisdiv>
+            <cmdsynopsis>
+                <command>flatpak config</command>
+                <arg choice="opt" rep="repeat">OPTION</arg>
+                <arg choice="plain">KEY</arg>
+                <arg choice="plain">VALUE</arg>
+            </cmdsynopsis>
+    </refsynopsisdiv>
+
+    <refsect1>
+        <title>Description</title>
+
+        <para>
+            Show and modify current configuration
+        </para>
+
+    </refsect1>
+
+    <refsect1>
+        <title>Options</title>
+
+        <para>The following options are understood:</para>
+
+        <variablelist>
+            <varlistentry>
+                <term><option>-h</option></term>
+                <term><option>--help</option></term>
+
+                <listitem><para>
+                    Show help options and exit.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--list</option></term>
+
+                <listitem><para>
+                    Print all keys and their values
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--set</option></term>
+
+                <listitem><para>
+                    Set key KEY to VALUE
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--unset</option></term>
+
+                <listitem><para>
+                    Unset key KEY
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--get</option></term>
+
+                <listitem><para>
+                  Print value of KEY.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--user</option></term>
+
+                <listitem><para>
+                    Configure per-user installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--system</option></term>
+
+                <listitem><para>
+                    Configure system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Configure the system-wide installation
+                    specified by <arg choice="plain">NAME</arg> among those defined in
+                    <filename>/etc/flatpak/installations.d/</filename>. Using
+                    <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
+                </para></listitem>
+            </varlistentry>
+
+        </variablelist>
+    </refsect1>
+
+    <refsect1>
+        <title>Examples</title>
+
+        <para>
+            <command>$ flatpak config --set language sv;en;fi</command>
+        </para>
+
+    </refsect1>
+
+    <refsect1>
+        <title>See also</title>
+
+        <para>
+            <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+        </para>
+
+    </refsect1>
+
+</refentry>

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -190,6 +190,13 @@
                     Show information for an installed application or runtime.
                 </para></listitem>
             </varlistentry>
+            <varlistentry>
+                <term><citerefentry><refentrytitle>flatpak-config</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
+
+                <listitem><para>
+                    Manage flatpak configuration.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
 
 


### PR DESCRIPTION
This adds a new CLI operation "flatpak config" which gets/sets global configuration, at this point only the language config is supported. This makes it easier to test and tweak the locale subsetting.
It also fixes update behaviour so that "flatpak update" always updates everything to match the current setting (athough if some pre-existing install has a language not in the current set then that language is also kept).