### PR TITLE
lib/installation: Don’t error from flatpak_get_system_installations()

### DIFF
--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -215,13 +215,13 @@ flatpak_get_system_installations (GCancellable *cancellable,
     {
       g_autoptr(GError) local_error = NULL;
       FlatpakDir *install_dir = g_ptr_array_index (system_dirs, i);
-      FlatpakInstallation *installation = NULL;
+      g_autoptr(FlatpakInstallation) installation = NULL;
 
       installation = flatpak_installation_new_for_dir (g_object_ref (install_dir),
                                                        cancellable,
                                                        &local_error);
       if (installation != NULL)
-        g_ptr_array_add (installs, installation);
+        g_ptr_array_add (installs, g_steal_pointer (&installation));
       else
         {
           /* Warn about the problem and continue without listing this installation. */

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -224,9 +224,8 @@ flatpak_get_system_installations (GCancellable *cancellable,
         g_ptr_array_add (installs, installation);
       else
         {
+          /* Warn about the problem and continue without listing this installation. */
           g_warning ("Unable to create FlatpakInstallation for: %s", local_error->message);
-          g_propagate_error (error, g_steal_pointer (&local_error));
-          goto out;
         }
     }
 


### PR DESCRIPTION
If a particular system installation is inaccessible (for example,
because it doesn’t currently exist, and we don’t have permissions to
create it), don’t error out of flatpak_get_system_installations().
Instead, do what the documentation says will happen, and ignore the
failure (emit a warning message about it).

The function continues to return an error if *no* installations could be
found.

Signed-off-by: Philip Withnall <withnall@endlessm.com>