### PR TITLE
flatpak remote-ls -u: only consider apps from the current remote

### DIFF
--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -226,6 +226,9 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
               if (deploy_data == NULL)
                 continue;
 
+              if (g_strcmp0 (flatpak_deploy_data_get_origin (deploy_data), remote) != 0)
+                continue;
+
               if (g_strcmp0 (flatpak_deploy_data_get_commit (deploy_data), checksum) == 0)
                 continue;
             }


### PR DESCRIPTION
Check that the origin from the deploy matches the current remote
before listing it as an upgrade.

https://github.com/flatpak/flatpak/issues/1372