### PR TITLE
doc: Fix docs for --update-appstream

### DIFF
--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -129,7 +129,7 @@
                 <term><option>--update-appstream</option></term>
 
                 <listitem><para>
-                    Run appstream-builder and to update the appstream branch after build.
+                    Update the appstream branch after the build.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -177,7 +177,7 @@
                 <term><option>--update-appstream</option></term>
 
                 <listitem><para>
-                    Run appstream-builder and to update the appstream branch after build.
+                    Update the appstream branch after the build.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build-import-bundle.xml
+++ b/doc/flatpak-build-import-bundle.xml
@@ -101,7 +101,7 @@
                 <term><option>--update-appstream</option></term>
 
                 <listitem><para>
-                    Run appstream-builder and to update the appstream branch after build.
+                    Update the appstream branch after the build.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
We no longer run appstream-builder (see commit 455d3a7b2) so update the
documentation for the --update-appstream option.