### PR TITLE
install: Add --reinstall

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -51,6 +51,7 @@ static gboolean opt_app;
 static gboolean opt_bundle;
 static gboolean opt_from;
 static gboolean opt_yes;
+static gboolean opt_reinstall;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to install for"), N_("ARCH") },
@@ -66,6 +67,7 @@ static GOptionEntry options[] = {
   { "gpg-file", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_gpg_file, N_("Check bundle signatures with GPG key from FILE (- for stdin)"), N_("FILE") },
   { "subpath", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_subpaths, N_("Only install this subpath"), N_("PATH") },
   { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
+  { "reinstall", 0, 0, G_OPTION_ARG_NONE, &opt_reinstall, N_("Uninstall first if already installed"), NULL },
   { NULL }
 };
 
@@ -286,7 +288,7 @@ install_bundle (FlatpakDir *dir,
     return FALSE;
 
   transaction = flatpak_transaction_new (dir, opt_yes, opt_no_pull, opt_no_deploy,
-                                         opt_no_static_deltas, !opt_no_deps, !opt_no_related);
+                                         opt_no_static_deltas, !opt_no_deps, !opt_no_related, opt_reinstall);
 
   if (!flatpak_transaction_add_install_bundle (transaction, file, gpg_data, error))
     return FALSE;
@@ -440,7 +442,7 @@ install_from (FlatpakDir *dir,
   g_print (_("Installing: %s\n"), slash + 1);
 
   transaction = flatpak_transaction_new (clone, opt_yes, opt_no_pull, opt_no_deploy,
-                                         opt_no_static_deltas, !opt_no_deps, !opt_no_related);
+                                         opt_no_static_deltas, !opt_no_deps, !opt_no_related, opt_reinstall);
 
   if (!flatpak_transaction_add_install (transaction, remote, ref, (const char **)opt_subpaths, error))
     return FALSE;
@@ -510,7 +512,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
 
   transaction = flatpak_transaction_new (dir, opt_yes, opt_no_pull, opt_no_deploy,
-                                         opt_no_static_deltas, !opt_no_deps, !opt_no_related);
+                                         opt_no_static_deltas, !opt_no_deps, !opt_no_related, opt_reinstall);
 
   for (i = 0; i < n_prefs; i++)
     {

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -187,7 +187,7 @@ flatpak_builtin_update (int           argc,
     {
       FlatpakTransaction *transaction = flatpak_transaction_new (g_ptr_array_index (dirs, k),
                                                                  opt_yes, opt_no_pull, opt_no_deploy,
-                                                                 opt_no_static_deltas, !opt_no_deps, !opt_no_related);
+                                                                 opt_no_static_deltas, !opt_no_deps, !opt_no_related, FALSE);
       g_ptr_array_add (transactions, transaction);
     }
 

--- a/app/flatpak-transaction.h
+++ b/app/flatpak-transaction.h
@@ -34,7 +34,8 @@ FlatpakTransaction *flatpak_transaction_new         (FlatpakDir          *dir,
                                                      gboolean             no_deploy,
                                                      gboolean             no_static_deltas,
                                                      gboolean             add_deps,
-                                                     gboolean             add_related);
+                                                     gboolean             add_related,
+                                                     gboolean             reinstall);
 void                flatpak_transaction_free        (FlatpakTransaction  *self);
 gboolean            flatpak_transaction_update_metadata (FlatpakTransaction  *self,
                                                          gboolean             all_remotes,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5567,11 +5567,24 @@ flatpak_dir_deploy (FlatpakDir          *self,
   return TRUE;
 }
 
+/* -origin remotes are deleted when the last ref refering to it is undeployed */
+static void
+maybe_prune_remote (FlatpakDir *self,
+                    const char *remote)
+{
+  if (remote != NULL &&
+      g_str_has_suffix (remote, "-origin") &&
+      flatpak_dir_get_remote_noenumerate (self, remote) &&
+      !flatpak_dir_remote_has_deploys (self, remote))
+    ostree_repo_remote_delete (self->repo, remote, NULL, NULL);
+}
+
 gboolean
 flatpak_dir_deploy_install (FlatpakDir   *self,
                             const char   *ref,
                             const char   *origin,
                             const char  **subpaths,
+                            gboolean      reinstall,
                             GCancellable *cancellable,
                             GError      **error)
 {
@@ -5582,6 +5595,7 @@ flatpak_dir_deploy_install (FlatpakDir   *self,
   gboolean ret = FALSE;
   g_autoptr(GError) local_error = NULL;
   g_auto(GStrv) ref_parts = g_strsplit (ref, "/", -1);
+  g_autofree char *remove_ref_from_remote = NULL;
 
   if (!flatpak_dir_lock (self, &lock,
                          cancellable, error))
@@ -5590,9 +5604,33 @@ flatpak_dir_deploy_install (FlatpakDir   *self,
   old_deploy_dir = flatpak_dir_get_if_deployed (self, ref, NULL, cancellable);
   if (old_deploy_dir != NULL)
     {
-      g_set_error (error, FLATPAK_ERROR, FLATPAK_ERROR_ALREADY_INSTALLED,
-                   _("%s branch %s already installed"), ref_parts[1], ref_parts[3]);
-      goto out;
+      if (reinstall)
+        {
+          g_autofree char *old_active = flatpak_dir_read_active (self, ref, cancellable);
+          g_autoptr(GVariant) old_deploy = NULL;
+          const char *old_origin;
+
+          old_deploy = flatpak_load_deploy_data (old_deploy_dir, cancellable, error);
+          if (old_deploy == NULL)
+            goto out;
+
+          /* If the old install was from a different remote, remove the ref */
+          old_origin = flatpak_deploy_data_get_origin (old_deploy);
+          if (strcmp (old_origin, origin) != 0)
+            remove_ref_from_remote = g_strdup (old_origin);
+
+          g_debug ("Removing old deployment for reinstall");
+          if (!flatpak_dir_undeploy (self, ref, old_active,
+                                     TRUE, FALSE,
+                                     cancellable, error))
+            goto out;
+        }
+      else
+        {
+          g_set_error (error, FLATPAK_ERROR, FLATPAK_ERROR_ALREADY_INSTALLED,
+                       _("%s branch %s already installed"), ref_parts[1], ref_parts[3]);
+          goto out;
+        }
     }
 
   deploy_base = flatpak_dir_get_deploy_dir (self, ref);
@@ -5619,6 +5657,15 @@ flatpak_dir_deploy_install (FlatpakDir   *self,
 
       if (!flatpak_dir_update_exports (self, ref_parts[1], cancellable, error))
         goto out;
+    }
+
+  /* Remove old ref if the reinstalled was from a different remote */
+  if (remove_ref_from_remote != NULL)
+    {
+      if (!flatpak_dir_remove_ref (self, remove_ref_from_remote, ref, cancellable, error))
+        goto out;
+
+      maybe_prune_remote (self, remove_ref_from_remote);
     }
 
   /* Release lock before doing possibly slow prune */
@@ -5867,6 +5914,7 @@ flatpak_dir_install (FlatpakDir          *self,
                      gboolean             no_pull,
                      gboolean             no_deploy,
                      gboolean             no_static_deltas,
+                     gboolean             reinstall,
                      const char          *ref,
                      const char          *remote_name,
                      const char         **opt_subpaths,
@@ -6029,6 +6077,9 @@ flatpak_dir_install (FlatpakDir          *self,
       if (no_deploy)
         helper_flags |= FLATPAK_HELPER_DEPLOY_FLAGS_NO_DEPLOY;
 
+      if (reinstall)
+        helper_flags |= FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL;
+
       g_debug ("Calling system helper: Deploy");
       if (!flatpak_system_helper_call_deploy_sync (system_helper,
                                                    child_repo_path ? child_repo_path : "",
@@ -6058,7 +6109,7 @@ flatpak_dir_install (FlatpakDir          *self,
   if (!no_deploy)
     {
       if (!flatpak_dir_deploy_install (self, ref, remote_name, opt_subpaths,
-                                       cancellable, error))
+                                       reinstall, cancellable, error))
         return FALSE;
     }
 
@@ -6281,7 +6332,7 @@ flatpak_dir_install_bundle (FlatpakDir          *self,
     }
   else
     {
-      if (!flatpak_dir_deploy_install (self, ref, remote, NULL, cancellable, error))
+      if (!flatpak_dir_deploy_install (self, ref, remote, NULL, FALSE, cancellable, error))
         return FALSE;
     }
 
@@ -6769,11 +6820,7 @@ flatpak_dir_uninstall (FlatpakDir          *self,
 
   glnx_release_lock_file (&lock);
 
-  if (repository != NULL &&
-      g_str_has_suffix (repository, "-origin") &&
-      flatpak_dir_get_remote_noenumerate (self, repository) &&
-      !flatpak_dir_remote_has_deploys (self, repository))
-    ostree_repo_remote_delete (self->repo, repository, NULL, NULL);
+  maybe_prune_remote (self, repository);
 
   if (!keep_ref)
     flatpak_dir_prune (self, cancellable, NULL);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -88,9 +88,10 @@ typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE = 1 << 0,
   FLATPAK_HELPER_DEPLOY_FLAGS_NO_DEPLOY = 1 << 1,
   FLATPAK_HELPER_DEPLOY_FLAGS_LOCAL_PULL = 1 << 2,
+  FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL = 1 << 3,
 } FlatpakHelperDeployFlags;
 
-#define FLATPAK_HELPER_DEPLOY_FLAGS_ALL (FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE|FLATPAK_HELPER_DEPLOY_FLAGS_NO_DEPLOY|FLATPAK_HELPER_DEPLOY_FLAGS_LOCAL_PULL)
+#define FLATPAK_HELPER_DEPLOY_FLAGS_ALL (FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE|FLATPAK_HELPER_DEPLOY_FLAGS_NO_DEPLOY|FLATPAK_HELPER_DEPLOY_FLAGS_LOCAL_PULL|FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL)
 
 typedef enum {
   FLATPAK_HELPER_UNINSTALL_FLAGS_NONE = 0,
@@ -436,12 +437,14 @@ gboolean   flatpak_dir_deploy_install (FlatpakDir   *self,
                                        const char   *ref,
                                        const char   *origin,
                                        const char  **subpaths,
+                                       gboolean      reinstall,
                                        GCancellable *cancellable,
                                        GError      **error);
 gboolean   flatpak_dir_install (FlatpakDir          *self,
                                 gboolean             no_pull,
                                 gboolean             no_deploy,
                                 gboolean             no_static_deltas,
+                                gboolean             reinstall,
                                 const char          *ref,
                                 const char          *remote_name,
                                 const char         **subpaths,

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1434,6 +1434,7 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_PULL) != 0,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_DEPLOY) != 0,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_STATIC_DELTAS) != 0,
+                            FALSE,
                             ref, remote_name, (const char **)subpaths,
                             ostree_progress, cancellable, error))
     goto out;

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -28,7 +28,7 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-
     skip_without_p2p
 fi
 
-echo "1..10"
+echo "1..12"
 
 #Regular repo
 setup_repo
@@ -75,6 +75,14 @@ fi
 
 install_repo test-gpg2
 echo "ok with alternative gpg key"
+
+if ${FLATPAK} ${U} install test-repo org.test.Platform 2> install-error-log; then
+    assert_not_reached "Should not be able to install again from different remote without reinstall"
+fi
+echo "ok failed to install again from different remote"
+
+${FLATPAK} ${U} install --reinstall test-repo org.test.Platform
+echo "ok re-install"
 
 ${FLATPAK} ${U} uninstall org.test.Platform org.test.Hello
 


### PR DESCRIPTION
If you're installing something and its already installed, we undeploy
the old install first before deploying the new. This makes it very
easy to switch an application from one remote to another, without
having to uninstall first, which is both painful and could cause
the download to be unnecessary large.