### PR TITLE
common/dir: Add a missing OstreeAsyncProgress default key

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2817,6 +2817,7 @@ oci_pull_init_progress (OstreeAsyncProgress *progress)
                              "total-delta-part-usize", "t", (guint64) 0,
                              "total-delta-superblocks", "u", 0,
                              "status", "s", "",
+                             "caught-error", "b", FALSE,
                              NULL);
 }
 


### PR DESCRIPTION
oci_pull_init_progress() seems to set all the default keys wanted by
ostree_repo_pull_default_console_progress_changed() except the
caught-error key, which was added in OSTree commit 5c4f26bd65b492.

Add that key, just in case something queries for it (if it’s missing
when that happens, an assertion failure will be hit).

Signed-off-by: Philip Withnall <withnall@endlessm.com>