### PR TITLE
[common/flatpak-run] add /dev/mali0 to --device=dri

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3076,6 +3076,7 @@ flatpak_run_add_environment_args (GPtrArray      *argv_array,
             "/dev/dri",
             /* mali */
             "/dev/mali",
+            "/dev/mali0",
             "/dev/umplock",
             /* nvidia */
             "/dev/nvidiactl",


### PR DESCRIPTION
Apparently this also appears depending on your Mali version.