### PR TITLE
correct appstream extract to not require component IDs ending in .desktop

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3860,15 +3860,20 @@ extract_appstream (OstreeRepo   *repo,
           component_id_text_node = flatpak_xml_find (component_id, NULL, NULL);
 
           component_id_text = g_strstrip (g_strdup (component_id_text_node->text));
-          if (!g_str_has_prefix (component_id_text, id) ||
-              !g_str_has_suffix (component_id_text, ".desktop"))
+
+          /* .desktop suffix in component ID is suggested, not required
+             (unless app ID actually ends in .desktop) */
+          if (g_str_has_suffix (component_id_text, ".desktop") &&
+              !g_str_has_suffix (id, ".desktop"))
+            component_id_text[strlen (component_id_text) - strlen (".desktop")] = 0;
+
+          if (!g_str_has_prefix (component_id_text, id))
             {
               component = component->next_sibling;
               continue;
             }
 
           g_print ("Extracting icons for component %s\n", component_id_text);
-          component_id_text[strlen (component_id_text) - strlen (".desktop")] = 0;
 
           if (!copy_icon (component_id_text, root, dest, "64x64", &my_error))
             {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3869,6 +3869,8 @@ extract_appstream (OstreeRepo   *repo,
 
           if (!g_str_has_prefix (component_id_text, id))
             {
+              g_print ("Skipping mismatched appstream component %s for app %s\n",
+                       component_id_text, id);
               component = component->next_sibling;
               continue;
             }


### PR DESCRIPTION
This is not required by the spec: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic