### PR TITLE
common/dir: Skip progress reporting while setting up extra-data

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2190,7 +2190,14 @@ default_progress_changed (OstreeAsyncProgress *progress,
       glnx_console_text (line);
     }
   else
-    ostree_repo_pull_default_console_progress_changed (progress, user_data);
+    {
+      /* We get some extra calls before we've really started due to the initialization of the
+         extra data, so ignore those */
+      if (ostree_async_progress_get_variant (progress, "outstanding-fetches") == NULL)
+        return;
+
+      ostree_repo_pull_default_console_progress_changed (progress, user_data);
+    }
 }
 
 /* Get the configured collection-id for @remote_name, squashing empty strings into


### PR DESCRIPTION
It’s somehow possible (I haven’t investigated how) for
flatpak_dir_setup_extra_data() to be called before the main keys (such
as `outstanding-fetches`) are set on a new OstreeAsyncProgress during a
flatpak_dir_pull() call with no OstreeAsyncProgress object provided by
the caller.

This means that an OstreeAsyncProgress with only the extra-data keys
would be passed through to
ostree_repo_pull_default_console_progress_changed(), which would cause
an assertion failure when it tried to read the `outstanding-fetches`
key.

Avoid that by not calling
ostree_repo_pull_default_console_progress_changed() until
`outstanding-fetches` is set.

Signed-off-by: Philip Withnall <withnall@endlessm.com>