### PR TITLE
dir: Emit an error on non-root downgrade attempts

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6663,6 +6663,9 @@ flatpak_dir_update (FlatpakDir          *self,
       gboolean gpg_verify;
       g_autofree char *collection_id = NULL;
 
+      if (allow_downgrade)
+        return flatpak_fail (error, "Can't update to a specific commit without root permissions");
+
       system_helper = flatpak_dir_get_system_helper (self);
       g_assert (system_helper != NULL);
 


### PR DESCRIPTION
For security, only root can downgrade flatpaks in the system
installation. However, the error message explaining this when a normal
user attempts a downgrade was removed in commit 44cf5076f. This commit
adds back the error message.

Since the current behavior is for a downgrade by a non-root user to fail
with the message "No updates", this commit doesn't fix a security issue.
It's purely about usability.

Fixes https://github.com/flatpak/flatpak/issues/1303