### PR TITLE
doc: Document -vv option

### DIFF
--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -102,7 +102,7 @@
                 <term><option>--verbose</option></term>
 
                 <listitem><para>
-                    Print debug information during command processing.
+                    Print debug information during command processing. Use -vv for more detail.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
As noted in https://github.com/flatpak/flatpak/issues/1370, `-vv` is documented in `flatpak --help` but not `man flatpak`, so add it to the latter. In practice it doesn't make much difference because `flatpak_debug2` is hardly used.