### PR TITLE
lib: Add flatpak_installation_launch_full()

### DIFF
--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -152,6 +152,17 @@ FLATPAK_EXTERN gboolean             flatpak_installation_launch (FlatpakInstalla
                                                                  const char          *commit,
                                                                  GCancellable        *cancellable,
                                                                  GError             **error);
+FLATPAK_EXTERN gboolean             flatpak_installation_launch_full (FlatpakInstallation  *self,
+                                                                      const char           *name,
+                                                                      const char           *arch,
+                                                                      const char           *branch,
+                                                                      const char           *commit,
+                                                                      gboolean              devel,
+                                                                      const char           *custom_command,
+                                                                      const guint           argc,
+                                                                      const gchar         **argv,
+                                                                      GCancellable         *cancellable,
+                                                                      GError              **error);
 FLATPAK_EXTERN GFileMonitor        *flatpak_installation_create_monitor (FlatpakInstallation *self,
                                                                          GCancellable        *cancellable,
                                                                          GError             **error);


### PR DESCRIPTION
This gives greater control over launching which is useful for development tools.

Only thing this didn't expose was extra permissions as I didn't see an overly simple way  to expose `FlatpakContext` options?

Don't merge this quite yet until I'm sure it covers all of our needs.