### PR TITLE
Make sure we bind files correctly

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -5018,10 +5018,10 @@ flatpak_bwrap_add_bind_arg (FlatpakBwrap *bwrap,
                             const char *src,
                             const char *dest)
 {
-  g_autofree char *dest_real = realpath (dest, NULL);
+  g_autofree char *src_real = realpath (src, NULL);
 
-  if (dest_real)
-    flatpak_bwrap_add_args (bwrap, type, src, dest_real, NULL);
+  if (src_real)
+    flatpak_bwrap_add_args (bwrap, type, src_real, dest, NULL);
 }
 
 


### PR DESCRIPTION
When we try to bind a file, e.g. with xdg-config/kdeglobals, we call
realpath() on dest_file, which will be the name of that file after we
bind it, in this case $HOME/.var/app/appName/config/kdeglobals, but
this file doesn't exist. What we actually want is to get real path
of the file we want to bind.