### PR TITLE
Update appstream data when searching

### DIFF
--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -24,6 +24,7 @@
 #include <appstream-glib.h>
 
 #include "flatpak-builtins.h"
+#include "flatpak-builtins-utils.h"
 #include "flatpak-dir.h"
 #include "flatpak-table-printer.h"
 #include "flatpak-utils.h"
@@ -211,6 +212,7 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
   g_autoptr(GPtrArray) dirs = NULL;
   g_autoptr(GOptionContext) context = g_option_context_new (_("TEXT - Search remote apps/runtimes for text"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
+  const char *arch = NULL;
 
   if (!flatpak_option_context_parse (context, NULL, &argc, &argv,
                                      FLATPAK_BUILTIN_FLAG_STANDARD_DIRS, &dirs, cancellable, error))
@@ -218,6 +220,10 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
 
   if (argc < 2)
     return usage_error (context, _("TEXT must be specified"), error);
+
+  arch = flatpak_get_arch ();
+  if (!update_appstream (dirs, NULL, arch, cancellable, error))
+    return FALSE;
 
   const char *search_text = argv[1];
   GSList *matches = NULL;

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -225,7 +225,7 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
     return usage_error (context, _("TEXT must be specified"), error);
 
   arch = flatpak_get_arch ();
-  if (!update_appstream (dirs, NULL, arch, FLATPAK_APPSTREAM_TTL, cancellable, error))
+  if (!update_appstream (dirs, NULL, arch, FLATPAK_APPSTREAM_TTL, TRUE, cancellable, error))
     return FALSE;
 
   const char *search_text = argv[1];

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -29,6 +29,9 @@
 #include "flatpak-table-printer.h"
 #include "flatpak-utils.h"
 
+/* Appstream data expires after a day */
+#define FLATPAK_APPSTREAM_TTL 86400
+
 static GPtrArray *
 get_remote_stores (GPtrArray *dirs, GCancellable *cancellable)
 {
@@ -222,7 +225,7 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
     return usage_error (context, _("TEXT must be specified"), error);
 
   arch = flatpak_get_arch ();
-  if (!update_appstream (dirs, NULL, arch, cancellable, error))
+  if (!update_appstream (dirs, NULL, arch, FLATPAK_APPSTREAM_TTL, cancellable, error))
     return FALSE;
 
   const char *search_text = argv[1];

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -92,7 +92,7 @@ flatpak_builtin_update (int           argc,
     opt_arch = (char *)flatpak_get_arch ();
 
   if (opt_appstream)
-    return update_appstream (dirs, argc >= 2 ? argv[1] : NULL, opt_arch, 0, cancellable, error);
+    return update_appstream (dirs, argc >= 2 ? argv[1] : NULL, opt_arch, 0, FALSE, cancellable, error);
 
   prefs = &argv[1];
   n_prefs = argc - 1;
@@ -229,7 +229,7 @@ flatpak_builtin_update (int           argc,
     }
 
   if (n_prefs == 0)
-    return update_appstream (dirs, NULL, opt_arch, 0, cancellable, error);
+    return update_appstream (dirs, NULL, opt_arch, 0, FALSE, cancellable, error);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -66,89 +66,6 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-static void
-no_progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
-{
-}
-
-static gboolean
-update_appstream (GPtrArray *dirs, const char *remote, GCancellable *cancellable, GError **error)
-{
-  gboolean changed;
-  gboolean res;
-  int i, j;
-
-  if (opt_arch == NULL)
-    opt_arch = (char *)flatpak_get_arch ();
-
-  if (remote == NULL)
-    {
-      g_auto(GStrv) remotes = NULL;
-
-      for (j = 0; j < dirs->len; j++)
-        {
-          FlatpakDir *dir = g_ptr_array_index (dirs, j);
-
-          remotes = flatpak_dir_list_remotes (dir, cancellable, error);
-          if (remotes == NULL)
-            return FALSE;
-
-          for (i = 0; remotes[i] != NULL; i++)
-            {
-              g_autoptr(GError) local_error = NULL;
-              g_autoptr(OstreeAsyncProgress) progress = NULL;
-
-              if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
-                  flatpak_dir_get_remote_noenumerate (dir, remotes[i]) ||
-                  !flatpak_dir_check_for_appstream_update (dir, remotes[i], opt_arch))
-                continue;
-
-              if (flatpak_dir_is_user (dir))
-                g_print (_("Updating appstream data for user remote %s\n"), remotes[i]);
-              else
-                g_print (_("Updating appstream data for remote %s\n"), remotes[i]);
-              progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
-              if (!flatpak_dir_update_appstream (dir, remotes[i], opt_arch, &changed,
-                                                 progress, cancellable, &local_error))
-                g_printerr (_("Error updating: %s\n"), local_error->message);
-              ostree_async_progress_finish (progress);
-            }
-        }
-    }
-  else
-    {
-      gboolean found = FALSE;
-
-      for (j = 0; j < dirs->len; j++)
-        {
-          FlatpakDir *dir = g_ptr_array_index (dirs, j);
-
-          if (flatpak_dir_has_remote (dir, remote))
-            {
-              g_autoptr(OstreeAsyncProgress) progress = NULL;
-
-              found = TRUE;
-
-              /* Early bail out check */
-              if (!flatpak_dir_check_for_appstream_update (dir, remote, opt_arch))
-                continue;
-
-              progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
-              res = flatpak_dir_update_appstream (dir, remote, opt_arch, &changed,
-                                                  progress, cancellable, error);
-              ostree_async_progress_finish (progress);
-              if (!res)
-                return FALSE;
-            }
-        }
-
-      if (!found)
-        return flatpak_fail (error, _("Remote \"%s\" not found"), remote);
-    }
-
-  return TRUE;
-}
-
 gboolean
 flatpak_builtin_update (int           argc,
                         char        **argv,
@@ -171,8 +88,11 @@ flatpak_builtin_update (int           argc,
                                      &dirs, cancellable, error))
     return FALSE;
 
+  if (opt_arch == NULL)
+    opt_arch = (char *)flatpak_get_arch ();
+
   if (opt_appstream)
-    return update_appstream (dirs, argc >= 2 ? argv[1] : NULL, cancellable, error);
+    return update_appstream (dirs, argc >= 2 ? argv[1] : NULL, opt_arch, cancellable, error);
 
   prefs = &argv[1];
   n_prefs = argc - 1;
@@ -309,7 +229,7 @@ flatpak_builtin_update (int           argc,
     }
 
   if (n_prefs == 0)
-    return update_appstream (dirs, NULL, cancellable, error);
+    return update_appstream (dirs, NULL, opt_arch, cancellable, error);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -92,7 +92,7 @@ flatpak_builtin_update (int           argc,
     opt_arch = (char *)flatpak_get_arch ();
 
   if (opt_appstream)
-    return update_appstream (dirs, argc >= 2 ? argv[1] : NULL, opt_arch, cancellable, error);
+    return update_appstream (dirs, argc >= 2 ? argv[1] : NULL, opt_arch, 0, cancellable, error);
 
   prefs = &argv[1];
   n_prefs = argc - 1;
@@ -229,7 +229,7 @@ flatpak_builtin_update (int           argc,
     }
 
   if (n_prefs == 0)
-    return update_appstream (dirs, NULL, opt_arch, cancellable, error);
+    return update_appstream (dirs, NULL, opt_arch, 0, cancellable, error);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -450,12 +450,22 @@ update_appstream (GPtrArray    *dirs,
               g_autoptr(GError) local_error = NULL;
               g_autoptr(OstreeAsyncProgress) progress = NULL;
               g_autoptr(GFile) ts_file = NULL;
+              g_autofree char *ts_file_path = NULL;
               g_autofree char *subdir = NULL;
+              guint64 ts_file_age;
 
               subdir = g_strdup_printf ("appstream/%s/%s/.timestamp", remotes[i], arch);
               ts_file = g_file_resolve_relative_path (flatpak_dir_get_path (dir), subdir);
-              if (get_file_age (ts_file) < ttl)
-                continue;
+              ts_file_path = g_file_get_path (ts_file);
+              ts_file_age = get_file_age (ts_file);
+              if (ts_file_age < ttl)
+                {
+                  g_debug ("%s age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, ts_file_path, ts_file_age, ttl);
+                  continue;
+                }
+              else
+                g_debug ("%s age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, ts_file_path, ts_file_age, ttl);
+
 
               if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
                   flatpak_dir_get_remote_noenumerate (dir, remotes[i]) ||

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -423,6 +423,7 @@ update_appstream (GPtrArray    *dirs,
                   const char   *remote,
                   const char   *arch,
                   guint64       ttl,
+                  gboolean      quiet,
                   GCancellable *cancellable,
                   GError      **error)
 {
@@ -473,9 +474,19 @@ update_appstream (GPtrArray    *dirs,
                 continue;
 
               if (flatpak_dir_is_user (dir))
-                g_print (_("Updating appstream data for user remote %s\n"), remotes[i]);
+                {
+                  if (quiet)
+                    g_debug (_("Updating appstream data for user remote %s\n"), remotes[i]);
+                  else
+                    g_print (_("Updating appstream data for user remote %s\n"), remotes[i]);
+                }
               else
-                g_print (_("Updating appstream data for remote %s\n"), remotes[i]);
+                {
+                  if (quiet)
+                    g_debug (_("Updating appstream data for remote %s\n"), remotes[i]);
+                  else
+                    g_print (_("Updating appstream data for remote %s\n"), remotes[i]);
+                }
               progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
               if (!flatpak_dir_update_appstream (dir, remotes[i], arch, &changed,
                                                  progress, cancellable, &local_error))

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -55,6 +55,7 @@ gboolean flatpak_resolve_duplicate_remotes (GPtrArray    *dirs,
 gboolean update_appstream (GPtrArray    *dirs,
                            const char   *remote,
                            const char   *arch,
+                           guint64       ttl,
                            GCancellable *cancellable,
                            GError      **error);
 

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -56,6 +56,7 @@ gboolean update_appstream (GPtrArray    *dirs,
                            const char   *remote,
                            const char   *arch,
                            guint64       ttl,
+                           gboolean      quiet,
                            GCancellable *cancellable,
                            GError      **error);
 

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -52,4 +52,10 @@ gboolean flatpak_resolve_duplicate_remotes (GPtrArray    *dirs,
                                             GCancellable *cancellable,
                                             GError      **error);
 
+gboolean update_appstream (GPtrArray    *dirs,
+                           const char   *remote,
+                           const char   *arch,
+                           GCancellable *cancellable,
+                           GError      **error);
+
 #endif /* __FLATPAK_BUILTINS_UTILS_H__ */

--- a/doc/flatpak-search.xml
+++ b/doc/flatpak-search.xml
@@ -42,6 +42,7 @@
             Searches for applications and runtimes matching
             <arg choice="plain">TEXT</arg>. Note that this uses appstream data
             that can be updated with <citerefentry><refentrytitle>flatpak-update</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+            The appstream data is updated automatically only if it's at least a day old.
         </para>
     </refsect1>
 


### PR DESCRIPTION
We may want to add an `--offline` option to search the appstream data that's already downloaded, but that can be a separate issue.