### PR TITLE
Allow remote-add --system to work with non-existing /var/lib/flatpak

### DIFF
--- a/app/flatpak-builtins-add-remote.c
+++ b/app/flatpak-builtins-add-remote.c
@@ -89,8 +89,15 @@ static GOptionEntry common_options[] = {
 static GKeyFile *
 get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *changed)
 {
-  GKeyFile *config = ostree_repo_copy_config (flatpak_dir_get_repo (dir));
+  OstreeRepo *repo;
+  GKeyFile *config;
   g_autofree char *group = g_strdup_printf ("remote \"%s\"", remote_name);
+
+  repo = flatpak_dir_get_repo (dir);
+  if (repo == NULL)
+    config = g_key_file_new ();
+  else
+    config = ostree_repo_copy_config (repo);
 
   if (opt_no_gpg_verify)
     {
@@ -314,7 +321,8 @@ flatpak_builtin_add_remote (int argc, char **argv,
 
   g_option_context_add_main_entries (context, common_options, NULL);
 
-  if (!flatpak_option_context_parse (context, add_options, &argc, &argv, 0, &dir, cancellable, error))
+  if (!flatpak_option_context_parse (context, add_options, &argc, &argv, FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO, &dir,
+                                     cancellable, error))
     return FALSE;
 
   if (argc < 2)

--- a/app/flatpak-builtins.h
+++ b/app/flatpak-builtins.h
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
 
 typedef enum {
   FLATPAK_BUILTIN_FLAG_NO_DIR = 1 << 0,
-  FLATPAK_BUILTIN_FLAG_NO_REPO = 1 << 1,
+  FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO = 1 << 1,
 } FlatpakBuiltinFlags;
 
 gboolean flatpak_option_context_parse (GOptionContext     *context,

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -293,12 +293,16 @@ flatpak_option_context_parse (GOptionContext     *context,
             return FALSE;
         }
 
-      if (!flatpak_dir_ensure_path (dir, cancellable, error))
-        return FALSE;
-
-      if (!(flags & FLATPAK_BUILTIN_FLAG_NO_REPO) &&
-          !flatpak_dir_ensure_repo (dir, cancellable, error))
-        return FALSE;
+      if (flags & FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO)
+        {
+          if (!flatpak_dir_maybe_ensure_repo (dir, cancellable, error))
+            return FALSE;
+        }
+      else
+        {
+          if (!flatpak_dir_ensure_repo (dir, cancellable, error))
+            return FALSE;
+        }
 
       flatpak_log_dir_access (dir);
     }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1566,7 +1566,7 @@ flatpak_dir_ensure_repo (FlatpakDir   *self,
       repodir = g_file_get_child (self->basedir, "repo");
       if (self->no_system_helper || self->user || getuid () == 0)
         {
-          repo = ostree_repo_new (repodir);
+          repo = system_ostree_repo_new (repodir);
         }
       else
         {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8912,12 +8912,14 @@ flatpak_dir_list_remotes (FlatpakDir   *self,
                           GCancellable *cancellable,
                           GError      **error)
 {
-  char **res;
+  char **res = NULL;
 
-  if (!flatpak_dir_ensure_repo (self, cancellable, error))
+  if (!flatpak_dir_maybe_ensure_repo (self, cancellable, error))
     return NULL;
 
-  res = ostree_repo_remote_list (self->repo, NULL);
+  if (self->repo)
+    res = ostree_repo_remote_list (self->repo, NULL);
+
   if (res == NULL)
     res = g_new0 (char *, 1); /* Return empty array, not error */
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1549,19 +1549,27 @@ flatpak_dir_recreate_repo (FlatpakDir   *self,
   return res;
 }
 
-gboolean
-flatpak_dir_ensure_repo (FlatpakDir   *self,
-                         GCancellable *cancellable,
-                         GError      **error)
+static gboolean
+_flatpak_dir_ensure_repo (FlatpakDir   *self,
+                          gboolean      allow_empty,
+                          GCancellable *cancellable,
+                          GError      **error)
 {
   g_autoptr(GFile) repodir = NULL;
   g_autoptr(OstreeRepo) repo = NULL;
+  g_autoptr(GError) my_error = NULL;
   gboolean use_helper = FALSE;
 
   if (self->repo == NULL)
     {
-      if (!flatpak_dir_ensure_path (self, cancellable, error))
-        return FALSE;
+      if (!flatpak_dir_ensure_path (self, cancellable, &my_error))
+        {
+          if (allow_empty)
+            return TRUE;
+
+          g_propagate_error (error, g_steal_pointer (&my_error));
+          return FALSE;
+        }
 
       repodir = g_file_get_child (self->basedir, "repo");
       if (self->no_system_helper || self->user || getuid () == 0)
@@ -1597,9 +1605,14 @@ flatpak_dir_ensure_repo (FlatpakDir   *self,
           if (g_strcmp0 (mode_env, "user") == 0)
             mode = OSTREE_REPO_MODE_BARE_USER;
 
-          if (!ostree_repo_create (repo, mode, cancellable, error))
+          if (!ostree_repo_create (repo, mode, cancellable, &my_error))
             {
               flatpak_rm_rf (repodir, cancellable, NULL);
+
+              if (allow_empty)
+                return TRUE;
+
+              g_propagate_error (error, g_steal_pointer (&my_error));
               return FALSE;
             }
 
@@ -1645,6 +1658,22 @@ flatpak_dir_ensure_repo (FlatpakDir   *self,
     }
 
   return TRUE;
+}
+
+gboolean
+flatpak_dir_ensure_repo (FlatpakDir   *self,
+                         GCancellable *cancellable,
+                         GError      **error)
+{
+  return _flatpak_dir_ensure_repo (self, FALSE, cancellable, error);
+}
+
+gboolean
+flatpak_dir_maybe_ensure_repo (FlatpakDir   *self,
+                               GCancellable *cancellable,
+                               GError      **error)
+{
+  return _flatpak_dir_ensure_repo (self, TRUE, cancellable, error);
 }
 
 char *

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -316,6 +316,9 @@ gboolean    flatpak_dir_recreate_repo (FlatpakDir   *self,
 gboolean    flatpak_dir_ensure_repo (FlatpakDir   *self,
                                      GCancellable *cancellable,
                                      GError      **error);
+gboolean    flatpak_dir_maybe_ensure_repo (FlatpakDir   *self,
+                                           GCancellable *cancellable,
+                                           GError      **error);
 char *      flatpak_dir_get_config (FlatpakDir *self,
 				    const char *key,
 				    GError    **error);


### PR DESCRIPTION
If /var is empty, such as in https://github.com/flatpak/flatpak/issues/113 we can't get into a useful state for using the system-helper. The workaround so for has been to run some operation as root which creates the inital empty repo. With this change you are able to run `flatpak remote-add ...` as a user even in this case, which will then initialize the repo.

This helps the stateless /var case at least when you're using the CLI.