### PR TITLE
docs: Document remote-ls without REMOTE

### DIFF
--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -71,7 +71,7 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
   g_autoptr(GHashTable) pref_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   g_autoptr(GHashTable) refs_hash = g_hash_table_new_full(g_direct_hash, g_direct_equal, (GDestroyNotify)g_hash_table_unref, g_free);
 
-  context = g_option_context_new (_(" REMOTE - Show available runtimes and applications"));
+  context = g_option_context_new (_(" [REMOTE] - Show available runtimes and applications"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv, 0, &dir, cancellable, error))

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -32,7 +32,7 @@
             <cmdsynopsis>
                 <command>flatpak remote-ls</command>
                 <arg choice="opt" rep="repeat">OPTION</arg>
-                <arg choice="plain">REMOTE</arg>
+                <arg choice="opt">REMOTE</arg>
             </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -41,8 +41,9 @@
 
         <para>
             Shows runtimes and applications that are available in the
-            remote repository with the name <arg choice="plain">REMOTE</arg>.
-            You can find all configured remote repositories with <citerefentry><refentrytitle>flatpak-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+            remote repository with the name <arg choice="plain">REMOTE</arg>,
+            or all remotes if one isn't specified. You can find all configured
+            remote repositories with <citerefentry><refentrytitle>flatpak-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
         </para>
         <para>
             Unless overridden with the --user or --installation options, this command


### PR DESCRIPTION
The "flatpak remote-ls" command can be used without specifying a remote,
so change the man page to reflect that.