### PR TITLE
search: Log access of flatpak directory

### DIFF
--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -46,8 +46,13 @@ get_remote_stores (GPtrArray *dirs, GCancellable *cancellable)
   for (i = 0; i < dirs->len; ++i)
     {
       FlatpakDir *dir = g_ptr_array_index (dirs, i);
-      g_autofree char *install_path = g_file_get_path (flatpak_dir_get_path (dir));
-      g_auto(GStrv) remotes = flatpak_dir_list_enumerated_remotes (dir, cancellable, &error);
+      g_autofree char *install_path = NULL;
+      g_auto(GStrv) remotes = NULL;
+
+      flatpak_log_dir_access (dir);
+
+      install_path = g_file_get_path (flatpak_dir_get_path (dir));
+      remotes = flatpak_dir_list_enumerated_remotes (dir, cancellable, &error);
       if (error)
         {
           g_warning ("%s", error->message);


### PR DESCRIPTION
This changes the search command to print debug output when accessing a
flatpak directory, to match the behavior of other commands.