### PR TITLE
deploy: Create the binary wrappers after having rewritten the exports

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5583,6 +5583,12 @@ flatpak_dir_deploy (FlatpakDir          *self,
       g_autofree char *bin_data = NULL;
       int r;
 
+      if (!flatpak_rewrite_export_dir (ref_parts[1], ref_parts[3], ref_parts[2],
+                                       keyfile, export,
+                                       cancellable,
+                                       error))
+        return FALSE;
+
       if (!flatpak_mkdir_p (bindir, cancellable, error))
         return FALSE;
 
@@ -5597,12 +5603,6 @@ flatpak_dir_deploy (FlatpakDir          *self,
       while (G_UNLIKELY (r == -1 && errno == EINTR));
       if (r == -1)
         return glnx_throw_errno_prefix (error, "fchmodat");
-
-      if (!flatpak_rewrite_export_dir (ref_parts[1], ref_parts[3], ref_parts[2],
-                                       keyfile, export,
-                                       cancellable,
-                                       error))
-        return FALSE;
 
     }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5583,13 +5583,13 @@ flatpak_dir_deploy (FlatpakDir          *self,
       g_autofree char *bin_data = NULL;
       int r;
 
+      if (!flatpak_mkdir_p (bindir, cancellable, error))
+        return FALSE;
+
       if (!flatpak_rewrite_export_dir (ref_parts[1], ref_parts[3], ref_parts[2],
                                        keyfile, export,
                                        cancellable,
                                        error))
-        return FALSE;
-
-      if (!flatpak_mkdir_p (bindir, cancellable, error))
         return FALSE;
 
       bin_data = g_strdup_printf ("#!/bin/sh\nexec %s/flatpak run --branch=%s --arch=%s %s \"$@\"\n",


### PR DESCRIPTION
Interestingly the telegram appid is "org.telegram.desktop", which means
the wrapper ends up having a .desktop extension which confuses the
desktop file exporter. We fix this by rewriting any exports before
creating the wrappers.

Fixes https://github.com/flathub/org.telegram.desktop/issues/18