### PR TITLE
Update info on Arch user namespaces in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,8 @@ has a recent enough version of Bubblewrap already, you can use
 
 Bubblewrap can run in two modes, either using unprivileged user
 namespaces or setuid mode. This requires that the kernel supports this,
-which some distributions disable. For instance, Arch completely
-disables user namespaces, while Debian supports unprivileged user
-namespaces, but only if you turn on the
-`kernel.unprivileged_userns_clone` sysctl.
+which some distributions disable. For instance, Debian and Arch 
+([linux](https://www.archlinux.org/packages/?name=linux) kernel v4.14.5 or later), support user namespaces with the `kernel.unprivileged_userns_clone` sysctl enabled.
 
 If unprivileged user namespaces are not available, then Bubblewrap must
 be built as setuid root. This is believed to be safe, as it is


### PR DESCRIPTION
As of linux kernel 4.14.5, user namespaces are enabled on Arch with the standard linux kernel.

Username spaces are disabled by default, but can be enabled with the
`kernel.unprivileged_userns_clone` sysctl.

More information regarding the change can be found in the Arch Linux [bug report](https://bugs.archlinux.org/task/36969).