### PR TITLE
search: Support --installation=NAME option

### DIFF
--- a/doc/flatpak-search.xml
+++ b/doc/flatpak-search.xml
@@ -68,6 +68,17 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Show a system-wide installation by <arg choice="plain">NAME</arg> among
+                    those defined in <filename>/etc/flatpak/installations.d/</filename>.
+                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
+                    <arg choice="plain">--system</arg>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-h</option></term>
                 <term><option>--help</option></term>
 


### PR DESCRIPTION
The other commands that support --user and --system allow you to specify
an installation using --installation, so this makes search consistent
with that.