### PR TITLE
Add --disable-document-portal configure option [0.10.x]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,13 @@ if test "x$enable_sandboxed_triggers" = "xno"; then
       [Define if sandboxed triggers are disabled])
 fi
 
+AC_ARG_ENABLE([document-portal],
+              AC_HELP_STRING([--disable-document-portal],
+                             [Disable document portal]),
+              [],
+              [enable_document_portal=yes])
+AM_CONDITIONAL(ENABLE_DOCUMENT_PORTAL, test "x$enable_document_portal" = "xyes")
+
 PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
 
 PKG_CHECK_MODULES(FUSE, [fuse])
@@ -444,6 +451,7 @@ echo "          ============="
 echo ""
 echo "          Build system helper:    $enable_system_helper"
 echo "          Build bubblewrap:       $build_bwrap"
+echo "          Build document portal:  $enable_document_portal"
 echo "          Use sandboxed triggers: $enable_sandboxed_triggers"
 echo "          Use seccomp:            $enable_seccomp"
 echo "          Privileged group:       $PRIVILEGED_GROUP"

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -1,9 +1,14 @@
 introspectiondir = $(datadir)/dbus-1/interfaces
 introspection_DATA = \
-	data/org.freedesktop.impl.portal.PermissionStore.xml \
-	data/org.freedesktop.portal.Documents.xml \
 	data/org.freedesktop.Flatpak.xml \
 	$(NULL)
+
+if ENABLE_DOCUMENT_PORTAL
+introspection_DATA += \
+	data/org.freedesktop.impl.portal.PermissionStore.xml \
+	data/org.freedesktop.portal.Documents.xml \
+	$(NULL)
+endif
 
 EXTRA_DIST += \
 	data/org.freedesktop.portal.Documents.xml \

--- a/document-portal/Makefile.am.inc
+++ b/document-portal/Makefile.am.inc
@@ -1,6 +1,10 @@
+if ENABLE_DOCUMENT_PORTAL
 libexec_PROGRAMS += \
 	xdg-document-portal \
 	$(NULL)
+systemduserunit_DATA += document-portal/xdg-document-portal.service
+dbus_service_DATA += document-portal/org.freedesktop.portal.Documents.service
+endif
 
 xdp_dbus_built_sources = document-portal/xdp-dbus.c document-portal/xdp-dbus.h
 BUILT_SOURCES += $(xdp_dbus_built_sources)
@@ -20,10 +24,7 @@ document-portal/%-dbus.h: document-portal/%-dbus.c
 	@true # Built as a side-effect of the rules for the .c
 
 service_in_files += document-portal/xdg-document-portal.service.in
-systemduserunit_DATA += document-portal/xdg-document-portal.service
-
 service_in_files += document-portal/org.freedesktop.portal.Documents.service.in
-dbus_service_DATA += document-portal/org.freedesktop.portal.Documents.service
 
 nodist_xdg_document_portal_SOURCES = \
 	$(xdp_dbus_built_sources)		\

--- a/permission-store/Makefile.am.inc
+++ b/permission-store/Makefile.am.inc
@@ -1,12 +1,13 @@
+if ENABLE_DOCUMENT_PORTAL
+systemduserunit_DATA += permission-store/xdg-permission-store.service
+dbus_service_DATA += permission-store/org.freedesktop.impl.portal.PermissionStore.service
 libexec_PROGRAMS += \
 	xdg-permission-store \
 	$(NULL)
+endif
 
 service_in_files += permission-store/xdg-permission-store.service.in
-systemduserunit_DATA += permission-store/xdg-permission-store.service
-
 service_in_files += permission-store/org.freedesktop.impl.portal.PermissionStore.service.in
-dbus_service_DATA += permission-store/org.freedesktop.impl.portal.PermissionStore.service
 
 nodist_xdg_permission_store_SOURCES = permission-store/permission-store-dbus.c permission-store/permission-store-dbus.h
 BUILT_SOURCES += $(nodist_xdg_permission_store_SOURCES)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -60,7 +60,7 @@ tests/services/org.freedesktop.Flatpak.SystemHelper.service: system-helper/org.f
 	mkdir -p tests/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" -e "s|\@extraargs\@| --session --no-idle-exit|" $< > $@
 
-tests/libtest.sh: tests/services/org.freedesktop.impl.portal.PermissionStore.service tests/services/org.freedesktop.portal.Documents.service  tests/services/org.freedesktop.Flatpak.service
+tests/libtest.sh: tests/services/org.freedesktop.impl.portal.PermissionStore.service tests/services/org.freedesktop.portal.Documents.service  tests/services/org.freedesktop.Flatpak.service tests/services/org.freedesktop.Flatpak.SystemHelper.service
 
 install-test-data-hook:
 if ENABLE_INSTALLED_TESTS
@@ -127,7 +127,11 @@ dist_test_scripts = \
 	tests/test-update-remote-configuration.sh \
 	$(NULL)
 
-test_programs = testdb test-doc-portal testlibrary
+test_programs = testlibrary
+
+if ENABLE_DOCUMENT_PORTAL
+test_programs += testdb test-doc-portal
+endif
 
 @VALGRIND_CHECK_RULES@
 VALGRIND_SUPPRESSIONS_FILES=tests/flatpak.supp tests/glib.supp


### PR DESCRIPTION
This disallows the installation of the document portal and
this option should be used when building the 0.10.x branch in
combination with the new xdg-desktop-portal release that contains
the document portal.