### PR TITLE
Various small Coverity fixes

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -346,6 +346,9 @@ flatpak_option_context_parse (GOptionContext     *context,
               g_ptr_array_add (dirs, flatpak_dir_get_user ());
 
               system_dirs = flatpak_dir_get_system_list (cancellable, error);
+              if (system_dirs == NULL)
+                return FALSE;
+
               for (i = 0; i < system_dirs->len; i++)
                 {
                   FlatpakDir *dir = g_ptr_array_index (system_dirs, i);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1655,7 +1655,11 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
             }
 
           /* Create .changes file early to avoid polling non-existing file in monitor */
-          flatpak_dir_mark_changed (self, NULL);
+          if (!flatpak_dir_mark_changed (self, &my_error))
+            {
+              g_warning ("Error marking directory as changed: %s", my_error->message);
+              g_clear_error (&my_error);
+            }
         }
       else
         {


### PR DESCRIPTION
The two ‘don’t ignore errors’ commits need reviewing by someone who knows what the intention of the code was here: I’ve assumed that since the errors weren’t propagated before, the correct fix is to warn about them, ignore them, and carry on; rather than propagating them. But it might be that propagation was forgotten about before and is actually the correct fix. It might instead be that warning about them is too severe, and instead we should use `g_debug()`.

The ‘Fix error handling for getting system dir list’ fix should be straightforward.