### PR TITLE
Backports for 0.8.x

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -1,0 +1,39 @@
+# This PAPR file is mostly inspired by the one in projectatomic/rpm-ostree;
+# if making enhancements here, consider doing them there first.
+branches:
+    - master
+    - auto
+    - try
+
+required: true
+context: f26-primary
+
+# This test case wants an "unprivileged container with bubblewrap",
+# which we don't have right now; so just provision a VM and do a
+# docker --privileged run.
+host:
+  distro: fedora/26/atomic
+
+env:
+    # TODO: CFLAGS: Readd -fsanitize-undefined-trap-on-error -fsanitize=address after debugging
+    # https://github.com/flatpak/flatpak/pull/849#issuecomment-308483205
+    CFLAGS: '-fsanitize=undefined -O2 -Wp,-D_FORTIFY_SOURCE=2'
+    ASAN_OPTIONS: 'detect_leaks=0'  # Right now we're not fully clean, but this gets us use-after-free etc
+    # TODO when we're doing leak checks: G_SLICE: "always-malloc"
+
+# copy yum.repos.d to get any injected repos from the host, which
+# will point to a closer mirror
+tests:
+  - docker run --privileged --rm
+    -e "CFLAGS=${CFLAGS:-}"
+    -e "ASAN_OPTIONS=${ASAN_OPTIONS:-}"
+    -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
+    -v $(pwd):/srv/code -w /srv/code
+    registry.fedoraproject.org/fedora:26 /bin/sh -c
+    "cp -fv /etc/yum.repos.d{.host/*.repo,} &&
+     ./ci/build-check.sh"
+
+timeout: 30m
+
+artifacts:
+  - test-suite.log

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+# Install build dependencies, run unit tests and installed tests.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+${dn}/build.sh
+make check
+
+if test -x /usr/bin/clang; then
+    git clean -dfx && git submodule foreach git clean -dfx
+    # And now a clang build to find unused variables; perhaps
+    # in the future these could parallelize
+    export CC=clang
+    export CFLAGS='-Werror=unused-variable'
+    build
+fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,9 +8,8 @@ dn=$(dirname $0)
 
 pkg_install sudo which attr fuse \
     libubsan libasan libtsan elfutils-libelf-devel libdwarf-devel \
-    elfutils git gettext-devel \
+    elfutils git gettext-devel ostree-devel ostree \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
-pkg_install_testing ostree-devel ostree
 pkg_install_if_os fedora gjs parallel clang
 pkg_install_builddeps flatpak
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+# Install build dependencies, run unit tests and installed tests.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+
+pkg_install sudo which attr fuse \
+    libubsan libasan libtsan \
+    elfutils git gettext-devel \
+    /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
+pkg_install_testing ostree-devel ostree
+pkg_install_if_os fedora gjs parallel clang
+pkg_install_builddeps flatpak
+
+build --enable-gtk-doc ${CONFIGOPTS:-}

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -7,7 +7,7 @@ dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
 pkg_install sudo which attr fuse \
-    libubsan libasan libtsan \
+    libubsan libasan libtsan elfutils-libelf-devel libdwarf-devel \
     elfutils git gettext-devel \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash
+
+make() {
+    /usr/bin/make -j $(getconf _NPROCESSORS_ONLN) "$@"
+}
+
+build() {
+    env NOCONFIGURE=1 ./autogen.sh
+    ./configure --prefix=/usr --libdir=/usr/lib64 "$@"
+    make V=1
+}
+
+pkg_install() {
+    yum -y install "$@"
+}
+
+pkg_install_testing() {
+    yum -y install --enablerepo=updates-testing "$@"
+}
+
+pkg_install_if_os() {
+    os=$1
+    shift
+    (. /etc/os-release;
+         if test "${os}" = "${ID}"; then
+            pkg_install "$@"
+         else
+             echo "Skipping installation on OS ${ID}: $@"
+         fi
+    )
+}
+
+pkg_builddep() {
+    # This is sadly the only case where it's a different command
+    if test -x /usr/bin/dnf; then
+        dnf builddep -y "$@"
+    else
+        yum-builddep -y "$@"
+    fi
+}
+
+pkg_install_builddeps() {
+    pkg=$1
+    if test -x /usr/bin/dnf; then
+        yum -y install dnf-plugins-core
+        yum install -y 'dnf-command(builddep)'
+        # Base buildroot
+        pkg_install @buildsys-build
+    else
+        yum -y install yum-utils
+        # Base buildroot, copied from the mock config sadly
+        yum -y install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz
+    fi
+    # builddeps+runtime deps
+    pkg_builddep $pkg
+    pkg_install $pkg
+    rpm -e $pkg
+}

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3057,6 +3057,7 @@ flatpak_ensure_data_dir (const char   *app_id,
   g_autoptr(GFile) dir = flatpak_get_data_dir (app_id);
   g_autoptr(GFile) data_dir = g_file_get_child (dir, "data");
   g_autoptr(GFile) cache_dir = g_file_get_child (dir, "cache");
+  g_autoptr(GFile) fontconfig_cache_dir = g_file_get_child (cache_dir, "fontconfig");
   g_autoptr(GFile) tmp_dir = g_file_get_child (cache_dir, "tmp");
   g_autoptr(GFile) config_dir = g_file_get_child (dir, "config");
 
@@ -3064,6 +3065,9 @@ flatpak_ensure_data_dir (const char   *app_id,
     return NULL;
 
   if (!flatpak_mkdir_p (cache_dir, cancellable, error))
+    return NULL;
+
+  if (!flatpak_mkdir_p (fontconfig_cache_dir, cancellable, error))
     return NULL;
 
   if (!flatpak_mkdir_p (tmp_dir, cancellable, error))

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2894,6 +2894,13 @@ static const struct {const char *env;
   {"XDG_DATA_DIRS", "/app/share:/usr/share"},
   {"SHELL", "/bin/sh"},
   {"TMPDIR", NULL}, /* Unset TMPDIR as it may not exist in the sandbox */
+
+  /* Some env vars are common enough and will affect the sandbox badly
+     if set on the host. We clear these always. */
+  {"PYTHONPATH", NULL},
+  {"PERLLIB", NULL},
+  {"PERL5LIB", NULL},
+  {"XCURSOR_PATH", NULL},
 };
 
 static const struct {const char *env;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3274,10 +3274,6 @@ add_font_path_args (GPtrArray *argv_array)
 static void
 add_icon_path_args (GPtrArray *argv_array)
 {
-  g_autoptr(GFile) home = NULL;
-  g_autoptr(GFile) user_font1 = NULL;
-  g_autoptr(GFile) user_font2 = NULL;
-
   if (g_file_test ("/usr/share/icons", G_FILE_TEST_IS_DIR))
     {
       add_args (argv_array,

--- a/dbus-proxy/flatpak-proxy.c
+++ b/dbus-proxy/flatpak-proxy.c
@@ -338,8 +338,6 @@ buffer_ref (Buffer *buffer)
   return buffer;
 }
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (Buffer, buffer_unref)
-
 static void
 free_side (ProxySide *side)
 {

--- a/document-portal/xdp-fuse.c
+++ b/document-portal/xdp-fuse.c
@@ -2307,7 +2307,7 @@ xdp_fuse_mainloop (gpointer data)
 gboolean
 xdp_fuse_init (GError **error)
 {
-  char *argv[] = { "xdp-fuse", "-osplice_write,splice_move", "-d" };
+  char *argv[] = { "xdp-fuse", "-osplice_write,splice_move" };
   struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (argv), argv);
   struct stat st;
   const char *path;


### PR DESCRIPTION
These are some backports of important behavioural changes to flatpak run in the 0.9.x series, we want these in 0.8.x so that new flatpaks that rely on these behaviours work.

I threw in the debug spew fix too, because that seemed simple and important.