### PR TITLE
search: Check substrings of app IDs, not just prefixes

### DIFF
--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -208,9 +208,15 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
       for (i = 0; i < apps->len; ++i)
         {
           AsApp *app = g_ptr_array_index (apps, i);
-          const guint score = as_app_search_matches (app, search_text);
+          guint score = as_app_search_matches (app, search_text);
           if (score == 0)
-            continue;
+            {
+              const char *app_id = as_app_get_id_filename (app);
+              if (g_strstr_len (app_id, -1, search_text) != NULL)
+                score = 50;
+              else
+                continue;
+            }
 
           // Avoid duplicate entries, but show multiple remotes
           GSList *list_entry = g_slist_find_custom (matches, app,

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -212,7 +212,7 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
           if (score == 0)
             {
               const char *app_id = as_app_get_id_filename (app);
-              if (g_strstr_len (app_id, -1, search_text) != NULL)
+              if (strcasestr (app_id, search_text) != NULL)
                 score = 50;
               else
                 continue;


### PR DESCRIPTION
Due to the way as_app_search_matches() works, "flatpak search" only
checks if the search text is a prefix of an element of the app ID, not
if it's any substring. Add a substring check, so for example you can
find SuperTuxKart using "flatpak search tuxkart".