### PR TITLE
configure: Fix copy_file_range detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,21 @@ else
 fi
 
 AC_CHECK_FUNCS(fdwalk)
+
 LIBGLNX_CONFIGURE
+# This is copied from a newer libglnx: https://github.com/GNOME/libglnx/commit/4577dc826a923d976ad1a98b4ed5ecc36eac6efe
+# We do this manually in the 0.10.x branch instead of bumping libglnx as on master
+AC_CHECK_DECLS([copy_file_range],
+        [], [], [[
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/mount.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <linux/loop.h>
+#include <linux/random.h>
+]])
+
 
 AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
 AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])


### PR DESCRIPTION
This is a manual copy of
  https://github.com/GNOME/libglnx/commit/4577dc826a923d976ad1a98b4ed5ecc36eac6efe

This way we don't have to update the libglnx dependency on the stable
branch.