### PR TITLE
Expose /usr and /etc if --filesystem=host

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2426,6 +2426,7 @@ typedef struct {
 
 struct _FlatpakExports {
   GHashTable *hash;
+  FlatpakFilesystemMode host_fs;
 };
 
 static void
@@ -2599,6 +2600,18 @@ exports_add_bwrap_args (FlatpakExports *exports,
                                   (ep->mode == FLATPAK_FILESYSTEM_MODE_READ_ONLY) ? "--ro-bind" : "--bind",
                                   path, path, NULL);
         }
+    }
+
+  if (exports->host_fs != 0)
+    {
+      if (g_file_test ("/usr", G_FILE_TEST_IS_DIR))
+	flatpak_bwrap_add_args (bwrap,
+				(exports->host_fs == FLATPAK_FILESYSTEM_MODE_READ_ONLY) ? "--ro-bind" : "--bind",
+				"/usr", "/run/host/usr", NULL);
+      if (g_file_test ("/etc", G_FILE_TEST_IS_DIR))
+	flatpak_bwrap_add_args (bwrap,
+				(exports->host_fs == FLATPAK_FILESYSTEM_MODE_READ_ONLY) ? "--ro-bind" : "--bind",
+				"/etc", "/run/host/etc", NULL);
     }
 }
 
@@ -2844,6 +2857,7 @@ export_paths_export_context (FlatpakContext *context,
           closedir (dir);
         }
       exports_path_expose (exports, fs_mode, "/run/media");
+      exports->host_fs = fs_mode;
     }
 
   home_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "home");

--- a/document-portal/xdp-main.c
+++ b/document-portal/xdp-main.c
@@ -447,7 +447,7 @@ validate_fd (int fd,
           strncpy (path_buffer, real_path, PATH_MAX);
         }
       else if (runtime_path != NULL &&
-               g_str_has_prefix (path_buffer, "/usr/"))
+               g_str_has_prefix (tmp_path_buf, "/usr/"))
         {
           const char *rel_path = tmp_path_buf + strlen ("/usr/");
           g_autofree char *real_path = g_build_filename (runtime_path, rel_path, NULL);

--- a/document-portal/xdp-main.c
+++ b/document-portal/xdp-main.c
@@ -453,6 +453,18 @@ validate_fd (int fd,
           g_autofree char *real_path = g_build_filename (runtime_path, rel_path, NULL);
           strncpy (path_buffer, real_path, PATH_MAX);
         }
+      else if (g_str_has_prefix (tmp_path_buf, "/run/host/usr/"))
+        {
+          const char *rel_path = tmp_path_buf + strlen ("/run/host/usr/");
+          g_autofree char *real_path = g_build_filename ("/usr", rel_path, NULL);
+          strncpy (path_buffer, real_path, PATH_MAX);
+        }
+      else if (g_str_has_prefix (tmp_path_buf, "/run/host/etc/"))
+        {
+          const char *rel_path = tmp_path_buf + strlen ("/run/host/etc/");
+          g_autofree char *real_path = g_build_filename ("/usr", rel_path, NULL);
+          strncpy (path_buffer, real_path, PATH_MAX);
+        }
       else if (had_newroot_prefix)
         {
           /* Create a separate copy to avoid memcpy-type issues where

--- a/document-portal/xdp-main.c
+++ b/document-portal/xdp-main.c
@@ -462,7 +462,7 @@ validate_fd (int fd,
       else if (g_str_has_prefix (tmp_path_buf, "/run/host/etc/"))
         {
           const char *rel_path = tmp_path_buf + strlen ("/run/host/etc/");
-          g_autofree char *real_path = g_build_filename ("/usr", rel_path, NULL);
+          g_autofree char *real_path = g_build_filename ("/etc", rel_path, NULL);
           strncpy (path_buffer, real_path, PATH_MAX);
         }
       else if (had_newroot_prefix)


### PR DESCRIPTION
Some apps, such as gnome-builder wants to access data from the
host, for instance in builders case the system includes. If you
have full filesystem access it is not really a loss of security
to also have /ect and /usr access, but for technical reasons
we can't expose them in the normal locations. However, we
can expose them in /run/host, so do that.

cc @chergert 