### PR TITLE
Allow installing directly from a local repo

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -463,6 +463,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
   g_autoptr(GPtrArray) dirs = NULL;
   FlatpakDir *dir;
   const char *remote;
+  g_autofree char *remote_url = NULL;
   char **prefs = NULL;
   int i, n_prefs;
   g_autofree char *target_branch = NULL;
@@ -497,7 +498,15 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
   if (argc < 3)
     return usage_error (context, _("REMOTE and REF must be specified"), error);
 
-  remote = argv[1];
+  if (g_path_is_absolute (argv[1]) ||
+      g_str_has_prefix (argv[1], "./"))
+    {
+      g_autoptr(GFile) remote_file = g_file_new_for_commandline_arg (argv[1]);
+      remote_url = g_file_get_uri (remote_file);
+      remote = remote_url;
+    }
+  else
+    remote = argv[1];
   prefs = &argv[2];
   n_prefs = argc - 2;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8806,6 +8806,9 @@ flatpak_dir_create_origin_remote (FlatpakDir   *self,
                                   gpg_data, cancellable, error))
     return NULL;
 
+  if (!ostree_repo_reload_config (self->repo, cancellable, error))
+    return FALSE;
+
   return g_steal_pointer (&remote);
 }
 

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -549,6 +549,8 @@ char      *flatpak_dir_create_origin_remote (FlatpakDir   *self,
                                              const char   *collection_id,
                                              GCancellable *cancellable,
                                              GError      **error);
+void       flatpak_dir_prune_origin_remote (FlatpakDir *self,
+                                            const char *remote);
 gboolean   flatpak_dir_create_remote_for_ref_file (FlatpakDir   *self,
                                                    GBytes  *data,
                                                    const char *default_arch,

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -75,6 +75,11 @@
             --runtime option, or by supplying the initial element in the REF.
         </para>
         <para>
+            If <arg choice="plain">REMOTE</arg> is a uri or a path (absolute or relative starting with ./)
+            to a local repository, then that repository will be used as the source, and a temporary remote
+            will be created for the lifetime of the <arg choice="plain">REF</arg>.
+        </para>
+        <para>
             The alternative form of the command (<arg>--from</arg> or
             <arg>--bundle</arg> allows you to
             install directly from a source such as a .flatpak


### PR DESCRIPTION
With this, you can do e.g. `flatpak install --user /path/to/repo org.the.App`, which will create an origin remote for that repo, which will be removed with the app (similar to the ones we add when installing from bundles). This is highly useful for testing local builds, and the goal is to use this from flatpak-builder for single command build + install.

This PR is WIP, because it starts with merging in the PRs #1243 and #1241, once those lands we can rebase it.