### PR TITLE
When updating from partial install, disable static deltas

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6381,6 +6381,11 @@ flatpak_dir_update (FlatpakDir          *self,
   if (deploy_data != NULL)
     old_subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
 
+  /* If the existing pull is partial, disable static deltas. They can
+     break, because ostree assumes all old objects are locally available. */
+  if (old_subpaths && old_subpaths[0] != NULL)
+    flatpak_flags |= FLATPAK_PULL_FLAGS_NO_STATIC_DELTAS;
+
   if (opt_subpaths)
     subpaths = opt_subpaths;
   else

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6362,6 +6362,7 @@ flatpak_dir_update (FlatpakDir          *self,
   const char **subpaths = NULL;
   g_autofree char *url = NULL;
   FlatpakPullFlags flatpak_flags;
+  g_autofree const char **old_subpaths = NULL;
   gboolean is_oci;
 
   /* This and @results are calculated in check_for_update. @results will be
@@ -6376,10 +6377,14 @@ flatpak_dir_update (FlatpakDir          *self,
 
   deploy_data = flatpak_dir_get_deploy_data (self, ref,
                                              cancellable, NULL);
+
+  if (deploy_data != NULL)
+    old_subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
+
   if (opt_subpaths)
     subpaths = opt_subpaths;
-  else if (deploy_data != NULL)
-    subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
+  else
+    subpaths = old_subpaths;
 
   if (!ostree_repo_remote_get_url (self->repo, remote_name, &url, error))
     return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6381,11 +6381,6 @@ flatpak_dir_update (FlatpakDir          *self,
   if (deploy_data != NULL)
     old_subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
 
-  /* If the existing pull is partial, disable static deltas. They can
-     break, because ostree assumes all old objects are locally available. */
-  if (old_subpaths && old_subpaths[0] != NULL)
-    flatpak_flags |= FLATPAK_PULL_FLAGS_NO_STATIC_DELTAS;
-
   if (opt_subpaths)
     subpaths = opt_subpaths;
   else
@@ -6414,6 +6409,12 @@ flatpak_dir_update (FlatpakDir          *self,
 
       system_helper = flatpak_dir_get_system_helper (self);
       g_assert (system_helper != NULL);
+
+      /* If the existing pull is partial, disable static deltas. They can
+         break, because ostree doesn't look at the parent repo for
+         commitpartial state. */
+      if (old_subpaths && old_subpaths[0] != NULL)
+        flatpak_flags |= FLATPAK_PULL_FLAGS_NO_STATIC_DELTAS;
 
       if (!flatpak_dir_ensure_repo (self, cancellable, error))
         return FALSE;


### PR DESCRIPTION
The delta can contain references to files in the parent which don't exist locally, which breaks.

I saw this when updating a partial locale to a full locale and there had been an update in the remote repo, so it used a delta.