### PR TITLE
ls-remote: Fix crash when ostree-metadata ref exists in remote

### DIFF
--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -144,7 +144,16 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
           char *ref = key;
-          char *partial_ref = flatpak_make_valid_id_prefix (strchr (ref, '/') + 1);
+          char *partial_ref;
+          const char *slash = strchr (ref, '/');
+
+          if (slash == NULL)
+            {
+              g_debug ("Invalid remote ref %s", ref);
+              continue;
+            }
+
+          partial_ref = flatpak_make_valid_id_prefix (slash + 1);
           g_hash_table_insert (pref_hash, partial_ref, ref);
         }
 


### PR DESCRIPTION
The code assumes that *all* refs in a remote contain a slash, which
technically is not the case, and pragmatically is definitely not the
case once the remote has an ostree-metadata ref.

Signed-off-by: Philip Withnall <withnall@endlessm.com>