### PR TITLE
common/dir: Use an actual function for autoptr support without P2P

### DIFF
--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -145,8 +145,10 @@ GQuark       flatpak_dir_error_quark (void);
 typedef void OstreeRepoFinderResult;
 typedef void** OstreeRepoFinderResultv;
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderResult, void)
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC (OstreeRepoFinderResultv, void, NULL)
+static inline void no_op (gpointer data) {}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoFinderResult, no_op)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (OstreeRepoFinderResultv, no_op, NULL)
 #endif  /* !FLATPAK_ENABLE_P2P */
 
 /**


### PR DESCRIPTION
When building with --disable-p2p, we create a stub type for
OstreeRepoFinderResult and OstreeRepoFinderResultv to avoid having to
add #ifdefs around all uses of them throughout the code base. We also
need to create autoptr functions for them so that the code can continue
to use g_autoptr(OstreeRepoFinderResult).

Previously, we were using `void` as the GDestroyNotify function for the
stub types. This wasn’t valid (it’s not a function), but it worked.

Since g_autolist() support has landed in GLib, this has broken. Fix it
by using a static inline no-op function as the GDestroyNotify function
instead. This should never be called, so exists purely to get things to
compile.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://github.com/flatpak/flatpak/issues/1279