### PR TITLE
Fix overrides

### DIFF
--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -51,7 +51,7 @@ flatpak_builtin_override (int argc, char **argv, GCancellable *cancellable, GErr
   g_autoptr(FlatpakContext) overrides = NULL;
   g_autoptr(GError) my_error = NULL;
 
-  context = g_option_context_new (_("APP - Override settings for application"));
+  context = g_option_context_new (_("[APP] - Override settings [for application]"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   arg_context = flatpak_context_new ();
@@ -64,16 +64,17 @@ flatpak_builtin_override (int argc, char **argv, GCancellable *cancellable, GErr
 
   dir = g_ptr_array_index (dirs, 0);
 
-  if (argc < 2)
-    return usage_error (context, _("APP must be specified"), error);
-
   if (argc > 2)
     return usage_error (context, _("Too many arguments"), error);
 
-  app = argv[1];
-
-  if (!flatpak_is_valid_name (app, &my_error))
-    return flatpak_fail (error, _("'%s' is not a valid application name: %s"), app, my_error->message);
+  if (argc >= 2)
+    {
+      app = argv[1];
+      if (!flatpak_is_valid_name (app, &my_error))
+        return flatpak_fail (error, _("'%s' is not a valid application name: %s"), app, my_error->message);
+    }
+  else
+    app = NULL;
 
   metakey = flatpak_load_override_keyfile (app, flatpak_dir_is_user (dir), &my_error);
   if (metakey == NULL)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1586,6 +1586,8 @@ flatpak_context_save_metadata (FlatpakContext *context,
             g_ptr_array_add (array, g_strconcat (key, ":create", NULL));
           else if (value != NULL)
             g_ptr_array_add (array, g_strdup (key));
+          else
+            g_ptr_array_add (array, g_strconcat ("!", key, NULL));
         }
 
       g_key_file_set_string_list (metakey,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2812,6 +2812,17 @@ exports_path_tmpfs (FlatpakExports *exports,
 }
 
 static void
+exports_path_expose_or_hide (FlatpakExports *exports,
+                             FlatpakFilesystemMode mode,
+                             const char *path)
+{
+  if (mode == 0)
+    exports_path_tmpfs (exports, path);
+  else
+    exports_path_expose (exports, mode, path);
+}
+
+static void
 exports_path_dir (FlatpakExports *exports,
                   const char *path)
 {
@@ -2875,8 +2886,7 @@ export_paths_export_context (FlatpakContext *context,
       const char *filesystem = key;
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-      if (value == NULL ||
-          strcmp (filesystem, "host") == 0 ||
+      if (strcmp (filesystem, "host") == 0 ||
           strcmp (filesystem, "home") == 0)
         continue;
 
@@ -2915,7 +2925,7 @@ export_paths_export_context (FlatpakContext *context,
                 g_string_append_printf (xdg_dirs_conf, "%s=\"%s\"\n",
                                         config_key, path);
 
-              exports_path_expose (exports, mode, subpath);
+              exports_path_expose_or_hide (exports, mode, subpath);
             }
         }
       else if (g_str_has_prefix (filesystem, "~/"))
@@ -2928,7 +2938,7 @@ export_paths_export_context (FlatpakContext *context,
             g_mkdir_with_parents (path, 0755);
 
           if (g_file_test (path, G_FILE_TEST_EXISTS))
-            exports_path_expose (exports, mode, path);
+            exports_path_expose_or_hide (exports, mode, path);
         }
       else if (g_str_has_prefix (filesystem, "/"))
         {
@@ -2936,7 +2946,7 @@ export_paths_export_context (FlatpakContext *context,
             g_mkdir_with_parents (filesystem, 0755);
 
           if (g_file_test (filesystem, G_FILE_TEST_EXISTS))
-            exports_path_expose (exports, mode, filesystem);
+            exports_path_expose_or_hide (exports, mode, filesystem);
         }
       else
         {

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -32,7 +32,7 @@
             <cmdsynopsis>
                 <command>flatpak override</command>
                 <arg choice="opt" rep="repeat">OPTION</arg>
-                <arg choice="plain">APP</arg>
+                <arg choice="opt">APP</arg>
             </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -48,6 +48,10 @@
             requested when it is started. But the user can override it
             on a particular instance by specifying extra arguments to
             flatpak run, or every time by using flatpak override.
+        </para>
+        <para>
+            If the application id is not specified then the overrides affect all applications,
+            but the per-application overrides can override the global overrides.
         </para>
         <para>
             Unless overridden with the --user or --installation options, this command


### PR DESCRIPTION
This makes --nofilesystem work properly and then adds support for global overrides (affecting all apps).

Fixes https://github.com/flatpak/flatpak/issues/1232