### PR TITLE
Document portal: implement add_named_full() function

### DIFF
--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -136,6 +136,43 @@
     </method>
 
     <!--
+        AddNamedFull:
+        @o_path_fds: open file descriptor for the parent directory
+        @filename: the basename for the file
+        @flags: flags, 1 == reuse_existing, 2 == persistent, 3 == as-needed-by-app
+        @app_id: an application ID, or empty string
+        @permissions: the permissions to grant, possible values are 'read', 'write', 'grant-permissions' and 'delete'
+        @doc_id: the ID of the file in the document store
+        @extra_info: Extra info returned
+
+        Creates an entry in the document store for writing a new file.
+
+        If the as-needed-by-app flag is given, file will only be added to
+        the document store if the application does not already have access to it.
+        For file that is not added to the document store, the doc_id will
+        contain an empty string.
+
+        Additionally, if app_id is specified, it will be given the permissions
+        listed in GrantPermission.
+
+        The method also returns some extra info that can be used to avoid
+        multiple roundtrips. For now it only contains as "mountpoint", the
+        fuse mountpoint of the document portal.
+
+        This method was added in version 3 of the org.freedesktop.portal.Documents interface.
+    -->
+    <method name="AddNamedFull">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
+      <arg type='h' name='o_path_fd' direction='in'/>
+      <arg type='ay' name='filename' direction='in'/>
+      <arg type='u' name='flags' direction='in'/>
+      <arg type='s' name='app_id' direction='in'/>
+      <arg type='as' name='permissions' direction='in'/>
+      <arg type='s' name='doc_id' direction='out'/>
+      <arg type='a{sv}' name='extra_out' direction='out'/>
+    </method>
+
+    <!--
         GrantPermissions:
         @doc_id: the ID of the file in the document store
         @app_id: the ID of the application to which permissions are granted


### PR DESCRIPTION
This is a convenient function which can be used with flags, adding option to return
real path of the file we are trying to open in case the sandboxed app has access
to it. It also registers this file automatically to document store so there is no
need to call grant_permission() afterwards.