### PR TITLE
Clean up update output

### DIFF
--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -94,7 +94,8 @@ update_appstream (GPtrArray *dirs, const char *remote, GCancellable *cancellable
               FlatpakTerminalProgress terminal_progress = { 0 };
 
               if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
-                  flatpak_dir_get_remote_noenumerate (dir, remotes[i]))
+                  flatpak_dir_get_remote_noenumerate (dir, remotes[i]) ||
+                  !flatpak_dir_check_for_appstream_update (dir, remotes[i], opt_arch))
                 continue;
 
               g_print (_("Updating appstream for remote %s\n"), remotes[i]);
@@ -115,7 +116,8 @@ update_appstream (GPtrArray *dirs, const char *remote, GCancellable *cancellable
         {
           FlatpakDir *dir = g_ptr_array_index (dirs, j);
 
-          if (flatpak_dir_has_remote (dir, remote))
+          if (flatpak_dir_has_remote (dir, remote) &&
+              flatpak_dir_check_for_appstream_update (dir, remote, opt_arch))
             {
               FlatpakTerminalProgress terminal_progress = { 0 };
 

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -103,7 +103,10 @@ update_appstream (GPtrArray *dirs, const char *remote, GCancellable *cancellable
                   !flatpak_dir_check_for_appstream_update (dir, remotes[i], opt_arch))
                 continue;
 
-              g_print (_("Updating appstream data for remote %s\n"), remotes[i]);
+              if (flatpak_dir_is_user (dir))
+                g_print (_("Updating appstream data for user remote %s\n"), remotes[i]);
+              else
+                g_print (_("Updating appstream data for remote %s\n"), remotes[i]);
               progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
               if (!flatpak_dir_update_appstream (dir, remotes[i], opt_arch, &changed,
                                                  progress, cancellable, &local_error))

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -66,6 +66,11 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
+static void
+no_progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
+{
+}
+
 static gboolean
 update_appstream (GPtrArray *dirs, const char *remote, GCancellable *cancellable, GError **error)
 {
@@ -91,20 +96,19 @@ update_appstream (GPtrArray *dirs, const char *remote, GCancellable *cancellable
           for (i = 0; remotes[i] != NULL; i++)
             {
               g_autoptr(GError) local_error = NULL;
-              FlatpakTerminalProgress terminal_progress = { 0 };
+              g_autoptr(OstreeAsyncProgress) progress = NULL;
 
               if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
                   flatpak_dir_get_remote_noenumerate (dir, remotes[i]) ||
                   !flatpak_dir_check_for_appstream_update (dir, remotes[i], opt_arch))
                 continue;
 
-              g_print (_("Updating appstream for remote %s\n"), remotes[i]);
-              g_autoptr(OstreeAsyncProgress) progress = flatpak_progress_new (flatpak_terminal_progress_cb, &terminal_progress);
+              g_print (_("Updating appstream data for remote %s\n"), remotes[i]);
+              progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
               if (!flatpak_dir_update_appstream (dir, remotes[i], opt_arch, &changed,
                                                  progress, cancellable, &local_error))
                 g_printerr (_("Error updating: %s\n"), local_error->message);
               ostree_async_progress_finish (progress);
-              flatpak_terminal_progress_end (&terminal_progress);
             }
         }
     }
@@ -119,17 +123,16 @@ update_appstream (GPtrArray *dirs, const char *remote, GCancellable *cancellable
           if (flatpak_dir_has_remote (dir, remote) &&
               flatpak_dir_check_for_appstream_update (dir, remote, opt_arch))
             {
-              FlatpakTerminalProgress terminal_progress = { 0 };
+              g_autoptr(OstreeAsyncProgress) progress = NULL;
 
               found = TRUE;
 
-              g_autoptr(OstreeAsyncProgress) progress = flatpak_progress_new (flatpak_terminal_progress_cb, &terminal_progress);
+              progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
               res = flatpak_dir_update_appstream (dir, remote, opt_arch, &changed,
                                                   progress, cancellable, error);
               ostree_async_progress_finish (progress);
               if (!res)
                 return FALSE;
-              flatpak_terminal_progress_end (&terminal_progress);
             }
         }
 

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -696,8 +696,11 @@ flatpak_transaction_run (FlatpakTransaction *self,
         {
           g_autoptr(OstreeAsyncProgress) progress = flatpak_progress_new (flatpak_terminal_progress_cb, &terminal_progress);
           opname = _("install");
-          g_print (_("Installing: %s from %s\n"), pref, op->remote);
-          res = flatpak_dir_install (self->dir,
+          if (flatpak_dir_is_user (self->dir))
+            g_print (_("Installing for user: %s from %s\n"), pref, op->remote);
+          else
+            g_print (_("Installing: %s from %s\n"), pref, op->remote);
+          res = flatpak_dir_install (self->dir ,
                                      self->no_pull,
                                      self->no_deploy,
                                      self->no_static_deltas,
@@ -720,7 +723,10 @@ flatpak_transaction_run (FlatpakTransaction *self,
                                                                          cancellable, &local_error);
           if (target_commit != NULL)
             {
-              g_print (_("Updating: %s from %s\n"), pref, op->remote);
+              if (flatpak_dir_is_user (self->dir))
+                g_print (_("Updating for user: %s from %s\n"), pref, op->remote);
+              else
+                g_print (_("Updating: %s from %s\n"), pref, op->remote);
               g_autoptr(OstreeAsyncProgress) progress = flatpak_progress_new (flatpak_terminal_progress_cb, &terminal_progress);
               res = flatpak_dir_update (self->dir,
                                         self->no_pull,
@@ -765,7 +771,10 @@ flatpak_transaction_run (FlatpakTransaction *self,
         {
           g_autofree char *bundle_basename = g_file_get_basename (op->bundle);
           opname = _("install bundle");
-          g_print (_("Installing: %s from bundle %s\n"), pref, bundle_basename);
+          if (flatpak_dir_is_user (self->dir))
+            g_print (_("Installing for user: %s from bundle %s\n"), pref, bundle_basename);
+          else
+            g_print (_("Installing: %s from bundle %s\n"), pref, bundle_basename);
           res = flatpak_dir_install_bundle (self->dir, op->bundle,
                                             op->remote, NULL,
                                             cancellable, &local_error);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -338,6 +338,9 @@ gboolean    flatpak_dir_deploy_appstream (FlatpakDir          *self,
                                           gboolean            *out_changed,
                                           GCancellable        *cancellable,
                                           GError             **error);
+gboolean    flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
+                                                    const char          *remote,
+                                                    const char          *arch);
 gboolean    flatpak_dir_update_appstream (FlatpakDir          *self,
                                           const char          *remote,
                                           const char          *arch,


### PR DESCRIPTION
This gives less verbose output when updating appstream, and adds information on if updates are per-user or system-wide.

Fixes https://github.com/flatpak/flatpak/issues/1233