### PR TITLE
session-helper: track destination of symlinks for host monitored files

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -427,9 +427,10 @@ file_changed (GFileMonitor     *monitor,
               GFileMonitorEvent event_type,
               char             *source)
 {
-  if (event_type == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT ||
-      event_type == G_FILE_MONITOR_EVENT_CREATED)
-    copy_file (source, monitor_dir);
+  if (event_type != G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
+    return;
+
+  copy_file (source, monitor_dir);
 }
 
 static void


### PR DESCRIPTION
In the case that /etc/resolv.conf is a symlink, we don't monitor the destination file which means that we don't update resolv.conf if eg it's a symlink to /run/NetworkManager, with catastrophic consequences to networking as you move networks. Set up a 2nd monitor in the case that the source file is a symlink, and track changes to that too, removing or replacing the 2nd monitor in case the symlink target changes. #1189 