### PR TITLE
Fix clang warning

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -370,6 +370,8 @@ flatpak_option_context_parse (GOptionContext     *context,
               if (dir == NULL)
                 return FALSE;
             }
+          else
+            g_assert_not_reached ();
 
           g_ptr_array_add (dirs, dir);
         }


### PR DESCRIPTION
I got this:
app/flatpak-main.c:364:20: warning: variable 'dir' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
          else if (opt_installations != NULL)
                   ^~~~~~~~~~~~~~~~~~~~~~~~~
app/flatpak-main.c:374:34: note: uninitialized use occurs here
          g_ptr_array_add (dirs, dir);
                                 ^~~
app/flatpak-main.c:364:16: note: remove the 'if' if its condition is always true
          else if (opt_installations != NULL)
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
app/flatpak-main.c:358:26: note: initialize the variable 'dir' to silence this warning
          FlatpakDir *dir;
                         ^
                          = NULL

However, that is never hit, its just the compiler being confuses, so we add a
g_assert_not_reached() in the last else case.

Reachability analysis:

If opt_installations is != NULL we will at the very least take the
last if, and if opt_installations == NULL, we will take the first one
if !opt_user, and the second if opt_user.