### PR TITLE
Preparations for extracting portals to xdg-desktop-portal

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -45,6 +45,7 @@ static gboolean opt_show_permissions;
 static gboolean opt_show_extensions;
 static char *opt_arch;
 static char **opt_installations;
+static char *opt_file_access;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to use"), N_("ARCH") },
@@ -57,6 +58,7 @@ static GOptionEntry options[] = {
   { "show-size", 's', 0, G_OPTION_ARG_NONE, &opt_show_size, N_("Show size"), NULL },
   { "show-metadata", 'm', 0, G_OPTION_ARG_NONE, &opt_show_metadata, N_("Show metadata"), NULL },
   { "show-permissions", 'M', 0, G_OPTION_ARG_NONE, &opt_show_permissions, N_("Show permissions"), NULL },
+  { "file-access", 0, 0, G_OPTION_ARG_FILENAME, &opt_file_access, N_("Query file access"), N_("PATH") },
   { "show-extensions", 'e', 0, G_OPTION_ARG_NONE, &opt_show_extensions, N_("Show extensions"), NULL },
   { NULL }
 };
@@ -166,7 +168,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
 
   metakey = flatpak_deploy_get_metadata (deploy);
 
-  if (opt_show_ref || opt_show_origin || opt_show_commit || opt_show_size || opt_show_metadata || opt_show_permissions)
+  if (opt_show_ref || opt_show_origin || opt_show_commit || opt_show_size || opt_show_metadata || opt_show_permissions || opt_file_access)
     friendly = FALSE;
 
   if (friendly)
@@ -274,7 +276,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
           g_print ("%s", data);
         }
 
-      if (opt_show_permissions)
+      if (opt_show_permissions || opt_file_access)
         {
           g_autoptr(FlatpakContext) context = NULL;
           g_autoptr(GKeyFile) keyfile = NULL;
@@ -284,15 +286,30 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
           if (context == NULL)
             return FALSE;
 
-          keyfile = g_key_file_new ();
+          if (opt_show_permissions)
+            {
+              keyfile = g_key_file_new ();
+              flatpak_context_save_metadata (context, TRUE, keyfile);
+              contents = g_key_file_to_data (keyfile, NULL, error);
+              if (contents == NULL)
+                return FALSE;
 
-          flatpak_context_save_metadata (context, TRUE, keyfile);
+              g_print ("%s", contents);
+            }
 
-          contents = g_key_file_to_data (keyfile, NULL, error);
-          if (contents == NULL)
-            return FALSE;
+          if (opt_file_access)
+            {
+              g_autoptr(FlatpakExports) exports = flatpak_context_get_exports (context, parts[1]);
+              FlatpakFilesystemMode mode;
 
-          g_print ("%s", contents);
+              mode = flatpak_exports_path_get_mode (exports, opt_file_access);
+              if (mode == 0)
+                g_print ("hidden\n");
+              else if (mode == FLATPAK_FILESYSTEM_MODE_READ_ONLY)
+                g_print ("read-only\n");
+              else
+                g_print ("read-write\n");
+            }
         }
     }
 

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -32,6 +32,7 @@
 #include "flatpak-builtins.h"
 #include "flatpak-utils.h"
 #include "flatpak-builtins-utils.h"
+#include "flatpak-run.h"
 
 static gboolean opt_user;
 static gboolean opt_system;
@@ -40,6 +41,7 @@ static gboolean opt_show_commit;
 static gboolean opt_show_origin;
 static gboolean opt_show_size;
 static gboolean opt_show_metadata;
+static gboolean opt_show_permissions;
 static gboolean opt_show_extensions;
 static char *opt_arch;
 static char **opt_installations;
@@ -54,6 +56,7 @@ static GOptionEntry options[] = {
   { "show-origin", 'o', 0, G_OPTION_ARG_NONE, &opt_show_origin, N_("Show origin"), NULL },
   { "show-size", 's', 0, G_OPTION_ARG_NONE, &opt_show_size, N_("Show size"), NULL },
   { "show-metadata", 'm', 0, G_OPTION_ARG_NONE, &opt_show_metadata, N_("Show metadata"), NULL },
+  { "show-permissions", 'M', 0, G_OPTION_ARG_NONE, &opt_show_permissions, N_("Show permissions"), NULL },
   { "show-extensions", 'e', 0, G_OPTION_ARG_NONE, &opt_show_extensions, N_("Show extensions"), NULL },
   { NULL }
 };
@@ -163,7 +166,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
 
   metakey = flatpak_deploy_get_metadata (deploy);
 
-  if (opt_show_ref || opt_show_origin || opt_show_commit || opt_show_size || opt_show_metadata)
+  if (opt_show_ref || opt_show_origin || opt_show_commit || opt_show_size || opt_show_metadata || opt_show_permissions)
     friendly = FALSE;
 
   if (friendly)
@@ -269,6 +272,27 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
             return FALSE;
 
           g_print ("%s", data);
+        }
+
+      if (opt_show_permissions)
+        {
+          g_autoptr(FlatpakContext) context = NULL;
+          g_autoptr(GKeyFile) keyfile = NULL;
+          g_autofree gchar *contents = NULL;
+
+          context = flatpak_context_load_for_deploy (deploy, error);
+          if (context == NULL)
+            return FALSE;
+
+          keyfile = g_key_file_new ();
+
+          flatpak_context_save_metadata (context, TRUE, keyfile);
+
+          contents = g_key_file_to_data (keyfile, NULL, error);
+          if (contents == NULL)
+            return FALSE;
+
+          g_print ("%s", contents);
         }
     }
 

--- a/common/flatpak-exports.h
+++ b/common/flatpak-exports.h
@@ -53,6 +53,8 @@ void flatpak_exports_add_path_dir (FlatpakExports *exports,
 
 gboolean flatpak_exports_path_is_visible (FlatpakExports *exports,
                                           const char *path);
+FlatpakFilesystemMode flatpak_exports_path_get_mode (FlatpakExports *exports,
+                                                     const char *path);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakExports, flatpak_exports_free);
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1545,7 +1545,10 @@ add_document_portal_args (FlatpakBwrap *bwrap,
         {
           if (g_dbus_message_to_gerror (reply, &local_error))
             {
-              g_message ("Can't get document portal: %s", local_error->message);
+              if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))
+                g_debug ("Document portal not available, not mounting /run/user/%d/doc", getuid ());
+              else
+                g_message ("Can't get document portal: %s", local_error->message);
             }
           else
             {


### PR DESCRIPTION
This is some combined work on the document portal in preparation for moving it to xdg-desktop-portal.

Changes are:
 * Make the as-needed feature take read-only vs read-write permissions into account
 * Add new flatpak info options --show-permissions and --file-access

Once we move the code the calls to detect the permissions will be changed to shell out to flatpak info --file-access.