### PR TITLE
Discover pulseaudio socket the way pulseaudio does it

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2018-01-25 14:08+0100\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: Czech <gnome-cs-list@gnome.org>\n"
@@ -150,7 +150,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NÁZEV UMÍSTĚNÍ - Přidat vzdálený repozitář"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "NÁZEV musí být určen"
 
@@ -168,7 +168,7 @@ msgstr "UMÍSTĚNÍ musí být určeno"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -234,7 +234,7 @@ msgstr "Architektura, pro kterou se má vytvořit balík"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Missing '=' in bind mount option '%s'"
 msgstr ""
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Není možné spustit aplikaci"
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "LOCATION and FILENAME must be specified"
 msgstr "UMÍSTĚNÍ a NÁZEV_SOUBORU musí být určeny"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Architektura, která se má použít"
@@ -1100,127 +1100,148 @@ msgstr "Nelze přepnout gid"
 msgid "Can't switch uid"
 msgstr "Nelze přepnout uid"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Zobrazit uživatelské instalace"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Zobrazit systémové instalace"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Zobrazit specifické systémové instalace"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Zobrazit referenci"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Zobrazit commit"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Zobrazit původ"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Zobrazit velikost"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Zobrazit metadata"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Zobrazit rozšíření"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Správa přístupu k souborům"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "CESTA"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Zobrazit rozšíření"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NÁZEV [VĚTEV] - Získat informace o instalované aplikaci a/nebo prostředí"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Ref:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "ID:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Architektura:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Větev:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Původ:"
 
-#: app/flatpak-builtins-info-remote.c:203
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
 msgid "Collection ID:"
 msgstr "ID kolekce:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr "Datum:"
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr "Předmět:"
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Aktivní commit:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Poslední commit:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Commit:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "alt-id:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr "Rodič:"
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Umístění:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Instalovaná velikost:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Prostředí:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Instalované podadresáře:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Rozšíření:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Podcesty:"
 
@@ -1245,36 +1266,41 @@ msgstr "Zobrazit záznam"
 msgid "Show parent"
 msgstr "Zobrazit rodiče"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 " VZDÁLENÉ REF - Zobrazit informace o aplikaci nebo prostředí ve vzdáleném "
 "repozitáři"
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "VZDÁLENÉ a REF musí být určeny"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 msgid "Download size:"
 msgstr "Stahovaná velikost:"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr "Historie:\n"
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr " Předmět:"
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr " Datum:"
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 msgid " Commit:"
 msgstr " Commit:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1312,10 +1338,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Instalovat pouze tuto podcestu"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "CESTA"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1476,7 +1498,7 @@ msgstr "Commit"
 msgid "Download size"
 msgstr "Stahovaná velikost"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "V repozitáři nejsou dostupné žádné ref informace"
 
@@ -1682,35 +1704,35 @@ msgstr "Povolit přesměrování souboru"
 msgid "APP [args...] - Run an app"
 msgstr "APLIKACE [argumenty...] - Spustit aplikaci"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr "TEXT - Vyhledat text ve vzdálených aplikacích/prostředích"
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 msgid "TEXT must be specified"
 msgstr "TEXT musí být určen"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 msgid "Application ID"
 msgstr "ID aplikace"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr "Verze"
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 msgid "Branch"
 msgstr "Větev"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 msgid "Remotes"
 msgstr "Vzdálené repozitáře"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 msgid "Description"
 msgstr "Popis"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 msgid "No matches found"
 msgstr "Nenalezeny žádné shody"
 
@@ -1776,31 +1798,11 @@ msgstr "Aktualizovat appstream pro vzdálený repozitář"
 msgid "Only update this subpath"
 msgstr "Aktualizovat pouze tuto podcestu"
 
-#: app/flatpak-builtins-update.c:107
-#, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Aktualizuji appstream data pro uživatelský vzdálený repozitář %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Aktualizuji appstream data pro vzdálený repozitář %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, c-format
-msgid "Error updating: %s\n"
-msgstr "Chyba během aktualizace: %s\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr "Vzdálený repozitář „%s“ nebyl nalezen"
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REF...] - Aktualizovat aplikace nebo prostředí"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 msgid "Looking for updates...\n"
 msgstr "Vyhledávají se aktualizace...\n"
 
@@ -1819,6 +1821,26 @@ msgid "No remote chosen to resolve ‘%s’ which exists in multiple installatio
 msgstr ""
 "Nebyl vybrán žádný vzdálený repozitář pro vyřešení „%s“, který existuje ve "
 "více instalacích"
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Aktualizuji appstream data pro uživatelský vzdálený repozitář %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Aktualizuji appstream data pro vzdálený repozitář %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, c-format
+msgid "Error updating: %s\n"
+msgstr "Chyba během aktualizace: %s\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
+msgstr "Vzdálený repozitář „%s“ nebyl nalezen"
 
 #. translators: please keep the leading space
 #: app/flatpak-main.c:62
@@ -1971,7 +1993,8 @@ msgid "Export a build dir to a repository"
 msgstr "Exportovat adresář sestavení do repozitáře"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Vytvořit soubor balíku z adresáře sestavení"
 
 #: app/flatpak-main.c:105
@@ -2043,22 +2066,22 @@ msgstr "NÁZEV"
 msgid "Builtin Commands:"
 msgstr "Vestavěné příkazy:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Neznámý příkaz „%s“"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Nebyl určen žádný příkaz"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "chyba:"
 
@@ -2090,9 +2113,9 @@ msgstr "Požadované prostředí pro %s (%s) není nainstalováno, vyhledává s
 msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr "Požadované prostředí %s nebylo nalezeno v nastaveném repozitáři.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2198,320 +2221,37 @@ msgstr "Chyba: Selhalo %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "Jedna nebo více operací selhalo"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr ""
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Během otevírání repozitáře %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Nemohu vytvořit adresář sestavení"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Neplatný sha256 pro dodatečná data uri %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Prázdný název pro uri dodatečných dat %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Nepodporovaný uri dodatečných dat %s"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Chyba během načítání místních dodatečných dat %s: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Chybná velikost pro dodatečná data %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Během stahování %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Chybná velikost pro dodatečná data %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Neplatný kontrolní součet pro dodatečná data %s"
-
-#: common/flatpak-dir.c:2742
-msgid "Remote OCI index has no registry uri"
-msgstr ""
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s commit %s je již nainstalováno"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Během stahování %s ze vzdáleného repozitáře %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Nemohu nalézt %s ve vzdáleném repozitáři %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Nedostatek paměti"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Selhalo čtení z exportovaného souboru"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Chyba při čtení mimetype xml souboru"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Neplatný mimetype xml soubor"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr ""
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr ""
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Neplatný sha256 pro dodatečná data"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Chybná velikost pro dodatečná data"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Neplatný kontrolní součet pro dodatečná data"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Během zapisování souboru dodatečných dat „%s“: "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "apply_extra skript selhal, návratová hodnota %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Během pokusu o vyřešení ref %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s není dostupné"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s větev %s je již nainstalováno"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Nelze číst commit %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr ""
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr ""
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Během pokusu o odstranění existujícího dodatečného adresáře: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Během pokusu o aplikaci dodatečných dat: "
-
-#: common/flatpak-dir.c:5433
-#, c-format
-msgid "Invalid deployed ref %s: "
-msgstr ""
-
-#: common/flatpak-dir.c:5440
-#, c-format
-msgid "Invalid commit ref %s: "
-msgstr ""
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr ""
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Tato verze aplikace %s je již nainstalována"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Nemohu změnit vzdálený repozitář během instalace balíčku"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s větev %s není nainstalováno"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s větev %s nenainstalováno"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr "Pro %s je dostupno více větví, musíte určit jednu z nich: "
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Nic nevyhovuje názvu %s"
-
-#: common/flatpak-dir.c:8119
-#, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Nemohu nalézt ref %s%s%s%s%s"
-
-#: common/flatpak-dir.c:8161
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Chyba během prohledávání vzdáleného repozitáře %s: %s"
-
-#: common/flatpak-dir.c:8206
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr "Chyba během prohledávání místního repozitáře: %s"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s nenainstalováno"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Nemohu nalézt instalaci %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Prostředí %s, větev %s je již nainstalováno"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Aplikace %s, větev %s je již nainstalováno"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Jméno vzdáleného adresáře nenastaveno"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Vzdálený default-branch nenastaven"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "Žádná cache ve vzdáleném shrnutí"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Žádný záznam pro %s v cache vzdáleného shrnutí "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Neplatný název dbus %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2520,153 +2260,436 @@ msgstr ""
 "Neplatné umístění systému souborů %s, platná umístění jsou: host, home, xdg-"
 "*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Neplatný formát env %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Sdílet s hostitelem"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "SDÍLET"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Zrušit sdílení s hostitelem"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Odhalit soket aplikaci"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOKET"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Neodhalovat soket aplikaci"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Odhalit zařízení aplikaci"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "ZAŘÍZENÍ"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Neodhalovat zařízení aplikaci"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Umožnit funkci"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "FUNKCE"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Neumožnit funkci"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Odhalit systém souborů aplikaci (:ro pro přístup pouze ke čtení)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "SYSTÉM_SOUBORŮ[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Neodhalovat systém souborů aplikaci"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "SYSTÉM_SOUBORŮ"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Nastavit proměnnou prostředí"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "PROMĚNNÁ=HODNOTA"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Povolit aplikaci vlastnit název na sběrnici sezení"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "NÁZEV_DBUS"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Povolit aplikaci komunikovat s názvem na sběrnici sezení"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Povolit aplikaci vlastnit název na systémové sběrnici"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Povolit aplikaci komunikovat s názvem na systémové sběrnici"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Přidat generickou volbu bezpečnostní politiky"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSYSTEM.KLÍČ=HODNOTA"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Odebrat generickou volbu bezpečnostní politiky"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Trvalý domovský adresář"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "NÁZEV_SOUBORU"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Nevyžadovat běžící sezení (bez vytvoření cgroups)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr ""
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Během otevírání repozitáře %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Nemohu vytvořit adresář sestavení"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Neplatný sha256 pro dodatečná data uri %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Prázdný název pro uri dodatečných dat %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Nepodporovaný uri dodatečných dat %s"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Chyba během načítání místních dodatečných dat %s: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Chybná velikost pro dodatečná data %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Během stahování %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Chybná velikost pro dodatečná data %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Neplatný kontrolní součet pro dodatečná data %s"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr ""
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s commit %s je již nainstalováno"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Během stahování %s ze vzdáleného repozitáře %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Nemohu nalézt %s ve vzdáleném repozitáři %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Nedostatek paměti"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Selhalo čtení z exportovaného souboru"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Chyba při čtení mimetype xml souboru"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Neplatný mimetype xml soubor"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr ""
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr ""
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Neplatný sha256 pro dodatečná data"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Chybná velikost pro dodatečná data"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Neplatný kontrolní součet pro dodatečná data"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Během zapisování souboru dodatečných dat „%s“: "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "apply_extra skript selhal, návratová hodnota %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Během pokusu o vyřešení ref %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s není dostupné"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s větev %s je již nainstalováno"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Nelze číst commit %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr ""
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr ""
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Během pokusu o odstranění existujícího dodatečného adresáře: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Během pokusu o aplikaci dodatečných dat: "
+
+#: common/flatpak-dir.c:5451
+#, c-format
+msgid "Invalid deployed ref %s: "
+msgstr ""
+
+#: common/flatpak-dir.c:5458
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr ""
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr ""
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Tato verze aplikace %s je již nainstalována"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Nemohu změnit vzdálený repozitář během instalace balíčku"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s větev %s není nainstalováno"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s větev %s nenainstalováno"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr "Pro %s je dostupno více větví, musíte určit jednu z nich: "
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Nic nevyhovuje názvu %s"
+
+#: common/flatpak-dir.c:8147
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Nemohu nalézt ref %s%s%s%s%s"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Chyba během prohledávání vzdáleného repozitáře %s: %s"
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Chyba během prohledávání místního repozitáře: %s"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s nenainstalováno"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Nemohu nalézt instalaci %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Prostředí %s, větev %s je již nainstalováno"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Aplikace %s, větev %s je již nainstalováno"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Jméno vzdáleného adresáře nenastaveno"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Vzdálený default-branch nenastaven"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Žádná cache ve vzdáleném shrnutí"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Žádný záznam pro %s v cache vzdáleného shrnutí "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Selhalo otevření dočasného souboru flatpak-info: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Selhalo otevření dočasného souboru: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Selhalo vytvoření synchronizační roury"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Selhalo otevření souboru s informacemi o aplikaci: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Selhala synchronizace s dbus proxy"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "ldconfig selhal, návratová hodnota %d"
@@ -2681,144 +2704,86 @@ msgstr "Migruji %s do %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Chyba během migrace: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Žádné zdroje dodatečných dat"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Stahuji metadata: %u/(odhadováno) %s"
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Stahuji: %s/%s"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Stahuji dodatečná data: %s/%s"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Stahuji soubory: %d/%d %s"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Instalovat podepsanou aplikaci"
+#~ msgid "Install signed application"
+#~ msgstr "Instalovat podepsanou aplikaci"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "K instalaci softwaru je vyžadováno ověření"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "K instalaci softwaru je vyžadováno ověření"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Instalovat podepsané prostředí"
+#~ msgid "Install signed runtime"
+#~ msgstr "Instalovat podepsané prostředí"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Aktualizovat podepsanou aplikaci"
+#~ msgid "Update signed application"
+#~ msgstr "Aktualizovat podepsanou aplikaci"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "K aktualizaci softwaru je vyžadováno ověření"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "K aktualizaci softwaru je vyžadováno ověření"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Aktualizovat podepsané prostředí"
+#~ msgid "Update signed runtime"
+#~ msgstr "Aktualizovat podepsané prostředí"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Aktualizovat vzdálená metadata"
+#~ msgid "Update remote metadata"
+#~ msgstr "Aktualizovat vzdálená metadata"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr "K aktualizaci vzdálených informací je vyžadováno ověření"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "K aktualizaci vzdálených informací je vyžadováno ověření"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
-msgid "Update system repository"
-msgstr "Aktualizovat systémový repozitář"
+#~ msgid "Update system repository"
+#~ msgstr "Aktualizovat systémový repozitář"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
-msgid "Authentication is required to update the system repository"
-msgstr "K aktualizaci systémového repozitáře je vyžadováno ověření"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "K aktualizaci systémového repozitáře je vyžadováno ověření"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Instalovat balík"
+#~ msgid "Install bundle"
+#~ msgstr "Instalovat balík"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Odinstalovat prostředí"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Odinstalovat prostředí"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "K odinstalování softwaru je vyžadováno ověření"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "K odinstalování softwaru je vyžadováno ověření"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Odinstalovat aplikaci"
+#~ msgid "Uninstall app"
+#~ msgstr "Odinstalovat aplikaci"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Nastavit vzdálený repozitář"
+#~ msgid "Configure Remote"
+#~ msgstr "Nastavit vzdálený repozitář"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "K nastavení repozitářů softwaru je vyžadováno ověření"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr "K nastavení repozitářů softwaru je vyžadováno ověření"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
-msgid "Configure"
-msgstr "Nastavit"
+#~ msgid "Configure"
+#~ msgstr "Nastavit"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
-msgid "Authentication is required to configure software installation"
-msgstr "K nastavení instalace softwaru je vyžadováno ověření"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr "K nastavení instalace softwaru je vyžadováno ověření"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Aktualizovat appstream"
+#~ msgid "Update appstream"
+#~ msgstr "Aktualizovat appstream"
 
 #~ msgid "No remote %s"
 #~ msgstr "Žádný vzdálený repozitář %s"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-04-07 13:52+0200\n"
 "Last-Translator: Mario Blättermann <mario.blaettermann@gmail.com>\n"
 "Language-Team: German <gnome-de@gnome.org>\n"
@@ -157,7 +157,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NAME ORT - Eine ferne Quelle hinzufügen"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "NAME muss angegeben werden"
 
@@ -175,7 +175,7 @@ msgstr "ORT muss angegeben werden"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -241,7 +241,7 @@ msgstr "Architektur für die gebündelt wird"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -402,7 +402,7 @@ msgstr "Kein Erweiterungspunkt entspricht %s in %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Fehlendes »=« in Bind-Mount-Option »%s«"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Anwendung kann nicht gestartet werden"
 
@@ -806,7 +806,7 @@ msgstr "ORT DATEINAME - Ein Dateibündel in eine lokale Quelle importieren"
 msgid "LOCATION and FILENAME must be specified"
 msgstr "ORT und DATEINAME müssen angegeben werden"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Zu verwendende Architektur"
@@ -1122,131 +1122,157 @@ msgstr "Gruppenkennung kann nicht gewechselt werden"
 msgid "Can't switch uid"
 msgstr "Benutzerkennung kann nicht gewechselt werden"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Benutzerinstallationen anzeigen"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Systemweite Installationen anzeigen"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Spezifische systemweite Installationen anzeigen"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Referenz anzeigen"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Commit anzeigen"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Ursprung anzeigen"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 #, fuzzy
 msgid "Show size"
 msgstr "Referenz anzeigen"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 #, fuzzy
 msgid "Show metadata"
 msgstr "Details zur entfernten Quelle anzeigen"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Hilfeoptionen anzeigen"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Dateizugriff verwalten"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "PFAD"
+
+#: app/flatpak-builtins-info.c:62
 #, fuzzy
 msgid "Show extensions"
 msgstr "Hilfeoptionen anzeigen"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NAME [ZWEIG] - Informationen über installierte Anwendung und/oder Laufzeit "
 "erhalten"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 #, fuzzy
 msgid "Branch:"
 msgstr "Zu verwendender Zweig"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Eine Anwendung ausführen"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 #, fuzzy
 msgid "Installed size:"
 msgstr "Signierte Laufzeitumgebung installieren"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 #, fuzzy
 msgid "Runtime:"
 msgstr "Zu verwendende Laufzeitumgebung"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 #, fuzzy
 msgid "Extension:"
 msgstr "Hilfeoptionen anzeigen"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr ""
 
@@ -1272,37 +1298,42 @@ msgstr ""
 msgid "Show parent"
 msgstr "Referenz anzeigen"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 #, fuzzy
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr "Anwendung oder Laufzeit von einer entfernten Quelle installieren"
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "FERNE QUELLE und REFERENZ muss angegeben werden"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "Referenz anzeigen"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Commit anzeigen"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1341,10 +1372,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Nur diesen Unterpfad installieren"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "PFAD"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1505,7 +1532,7 @@ msgstr ""
 msgid "Download size"
 msgstr "Referenz anzeigen"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 #, fuzzy
 msgid "No ref information available in repository"
 msgstr "DATEI - Informationen über die exportierte Datei erhalten"
@@ -1720,40 +1747,40 @@ msgstr ""
 msgid "APP [args...] - Run an app"
 msgstr "ANWENDUNG [Argumente …] - Eine Anwendung ausführen"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "ENTFERNTE QUELLE muss angegeben werden"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "Eine Anwendung ausführen"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Zu verwendender Zweig"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "Keine entfernte Quelle %s"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Vollständige Beschreibung"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "Kein Treffer für %s"
@@ -1822,31 +1849,11 @@ msgstr "Appstream für entfernte Quelle aktualisieren"
 msgid "Only update this subpath"
 msgstr "Nur diesen Unterpfad aktualisieren"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Appstream für ferne Quelle %s wird aktualisiert\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Appstream für ferne Quelle %s wird aktualisiert\n"
-
-#: app/flatpak-builtins-update.c:113
-#, fuzzy, c-format
-msgid "Error updating: %s\n"
-msgstr "Zusammenfassung wird aktualisiert\n"
-
-#: app/flatpak-builtins-update.c:143
-#, fuzzy, c-format
-msgid "Remote \"%s\" not found"
-msgstr "Daten wurden nicht gefunden"
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REF…] - Anwendungen oder Laufzeitumgebungen aktualisieren"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 #, fuzzy
 msgid "Looking for updates...\n"
 msgstr "Nach %s suchen\n"
@@ -1865,6 +1872,26 @@ msgstr "Was wollen Sie installieren (0 zum Abbrechen)?"
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
 msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Appstream für ferne Quelle %s wird aktualisiert\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Appstream für ferne Quelle %s wird aktualisiert\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, fuzzy, c-format
+msgid "Error updating: %s\n"
+msgstr "Zusammenfassung wird aktualisiert\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, fuzzy, c-format
+msgid "Remote \"%s\" not found"
+msgstr "Daten wurden nicht gefunden"
 
 #. translators: please keep the leading space
 #: app/flatpak-main.c:62
@@ -2018,7 +2045,8 @@ msgid "Export a build dir to a repository"
 msgstr "Erstellungsordner in eine Quelle exportieren"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Eine Bündel-Datei aus einem Erstellungsordner erzeugen"
 
 #: app/flatpak-main.c:105
@@ -2094,22 +2122,22 @@ msgstr "DATEINAME"
 msgid "Builtin Commands:"
 msgstr "Eingebaute Befehle:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Unbekannter Befehl »%s«"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Kein Befehl angegeben"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "Fehler:"
 
@@ -2144,9 +2172,9 @@ msgstr ""
 "Die erforderliche Laufzeit %s wurde in keiner konfigurierten entfernten "
 "Quelle gefunden.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2252,323 +2280,37 @@ msgstr "Fehler: %s %s ist fehlgeschlagen: %s\n"
 msgid "One or more operations failed"
 msgstr "Ein oder mehrere Vorgänge sind fehlgeschlagen"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Keine Ersetzungen für %s gefunden"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Während des Öffnens der Quelle %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Bereitstellungsordner konnte nicht erstellt werden"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Ungültiges sha256 für die Adresse %s der Extradaten"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Leerer Name für die Adresse %s der Extradaten"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Nicht unterstützte Adresse %s der Extradaten"
-
-#: common/flatpak-dir.c:2647
-#, fuzzy, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Commit %s konnte nicht gelesen werden: "
-
-#: common/flatpak-dir.c:2650
-#, fuzzy, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Falsche Größe für Extradaten %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Während des Herunterladens von %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Falsche Größe für Extradaten %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Ungültige Prüfsumme für Extradaten %s"
-
-#: common/flatpak-dir.c:2742
-#, fuzzy
-msgid "Remote OCI index has no registry uri"
-msgstr "NAME [ORT] - eine ferne Quelle hinzufügen"
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s-Commit %s wurde bereits installiert"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Während des Holens von %s von der entfernten Quelle %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "%s konnte nicht in entfernter Quelle %s gefunden werden"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Nicht genug Speicher"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Lesen aus der exportierten Datei fehlgeschlagen"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Während des Versuchs, abgekoppelte Metadaten zu holen: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Beim Anlegen von extradir: "
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Ungültige sha256 für zusätzliche Daten"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Falsche Größe für zusätzliche Daten"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Ungültige Prüfsumme für zusätzliche Daten"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Fehler beim Schreiben der zusätzlichen Datendatei: »%s«: "
-
-#: common/flatpak-dir.c:5181
-#, fuzzy, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "Skript apply_extra ist fehlgeschlagen"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Während des Auflösens der Referenz %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s ist nicht verfügbar"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s Zweig %s wurde bereits installiert"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Commit %s konnte nicht gelesen werden: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Während des Versuchs, eine Arbeitskopie von %s nach %s zu erstellen: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr ""
-"Während des Versuchs, eine Arbeitskopie des Metadaten-Unterordners zu "
-"erstellen: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Während des Versuchs, den bestehenden Extraordner zu entfernen: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Während des Versuchs, zusätzliche Daten anzuwenden: "
-
-#: common/flatpak-dir.c:5433
-#, fuzzy, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Ungültige Prozesskennung %s"
-
-#: common/flatpak-dir.c:5440
-#, fuzzy, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Ungültige Prozesskennung %s"
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr ""
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Diese Version von %s ist bereits installiert"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr ""
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s Zweig %s ist nicht installiert"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s Zweig %s ist nicht installiert"
-
-#: common/flatpak-dir.c:7489
-#, fuzzy, c-format
-msgid "Pruning repo failed: %s"
-msgstr "Zugehörige werden installiert: %s\n"
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Kein Treffer für %s"
-
-#: common/flatpak-dir.c:8119
-#, fuzzy, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "%s%s%s%s%s kann nicht in ferner Quelle %s gefunden werden"
-
-#: common/flatpak-dir.c:8161
-#, fuzzy, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Fehler: %s %s ist fehlgeschlagen: %s\n"
-
-#: common/flatpak-dir.c:8206
-#, fuzzy, c-format
-msgid "Error searching local repository: %s"
-msgstr "Referenz in lokaler Quelle behalten"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s ist nicht installiert"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Installation %s konnte nicht gefunden werden"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Laufzeitumgebung %s, Zweig %s ist bereits installiert"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Anwendung %s, Zweig %s ist bereits installiert"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Entfernter Titel nicht gesetzt"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Vorgabe-Zweig für ferne Quelle nicht definiert"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr ""
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr ""
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Unbekannter Freigabetyp %s, zulässige Typen sind: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Unbekannter Regeltyp %s, zulässige Typen sind: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Ungültiger Dbus-Name %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Unbekannter Socket-Typ %s, zulässige Typen sind: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Unbekannter Gerätetyp %s, zulässige Typen sind: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Unbekannter Funktionstyp %s, zulässige Typen sind: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, fuzzy, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2577,158 +2319,444 @@ msgstr ""
 "Unbekannter Dateisystem-Ort %s, zulässige Typen sind: host, home, xdg-"
 "*[/...], ~/Ordner, /Ordner"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Ungültiges Umgebungsformat: %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Mit Rechner teilen"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "FREIGABE"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Freigabe für Rechner aufheben"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Socket für die Anwendung sichtbar machen"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOCKET"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Socket vor der Anwendung verbergen"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Gerät für die Anwendung sichtbar machen"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "GERÄT"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Gerät vor der Anwendung verbergen"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Funktion erlauben"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "FUNKTION"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Funktion nicht erlauben"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr ""
 "Das Dateisystem für die Anwendung sichtbar machen (:ro für schreibgeschützt)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "DATEISYSTEM[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Das Dateisystem vor der Anwendung verbergen"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "DATEISYSTEM"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Umgebungsvariable festlegen"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "VAR=WERT"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr ""
 "Der Anwendung erlauben, einen Namen auf dem Sitzungsbus zu beanspruchen"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "DBUS_NAME"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Der Anwendung erlauben, mit Namen auf dem Sitzungsbus zu kommunizieren"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr ""
 "Der Anwendung erlauben, einen Namen auf dem Sitzungsbus zu beanspruchen"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Der Anwendung erlauben, mit Namen auf dem Systembus zu kommunizieren"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Allgemeine Richtlinien-Einstellungen hinzufügen"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSYSTEM.SCHLÜSSEL=WERT"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Allgemeine Richtlinien-Einstellungen entfernen"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Basisordner beständig machen"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "DATEINAME"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr ""
 "Laufende Sitzung als nicht erforderlich festlegen (keine Erstellung von "
 "cgroups)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Keine Ersetzungen für %s gefunden"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Während des Öffnens der Quelle %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Bereitstellungsordner konnte nicht erstellt werden"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Ungültiges sha256 für die Adresse %s der Extradaten"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Leerer Name für die Adresse %s der Extradaten"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Nicht unterstützte Adresse %s der Extradaten"
+
+#: common/flatpak-dir.c:2661
+#, fuzzy, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Commit %s konnte nicht gelesen werden: "
+
+#: common/flatpak-dir.c:2664
+#, fuzzy, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Falsche Größe für Extradaten %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Während des Herunterladens von %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Falsche Größe für Extradaten %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Ungültige Prüfsumme für Extradaten %s"
+
+#: common/flatpak-dir.c:2756
+#, fuzzy
+msgid "Remote OCI index has no registry uri"
+msgstr "NAME [ORT] - eine ferne Quelle hinzufügen"
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s-Commit %s wurde bereits installiert"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Während des Holens von %s von der entfernten Quelle %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "%s konnte nicht in entfernter Quelle %s gefunden werden"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Nicht genug Speicher"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Lesen aus der exportierten Datei fehlgeschlagen"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Während des Versuchs, abgekoppelte Metadaten zu holen: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Beim Anlegen von extradir: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Ungültige sha256 für zusätzliche Daten"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Falsche Größe für zusätzliche Daten"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Ungültige Prüfsumme für zusätzliche Daten"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Fehler beim Schreiben der zusätzlichen Datendatei: »%s«: "
+
+#: common/flatpak-dir.c:5199
+#, fuzzy, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "Skript apply_extra ist fehlgeschlagen"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Während des Auflösens der Referenz %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s ist nicht verfügbar"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s Zweig %s wurde bereits installiert"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Commit %s konnte nicht gelesen werden: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Während des Versuchs, eine Arbeitskopie von %s nach %s zu erstellen: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr ""
+"Während des Versuchs, eine Arbeitskopie des Metadaten-Unterordners zu "
+"erstellen: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Während des Versuchs, den bestehenden Extraordner zu entfernen: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Während des Versuchs, zusätzliche Daten anzuwenden: "
+
+#: common/flatpak-dir.c:5451
+#, fuzzy, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Ungültige Prozesskennung %s"
+
+#: common/flatpak-dir.c:5458
+#, fuzzy, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Ungültige Prozesskennung %s"
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr ""
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Diese Version von %s ist bereits installiert"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr ""
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s Zweig %s ist nicht installiert"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s Zweig %s ist nicht installiert"
+
+#: common/flatpak-dir.c:7517
+#, fuzzy, c-format
+msgid "Pruning repo failed: %s"
+msgstr "Zugehörige werden installiert: %s\n"
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Kein Treffer für %s"
+
+#: common/flatpak-dir.c:8147
+#, fuzzy, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "%s%s%s%s%s kann nicht in ferner Quelle %s gefunden werden"
+
+#: common/flatpak-dir.c:8189
+#, fuzzy, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Fehler: %s %s ist fehlgeschlagen: %s\n"
+
+#: common/flatpak-dir.c:8234
+#, fuzzy, c-format
+msgid "Error searching local repository: %s"
+msgstr "Referenz in lokaler Quelle behalten"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s ist nicht installiert"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Installation %s konnte nicht gefunden werden"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Laufzeitumgebung %s, Zweig %s ist bereits installiert"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Anwendung %s, Zweig %s ist bereits installiert"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Entfernter Titel nicht gesetzt"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Vorgabe-Zweig für ferne Quelle nicht definiert"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr ""
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr ""
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Öffnen der temporären flatpak-Informationsdatei fehlgeschlagen: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Temporäre Datei konnte nicht geöffnet werden: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "»Sync-Pipe« konnte nicht erstellt werden"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Öffnen der Informationsdatei der Anwendung fehlgeschlagen: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Abgleich mit Dbus-Proxy ist fehlgeschlagen"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, fuzzy, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "Skript apply_extra ist fehlgeschlagen"
@@ -2743,150 +2771,94 @@ msgstr "Aktualisieren: %s von %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Fehler: %s %s ist fehlgeschlagen: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Keine zusätzlichen Datenquellen"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr ""
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, fuzzy, c-format
 msgid "Downloading: %s/%s"
 msgstr "Referenz anzeigen"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, fuzzy, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Referenz anzeigen"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, fuzzy, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Referenz anzeigen"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Signierte Anwendung installieren"
+#~ msgid "Install signed application"
+#~ msgstr "Signierte Anwendung installieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Legitimierung wird benötigt, um Software zu installieren"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Legitimierung wird benötigt, um Software zu installieren"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Signierte Laufzeitumgebung installieren"
+#~ msgid "Install signed runtime"
+#~ msgstr "Signierte Laufzeitumgebung installieren"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Signierte Anwendung aktualisieren"
+#~ msgid "Update signed application"
+#~ msgstr "Signierte Anwendung aktualisieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Legitimierung wird benötigt, um Software zu aktualisieren"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Legitimierung wird benötigt, um Software zu aktualisieren"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Signierte Laufzeitumgebung aktualisieren"
+#~ msgid "Update signed runtime"
+#~ msgstr "Signierte Laufzeitumgebung aktualisieren"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
 #, fuzzy
-msgid "Update remote metadata"
-msgstr "ORT - Metadaten der Quelle aktualisieren"
+#~ msgid "Update remote metadata"
+#~ msgstr "ORT - Metadaten der Quelle aktualisieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
 #, fuzzy
-msgid "Authentication is required to update remote info"
-msgstr "Legitimierung wird benötigt, um Software zu aktualisieren"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Legitimierung wird benötigt, um Software zu aktualisieren"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
 #, fuzzy
-msgid "Update system repository"
-msgstr "Zusammenfassungsdatei in einer Quelle aktualisieren"
+#~ msgid "Update system repository"
+#~ msgstr "Zusammenfassungsdatei in einer Quelle aktualisieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
 #, fuzzy
-msgid "Authentication is required to update the system repository"
-msgstr "Legitimierung wird benötigt, um Software zu aktualisieren"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Legitimierung wird benötigt, um Software zu aktualisieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Bündel installieren"
+#~ msgid "Install bundle"
+#~ msgstr "Bündel installieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Laufzeitumgebung deinstallieren"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Laufzeitumgebung deinstallieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Legitimierung wird benötigt, um Software zu deinstallieren"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Legitimierung wird benötigt, um Software zu deinstallieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Anwendung deinstallieren"
+#~ msgid "Uninstall app"
+#~ msgstr "Anwendung deinstallieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Ferne Quelle einrichten"
+#~ msgid "Configure Remote"
+#~ msgstr "Ferne Quelle einrichten"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "Legitimierung wird benötigt, um die Softwarequellen zu konfigurieren"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr ""
+#~ "Legitimierung wird benötigt, um die Softwarequellen zu konfigurieren"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
 #, fuzzy
-msgid "Configure"
-msgstr "Ferne Quelle einrichten"
+#~ msgid "Configure"
+#~ msgstr "Ferne Quelle einrichten"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
 #, fuzzy
-msgid "Authentication is required to configure software installation"
-msgstr "Legitimierung wird benötigt, um die Softwarequellen zu konfigurieren"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr ""
+#~ "Legitimierung wird benötigt, um die Softwarequellen zu konfigurieren"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Appstream aktualisieren"
+#~ msgid "Update appstream"
+#~ msgstr "Appstream aktualisieren"
 
 #~ msgid "No remote %s"
 #~ msgstr "Keine entfernte Quelle %s"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-09-12 17:20+0200\n"
 "Last-Translator: Aitor González Fernández <reimashi@gmail.com>\n"
 "Language-Team: Spanish <gnome-es-list@gnome.org>\n"
@@ -152,7 +152,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NOMBRE LOCALIZACIÓN - Añadir un repositorio remoto"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "Se debe especificar el NOMBRE"
 
@@ -170,7 +170,7 @@ msgstr "Se debe especificar la LOCALIZACIÓN"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -239,7 +239,7 @@ msgstr "Arquitectura para empaquetar"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -403,7 +403,7 @@ msgstr "No hay un punto de extensión que coincida con %s en %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Falta un '=' en las opciones de punto de montaje '%s'"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "No se pudo iniciar la aplicación"
 
@@ -809,7 +809,7 @@ msgstr "LOCALIZACIÓN NOMBRE_ARCHIVO - Importa un paquete al repositorio local"
 msgid "LOCATION and FILENAME must be specified"
 msgstr "Se debe especificar LOCALIZACIÓN y NOMBRE_ARCHIVO"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Arquitectura a usar"
@@ -1128,124 +1128,150 @@ msgstr "No se puede cambiar el GID"
 msgid "Can't switch uid"
 msgstr "No se puede cambiar el UID"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Mostrar instalaciones del usuario"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Mostrar instalaciones del sistema"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Mostrar instalaciones especificas del sistema"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Mostrar referencia"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Mostrar commit"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Mostrar origen"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Mostrar tamaño"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Mostrar metadatos"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Mostrar extensiones"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Administrar el acceso a archivos"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "RUTA"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Mostrar extensiones"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NOMBRE [RAMA] - Obtiene información a cerca de una aplicación y/o runtime "
 "instalado"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "referencia no presente en el origen"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Referencia:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "ID:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Arquitectura:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Rama:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Origen:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "ID de colección"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Commit activo:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Ultimo commit:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Commit:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "id-alternativo:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Localización:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Tamaño de la instalación:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Runtime:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Subdirectorios de la instalación:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Extensión:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Subdirectorios:"
 
@@ -1271,36 +1297,41 @@ msgstr ""
 msgid "Show parent"
 msgstr "Mostrar referencia"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "Se debe especificar REMOTO y REFERENCIA"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "Tamaño de la descarga"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Commit:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1341,10 +1372,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Solo instalar este subdirectorio"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "RUTA"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1510,7 +1537,7 @@ msgstr "Commit"
 msgid "Download size"
 msgstr "Tamaño de la descarga"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "Información de referencia no disponible en el repositorio"
 
@@ -1723,40 +1750,40 @@ msgstr "Habilitar el reenvío de archivos"
 msgid "APP [args...] - Run an app"
 msgstr "APLICACION [argumentos...] - Ejecuta una aplicación"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "Se debe especificar REMOTO"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "ID de colección"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Rama:"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "Sin remoto %s"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Descripción completa"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "Ninguna coincidencia %s"
@@ -1823,31 +1850,11 @@ msgstr "Actualizar appstream para un repositorio remoto"
 msgid "Only update this subpath"
 msgstr "Solo actualizar este subdirectorio"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Actualizando appstream para el repositorio remoto %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Actualizando appstream para el repositorio remoto %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, fuzzy, c-format
-msgid "Error updating: %s\n"
-msgstr "Actualizando %s"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr ""
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REFERENCIA ...] - Actualiza aplicaciones y tiempos de ejecución"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 #, fuzzy
 msgid "Looking for updates...\n"
 msgstr "Sin actualizaciones.\n"
@@ -1865,6 +1872,26 @@ msgstr "¿Cual quieres instalar (0 para abortar)?"
 #: app/flatpak-builtins-utils.c:374
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
+msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Actualizando appstream para el repositorio remoto %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Actualizando appstream para el repositorio remoto %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, fuzzy, c-format
+msgid "Error updating: %s\n"
+msgstr "Actualizando %s"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
 msgstr ""
 
 #. translators: please keep the leading space
@@ -2023,7 +2050,8 @@ msgid "Export a build dir to a repository"
 msgstr "Exportar un directorio de compilación a un repositorio"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Crear un paquete desde un directorio de compilación"
 
 #: app/flatpak-main.c:105
@@ -2099,22 +2127,22 @@ msgstr "NOMBRE"
 msgid "Builtin Commands:"
 msgstr "Comandos Incorporados:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Comando desconocido '%s'"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Comando no especificado"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "error:"
 
@@ -2150,9 +2178,9 @@ msgstr ""
 "El tiempo de ejecución %s requerido no se ha podido encontrar en un "
 "repositorio remoto de entre los configurados.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2263,323 +2291,37 @@ msgstr "Error: Fallo al %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "Han fallado una o más operaciones"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "No se han encontrado anulaciones para %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Mientras se abría el repositorio %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "No se puede crear el directorio de despliegue"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr ""
-"Suma de verificación sha256 inválida para los datos adicionales de la uri %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Nombre vacío para los datos adicionales de la uri %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Uri de datos adicionales no soportada %s"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Fallo al cargar los datos adicionales locales %s: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Tamaño incorrecto en los datos adicionales %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Mientras se descargan %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Tamaño incorrecto en los datos adicionales %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Suma de verificación inválida en los datos adicionales %s"
-
-#: common/flatpak-dir.c:2742
-msgid "Remote OCI index has no registry uri"
-msgstr ""
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s commit %s ya está instalado"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Mientras se está cargando %s desde el repositorio remoto %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "No se puede encontrar %s en el repositorio remoto %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "No hay suficiente memoria"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Fallo al leer desde un archivo exportado"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Error al leer un archivo de tipo mime XML"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Archivo de tipo mime XML inválido"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Al obtener metadatos individuales: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Al crear directorios adicionales:"
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Suma de verificación sha256 inválida para los datos adicionales"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Tamaño  incorrecto para los datos adicionales"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Firma de verificación incorrecta para los datos adicionales"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Al escribir el archivo de datos adicionales '%s': "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "Ha fallado el script apply_extra, código de error %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Mientras se intentan resolver las referencias %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s no está disponible"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s rama %s ya se encuentra instalada"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Error al leer el commit %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Al intentar revisar %s en %s: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Al intentar revisar el subdirectorio de metadatos: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Al intentar eliminar el directorio extra existente:"
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Al intentar aplicar datos adicionales: "
-
-#: common/flatpak-dir.c:5433
-#, fuzzy, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "PID %s inválido"
-
-#: common/flatpak-dir.c:5440
-#, fuzzy, c-format
-msgid "Invalid commit ref %s: "
-msgstr "PID %s inválido"
-
-#: common/flatpak-dir.c:5448
-#, fuzzy, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
-
-#: common/flatpak-dir.c:5456
-#, fuzzy, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
-
-#: common/flatpak-dir.c:5464
-#, fuzzy, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
-
-#: common/flatpak-dir.c:5470
-#, fuzzy, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr "Los metadatos no coinciden con el commit"
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Esta versión de %s ya está instalada"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr ""
-"No se puede cambiar el repositorio remoto durante la instalación de un "
-"paquete"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s rama %s no está instalada"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s rama %s no instalada"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Ninguna coincidencia %s"
-
-#: common/flatpak-dir.c:8119
-#, fuzzy, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "No se ha encontrado %s%s%s%s%s en el repositorio remoto %s"
-
-#: common/flatpak-dir.c:8161
-#, fuzzy, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Error: Fallo al %s %s: %s\n"
-
-#: common/flatpak-dir.c:8206
-#, fuzzy, c-format
-msgid "Error searching local repository: %s"
-msgstr "Mantener referencia en el repositorio local"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s no instalado"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "No se pudo encontrar la instalación %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "El tiempo de ejecución %s, rama %s ya se encuentra instalado"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "La aplicación %s, rama %s ya se encuentra instalada"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Titulo de repositorio remoto no establecido"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Rama por defecto del repositorio remoto no establecida"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "No hay un caché de flatpak en el repositorio remoto"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Ninguna entrada para %s en el caché de flatpak del repositorio remoto "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Tipo de recurso compartido %s inválido, los tipos válidos son: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Tipo de póliza  %s inválida, los tipos válidos son: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Nombre dbus inválido: %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Tipo de socket desconocido %s, los tipos válidos son: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Tipo de dispositivo desconocido %s, los tipos válidos son: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Tipo de característica desconocido %s, los tipos válidos son: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2588,154 +2330,440 @@ msgstr ""
 "Ruta desconocida en el sistema de archivos %s, algunas rutas válidas son: "
 "host, home, xdg-*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Formato de entorno inválido %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Compartir con el huesped"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "COMPARTIR"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Dejar de compartir con el huesped"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Exponer socket a la aplicación"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOCKET"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "No exponer socket a la aplicación"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Exponer dispositivo a la aplicación"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "DISPOSITIVO"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "No exponer dispositivo a la aplicación"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Permitir característica"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "CARACTERÍSTICA"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "No permitir característica"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr ""
 "Exponer los archivos del sistema a la aplicación (:ro solo en modo lectura)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "SISTEMA_ARCHIVOS[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "No exponer los archivos del sistema a la aplicación"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "SISTEMA_ARCHIVOS"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Establecer variable de entorno"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "VARIABLE=VALOR"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Permitir que la aplicación tenga nombre propio en el bus de sesión"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "NOMBRE_DBUS"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Permitir a la aplicación hablar con un nombre en el bus de sesión"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Permitir que la aplicación tenga nombre propio en el bus de sistema"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Permitir a la aplicación hablar con un nombre en el bus de sistema"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Añadir opción de póliza genérica"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSISTEMA.CLAVE=VALOR"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Eliminar opción de póliza genérica"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Directorio de inicio con persistencia"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "NOMBRE_ARCHIVO"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "No requerir una sesión en ejecución (no se crearán cgroups)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "No se han encontrado anulaciones para %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Mientras se abría el repositorio %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "No se puede crear el directorio de despliegue"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr ""
+"Suma de verificación sha256 inválida para los datos adicionales de la uri %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Nombre vacío para los datos adicionales de la uri %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Uri de datos adicionales no soportada %s"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Fallo al cargar los datos adicionales locales %s: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Tamaño incorrecto en los datos adicionales %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Mientras se descargan %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Tamaño incorrecto en los datos adicionales %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Suma de verificación inválida en los datos adicionales %s"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr ""
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s commit %s ya está instalado"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Mientras se está cargando %s desde el repositorio remoto %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "No se puede encontrar %s en el repositorio remoto %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "No hay suficiente memoria"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Fallo al leer desde un archivo exportado"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Error al leer un archivo de tipo mime XML"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Archivo de tipo mime XML inválido"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Al obtener metadatos individuales: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Al crear directorios adicionales:"
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Suma de verificación sha256 inválida para los datos adicionales"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Tamaño  incorrecto para los datos adicionales"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Firma de verificación incorrecta para los datos adicionales"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Al escribir el archivo de datos adicionales '%s': "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "Ha fallado el script apply_extra, código de error %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Mientras se intentan resolver las referencias %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s no está disponible"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s rama %s ya se encuentra instalada"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Error al leer el commit %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Al intentar revisar %s en %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Al intentar revisar el subdirectorio de metadatos: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Al intentar eliminar el directorio extra existente:"
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Al intentar aplicar datos adicionales: "
+
+#: common/flatpak-dir.c:5451
+#, fuzzy, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "PID %s inválido"
+
+#: common/flatpak-dir.c:5458
+#, fuzzy, c-format
+msgid "Invalid commit ref %s: "
+msgstr "PID %s inválido"
+
+#: common/flatpak-dir.c:5466
+#, fuzzy, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
+
+#: common/flatpak-dir.c:5474
+#, fuzzy, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
+
+#: common/flatpak-dir.c:5482
+#, fuzzy, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
+
+#: common/flatpak-dir.c:5488
+#, fuzzy, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "La referencias desplegadas %s no coinciden con el commit (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Los metadatos no coinciden con el commit"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Esta versión de %s ya está instalada"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr ""
+"No se puede cambiar el repositorio remoto durante la instalación de un "
+"paquete"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s rama %s no está instalada"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s rama %s no instalada"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Ninguna coincidencia %s"
+
+#: common/flatpak-dir.c:8147
+#, fuzzy, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "No se ha encontrado %s%s%s%s%s en el repositorio remoto %s"
+
+#: common/flatpak-dir.c:8189
+#, fuzzy, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Error: Fallo al %s %s: %s\n"
+
+#: common/flatpak-dir.c:8234
+#, fuzzy, c-format
+msgid "Error searching local repository: %s"
+msgstr "Mantener referencia en el repositorio local"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s no instalado"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "No se pudo encontrar la instalación %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "El tiempo de ejecución %s, rama %s ya se encuentra instalado"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "La aplicación %s, rama %s ya se encuentra instalada"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Titulo de repositorio remoto no establecido"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Rama por defecto del repositorio remoto no establecida"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "No hay un caché de flatpak en el repositorio remoto"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Ninguna entrada para %s en el caché de flatpak del repositorio remoto "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Fallo al abrir un archivo temporal de flatpak-info: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Fallo al abrir un archivo temporal: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Ha sido imposible crear una tubería sincronizada"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Fallo al abrir el archivo de información de una aplicación: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Fallo al sincronizar con el proxy de dbus"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, fuzzy, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "Ha fallado el script apply_extra, código de error %d"
@@ -2752,152 +2780,94 @@ msgstr ""
 msgid "Error during migration: %s\n"
 msgstr "Error: Fallo al %s %s: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Sin orígenes de datos adicionales"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr ""
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, fuzzy, c-format
 msgid "Downloading: %s/%s"
 msgstr "Descargando %s"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, fuzzy, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Descargando %s"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, fuzzy, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Descargando %s"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Instalar aplicación firmada"
+#~ msgid "Install signed application"
+#~ msgstr "Instalar aplicación firmada"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "La autentificación es obligatoria para instalar un programa"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "La autentificación es obligatoria para instalar un programa"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Instalar tiempo de ejecución firmado"
+#~ msgid "Install signed runtime"
+#~ msgstr "Instalar tiempo de ejecución firmado"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Actualizar aplicación firmada"
+#~ msgid "Update signed application"
+#~ msgstr "Actualizar aplicación firmada"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "La autentificación es obligatoria para actualizar un programa"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "La autentificación es obligatoria para actualizar un programa"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Actualizar tiempo de ejecución firmado"
+#~ msgid "Update signed runtime"
+#~ msgstr "Actualizar tiempo de ejecución firmado"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Actualizar metadatos remotos"
+#~ msgid "Update remote metadata"
+#~ msgstr "Actualizar metadatos remotos"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr ""
-"La autentificación es obligatoria para actualizar la información remota"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr ""
+#~ "La autentificación es obligatoria para actualizar la información remota"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
 #, fuzzy
-msgid "Update system repository"
-msgstr "Actualizar el archivo de resumen en un repositorio"
+#~ msgid "Update system repository"
+#~ msgstr "Actualizar el archivo de resumen en un repositorio"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
 #, fuzzy
-msgid "Authentication is required to update the system repository"
-msgstr ""
-"La autentificación es obligatoria para actualizar la información remota"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr ""
+#~ "La autentificación es obligatoria para actualizar la información remota"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Instalar paquete"
+#~ msgid "Install bundle"
+#~ msgstr "Instalar paquete"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Desinstalar tiempo de ejecución"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Desinstalar tiempo de ejecución"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "La autentificación es obligatoria para desinstalar un programa"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "La autentificación es obligatoria para desinstalar un programa"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Desinstalar aplicación"
+#~ msgid "Uninstall app"
+#~ msgstr "Desinstalar aplicación"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Configurar Repositorio Remoto"
+#~ msgid "Configure Remote"
+#~ msgstr "Configurar Repositorio Remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr ""
-"La autentificación es obligatoria para configurar repositorio de software"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr ""
+#~ "La autentificación es obligatoria para configurar repositorio de software"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
 #, fuzzy
-msgid "Configure"
-msgstr "Configurar Repositorio Remoto"
+#~ msgid "Configure"
+#~ msgstr "Configurar Repositorio Remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
 #, fuzzy
-msgid "Authentication is required to configure software installation"
-msgstr ""
-"La autentificación es obligatoria para configurar repositorio de software"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr ""
+#~ "La autentificación es obligatoria para configurar repositorio de software"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Actualizar appstream"
+#~ msgid "Update appstream"
+#~ msgstr "Actualizar appstream"
 
 #~ msgid "No remote %s"
 #~ msgstr "Sin remoto %s"

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-09-26 17:32+0200\n"
 "Last-Translator: Fran Dieguez <frandieguez@gnome.org>\n"
 "Language-Team: Galician <gnome-l10n-gl@gnome.org>\n"
@@ -153,7 +153,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NOME LOCALIZACION - Engade un novo repositorio remoto"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "Debe especificar o NOME"
 
@@ -171,7 +171,7 @@ msgstr "Debe especificar a LOCALIZACION"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -239,7 +239,7 @@ msgstr "Arquitectura para empaquetar"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -399,7 +399,7 @@ msgstr "Non hai ningún punto de extensión que coincida con %s en %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Falta o «=» na opción «%s» de punto de montaxe"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Non foi posíbel iniciar o aplicativo"
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "LOCATION and FILENAME must be specified"
 msgstr "Debe especificar a LOCALIZACION e o NOMEFICHEIRO"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Arquitectura a usar"
@@ -1123,123 +1123,149 @@ msgstr "Non é posíbel trocar o GID"
 msgid "Can't switch uid"
 msgstr "Non é posíbel trocar o UID"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Mostrar instalacións do usuario"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Mostrar instalacións do sistema"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Mostrar instalacións específicas do sistema"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Mostrar referencia"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Mostrar remisión"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Mostrar orixe"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Mostrar tamaño"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Mostrar metadatos"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Mostrar extensións"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Xestionar o acceso ao ficheiro"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "RUTA"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Mostrar extensións"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NOME [RAMA] - Obtén información sobre o aplicativo e/ou runtime instalado"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "referencia non presente no orixe"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Referencia:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "ID:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Arquitectura:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Rama:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Orixe:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "ID de colección"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Remisión activa:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Última remisión:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Remisión:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "alt-id:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Localización:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Tamaño da instalación:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Runtime:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Subdirectorios da instalación:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Extensión:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Subdirectorios:"
 
@@ -1265,36 +1291,41 @@ msgstr ""
 msgid "Show parent"
 msgstr "Mostrar referencia"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "Debe especificar REMOTO e REF"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "Tamaño de descarga"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Remisión:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1332,10 +1363,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Só instalar esta subruta"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "RUTA"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1498,7 +1525,7 @@ msgstr "Remisión"
 msgid "Download size"
 msgstr "Tamaño de descarga"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "Non hai información dispoñíbel para a referencia no repositorio"
 
@@ -1709,40 +1736,40 @@ msgstr "Activar redirección de ficheiro"
 msgid "APP [args...] - Run an app"
 msgstr "APP [argumentos...] - Executa un aplicativo"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "Debe especificar o NOME"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "ID de colección"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Rama:"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "Sen remoto %s"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Descrición completa"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "Nada coincide con %s"
@@ -1809,32 +1836,11 @@ msgstr "Actualizar appstream desde o remoto"
 msgid "Only update this subpath"
 msgstr "Só actualizar esta subruta"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Actualizando appstream para o remoto %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Actualizando appstream para o remoto %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, fuzzy, c-format
-msgid "Error updating: %s\n"
-msgstr ""
-"Produciuse un erro ao actualizar os metadatos adicionais para «%s»: %s\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr ""
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REF...] - Actualizar aplicativos ou runtimes"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 #, fuzzy
 msgid "Looking for updates...\n"
 msgstr "Non hai actualizacións.\n"
@@ -1852,6 +1858,27 @@ msgstr "Cal desexa instalar (0 para abortar)?"
 #: app/flatpak-builtins-utils.c:374
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
+msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Actualizando appstream para o remoto %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Actualizando appstream para o remoto %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, fuzzy, c-format
+msgid "Error updating: %s\n"
+msgstr ""
+"Produciuse un erro ao actualizar os metadatos adicionais para «%s»: %s\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
 msgstr ""
 
 #. translators: please keep the leading space
@@ -2006,7 +2033,8 @@ msgid "Export a build dir to a repository"
 msgstr "Exportar un directorio de construción a un repositorio"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Crear un ficheiro empaquetado desde un directorio de construción"
 
 #: app/flatpak-main.c:105
@@ -2080,22 +2108,22 @@ msgstr "NOME"
 msgid "Builtin Commands:"
 msgstr "Ordes incrustadas:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Orde descoñecida «%s»"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Non se especificou ningunha orde"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "erro:"
 
@@ -2127,9 +2155,9 @@ msgstr "O runtime requirido para %s (%s) non instalado, buscando…\n"
 msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr "O runtime %s requirido non se atopou nun remoto configurado.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2236,321 +2264,37 @@ msgstr "Erro: fallou o %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "Fallaron unha ou máis operacións"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Non se atopou ningunha sobrescritura para %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Ao abrir o repositorio %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Non é posíbel crear o directorio de despregue"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "SHA256 non válido para o uri de datos adicionais %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Nome baleiro para o uri de datos adicinais %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "URI de datos adicinais %s non admitido"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Produciuse un fallo ao cargar os datos adicinais locais %s: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Tamaño dos datos adicinais incorrecto %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Ao descargar %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Tamaño dos datos adicinais %s incorrecto"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Suma de verificación non válida para os datos adicinais %s"
-
-#: common/flatpak-dir.c:2742
-msgid "Remote OCI index has no registry uri"
-msgstr ""
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s remisión %s xa instalado"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Ao obter %s desde o remoto %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Non é posíbel atopar %s no remoto %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Non hai momoria dabondo"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Produciuse un fallo ao ler o ficheiro exportado"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Produciuse un erro ao ler o ficheiro xml de mimetype"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Ficheiro xml de mimetype non válido"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Mentres se obtiñan os metadatos desanexados: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Ao crear o directorio adicional: "
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "SHA256 non válido para os datos adicionais"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Tamaño dos datos adicinais incorrecto"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Suma de verificación non válida para os datos adicinais"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Ao escribir o ficheiro de datos adicionais «%s»: "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "apply_extra script failed, estado de saída %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Ao tentar resolver a referencia %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s non está dispoñíbel"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s rama %s xa instalado"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Produciuse un fallo ao ler a remisión %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Ao tentar obter %s en %s: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Ao tentar obter a subruta de metadatos: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Ao tentar eliminar o directorio adicinal existente: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Ao tentar aplicar os datos adicionais: "
-
-#: common/flatpak-dir.c:5433
-#, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Referencia %s despregada non válida: "
-
-#: common/flatpak-dir.c:5440
-#, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Referencia de remisión %s non válida: "
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "O tipo %s da referencia despregada non coincide coa remisión (%s)"
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "O nome %s da referencia despregada non coincide coa remisión (%s)"
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr ""
-"A arquitectura %s da referencia despregada non coincide coa remisión (%s)"
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "A rama %s da referencia despregada non coincide coa remisión (%s)"
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "A referencia %s despregada non coincide coa remisión (%s)"
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr "Os metadatos despregados non coinciden coa remisión"
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Esta versión de %s xa está instalada"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Non é posíbel cambiar o remoto durante a instalación dun paquete"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s rama %s non está instalado"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s rama %s non instalado"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Nada coincide con %s"
-
-#: common/flatpak-dir.c:8119
-#, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Non se puido atopar a referencia %s%s%s%s%s"
-
-#: common/flatpak-dir.c:8161
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Produciuse un erro ao buscar o remoto %s: %s"
-
-#: common/flatpak-dir.c:8206
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr "Produciuse un erro ao buscar no repositorio local: %s"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s non está instalado"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Non foi posíbel atopar a instalación %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Runtime %s, rama %s xa está instalado"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Aplicativo %s, rama %s xa está instalado"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Título do repositorio remoto non está estabelecido"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Rama por omisión do repositorio remoto non estabelecida"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "Non hai caché de flatpak na descrición do remoto"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Non hai ningunha entrada para %s na caché de flatpak do resumo remoto "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Tipo de compartido %s descoñecido, os tipos validos son: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Tipo de normativa %s descoñecida, os tipos válidos son: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Nome de dbus %s non válido\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Tipo de socket %s descoñecido, os tipos validos son: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Tipo de dispositivo %s descoñecido, os tipos válidos son: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Tipo de característica %s descoñecida, os tipos validos son: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2559,154 +2303,438 @@ msgstr ""
 "Localización de sistema de ficheiros %s descoñecido, as localizacións "
 "válidas son: hos, home, xdg-*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Formato de env %s non válido"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Compartir co anfitrión"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "COMPARTIR"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Deixar de compartir co anfitrión"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Expoñer o socket ao aplicativo"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOCKET"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Non expoñer o socket ao aplicativo"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Expoñer o dispositivo ao aplicativo"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "DISPOSITIVO"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Non expoñer o dispositivo ao aplicativo"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Permitir característica"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "CARACTERÍSTICA"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "No permitir característica"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Expoñer o sistema de ficheiros ao aplicativo (:ro para só lectura)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "SISTEMA_FICHEIROS[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Non expoñer o sistema de ficheiros ao aplicativo"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "SISTEMA_FICHEIROS"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Estabelecer variábel de ambiente"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "VAR=VALOR"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Permitir que o aplicativo teña un nome propio no bus de sesión"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "NOME_DBUS"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Permitir ao aplicativo falar cun nome no bus de sesión"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Permitir ao aplicativo posuír un nome propio no bus do sistema"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Permitir ao aplicativo falar cun nome no bus de sistema"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Engadir unha opción de normativa xenérica"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSISTEMA.CHAVE=VALOR"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Eliminar opción de normativa xenérica"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Persistir o directorio persoal"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "NOME_FICHEIRO"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Non requirir unha sesión en execución (sen creación de cgroups)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Non se atopou ningunha sobrescritura para %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Ao abrir o repositorio %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Non é posíbel crear o directorio de despregue"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "SHA256 non válido para o uri de datos adicionais %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Nome baleiro para o uri de datos adicinais %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "URI de datos adicinais %s non admitido"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Produciuse un fallo ao cargar os datos adicinais locais %s: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Tamaño dos datos adicinais incorrecto %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Ao descargar %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Tamaño dos datos adicinais %s incorrecto"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Suma de verificación non válida para os datos adicinais %s"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr ""
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s remisión %s xa instalado"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Ao obter %s desde o remoto %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Non é posíbel atopar %s no remoto %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Non hai momoria dabondo"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Produciuse un fallo ao ler o ficheiro exportado"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Produciuse un erro ao ler o ficheiro xml de mimetype"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Ficheiro xml de mimetype non válido"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Mentres se obtiñan os metadatos desanexados: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Ao crear o directorio adicional: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "SHA256 non válido para os datos adicionais"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Tamaño dos datos adicinais incorrecto"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Suma de verificación non válida para os datos adicinais"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Ao escribir o ficheiro de datos adicionais «%s»: "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "apply_extra script failed, estado de saída %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Ao tentar resolver a referencia %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s non está dispoñíbel"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s rama %s xa instalado"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Produciuse un fallo ao ler a remisión %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Ao tentar obter %s en %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Ao tentar obter a subruta de metadatos: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Ao tentar eliminar o directorio adicinal existente: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Ao tentar aplicar os datos adicionais: "
+
+#: common/flatpak-dir.c:5451
+#, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Referencia %s despregada non válida: "
+
+#: common/flatpak-dir.c:5458
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Referencia de remisión %s non válida: "
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "O tipo %s da referencia despregada non coincide coa remisión (%s)"
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "O nome %s da referencia despregada non coincide coa remisión (%s)"
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr ""
+"A arquitectura %s da referencia despregada non coincide coa remisión (%s)"
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "A rama %s da referencia despregada non coincide coa remisión (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "A referencia %s despregada non coincide coa remisión (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Os metadatos despregados non coinciden coa remisión"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Esta versión de %s xa está instalada"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Non é posíbel cambiar o remoto durante a instalación dun paquete"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s rama %s non está instalado"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s rama %s non instalado"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Nada coincide con %s"
+
+#: common/flatpak-dir.c:8147
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Non se puido atopar a referencia %s%s%s%s%s"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Produciuse un erro ao buscar o remoto %s: %s"
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Produciuse un erro ao buscar no repositorio local: %s"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s non está instalado"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Non foi posíbel atopar a instalación %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Runtime %s, rama %s xa está instalado"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Aplicativo %s, rama %s xa está instalado"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Título do repositorio remoto non está estabelecido"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Rama por omisión do repositorio remoto non estabelecida"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Non hai caché de flatpak na descrición do remoto"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Non hai ningunha entrada para %s na caché de flatpak do resumo remoto "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Produciuse un fallo ao abrir o ficheiro temporal flatpak-info: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Produciuse un fallo ao abrir o ficheiro temporal: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Non foi posíbel crear a tubería de sincronización"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr ""
 "Produciuse un fallo ao abrir o ficheiro de información de aplicativo: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Procuciuse un fallo ao sincronizarse co proxi de dbus"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, fuzzy, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "apply_extra script failed, estado de saída %d"
@@ -2721,148 +2749,90 @@ msgstr "Actualizando: %s desde %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Produciuse un erro ao buscar o remoto %s: %s"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Non hai orixes de datos adicionais"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr ""
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, fuzzy, c-format
 msgid "Downloading: %s/%s"
 msgstr "Ao descargar %s: "
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, fuzzy, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Non hai orixes de datos adicionais"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr ""
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Instalar aplicativo asinado"
+#~ msgid "Install signed application"
+#~ msgstr "Instalar aplicativo asinado"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Requírese autenticación para instalar software"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Requírese autenticación para instalar software"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Instalar runtime asinado"
+#~ msgid "Install signed runtime"
+#~ msgstr "Instalar runtime asinado"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Actualizar aplicativo asinado"
+#~ msgid "Update signed application"
+#~ msgstr "Actualizar aplicativo asinado"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Requírese autenticación para actualizar software"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Requírese autenticación para actualizar software"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Actualizar runtime asinado"
+#~ msgid "Update signed runtime"
+#~ msgstr "Actualizar runtime asinado"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Actualizar metadatos do remoto"
+#~ msgid "Update remote metadata"
+#~ msgstr "Actualizar metadatos do remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr "Requírese autenticación para actualizar a información do remoto"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Requírese autenticación para actualizar a información do remoto"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
 #, fuzzy
-msgid "Update system repository"
-msgstr "Actualizaar o ficheiro de resumo no repositorio"
+#~ msgid "Update system repository"
+#~ msgstr "Actualizaar o ficheiro de resumo no repositorio"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
 #, fuzzy
-msgid "Authentication is required to update the system repository"
-msgstr "Requírese autenticación para actualizar a información do remoto"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Requírese autenticación para actualizar a información do remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Instalar paquete"
+#~ msgid "Install bundle"
+#~ msgstr "Instalar paquete"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Desinstalar paquete"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Desinstalar paquete"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Requírese autenticación para desinstalar software"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Requírese autenticación para desinstalar software"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Descativar aplicativo"
+#~ msgid "Uninstall app"
+#~ msgstr "Descativar aplicativo"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Configurar remoto"
+#~ msgid "Configure Remote"
+#~ msgstr "Configurar remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "Requírese autenticación para configurar os repositorios de software"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr "Requírese autenticación para configurar os repositorios de software"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
 #, fuzzy
-msgid "Configure"
-msgstr "Configurar remoto"
+#~ msgid "Configure"
+#~ msgstr "Configurar remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
 #, fuzzy
-msgid "Authentication is required to configure software installation"
-msgstr "Requírese autenticación para configurar os repositorios de software"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr "Requírese autenticación para configurar os repositorios de software"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Actualizar appstream"
+#~ msgid "Update appstream"
+#~ msgstr "Actualizar appstream"
 
 #~ msgid "No remote %s"
 #~ msgstr "Sen remoto %s"

--- a/po/hu.po
+++ b/po/hu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2018-01-26 15:02+0100\n"
 "Last-Translator: Balázs Meskó <mesko.balazs@fsf.hu>\n"
 "Language-Team: Hungarian <openscope at googlegroups dot com>\n"
@@ -150,7 +150,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NÉV HELY - Egy távoli tároló hozzáadása"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "A NÉV megadása kötelező"
 
@@ -168,7 +168,7 @@ msgstr "A HELY megadása kötelező"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -235,7 +235,7 @@ msgstr "Csomagolás ezen architektúrához"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -395,7 +395,7 @@ msgstr "Nincs %s illeszkedésű kiterjesztéspont ebben: %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Hiányzó „=” a(z) „%s” kötési csatolás kapcsolóban"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Nem indítható el az alkalmazás"
 
@@ -801,7 +801,7 @@ msgstr "HELY FÁJLNÉV - Egy fájlcsomag importálása egy helyi tárolóba"
 msgid "LOCATION and FILENAME must be specified"
 msgstr "A HELY és FÁJLNÉV megadása kötelező"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Használandó architektúra"
@@ -1119,124 +1119,150 @@ msgstr "Nem állítható át a GID"
 msgid "Can't switch uid"
 msgstr "Nem állítható át az UID"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Felhasználói telepítések megjelenítése"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Rendszerszintű telepítések megjelenítése"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Bizonyos rendszerszintű telepítések megjelenítése"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Hivatkozás megjelenítése"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Kommit megjelenítése"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Eredet megjelenítése"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Méret megjelenítése"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Metaadatok megjelenítése"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Kiterjesztések megjelenítése"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Fájlhozzáférés kezelése"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "ÚTVONAL"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Kiterjesztések megjelenítése"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NÉV [ÁG] - Információk lekérése a telepített alkalmazásról és/vagy "
 "futtatókörnyezetről"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "a hivatkozás nincs jelen az eredetben"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Hivatkozás:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "Azonosító:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Architektúra:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Ág:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Eredet:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Gyűjteményazonosító"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr "Dátum:"
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr "Tárgy:"
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Aktív kommit:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Legutolsó kommit:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Kommit:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "alternatív azonosító:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr "Szülő:"
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Hely:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Telepített méret:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Futtatókörnyezet:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Telepített alkönyvtárak:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Kiterjesztés:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Alútvonalak:"
 
@@ -1261,36 +1287,41 @@ msgstr "Napló megjelenítése"
 msgid "Show parent"
 msgstr "Szülő megjelenítése"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 " TÁVOLI HIVATKOZÁS – Információk megjelenítése az alkalmazásról vagy "
 "futtatókörnyezetről a távoli tárolóban"
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "A TÁVOLI és HIVATKOZÁS megadása kötelező"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 msgid "Download size:"
 msgstr "Letöltési méret:"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr "Előzmények:\n"
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr " Tárgy:"
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr " Dátum:"
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 msgid " Commit:"
 msgstr " Kommit:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1329,10 +1360,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Csak ezen alútvonal telepítése"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "ÚTVONAL"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1496,7 +1523,7 @@ msgstr "Kommit"
 msgid "Download size"
 msgstr "Letöltési méret"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "Nem érhetőek el hivatkozásinformációk a tárolóban"
 
@@ -1706,36 +1733,36 @@ msgstr "Fájltovábbítás engedélyezése"
 msgid "APP [args...] - Run an app"
 msgstr "ALKALMAZÁS [argumentumok…] - Alkalmazás futtatása"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 "SZÖVEG – Távoli alkalmazások vagy futtatókörnyezetek keresése a szöveghez"
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 msgid "TEXT must be specified"
 msgstr "A SZÖVEG megadása kötelező"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 msgid "Application ID"
 msgstr "Alkalmazásazonosító"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr "Verzió"
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 msgid "Branch"
 msgstr "Ág"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 msgid "Remotes"
 msgstr "Távoli tárolók"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 msgid "Description"
 msgstr "Leírás"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 msgid "No matches found"
 msgstr "Nincs találat"
 
@@ -1801,31 +1828,11 @@ msgstr "Az AppStream frissítése a távolihoz"
 msgid "Only update this subpath"
 msgstr "Csak ezen alútvonal frissítése"
 
-#: app/flatpak-builtins-update.c:107
-#, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Az appstream adatok frissítése a felhasználó %s távoli tárolójához\n"
-
-#: app/flatpak-builtins-update.c:109
-#, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Az appstream adatok frissítése a(z) %s távoli tárolóhoz\n"
-
-#: app/flatpak-builtins-update.c:113
-#, c-format
-msgid "Error updating: %s\n"
-msgstr "Hiba a frissítéskor: %s\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr "A(z) „%s” távoli tároló nem található"
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[HIVATKOZÁS…] – Alkalmazások vagy futtatókörnyezetek frissítése"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 msgid "Looking for updates...\n"
 msgstr "Frissítések keresése…\n"
 
@@ -1844,6 +1851,26 @@ msgid "No remote chosen to resolve ‘%s’ which exists in multiple installatio
 msgstr ""
 "Nem lett távoli tároló kiválasztva a(z) „%s” feloldásához, amely több "
 "telepítésben is létezik"
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Az appstream adatok frissítése a felhasználó %s távoli tárolójához\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Az appstream adatok frissítése a(z) %s távoli tárolóhoz\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, c-format
+msgid "Error updating: %s\n"
+msgstr "Hiba a frissítéskor: %s\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
+msgstr "A(z) „%s” távoli tároló nem található"
 
 #. translators: please keep the leading space
 #: app/flatpak-main.c:62
@@ -1998,7 +2025,8 @@ msgid "Export a build dir to a repository"
 msgstr "Összeállítási könyvtár exportálása tárolóba"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Csomagfájl létrehozása összeállítási könyvtárból"
 
 #: app/flatpak-main.c:105
@@ -2071,24 +2099,25 @@ msgstr "NÉV"
 msgid "Builtin Commands:"
 msgstr "Beépített parancsok:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
+#, fuzzy
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 "Az --installation kapcsoló többször használva volt, egy olyan parancsnál, "
 "amely csak egy telepítésnél működik"
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Ismeretlen „%s” parancs"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Nincs parancs megadva"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "hiba:"
 
@@ -2121,9 +2150,9 @@ msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr ""
 "A szükséges %s futtatókörnyezet nem található a beállított távoliban.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2229,321 +2258,37 @@ msgstr "Hiba: %s %s sikertelen: %s\n"
 msgid "One or more operations failed"
 msgstr "Egy vagy több művelet sikertelen"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Nem találhatók felülbírálások ehhez: %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "A(z) %s tároló megnyitása közben: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Nem lehet létrehozni a telepítési könyvtárat"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Érvénytelen sha256 a további adat URI-nál: %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Üres név a további adat URI-nál: %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Nem támogatott további adat URI: %s"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Nem sikerült a(z) %s helyi további adat betöltése: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Hibás méret a(z) %s további adatnál"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "A(z) %s letöltése közben: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Hibás méret a(z) %s további adatnál"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Érvénytelen ellenőrzőösszeg a(z) %s további adatnál"
-
-#: common/flatpak-dir.c:2742
-msgid "Remote OCI index has no registry uri"
-msgstr "A távoli OCI indexnek nincs regisztrációs URI-ja"
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "A(z) %s kommit %s már telepítve van"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "A(z) %s lekérése közben a(z) %s távoliról: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "A(z) %s nem található a(z) %s távoliban"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Nincs elég memória"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Nem sikerült olvasni az exportált fájlból"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Hiba a MIME-típus XML-fájl olvasásakor"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Érvénytelen MIME-típus XML-fájl"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "A különálló metaadatok lekérése közben: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "A további könyvtár létrehozása közben: "
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Érvénytelen sha256 a további adatnál"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Hibás méret a további adatnál"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Érvénytelen ellenőrzőösszeg a további adatnál"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "A(z) „%s” további adatfájl írása közben: "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "Az apply_extra parancsfájl sikertelen, kilépési állapot: %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "A(z) %s hivatkozás feloldására tett kísérlet közben: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "A(z) %s nem érhető el"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "A(z) %s %s ág már telepítve van"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Nem sikerült olvasni a(z) %s kommitot: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "A(z) %s -> %s átváltására tett kísérlet közben: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "A metaadatok alútvonalának átváltására tett kísérlet közben: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "A meglévő további könyvtár eltávolítására tett kísérlet közben: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "A további adatok alkalmazására tett kísérlet közben: "
-
-#: common/flatpak-dir.c:5433
-#, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Érvénytelen %s üzembe állított hivatkozás:"
-
-#: common/flatpak-dir.c:5440
-#, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Érvénytelen %s kommithivatkozás: "
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "Az üzembe állított %s típus nem egyezik a kommittal (%s)"
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "Az üzembe állított %s név nem egyezik a kommittal (%s)"
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr "Az üzembe állított %s architektúra nem egyezik a kommittal (%s)"
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "Az üzembe állított %s ág nem egyezik a kommittal (%s)"
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "Az üzembe állított %s hivatkozás nem egyezik a kommittal (%s)"
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr "Az üzembe állított metaadatok nem egyeznek a kommittal"
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "A(z) %s ezen verziója már telepítve van"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Nem lehet megváltoztatni a távolit csomagtelepítés közben"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "A(z) %s %s ág nincs telepítve"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "A(z) %s %s ág nincs telepítve"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr "A tároló nyesése meghiúsult: %s"
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr "Több ág is elérhető ehhez: %s, meg kell adnia az egyiket:"
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Semmi sem egyezik: %s"
-
-#: common/flatpak-dir.c:8119
-#, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "A(z) %s%s%s%s%s hivatkozás nem található"
-
-#: common/flatpak-dir.c:8161
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Hiba a távoli %s tárolóban keresésnél: %s"
-
-#: common/flatpak-dir.c:8206
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr "Hiba a helyi tárolóban keresésnél: %s"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "A(z) %s %s nincs telepítve"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Nem található a telepítési %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "A(z) %s futtatókörnyezet, %s ág már telepítve van"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "A(z) %s alkalmazás, %s ág már telepítve van"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "A távoli cím nincs beállítva"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "A távoli alapértelmezett ág nincs beállítva"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "Nincs flatpak gyorsítótár a távoli összegzésben"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr ""
-"Nincs bejegyzés a(z) %s esetén a távoli összegzés flatpak gyorsítótárban "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Ismeretlen %s megosztástípus, az érvényes típusok: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Ismeretlen %s házirendtípus, az érvényes típusok: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Ismeretlen %s D-Bus név\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Ismeretlen %s foglalattípus, az érvényes típusok: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Ismeretlen %s eszköztípus, az érvényes típusok: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Ismeretlen %s jellemzőtípus, az érvényes típusok: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2552,155 +2297,439 @@ msgstr ""
 "Ismeretlen %s fájlrendszer hely, az érvényes típusok: gép, saját könyvtár, "
 "xdg-*[/...], ~/könyvtár, /könyvtár"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Érvénytelen %s env formátum"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Megosztás a gazdagéppel"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "MEGOSZTÁS"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Megosztás megszüntetése a gazdagéppel"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Foglalat elérhetővé tétele az alkalmazásnak"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "FOGLALAT"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Ne tegye elérhetővé a foglalatot az alkalmazásnak"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Eszköz elérhetővé tétele az alkalmazásnak"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "ESZKÖZ"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Ne tegye elérhetővé az eszközt az alkalmazásnak"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Jellemző engedélyezése"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "JELLEMZŐ"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Ne engedélyezze a jellemzőt"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr ""
 "Fájlrendszer elérhetővé tétele az alkalmazásnak (:ro a csak olvashatóhoz)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "FÁJLRENDSZER[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Ne tegye elérhetővé a fájlrendszert az alkalmazásnak"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "FÁJLRENDSZER"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Környezeti változó beállítása"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "VÁLTOZÓ=ÉRTÉK"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Név birtoklásának lehetővé tétele az alkalmazásnak a munkamenetbuszon"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "DBUS_NÉV"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr ""
 "A névhez való beszéd lehetővé tétele az alkalmazásnak a munkamenetbuszon"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Név birtoklásának lehetővé tétele az alkalmazásnak a rendszerbuszon"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "A névhez való beszéd lehetővé tétele az alkalmazásnak a rendszerbuszon"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Általános irányelv-lehetőség hozzáadása"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "ALRENDSZER.KULCS=ÉRTÉK"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Általános irányelv-lehetőség eltávolítása"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Saját könyvtár megőrzése"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "FÁJLNÉV"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Ne követeljen meg egy futó munkamenetet (nincs cgroups létrehozás)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Nem találhatók felülbírálások ehhez: %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "A(z) %s tároló megnyitása közben: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Nem lehet létrehozni a telepítési könyvtárat"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Érvénytelen sha256 a további adat URI-nál: %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Üres név a további adat URI-nál: %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Nem támogatott további adat URI: %s"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Nem sikerült a(z) %s helyi további adat betöltése: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Hibás méret a(z) %s további adatnál"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "A(z) %s letöltése közben: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Hibás méret a(z) %s további adatnál"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Érvénytelen ellenőrzőösszeg a(z) %s további adatnál"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr "A távoli OCI indexnek nincs regisztrációs URI-ja"
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "A(z) %s kommit %s már telepítve van"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "A(z) %s lekérése közben a(z) %s távoliról: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "A(z) %s nem található a(z) %s távoliban"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Nincs elég memória"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Nem sikerült olvasni az exportált fájlból"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Hiba a MIME-típus XML-fájl olvasásakor"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Érvénytelen MIME-típus XML-fájl"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "A különálló metaadatok lekérése közben: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "A további könyvtár létrehozása közben: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Érvénytelen sha256 a további adatnál"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Hibás méret a további adatnál"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Érvénytelen ellenőrzőösszeg a további adatnál"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "A(z) „%s” további adatfájl írása közben: "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "Az apply_extra parancsfájl sikertelen, kilépési állapot: %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "A(z) %s hivatkozás feloldására tett kísérlet közben: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "A(z) %s nem érhető el"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "A(z) %s %s ág már telepítve van"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Nem sikerült olvasni a(z) %s kommitot: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "A(z) %s -> %s átváltására tett kísérlet közben: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "A metaadatok alútvonalának átváltására tett kísérlet közben: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "A meglévő további könyvtár eltávolítására tett kísérlet közben: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "A további adatok alkalmazására tett kísérlet közben: "
+
+#: common/flatpak-dir.c:5451
+#, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Érvénytelen %s üzembe állított hivatkozás:"
+
+#: common/flatpak-dir.c:5458
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Érvénytelen %s kommithivatkozás: "
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "Az üzembe állított %s típus nem egyezik a kommittal (%s)"
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "Az üzembe állított %s név nem egyezik a kommittal (%s)"
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr "Az üzembe állított %s architektúra nem egyezik a kommittal (%s)"
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "Az üzembe állított %s ág nem egyezik a kommittal (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "Az üzembe állított %s hivatkozás nem egyezik a kommittal (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Az üzembe állított metaadatok nem egyeznek a kommittal"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "A(z) %s ezen verziója már telepítve van"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Nem lehet megváltoztatni a távolit csomagtelepítés közben"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "A(z) %s %s ág nincs telepítve"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "A(z) %s %s ág nincs telepítve"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr "A tároló nyesése meghiúsult: %s"
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr "Több ág is elérhető ehhez: %s, meg kell adnia az egyiket:"
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Semmi sem egyezik: %s"
+
+#: common/flatpak-dir.c:8147
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "A(z) %s%s%s%s%s hivatkozás nem található"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Hiba a távoli %s tárolóban keresésnél: %s"
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Hiba a helyi tárolóban keresésnél: %s"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "A(z) %s %s nincs telepítve"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Nem található a telepítési %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "A(z) %s futtatókörnyezet, %s ág már telepítve van"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "A(z) %s alkalmazás, %s ág már telepítve van"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "A távoli cím nincs beállítva"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "A távoli alapértelmezett ág nincs beállítva"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Nincs flatpak gyorsítótár a távoli összegzésben"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr ""
+"Nincs bejegyzés a(z) %s esetén a távoli összegzés flatpak gyorsítótárban "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Nem sikerült megnyitni a flatpak-információs átmeneti fájlt: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Nem sikerült megnyitni az átmeneti fájlt: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Nem hozható létre szinkronizálási cső"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Nem sikerült megnyitni az alkalmazás-információs fájlt: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Nem sikerült szinkronizálni a dbus proxyval"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "ldconfig meghiúsult, kilépési állapot: %d"
@@ -2715,144 +2744,86 @@ msgstr "%s migrálása ide: %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Hiba a migráció során: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Nincsenek további adatforrások"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Metaadatok letöltése: %u/%s (becslés)"
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Letöltés: %s/%s"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "További adatok letöltése: %s/%s"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Fájlok letöltése: %d/%d %s"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Aláírt alkalmazás telepítése"
+#~ msgid "Install signed application"
+#~ msgstr "Aláírt alkalmazás telepítése"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Hitelesítés szükséges a szoftver telepítéséhez"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Hitelesítés szükséges a szoftver telepítéséhez"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Aláírt futtatókörnyezet telepítése"
+#~ msgid "Install signed runtime"
+#~ msgstr "Aláírt futtatókörnyezet telepítése"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Aláírt alkalmazás frissítése"
+#~ msgid "Update signed application"
+#~ msgstr "Aláírt alkalmazás frissítése"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Hitelesítés szükséges a szoftver frissítéséhez"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Hitelesítés szükséges a szoftver frissítéséhez"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Aláírt futtatókörnyezet frissítése"
+#~ msgid "Update signed runtime"
+#~ msgstr "Aláírt futtatókörnyezet frissítése"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Távoli metaadatok frissítése"
+#~ msgid "Update remote metadata"
+#~ msgstr "Távoli metaadatok frissítése"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr "Hitelesítés szükséges a távoli információk frissítéséhez"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Hitelesítés szükséges a távoli információk frissítéséhez"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
-msgid "Update system repository"
-msgstr "Rendszertároló frissítése"
+#~ msgid "Update system repository"
+#~ msgstr "Rendszertároló frissítése"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
-msgid "Authentication is required to update the system repository"
-msgstr "Hitelesítés szükséges a rendszertároló frissítéséhez"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Hitelesítés szükséges a rendszertároló frissítéséhez"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Csomag telepítése"
+#~ msgid "Install bundle"
+#~ msgstr "Csomag telepítése"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Futtatókörnyezet eltávolítása"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Futtatókörnyezet eltávolítása"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Hitelesítés szükséges a szoftver eltávolításához"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Hitelesítés szükséges a szoftver eltávolításához"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Alkalmazás eltávolítása"
+#~ msgid "Uninstall app"
+#~ msgstr "Alkalmazás eltávolítása"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Távoli beállítása"
+#~ msgid "Configure Remote"
+#~ msgstr "Távoli beállítása"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "Hitelesítés szükséges a szoftvertárolók beállításához"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr "Hitelesítés szükséges a szoftvertárolók beállításához"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
-msgid "Configure"
-msgstr "Beállítás"
+#~ msgid "Configure"
+#~ msgstr "Beállítás"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
-msgid "Authentication is required to configure software installation"
-msgstr "Hitelesítés szükséges a szoftvertelepítés beállításához"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr "Hitelesítés szükséges a szoftvertelepítés beállításához"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "AppStream frissítése"
+#~ msgid "Update appstream"
+#~ msgstr "AppStream frissítése"
 
 #~ msgid "No remote %s"
 #~ msgstr "Nincs távoli %s"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2018-01-18 03:24+0000\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2018-01-18 17:44+0700\n"
 "Last-Translator: Kukuh Syafaat <syafaatkukuh@gmail.com>\n"
 "Language-Team: Indonesian <gnome-l10n-id@googlegroups.com>\n"
@@ -147,7 +147,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NAMA LOKASI - Tambah repositori remote"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "NAMA harus ditentukan"
 
@@ -165,7 +165,7 @@ msgstr "LOKASI harus ditentukan"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -231,7 +231,7 @@ msgstr "Arsitektur tujuan bundel"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -390,7 +390,7 @@ msgstr "Tidak ada titik ekstensi %s yang cocok pada %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Kehilangan '=' pada opsi kait bind '%s'"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Tidak dapat memulai aplikasi"
 
@@ -787,7 +787,7 @@ msgstr "LOKASI NAMABERKAS - Impor bundel berkas ke repositori lokal"
 msgid "LOCATION and FILENAME must be specified"
 msgstr "LOKASI dan NAMABERKAS harus ditentukan"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Arsitektur yang digunakan"
@@ -1101,124 +1101,150 @@ msgstr "Tidak dapat berganti gid"
 msgid "Can't switch uid"
 msgstr "Tidak dapat berganti uid"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Tampilkan pemasangan pengguna"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Tampilkan pemasangan di seluruh sistem"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Tampilkan pemasangan tertentu di seluruh sistem"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Tampilkan ref"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Tampilkan komit"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Tampilkan asal"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Tampilkan ukuran"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Tampilkan metadata"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Tampilkan ekstensi"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Kelola akses berkas"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "PATH"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Tampilkan ekstensi"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NAMA [CABANG] - Dapatkan info tentang aplikasi dan/atau runtime yang "
 "terpasang"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "ref tidak ada di asal"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Ref:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "ID:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Arsitektur:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Cabang:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Asal:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "ID Koleksi"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr "Tanggal:"
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr "Subjek:"
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Komit aktif:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Komit terbaru:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Komit:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "alt-id:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr "Induk:"
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Lokasi:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Ukuran terpasang:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Runtime:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Subdirektori terpasang:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Ekstensi:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Subpath:"
 
@@ -1243,35 +1269,40 @@ msgstr "Tampilkan log"
 msgid "Show parent"
 msgstr "Tampilkan induk"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 " REMOTE REF - Tampilkan informasi tentang aplikasi atau runtime pada remote"
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "REMOTE dan REF harus ditentukan"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 msgid "Download size:"
 msgstr "Ukuran unduh:"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr "Riwayat:\n"
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr " Subjek:"
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr " Tanggal:"
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 msgid " Commit:"
 msgstr " Komit:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1309,10 +1340,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Hanya pasang subpath ini"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "PATH"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1473,7 +1500,7 @@ msgstr "Komit"
 msgid "Download size"
 msgstr "Ukuran unduh"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "Tidak ada informasi ref yang tersedia dalam repositori"
 
@@ -1683,35 +1710,35 @@ msgstr "Aktifkan penerusan berkas"
 msgid "APP [args...] - Run an app"
 msgstr "APL [argumen...] - Jalankan aplikasi"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr "TEXT - Cari aplikasi remote/runtime untuk teks"
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 msgid "TEXT must be specified"
 msgstr "TEXT harus ditentukan"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 msgid "Application ID"
 msgstr "ID Aplikasi"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr "Versi"
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 msgid "Branch"
 msgstr "Cabang"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 msgid "Remotes"
 msgstr "Remote"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 msgid "Description"
 msgstr "Deskripsi"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 msgid "No matches found"
 msgstr "Tidak ditemukan kecocokan"
 
@@ -1777,31 +1804,11 @@ msgstr "Perbarui appstream untuk remote"
 msgid "Only update this subpath"
 msgstr "Hanya perbarui subpath ini"
 
-#: app/flatpak-builtins-update.c:107
-#, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Memperbarui data appstream untuk remote pengguna %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Memperbarui data appstream untuk remote %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, c-format
-msgid "Error updating: %s\n"
-msgstr "Galat memperbarui: %s\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr "Remote \"%s\" tidak ditemukan"
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REF...] - Perbarui aplikasi atau runtime"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 msgid "Looking for updates...\n"
 msgstr ""
 "Mencari pembaruan...\n"
@@ -1822,6 +1829,26 @@ msgid "No remote chosen to resolve ‘%s’ which exists in multiple installatio
 msgstr ""
 "Tidak ada remote yang dipilih untuk menyelesaikan '%s' yang ada pada "
 "beberapa pemasangan"
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Memperbarui data appstream untuk remote pengguna %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Memperbarui data appstream untuk remote %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, c-format
+msgid "Error updating: %s\n"
+msgstr "Galat memperbarui: %s\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
+msgstr "Remote \"%s\" tidak ditemukan"
 
 #. translators: please keep the leading space
 #: app/flatpak-main.c:62
@@ -1974,7 +2001,8 @@ msgid "Export a build dir to a repository"
 msgstr "Ekspor direktori bangun ke repositori"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Buat berkas bundel dari direktori bangun"
 
 #: app/flatpak-main.c:105
@@ -2099,9 +2127,9 @@ msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr ""
 "Runtime %s yang dibutuhkan tidak ditemukan di remote yang dikonfigurasi.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10523
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2209,321 +2237,37 @@ msgstr "Galat: Gagal untuk %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "Satu atau beberapa operasi gagal"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Tidak ada penimpaan yang ditemukan untuk %s"
-
-#: common/flatpak-dir.c:1671
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Saat membuka repositori %s: "
-
-#: common/flatpak-dir.c:1905 common/flatpak-dir.c:5305
-msgid "Can't create deploy directory"
-msgstr "Tidak dapat membuat direktori deploy"
-
-#: common/flatpak-dir.c:2625
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Sha256 tidak valid untuk data ekstra uri %s"
-
-#: common/flatpak-dir.c:2630
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Nama kosong untuk data ekstra uri %s"
-
-#: common/flatpak-dir.c:2637
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Data ekstra yang tidak didukung uri %s"
-
-#: common/flatpak-dir.c:2651
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Gagal memuat data-ekstra lokal %s: %s"
-
-#: common/flatpak-dir.c:2654
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Ukuran yang salah untuk data-ekstra %s"
-
-#: common/flatpak-dir.c:2669
-#, c-format
-msgid "While downloading %s: "
-msgstr "Saat mengunduh %s: "
-
-#: common/flatpak-dir.c:2676
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Ukuran yang salah untuk data ekstra %s"
-
-#: common/flatpak-dir.c:2687
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Checksum tidak valid untuk data ekstra %s"
-
-#: common/flatpak-dir.c:2746
-msgid "Remote OCI index has no registry uri"
-msgstr "Indeks remote OCI tidak memiliki registry uri"
-
-#: common/flatpak-dir.c:2962
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s komit %s sudah terpasang"
-
-#: common/flatpak-dir.c:3304 common/flatpak-dir.c:3618
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Saat menarik %s dari remote %s: "
-
-#: common/flatpak-dir.c:3503
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Tidak dapat menemukan %s di remote %s"
-
-#: common/flatpak-dir.c:4176
-msgid "Not enough memory"
-msgstr "Memori tidak cukup"
-
-#: common/flatpak-dir.c:4195
-msgid "Failed to read from exported file"
-msgstr "Gagal membaca dari berkas yang diekspor"
-
-#: common/flatpak-dir.c:4386
-msgid "Error reading mimetype xml file"
-msgstr "Kesalahan saat membaca berkas xml mimetype"
-
-#: common/flatpak-dir.c:4391
-msgid "Invalid mimetype xml file"
-msgstr "Berkas xml mimetype tidak valid"
-
-#: common/flatpak-dir.c:4934
-msgid "While getting detached metadata: "
-msgstr "Saat mendapatkan metadata yang terpisah: "
-
-#: common/flatpak-dir.c:4952
-msgid "While creating extradir: "
-msgstr "Saat membuat direktori ekstra: "
-
-#: common/flatpak-dir.c:4973
-msgid "Invalid sha256 for extra data"
-msgstr "Sha256 tidak valid untuk data ekstra"
-
-#: common/flatpak-dir.c:5002
-msgid "Wrong size for extra data"
-msgstr "Ukuran yang salah untuk data ekstra"
-
-#: common/flatpak-dir.c:5006
-msgid "Invalid checksum for extra data"
-msgstr "Checksum tidak valid untuk data ekstra"
-
-#: common/flatpak-dir.c:5015
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Saat menulis berkas data ekstra '%s': "
-
-#: common/flatpak-dir.c:5185
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "Skrip apply_extra gagal, status keluar %d"
-
-#: common/flatpak-dir.c:5264
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Saat mencoba menyelesaikan ref %s: "
-
-#: common/flatpak-dir.c:5279
-#, c-format
-msgid "%s is not available"
-msgstr "%s tak tersedia"
-
-#: common/flatpak-dir.c:5294 common/flatpak-dir.c:5726
-#: common/flatpak-dir.c:6508 common/flatpak-dir.c:6521
-#: common/flatpak-dir.c:6597
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s cabang %s sudah terpasang"
-
-#: common/flatpak-dir.c:5313
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Gagal membaca komit %s: "
-
-#: common/flatpak-dir.c:5333
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Saat mencoba melakukan checkout %s ke %s: "
-
-#: common/flatpak-dir.c:5358 common/flatpak-dir.c:5389
-msgid "While trying to checkout metadata subpath: "
-msgstr "Saat mencoba melakukan checkout metadata subpath: "
-
-#: common/flatpak-dir.c:5399
-msgid "While trying to remove existing extra dir: "
-msgstr "Saat mencoba menghapus direktori tambahan yang ada: "
-
-#: common/flatpak-dir.c:5410
-msgid "While trying to apply extra data: "
-msgstr "Saat mencoba menerapkan data tambahan: "
-
-#: common/flatpak-dir.c:5437
-#, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Ref %s yang dideploy tidak valid: "
-
-#: common/flatpak-dir.c:5444
-#, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Komit ref %s tidak valid: "
-
-#: common/flatpak-dir.c:5452
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "Jenis ref %s yang dideploy tidak cocok dengan komit (%s)"
-
-#: common/flatpak-dir.c:5460
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "Nama ref %s yang dideploy tidak cocok dengan komit (%s)"
-
-#: common/flatpak-dir.c:5468
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr "Arsitektur ref %s yang dideploy tidak cocok dengan komit (%s)"
-
-#: common/flatpak-dir.c:5474
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "Cabang ref %s yang dideploy tidak cocok dengan komit (%s)"
-
-#: common/flatpak-dir.c:5480
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "Ref %s yang dideploy tidak cocok dengan komit (%s)"
-
-#: common/flatpak-dir.c:5499
-msgid "Deployed metadata does not match commit"
-msgstr "Metadata yang dideploy tidak cocok dengan komit"
-
-#: common/flatpak-dir.c:6369
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Versi %s ini sudah terpasang"
-
-#: common/flatpak-dir.c:6376
-msgid "Can't change remote during bundle install"
-msgstr "Tidak dapat mengubah remote saat memasang paket"
-
-#: common/flatpak-dir.c:6931
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s cabang %s tidak terpasang"
-
-#: common/flatpak-dir.c:7176
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s cabang %s tidak terpasang"
-
-#: common/flatpak-dir.c:7500
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr "Repo pemangkasan gagal: %s"
-
-#: common/flatpak-dir.c:8027
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-"Beberapa cabang tersedia untuk %s, Anda harus menentukan salah satu dari: "
-
-#: common/flatpak-dir.c:8048
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Tidak ada yang cocok dengan %s"
-
-#: common/flatpak-dir.c:8130
-#, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Tidak dapat menemukan ref %s%s%s%s%s"
-
-#: common/flatpak-dir.c:8172
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Galat mencari remote %s: %s"
-
-#: common/flatpak-dir.c:8217
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr "Galat mencari repositori lokal: %s"
-
-#: common/flatpak-dir.c:8343
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s tidak terpasang"
-
-#: common/flatpak-dir.c:8510
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Tidak dapat menemukan pemasangan %s"
-
-#: common/flatpak-dir.c:9109
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Runtime %s, cabang %s telah terpasang"
-
-#: common/flatpak-dir.c:9110
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Aplikasi %s, cabang %s sudah terpasang"
-
-#: common/flatpak-dir.c:9590
-msgid "Remote title not set"
-msgstr "Judul remote tidak diatur"
-
-#: common/flatpak-dir.c:9612
-msgid "Remote default-branch not set"
-msgstr "Cabang bawaaan remote tidak diatur"
-
-#: common/flatpak-dir.c:10200
-msgid "No flatpak cache in remote summary"
-msgstr "Tidak ada cache flatpak dalam ringkasan remote"
-
-#: common/flatpak-dir.c:10210
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Tidak ada entri untuk %s dalam ringkasan remote cache flatpak "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Tipe berbagi %s tidak diketahui, tipe yang valid adalah: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Tipe kebijakan %s tidak diketahui, tipe yang valid adalah: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Nama dbus %s tidak valid\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Tipe soket %s tidak diketahui, tipe yang valid adalah: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Tipe perangkat %s tidak diketahui, tipe yang valid adalah: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Tipe fitur %s tidak diketahui, tipe yang valid adalah: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2532,153 +2276,437 @@ msgstr ""
 "Lokasi sistem berkas %s tidak diketahui, lokasi yang valid adalah: host, "
 "home, xdg-*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Format env tidak valid %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Berbagi dengan host"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "BERBAGI"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Tidak berbagi dengan host"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Ekspos soket ke aplikasi"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOKET"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Jangan ekspos soket ke aplikasi"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Ekspos perangkat ke aplikasi"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "PERANGKAT"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Jangan ekspos perangkat ke aplikasi"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Izinkan fitur"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "FITUR"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Jangan izinkan fitur"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Ekspos sistem berkas ke aplikasi (:ro untuk hanya baca)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "SISTEMBERKAS[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Jangan ekspos sistem berkas ke aplikasi"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "SISTEMBERKAS"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Atur variabel lingkungan"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "VAR=NILAI"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Izinkan aplikasi memiliki nama di bus sesi"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "DBUS_NAME"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Izinkan aplikasi berbicara dengan nama di bus sesi"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Izinkan aplikasi memiliki nama di bus sistem"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Izinkan aplikasi berbicara dengan nama di bus sistem"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Tambahkan opsi kebijakan umum"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSISTEM.KUNCI=NILAI"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Hapus opsi kebijakan umum"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Direktori home yang tetap"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "NAMABERKAS"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Tidak memerlukan sesi berjalan (tidak ada pembuatan cgroups)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Tidak ada penimpaan yang ditemukan untuk %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Saat membuka repositori %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Tidak dapat membuat direktori deploy"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Sha256 tidak valid untuk data ekstra uri %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Nama kosong untuk data ekstra uri %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Data ekstra yang tidak didukung uri %s"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Gagal memuat data-ekstra lokal %s: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Ukuran yang salah untuk data-ekstra %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Saat mengunduh %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Ukuran yang salah untuk data ekstra %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Checksum tidak valid untuk data ekstra %s"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr "Indeks remote OCI tidak memiliki registry uri"
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s komit %s sudah terpasang"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Saat menarik %s dari remote %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Tidak dapat menemukan %s di remote %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Memori tidak cukup"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Gagal membaca dari berkas yang diekspor"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Kesalahan saat membaca berkas xml mimetype"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Berkas xml mimetype tidak valid"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Saat mendapatkan metadata yang terpisah: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Saat membuat direktori ekstra: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Sha256 tidak valid untuk data ekstra"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Ukuran yang salah untuk data ekstra"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Checksum tidak valid untuk data ekstra"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Saat menulis berkas data ekstra '%s': "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "Skrip apply_extra gagal, status keluar %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Saat mencoba menyelesaikan ref %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s tak tersedia"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s cabang %s sudah terpasang"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Gagal membaca komit %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Saat mencoba melakukan checkout %s ke %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Saat mencoba melakukan checkout metadata subpath: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Saat mencoba menghapus direktori tambahan yang ada: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Saat mencoba menerapkan data tambahan: "
+
+#: common/flatpak-dir.c:5451
+#, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Ref %s yang dideploy tidak valid: "
+
+#: common/flatpak-dir.c:5458
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Komit ref %s tidak valid: "
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "Jenis ref %s yang dideploy tidak cocok dengan komit (%s)"
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "Nama ref %s yang dideploy tidak cocok dengan komit (%s)"
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr "Arsitektur ref %s yang dideploy tidak cocok dengan komit (%s)"
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "Cabang ref %s yang dideploy tidak cocok dengan komit (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "Ref %s yang dideploy tidak cocok dengan komit (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Metadata yang dideploy tidak cocok dengan komit"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Versi %s ini sudah terpasang"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Tidak dapat mengubah remote saat memasang paket"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s cabang %s tidak terpasang"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s cabang %s tidak terpasang"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr "Repo pemangkasan gagal: %s"
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+"Beberapa cabang tersedia untuk %s, Anda harus menentukan salah satu dari: "
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Tidak ada yang cocok dengan %s"
+
+#: common/flatpak-dir.c:8147
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Tidak dapat menemukan ref %s%s%s%s%s"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Galat mencari remote %s: %s"
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Galat mencari repositori lokal: %s"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s tidak terpasang"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Tidak dapat menemukan pemasangan %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Runtime %s, cabang %s telah terpasang"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Aplikasi %s, cabang %s sudah terpasang"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Judul remote tidak diatur"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Cabang bawaaan remote tidak diatur"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Tidak ada cache flatpak dalam ringkasan remote"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Tidak ada entri untuk %s dalam ringkasan remote cache flatpak "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Gagal membuka berkas temporer flatpak-info: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Gagal membuka berkas temporer: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Tidak dapat membuat pipa sinkronisasi"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Gagal membuka berkas info aplikasi: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Gagal melakukan sinkronisasi dengan proksi dbus"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "ldconfig gagal, status keluar %d"
@@ -2693,144 +2721,88 @@ msgstr "Migrasi %s ke %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Galat saat migrasi: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Tidak ada sumber data tambahan"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Mengunduh metadata: %u /(perkiraan) %s"
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Mengunduh: %s/%s"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Mengunduh data ekstra: %s/%s"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Mengunduh berkas: %d/%d %s"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Pasang aplikasi yang ditandatangani"
+#~ msgid "Install signed application"
+#~ msgstr "Pasang aplikasi yang ditandatangani"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Otentikasi diperlukan untuk memasang perangkat lunak"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Otentikasi diperlukan untuk memasang perangkat lunak"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Pasang runtime yang ditandatangani"
+#~ msgid "Install signed runtime"
+#~ msgstr "Pasang runtime yang ditandatangani"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Perbarui aplikasi yang ditandatangani"
+#~ msgid "Update signed application"
+#~ msgstr "Perbarui aplikasi yang ditandatangani"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Otentikasi diperlukan untuk memperbarui perangkat lunak"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Otentikasi diperlukan untuk memperbarui perangkat lunak"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Perbarui runtime yang ditandatangani"
+#~ msgid "Update signed runtime"
+#~ msgstr "Perbarui runtime yang ditandatangani"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Perbarui metadata remote"
+#~ msgid "Update remote metadata"
+#~ msgstr "Perbarui metadata remote"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr "Otentikasi diperlukan untuk memperbarui info remote"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Otentikasi diperlukan untuk memperbarui info remote"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
-msgid "Update system repository"
-msgstr "Perbarui repositori sistem"
+#~ msgid "Update system repository"
+#~ msgstr "Perbarui repositori sistem"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
-msgid "Authentication is required to update the system repository"
-msgstr "Otentikasi diperlukan untuk memperbarui repositori sistem"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Otentikasi diperlukan untuk memperbarui repositori sistem"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Pasang bundel"
+#~ msgid "Install bundle"
+#~ msgstr "Pasang bundel"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Hapus runtime"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Hapus runtime"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Otentikasi diperlukan untuk menghapus perangkat lunak"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Otentikasi diperlukan untuk menghapus perangkat lunak"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Hapus aplikasi"
+#~ msgid "Uninstall app"
+#~ msgstr "Hapus aplikasi"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Mengkonfigurasi Remote"
+#~ msgid "Configure Remote"
+#~ msgstr "Mengkonfigurasi Remote"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "Otentikasi diperlukan untuk mengkonfigurasi repositori perangkat lunak"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr ""
+#~ "Otentikasi diperlukan untuk mengkonfigurasi repositori perangkat lunak"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
-msgid "Configure"
-msgstr "Konfigurasi"
+#~ msgid "Configure"
+#~ msgstr "Konfigurasi"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
-msgid "Authentication is required to configure software installation"
-msgstr "Otentikasi diperlukan untuk mengkonfigurasi pemasangan perangkat lunak"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr ""
+#~ "Otentikasi diperlukan untuk mengkonfigurasi pemasangan perangkat lunak"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Perbarui appstream"
+#~ msgid "Update appstream"
+#~ msgstr "Perbarui appstream"
 
 #~ msgid "No remote %s"
 #~ msgstr "Tidak ada remote %s"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-21 11:12+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-12-21 19:22+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <community-poland@mozilla.org>\n"
@@ -149,7 +149,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NAZWA POŁOŻENIE — dodaje zdalne repozytorium"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "Należy podać NAZWĘ"
 
@@ -167,7 +167,7 @@ msgstr "Należy podać POŁOŻENIE"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -235,7 +235,7 @@ msgstr "Architektura pakietu"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -400,7 +400,7 @@ msgstr "Brak punktu rozszerzeń pasującego do %s w %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Brak „=” w opcji montowania dowiązania „%s”"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Nie można uruchomić programu"
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "LOCATION and FILENAME must be specified"
 msgstr "Należy podać POŁOŻENIE i NAZWĘ-PLIKU"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Używana architektura"
@@ -1130,124 +1130,150 @@ msgstr "Nie można przełączyć GID"
 msgid "Can't switch uid"
 msgstr "Nie można przełączyć UID"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Wyświetla instalacje użytkownika"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Wyświetla instalacje systemowe"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Wyświetla podane instalacje systemowe"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Wyświetla odniesienie"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Wyświetla zatwierdzenie"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Wyświetla pochodzenie"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Wyświetla rozmiar"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Wyświetla metadane"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Wyświetla rozszerzenia"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Zarządza dostępem do plików"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "ŚCIEŻKA"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Wyświetla rozszerzenia"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NAZWA [GAŁĄŹ] — pobiera informacje o zainstalowanym programie lub środowisku "
 "wykonawczym"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "odniesienia nie ma w pochodzeniu"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Odniesienie:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "Identyfikator:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Architektura:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Gałąź:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Pochodzenie:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Identyfikator kolekcji"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr "Data:"
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr "Temat:"
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Aktywne zatwierdzenie:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Najnowsze zatwierdzenie:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Zatwierdzenie:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "Alternatywny identyfikator:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr "Element nadrzędny:"
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Położenie:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Rozmiar po instalacji:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Środowisko wykonawcze:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Zainstalowane podkatalogi:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Rozszerzenie:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Podścieżki:"
 
@@ -1272,36 +1298,41 @@ msgstr "Wyświetla dziennik"
 msgid "Show parent"
 msgstr "Wyświetla element nadrzędny"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 " REPOZYTORIUM ODNIESIENIE — wyświetla informacje o programie lub środowisku "
 "wykonawczym w repozytorium"
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "Należy podać REPOZYTORIUM i ODNIESIENIE"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 msgid "Download size:"
 msgstr "Rozmiar do pobrania:"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr "Historia:\n"
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr " Temat:"
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr " Data:"
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 msgid " Commit:"
 msgstr " Zatwierdzenie:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1340,10 +1371,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Instaluje tylko tę podścieżkę"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "ŚCIEŻKA"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1509,7 +1536,7 @@ msgstr "Zatwierdzenie"
 msgid "Download size"
 msgstr "Rozmiar do pobrania"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "Brak dostępnych informacji o odniesieniu w repozytorium"
 
@@ -1718,36 +1745,36 @@ msgstr "Włącza przekazywanie plików"
 msgid "APP [args...] - Run an app"
 msgstr "PROGRAM [parametry…] — uruchamia program"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 "TEKST — wyszukuje programy/środowiska wykonawcze repozytorium według tekstu"
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 msgid "TEXT must be specified"
 msgstr "Należy podać TEKST"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 msgid "Application ID"
 msgstr "Identyfikator programu"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr "Wersja"
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 msgid "Branch"
 msgstr "Gałąź"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 msgid "Remotes"
 msgstr "Repozytoria"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 msgid "Description"
 msgstr "Opis"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 msgid "No matches found"
 msgstr "Brak wyników"
 
@@ -1813,31 +1840,11 @@ msgstr "Aktualizuje AppStream dla repozytorium"
 msgid "Only update this subpath"
 msgstr "Aktualizuje tylko tę podścieżkę"
 
-#: app/flatpak-builtins-update.c:107
-#, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Aktualizowanie danych AppStream dla repozytorium użytkownika %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Aktualizowanie danych AppStream dla repozytorium %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, c-format
-msgid "Error updating: %s\n"
-msgstr "Błąd podczas aktualizowania: %s\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr "Nie odnaleziono repozytorium „%s”"
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[ODNIESIENIE…] — aktualizuje programy lub środowiska wykonawcze"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 msgid "Looking for updates...\n"
 msgstr "Wyszukiwanie aktualizacji…\n"
 
@@ -1856,6 +1863,26 @@ msgid "No remote chosen to resolve ‘%s’ which exists in multiple installatio
 msgstr ""
 "Nie wybrano repozytorium do rozwiązania „%s”, które istnieje w wielu "
 "instalacjach"
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Aktualizowanie danych AppStream dla repozytorium użytkownika %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Aktualizowanie danych AppStream dla repozytorium %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, c-format
+msgid "Error updating: %s\n"
+msgstr "Błąd podczas aktualizowania: %s\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
+msgstr "Nie odnaleziono repozytorium „%s”"
 
 #. translators: please keep the leading space
 #: app/flatpak-main.c:62
@@ -2010,7 +2037,8 @@ msgid "Export a build dir to a repository"
 msgstr "Eksportuje katalog budowania do repozytorium"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Tworzy pakiet z katalogu budowania"
 
 #: app/flatpak-main.c:105
@@ -2136,9 +2164,9 @@ msgstr ""
 "Nie odnaleziono wymaganego środowiska wykonawczego %s w skonfigurowanym "
 "repozytorium.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10512
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2244,322 +2272,37 @@ msgstr "Błąd: %s %s się nie powiodła: %s\n"
 msgid "One or more operations failed"
 msgstr "Jedno lub więcej działań się nie powiodło"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Nie odnaleziono zastępników dla %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Podczas otwierania repozytorium %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Nie można utworzyć katalogu wdrażania"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Nieprawidłowa suma SHA256 dla adresu URI %s dodatkowych danych"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Pusta nazwa dla adresu URI %s dodatkowych danych"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Nieobsługiwany adres URI %s dodatkowych danych"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Wczytanie lokalnych dodatkowych danych %s się nie powiodło: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Błędny rozmiar dodatkowych danych %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Podczas pobierania %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Błędny rozmiar dodatkowych danych %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Nieprawidłowa suma kontrolna dodatkowych danych %s"
-
-#: common/flatpak-dir.c:2742
-msgid "Remote OCI index has no registry uri"
-msgstr "Indeks OCI repozytorium nie ma adresu URI rejestru"
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "Już zainstalowano %s zatwierdzenie %s"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Podczas pobierania %s z repozytorium %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Nie można odnaleźć %s w repozytorium %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Za mało pamięci"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Odczytanie z wyeksportowanego pliku się nie powiodło"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Błąd podczas odczytywania pliku XML typu MIME"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Nieprawidłowy plik XML typu MIME"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Podczas pobierania odłączonych metadanych: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Podczas tworzenia dodatkowego katalogu: "
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Nieprawidłowa suma SHA256 dodatkowych danych"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Błędny rozmiar dodatkowych danych"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Nieprawidłowa suma kontrolna dodatkowych danych"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Podczas zapisywania pliku dodatkowych danych „%s”: "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "Skrypt „apply_extra” się nie powiódł, stan wyjścia %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Podczas rozwiązywania odniesienia %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s jest niedostępne"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "Już zainstalowano %s gałąź %s"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Odczytanie zatwierdzenia %s się nie powiodło: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Podczas wymeldowywania %s do %s: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Podczas wymeldowywania podścieżki metadanych: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Podczas usuwania istniejącego dodatkowego katalogu: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Podczas zastosowywania dodatkowych danych: "
-
-#: common/flatpak-dir.c:5433
-#, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Nieprawidłowe wdrożone odniesienie %s: "
-
-#: common/flatpak-dir.c:5440
-#, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Nieprawidłowe odniesienie zatwierdzenia %s: "
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "Rodzaj wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "Nazwa wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr ""
-"Architektura wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "Gałąź wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "Wdrożone odniesienie %s nie pasuje do zatwierdzenia (%s)"
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr "Wdrożone metadane nie pasują do zatwierdzenia"
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Ta wersja programu %s jest już zainstalowana"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Nie można zmienić repozytorium podczas instalacji pakietu"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "Nie zainstalowano %s gałęzi %s"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "Nie zainstalowano %s gałęzi %s"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr "Usuwanie nieużywanych obiektów z repozytorium się nie powiodło: %s"
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr "Dla %s dostępnych jest wiele gałęzi, należy podać jedną z: "
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Nic nie pasuje do %s"
-
-#: common/flatpak-dir.c:8119
-#, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Nie można odnaleźć odniesienia %s%s%s%s%s"
-
-#: common/flatpak-dir.c:8161
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Błąd podczas wyszukiwania repozytorium %s: %s"
-
-#: common/flatpak-dir.c:8206
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr "Błąd podczas wyszukiwania lokalnego repozytorium: %s"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "Nie zainstalowano %s %s"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Nie można odnaleźć instalacji %s"
-
-#: common/flatpak-dir.c:9098
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Już zainstalowano środowisko wykonawcze %s, gałąź %s"
-
-#: common/flatpak-dir.c:9099
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Już zainstalowano program %s, gałąź %s"
-
-#: common/flatpak-dir.c:9579
-msgid "Remote title not set"
-msgstr "Nie ustawiono tytułu repozytorium"
-
-#: common/flatpak-dir.c:9601
-msgid "Remote default-branch not set"
-msgstr "Nie ustawiono domyślnej gałęzi repozytorium"
-
-#: common/flatpak-dir.c:10189
-msgid "No flatpak cache in remote summary"
-msgstr "Brak pamięci podręcznej Flatpak w podsumowaniu repozytorium"
-
-#: common/flatpak-dir.c:10199
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr ""
-"Brak wpisu dla %s w pamięci podręcznej Flatpak podsumowania repozytorium "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Nieznany typ udziału %s, prawidłowe typy: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Nieznany typ polityki %s, prawidłowe typy: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Nieprawidłowa nazwa D-Bus %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Nieznany typ gniazda %s, prawidłowe typy: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Nieznany typ urządzenia %s, prawidłowe typy: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Nieznany typ funkcji %s, prawidłowe typy: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2568,153 +2311,438 @@ msgstr ""
 "Nieznane położenie systemu plików %s, prawidłowe położenia: host, home, xdg-"
 "*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Nieznany format środowiska %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Udostępnia temu komputerowi"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "UDZIAŁ"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Przestaje udostępniać temu komputerowi"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Udostępnia gniazdo programowi"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "GNIAZDO"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Nie udostępnia gniazda programowi"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Udostępnia urządzenie programowi"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "URZĄDZENIE"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Nie udostępnia urządzenia programowi"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Zezwala na funkcję"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "FUNKCJA"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Bez zezwolenia na funkcję"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Udostępnia system plików programowi (:ro dla tylko do odczytu)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "SYSTEM-PLIKÓW[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Nie udostępnia systemu plików programowi"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "SYSTEM-PLIKÓW"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Ustawia zmienną środowiskową"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "ZMIENNA=WARTOŚĆ"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Zezwala programowi na posiadanie nazwy na magistrali sesji"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "NAZWA_D-BUS"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Umożliwia programowi rozmawianie z nazwą na magistrali sesji"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Zezwala programowi na posiadanie nazwy na magistrali systemu"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Umożliwia programowi rozmawianie z nazwą na magistrali systemu"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Dodaje ogólną opcję polityki"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "PODSYSTEM.KLUCZ=WARTOŚĆ"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Usuwa ogólną opcję polityki"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Trwały katalog domowy"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "NAZWA-PLIKU"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Bez wymagania działającej sesji (bez tworzenia cgroups)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Nie odnaleziono zastępników dla %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Podczas otwierania repozytorium %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Nie można utworzyć katalogu wdrażania"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Nieprawidłowa suma SHA256 dla adresu URI %s dodatkowych danych"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Pusta nazwa dla adresu URI %s dodatkowych danych"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Nieobsługiwany adres URI %s dodatkowych danych"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Wczytanie lokalnych dodatkowych danych %s się nie powiodło: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Błędny rozmiar dodatkowych danych %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Podczas pobierania %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Błędny rozmiar dodatkowych danych %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Nieprawidłowa suma kontrolna dodatkowych danych %s"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr "Indeks OCI repozytorium nie ma adresu URI rejestru"
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "Już zainstalowano %s zatwierdzenie %s"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Podczas pobierania %s z repozytorium %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Nie można odnaleźć %s w repozytorium %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Za mało pamięci"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Odczytanie z wyeksportowanego pliku się nie powiodło"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Błąd podczas odczytywania pliku XML typu MIME"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Nieprawidłowy plik XML typu MIME"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Podczas pobierania odłączonych metadanych: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Podczas tworzenia dodatkowego katalogu: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Nieprawidłowa suma SHA256 dodatkowych danych"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Błędny rozmiar dodatkowych danych"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Nieprawidłowa suma kontrolna dodatkowych danych"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Podczas zapisywania pliku dodatkowych danych „%s”: "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "Skrypt „apply_extra” się nie powiódł, stan wyjścia %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Podczas rozwiązywania odniesienia %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s jest niedostępne"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "Już zainstalowano %s gałąź %s"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Odczytanie zatwierdzenia %s się nie powiodło: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Podczas wymeldowywania %s do %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Podczas wymeldowywania podścieżki metadanych: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Podczas usuwania istniejącego dodatkowego katalogu: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Podczas zastosowywania dodatkowych danych: "
+
+#: common/flatpak-dir.c:5451
+#, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Nieprawidłowe wdrożone odniesienie %s: "
+
+#: common/flatpak-dir.c:5458
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Nieprawidłowe odniesienie zatwierdzenia %s: "
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "Rodzaj wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "Nazwa wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr ""
+"Architektura wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "Gałąź wdrożonego odniesienia %s nie pasuje do zatwierdzenia (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "Wdrożone odniesienie %s nie pasuje do zatwierdzenia (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Wdrożone metadane nie pasują do zatwierdzenia"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Ta wersja programu %s jest już zainstalowana"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Nie można zmienić repozytorium podczas instalacji pakietu"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "Nie zainstalowano %s gałęzi %s"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "Nie zainstalowano %s gałęzi %s"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr "Usuwanie nieużywanych obiektów z repozytorium się nie powiodło: %s"
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr "Dla %s dostępnych jest wiele gałęzi, należy podać jedną z: "
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Nic nie pasuje do %s"
+
+#: common/flatpak-dir.c:8147
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Nie można odnaleźć odniesienia %s%s%s%s%s"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Błąd podczas wyszukiwania repozytorium %s: %s"
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Błąd podczas wyszukiwania lokalnego repozytorium: %s"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "Nie zainstalowano %s %s"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Nie można odnaleźć instalacji %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Już zainstalowano środowisko wykonawcze %s, gałąź %s"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Już zainstalowano program %s, gałąź %s"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Nie ustawiono tytułu repozytorium"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Nie ustawiono domyślnej gałęzi repozytorium"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Brak pamięci podręcznej Flatpak w podsumowaniu repozytorium"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr ""
+"Brak wpisu dla %s w pamięci podręcznej Flatpak podsumowania repozytorium "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Otwarcie pliku tymczasowego „flatpak-info” się nie powiodło: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Otwarcie pliku tymczasowego się nie powiodło: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Utworzenie potoku synchronizacji się nie powiodło"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Otwarcie pliku informacji o programie się nie powiodło: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Synchronizacja z pośrednikiem D-Bus się nie powiodła"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "ldconfig się nie powiodło, stan wyjścia %d"
@@ -2729,144 +2757,90 @@ msgstr "Migrowanie %s do %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Błąd podczas migracji: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Brak źródeł dodatkowych danych"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Pobieranie metadanych: %u/(szacowanie) %s"
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Pobieranie: %s/%s"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Pobieranie dodatkowych danych: %s/%s"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Pobieranie plików: %d/%d %s"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Instalacja podpisanego programu"
+#~ msgid "Install signed application"
+#~ msgstr "Instalacja podpisanego programu"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Wymagane jest uwierzytelnienie, aby zainstalować oprogramowanie"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Wymagane jest uwierzytelnienie, aby zainstalować oprogramowanie"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Instalacja podpisanego środowiska wykonawczego"
+#~ msgid "Install signed runtime"
+#~ msgstr "Instalacja podpisanego środowiska wykonawczego"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Aktualizacja podpisanego programu"
+#~ msgid "Update signed application"
+#~ msgstr "Aktualizacja podpisanego programu"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Wymagane jest uwierzytelnienie, aby zaktualizować oprogramowanie"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Wymagane jest uwierzytelnienie, aby zaktualizować oprogramowanie"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Aktualizacja podpisanego środowiska wykonawczego"
+#~ msgid "Update signed runtime"
+#~ msgstr "Aktualizacja podpisanego środowiska wykonawczego"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Aktualizacja metadanych repozytorium"
+#~ msgid "Update remote metadata"
+#~ msgstr "Aktualizacja metadanych repozytorium"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr ""
-"Wymagane jest uwierzytelnienie, aby zaktualizować informacje o repozytorium"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr ""
+#~ "Wymagane jest uwierzytelnienie, aby zaktualizować informacje "
+#~ "o repozytorium"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
-msgid "Update system repository"
-msgstr "Aktualizacja repozytorium systemu"
+#~ msgid "Update system repository"
+#~ msgstr "Aktualizacja repozytorium systemu"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
-msgid "Authentication is required to update the system repository"
-msgstr "Wymagane jest uwierzytelnienie, aby zaktualizować repozytorium systemu"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr ""
+#~ "Wymagane jest uwierzytelnienie, aby zaktualizować repozytorium systemu"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Instalacja pakietu"
+#~ msgid "Install bundle"
+#~ msgstr "Instalacja pakietu"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Odinstalowanie środowiska wykonawczego"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Odinstalowanie środowiska wykonawczego"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Wymagane jest uwierzytelnienie, aby odinstalować oprogramowanie"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Wymagane jest uwierzytelnienie, aby odinstalować oprogramowanie"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Odinstalowanie programu"
+#~ msgid "Uninstall app"
+#~ msgstr "Odinstalowanie programu"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Konfiguracja repozytorium"
+#~ msgid "Configure Remote"
+#~ msgstr "Konfiguracja repozytorium"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr ""
-"Wymagane jest uwierzytelnienie, aby skonfigurować repozytoria oprogramowania"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr ""
+#~ "Wymagane jest uwierzytelnienie, aby skonfigurować repozytoria "
+#~ "oprogramowania"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
-msgid "Configure"
-msgstr "Konfiguracja"
+#~ msgid "Configure"
+#~ msgstr "Konfiguracja"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
-msgid "Authentication is required to configure software installation"
-msgstr ""
-"Wymagane jest uwierzytelnienie, aby skonfigurować instalację oprogramowania"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr ""
+#~ "Wymagane jest uwierzytelnienie, aby skonfigurować instalację "
+#~ "oprogramowania"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Aktualizacja danych AppStream"
+#~ msgid "Update appstream"
+#~ msgstr "Aktualizacja danych AppStream"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-09-08 21:48-0200\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <gnome-pt_br-list@gnome.org>\n"
@@ -151,7 +151,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NOME LOCALIZAÇÃO – Adiciona um repositório remoto"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "NOME deve ser especificado"
 
@@ -169,7 +169,7 @@ msgstr "LOCALIZAÇÃO deve ser especificada"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -235,7 +235,7 @@ msgstr "Arquitetura para a qual será empacotada"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -394,7 +394,7 @@ msgstr "Nenhum ponto de extensão correspondendo %s em %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Faltando “=” na opção de montagem associativa “%s”"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Não foi possível iniciar o aplicativo"
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "LOCATION and FILENAME must be specified"
 msgstr "LOCALIZAÇÃO e ARQUIVO devem ser especificados"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Arquitetura para usar"
@@ -1113,122 +1113,148 @@ msgstr "Não foi possível trocar o gid"
 msgid "Can't switch uid"
 msgstr "Não foi possível trocar o uid"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Mostra instalações do usuário"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Mostra instalações do sistema"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Mostra instalações específicas do sistema"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Mostra referência"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Mostra commit"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Mostra origem"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Mostra tamanho"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Mostra metadados"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Mostra extensões"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Gerência de acesso a arquivos"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "CAMINHO"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Mostra extensões"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr "NOME [RAMO] – Obtém info sobre aplicativo e/ou runtime instalados"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "ref não presento na origem"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Ref:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "ID:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Arq.:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Ramo:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Origem:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "ID de coleção"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Commit ativo:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Último commit:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Commit:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "alt-id:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Localização:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Tamanho instalado:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Runtime:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Subdiretórios instalados:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Extensões:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Subcaminhos:"
 
@@ -1254,36 +1280,41 @@ msgstr ""
 msgid "Show parent"
 msgstr "Mostra referência"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "REMOTO e REF devem ser especificados"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "Tamanho baixado"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Commit:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1320,10 +1351,6 @@ msgstr "Verifica assinaturas de pacote com chave GPG do ARQUIVO (- para stdin)"
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Instala apenas esse subcaminho"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "CAMINHO"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1486,7 +1513,7 @@ msgstr "Commit"
 msgid "Download size"
 msgstr "Tamanho baixado"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "Nenhuma informação de ref disponível no repositório"
 
@@ -1694,40 +1721,40 @@ msgstr "Habilita encaminhamento de arquivo"
 msgid "APP [args...] - Run an app"
 msgstr "APLICATIVO [args…] – Executa um aplicativo"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "REMOTO deve ser especificado"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "ID de coleção"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Ramo:"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "Nenhum remoto %s"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Descrição completa"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "Sem combinações com %s"
@@ -1794,31 +1821,11 @@ msgstr "Atualiza appstream para remoto"
 msgid "Only update this subpath"
 msgstr "Atualiza apenas esse subcaminho"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Atualizando appstream para remoto %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Atualizando appstream para remoto %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, fuzzy, c-format
-msgid "Error updating: %s\n"
-msgstr "Atualizando resumo\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr ""
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REF…] – Atualiza aplicativos ou runtimes"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 #, fuzzy
 msgid "Looking for updates...\n"
 msgstr "Nenhuma atualização.\n"
@@ -1836,6 +1843,26 @@ msgstr "Qual você deseja instalar (0 para abortar)?"
 #: app/flatpak-builtins-utils.c:374
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
+msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Atualizando appstream para remoto %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Atualizando appstream para remoto %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, fuzzy, c-format
+msgid "Error updating: %s\n"
+msgstr "Atualizando resumo\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
 msgstr ""
 
 #. translators: please keep the leading space
@@ -1990,7 +2017,8 @@ msgid "Export a build dir to a repository"
 msgstr "Exporta um diretório de compilação para um repositório"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Cria um arquivo de pacote a partir de um diretório de compilação"
 
 #: app/flatpak-main.c:105
@@ -2065,22 +2093,22 @@ msgstr "NOME"
 msgid "Builtin Commands:"
 msgstr "Comandos embutidos:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Comando desconhecido “%s”"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Nenhum comando especificado"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "erro:"
 
@@ -2112,9 +2140,9 @@ msgstr "Runtime exigido para %s (%s) não está instalado, pesquisando…\n"
 msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr "O runtime exigido %s não foi localizado em um remoto configurado.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2220,320 +2248,37 @@ msgstr "Erro: Falha ao %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "Uma ou mais operações falharam"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Nenhuma substituição localizada para %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Ao abrir o repositório %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Não foi possível criar um diretório de deploy"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "sha256 inválido para uri de dados extras %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Nome vazio para uri de dados extras %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Sem suporte à uri de dados extras %s"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Falha ao carregar extra-data local %s: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Tamanho inválido para extra-data %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Enquanto baixava %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Tamanho inválido para dados extras %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Soma de verificação inválida para dados extras %s"
-
-#: common/flatpak-dir.c:2742
-msgid "Remote OCI index has no registry uri"
-msgstr ""
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s commit %s já está instalado"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Enquanto executava pull de %s a partir do remoto %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Não foi possível localizar %s no remoto %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Memória insuficiente"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Falha ao ler do arquivo exportado"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Erro ao ler o arquivo xml de tipo mime"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Arquivo inválido de xml de tipo mim"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Enquanto obtinha metadados destacados: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Enquanto criava extradir: "
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "sha256 inválido para dados extras"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Tamanho inválido para dados extras"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Soma de verificação inválida para dados extras"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Enquanto escrevia o arquivo de dados extras “%s”: "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "script apply_extra falhou, status de saída %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Enquanto tentava resolver ref %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s não está disponível"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s ramo %s já está instalado"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Falha ao ler commit %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Enquanto tentava fazer checkout de %s para %s: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Enquanto tentava fazer checkout do subcaminho de metadados: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Enquanto tentava remover diretório extra existente: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Enquanto tentava aplicar dados extras: "
-
-#: common/flatpak-dir.c:5433
-#, fuzzy, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Pid inválido %s"
-
-#: common/flatpak-dir.c:5440
-#, fuzzy, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Pid inválido %s"
-
-#: common/flatpak-dir.c:5448
-#, fuzzy, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "Ref implementado %s não coincide com o commit (%s)"
-
-#: common/flatpak-dir.c:5456
-#, fuzzy, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "Ref implementado %s não coincide com o commit (%s)"
-
-#: common/flatpak-dir.c:5464
-#, fuzzy, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr "Ref implementado %s não coincide com o commit (%s)"
-
-#: common/flatpak-dir.c:5470
-#, fuzzy, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "Ref implementado %s não coincide com o commit (%s)"
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "Ref implementado %s não coincide com o commit (%s)"
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr "Metadados implementados não coincidem com o commit"
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Essa versão de %s já está instalada"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Não é possível alterar remoto durante instalação de pacote"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s ramo %s não está instalado"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s ramo %s não está instalado"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Sem combinações com %s"
-
-#: common/flatpak-dir.c:8119
-#, fuzzy, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Não foi possível localizar %s%s%s%s%s no remoto %s"
-
-#: common/flatpak-dir.c:8161
-#, fuzzy, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Erro: Falha ao %s %s: %s\n"
-
-#: common/flatpak-dir.c:8206
-#, fuzzy, c-format
-msgid "Error searching local repository: %s"
-msgstr "Mantém referência no repositório local"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s não instalado"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Não foi possível localizar instalação de %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Runtime %s, ramo %s já está instalado"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Aplicativo %s, ramo %s já está instalado"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Título remoto não definido"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Ramo padrão remoto não definido"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "Nenhum cache de flatpak no sumário remoto"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Nenhuma entrada para %s no cache de flatpak de sumário remoto "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Tipo de compartilhamento desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Tipo de política desconhecida %s, tipos válidos são: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Nome de dbus inválido %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Tipo de soquete desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Tipo de dispositivo desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Tipo de recurso desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2542,154 +2287,437 @@ msgstr ""
 "Localização de sistema de arquivos desconhecida %s, localizações válidas "
 "são: host, home, xdg-*[/…], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Formato de env inválido %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Compartilha com o host"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "COMPARTILHAR"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Desfaz compartilhamento com o host"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Expõe o soquete para o aplicativo"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOQUETE"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Não expõe o soquete para o aplicativo"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Expõe o dispositivo para o aplicativo"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "DISPOSITIVO"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Não expõe o dispositivo para o aplicativo"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Permiti a funcionalidade"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "FUNCIONALIDADE"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Não permite funcionalidade"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr ""
 "Expõe o sistema de arquivos para o aplicativo (:ro para somente leitura)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "SISTEMA_DE_ARQUIVOS[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Não expõe o sistema de arquivos para o aplicativo"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "SISTEMA_DE_ARQUIVOS"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Define uma variável de ambiente"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "VAR=VALOR"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Permite o aplicativo ter um nome no barramento de sessão"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "NOME_DBUS"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Permite o aplicativo falar com um nome no barramento de sessão"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Permite o aplicativo ter um nome no barramento de sistema"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Permite o aplicativo falar com um nome no barramento de sistema"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Adiciona uma opção de política genérica"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSISTEMA.CHAVE=VALOR"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Remove uma opção de política genérica"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Persiste o diretório pessoal"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "ARQUIVO"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Não exige uma sessão em execução (sem criação de cgroups)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Nenhuma substituição localizada para %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Ao abrir o repositório %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Não foi possível criar um diretório de deploy"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "sha256 inválido para uri de dados extras %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Nome vazio para uri de dados extras %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Sem suporte à uri de dados extras %s"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Falha ao carregar extra-data local %s: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Tamanho inválido para extra-data %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Enquanto baixava %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Tamanho inválido para dados extras %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Soma de verificação inválida para dados extras %s"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr ""
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s commit %s já está instalado"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Enquanto executava pull de %s a partir do remoto %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Não foi possível localizar %s no remoto %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Memória insuficiente"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Falha ao ler do arquivo exportado"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Erro ao ler o arquivo xml de tipo mime"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Arquivo inválido de xml de tipo mim"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Enquanto obtinha metadados destacados: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Enquanto criava extradir: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "sha256 inválido para dados extras"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Tamanho inválido para dados extras"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Soma de verificação inválida para dados extras"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Enquanto escrevia o arquivo de dados extras “%s”: "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "script apply_extra falhou, status de saída %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Enquanto tentava resolver ref %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s não está disponível"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s ramo %s já está instalado"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Falha ao ler commit %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Enquanto tentava fazer checkout de %s para %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Enquanto tentava fazer checkout do subcaminho de metadados: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Enquanto tentava remover diretório extra existente: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Enquanto tentava aplicar dados extras: "
+
+#: common/flatpak-dir.c:5451
+#, fuzzy, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Pid inválido %s"
+
+#: common/flatpak-dir.c:5458
+#, fuzzy, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Pid inválido %s"
+
+#: common/flatpak-dir.c:5466
+#, fuzzy, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "Ref implementado %s não coincide com o commit (%s)"
+
+#: common/flatpak-dir.c:5474
+#, fuzzy, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "Ref implementado %s não coincide com o commit (%s)"
+
+#: common/flatpak-dir.c:5482
+#, fuzzy, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr "Ref implementado %s não coincide com o commit (%s)"
+
+#: common/flatpak-dir.c:5488
+#, fuzzy, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "Ref implementado %s não coincide com o commit (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "Ref implementado %s não coincide com o commit (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Metadados implementados não coincidem com o commit"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Essa versão de %s já está instalada"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Não é possível alterar remoto durante instalação de pacote"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s ramo %s não está instalado"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s ramo %s não está instalado"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Sem combinações com %s"
+
+#: common/flatpak-dir.c:8147
+#, fuzzy, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Não foi possível localizar %s%s%s%s%s no remoto %s"
+
+#: common/flatpak-dir.c:8189
+#, fuzzy, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Erro: Falha ao %s %s: %s\n"
+
+#: common/flatpak-dir.c:8234
+#, fuzzy, c-format
+msgid "Error searching local repository: %s"
+msgstr "Mantém referência no repositório local"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s não instalado"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Não foi possível localizar instalação de %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Runtime %s, ramo %s já está instalado"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Aplicativo %s, ramo %s já está instalado"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Título remoto não definido"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Ramo padrão remoto não definido"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Nenhum cache de flatpak no sumário remoto"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Nenhuma entrada para %s no cache de flatpak de sumário remoto "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Falha ao abrir arquivo temporário de flatpak-info: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Falha ao abrir arquivo temporário: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Não foi possível criar um pipe de sincronização"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Falha ao abrir arquivo informação do aplicativo: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Falha ao sincronizar com proxy de dbus"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, fuzzy, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "script apply_extra falhou, status de saída %d"
@@ -2704,148 +2732,92 @@ msgstr "Atualizando: %s de %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Erro: Falha ao %s %s: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Nenhuma fonte de dados extras"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr ""
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, fuzzy, c-format
 msgid "Downloading: %s/%s"
 msgstr "Mostra tamanho"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, fuzzy, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Mostra tamanho"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, fuzzy, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Mostra tamanho"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Instalar aplicativo assinado"
+#~ msgid "Install signed application"
+#~ msgstr "Instalar aplicativo assinado"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Autenticação é necessária para instalar software"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Autenticação é necessária para instalar software"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Instalar runtime assinado"
+#~ msgid "Install signed runtime"
+#~ msgstr "Instalar runtime assinado"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Atualizar aplicativo assinado"
+#~ msgid "Update signed application"
+#~ msgstr "Atualizar aplicativo assinado"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Autenticação é necessária para atualizar software"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Autenticação é necessária para atualizar software"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Atualizar runtime assinado"
+#~ msgid "Update signed runtime"
+#~ msgstr "Atualizar runtime assinado"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Atualizar metadados remotos"
+#~ msgid "Update remote metadata"
+#~ msgstr "Atualizar metadados remotos"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr "Autenticação é necessária para atualizar informações remotas"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Autenticação é necessária para atualizar informações remotas"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
 #, fuzzy
-msgid "Update system repository"
-msgstr "Atualiza o arquivo de sumário num repositório"
+#~ msgid "Update system repository"
+#~ msgstr "Atualiza o arquivo de sumário num repositório"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
 #, fuzzy
-msgid "Authentication is required to update the system repository"
-msgstr "Autenticação é necessária para atualizar informações remotas"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Autenticação é necessária para atualizar informações remotas"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Instalar pacote"
+#~ msgid "Install bundle"
+#~ msgstr "Instalar pacote"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Desinstalar runtime"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Desinstalar runtime"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Autenticação é necessária para desinstalar software"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Autenticação é necessária para desinstalar software"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Desinstalar aplicativo"
+#~ msgid "Uninstall app"
+#~ msgstr "Desinstalar aplicativo"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Configurar remoto"
+#~ msgid "Configure Remote"
+#~ msgstr "Configurar remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "Autenticação é necessária para configurar os repositórios de software"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr ""
+#~ "Autenticação é necessária para configurar os repositórios de software"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
 #, fuzzy
-msgid "Configure"
-msgstr "Configurar remoto"
+#~ msgid "Configure"
+#~ msgstr "Configurar remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
 #, fuzzy
-msgid "Authentication is required to configure software installation"
-msgstr "Autenticação é necessária para configurar os repositórios de software"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr ""
+#~ "Autenticação é necessária para configurar os repositórios de software"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Atualizar appstream"
+#~ msgid "Update appstream"
+#~ msgstr "Atualizar appstream"
 
 #~ msgid "No remote %s"
 #~ msgstr "Nenhum remoto %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-02-10 11:59+0300\n"
 "Last-Translator: Roman Kharin <romiq.kh@gmail.com>\n"
 "Language-Team: romiq.kh@gmail.com\n"
@@ -154,7 +154,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "ИМЯ ПУТЬ - Добавить удалённый репозиторий"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "Должно быть указано ИМЯ"
 
@@ -172,7 +172,7 @@ msgstr "Должен быть указан ПУТЬ"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -240,7 +240,7 @@ msgstr "Архитектура для пакета"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -402,7 +402,7 @@ msgstr "Не найдена точка расширения подходящая
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Отсутствует '=' в параметре связанного монтирования '%s'"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Невозможно запустить приложение"
 
@@ -802,7 +802,7 @@ msgstr "ПУТЬ ИМЯ_ФАЙЛА - Импортировать файл с па
 msgid "LOCATION and FILENAME must be specified"
 msgstr "Должны быть указаны ПУТЬ и ИМЯ_ФАЙЛА"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Использовать архитектуру"
@@ -1118,131 +1118,157 @@ msgstr "Невозможно изменить группу пользовате�
 msgid "Can't switch uid"
 msgstr "Невозможно сменить пользователя"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Показать установленное только для пользователя"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Показать установленное для всех пользователей"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Показать установленное в указанном каталоге"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Показать ссылки"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Показать зафиксированные изменения"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Показать происхождение"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 #, fuzzy
 msgid "Show size"
 msgstr "Показать ссылки"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 #, fuzzy
 msgid "Show metadata"
 msgstr "Показать подробности про удалённый репозиторий"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Показать параметры справки"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Управление доступом к файлам"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "ПУТЬ"
+
+#: app/flatpak-builtins-info.c:62
 #, fuzzy
 msgid "Show extensions"
 msgstr "Показать параметры справки"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "ИМЯ [ВЕТКА] - Получить информацию об установленных приложениях и/или средах "
 "исполнения"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 #, fuzzy
 msgid "Branch:"
 msgstr "Используемая ветка"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Запустить приложение"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 #, fuzzy
 msgid "Installed size:"
 msgstr "Установка: %s\n"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 #, fuzzy
 msgid "Runtime:"
 msgstr "Используемая среда исполнения"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 #, fuzzy
 msgid "Extension:"
 msgstr "Показать параметры справки"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr ""
 
@@ -1268,36 +1294,41 @@ msgstr ""
 msgid "Show parent"
 msgstr "Показать ссылки"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "Должны быть указаны УДАЛЁННЫЙ_РЕПО и ССЫЛКА"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "Показать ссылки"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Показать зафиксированные изменения"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1334,10 +1365,6 @@ msgstr "Проверять подписи пакета ключом GPG из Ф�
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Устанавливать только указанный подкаталог"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "ПУТЬ"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1501,7 +1528,7 @@ msgstr ""
 msgid "Download size"
 msgstr "Показать ссылки"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 #, fuzzy
 msgid "No ref information available in repository"
 msgstr "ФАЙЛ - Получить информацию об экспортированном файле"
@@ -1716,40 +1743,40 @@ msgstr ""
 msgid "APP [args...] - Run an app"
 msgstr "ПРИЛОЖЕНИЕ [параметры...] - Запустить приложение"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "Должен быть указан УДАЛЕННЫЙ_РЕПО"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "Запустить приложение"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Используемая ветка"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "Нет удалённого репозитория %s"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Полное описание"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "Совпадений не обнаружено %s"
@@ -1816,31 +1843,11 @@ msgstr "Обновить ветку appstream для удалённого реп
 msgid "Only update this subpath"
 msgstr "Обновлять только указанный подкаталог"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Обновление ветки appstream для удалённого репозитория %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Обновление ветки appstream для удалённого репозитория %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, fuzzy, c-format
-msgid "Error updating: %s\n"
-msgstr "Обновление сводной информации\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr ""
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[ССЫЛКА...] - Обновить приложения или среды исполнения"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 #, fuzzy
 msgid "Looking for updates...\n"
 msgstr "Нет обновлений\n"
@@ -1858,6 +1865,26 @@ msgstr "Которую версию установить (0 - отмена)?"
 #: app/flatpak-builtins-utils.c:374
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
+msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Обновление ветки appstream для удалённого репозитория %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Обновление ветки appstream для удалённого репозитория %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, fuzzy, c-format
+msgid "Error updating: %s\n"
+msgstr "Обновление сводной информации\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
 msgstr ""
 
 #. translators: please keep the leading space
@@ -2012,7 +2039,8 @@ msgid "Export a build dir to a repository"
 msgstr "Экспортировать из каталога сборки в репозиторий"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Создать файл с пакетом из каталога сборки"
 
 #: app/flatpak-main.c:105
@@ -2087,22 +2115,22 @@ msgstr "ИМЯ_ФАЙЛА"
 msgid "Builtin Commands:"
 msgstr "Встроенные команды:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Неизвестная команда '%s'"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Команда не указана"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "ошибка:"
 
@@ -2136,9 +2164,9 @@ msgstr ""
 "Требуемая среда исполнения %s не найдена в настроенных удалённых "
 "репозиториях.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2244,321 +2272,37 @@ msgstr "Ошибка: Не удалось %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "Одна или более операций закончилась с ошибкой"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Не найдено переопределений для %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Во время открытия репозитория %s:"
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Невозможно создать каталог для развёртывания"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Некорректная сумма sha256 для дополнительных данных по адресу %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Пустое имя для дополнительных данных по адресу %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Не поддерживаемые дополнительные данные по адресу %s"
-
-#: common/flatpak-dir.c:2647
-#, fuzzy, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Ошибка чтения зафиксированного изменения %s: "
-
-#: common/flatpak-dir.c:2650
-#, fuzzy, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Неправильный размер дополнительных данных по адресу %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Во время загрузки %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Неправильный размер дополнительных данных по адресу %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Некорректная контрольная сумма дополнительных данных по адресу %s"
-
-#: common/flatpak-dir.c:2742
-#, fuzzy
-msgid "Remote OCI index has no registry uri"
-msgstr "ПУТЬ является реестром oci"
-
-#: common/flatpak-dir.c:2958
-#, fuzzy, c-format
-msgid "%s commit %s already installed"
-msgstr "%s ветка %s уже установлено"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Во время получения %s из удалённого репозитория %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Не найден %s в удалённом репозитории %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Не достаточно памяти"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Ошибка чтения из экспортированного файла"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Во время получения отсоединённых метаданных:"
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Во время создания каталога с дополнительными данными:"
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Некорректная контрольная сумма sha256 для дополнительных данных"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Некорректный размер дополнительных данных"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Некорректная контрольная сумма для дополнительных данных"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Во время записи в файл дополнительных данных '%s': "
-
-#: common/flatpak-dir.c:5181
-#, fuzzy, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "скрипт apply_extra закончился с ошибкой"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Во время поиска назначения ссылки %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s не доступно"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s ветка %s уже установлено"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Ошибка чтения зафиксированного изменения %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Во время получения %s в %s: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Во время получения метаданных подкаталога "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Во время удаления существующего каталога с дополнительными данными: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Во время применения дополнительных данных: "
-
-#: common/flatpak-dir.c:5433
-#, fuzzy, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Неверный pid %s"
-
-#: common/flatpak-dir.c:5440
-#, fuzzy, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Неверный pid %s"
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr ""
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Указанная версия %s уже установлена"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Невозможно изменить удалённый репозиторий во время установки пакета"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s ветка %s не установлено"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s ветка %s не установлена"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Совпадений не обнаружено %s"
-
-#: common/flatpak-dir.c:8119
-#, fuzzy, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Невозможно найти %s%s%s%s%s в удалённом репозитории %s"
-
-#: common/flatpak-dir.c:8161
-#, fuzzy, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Ошибка: Не удалось %s %s: %s\n"
-
-#: common/flatpak-dir.c:8206
-#, fuzzy, c-format
-msgid "Error searching local repository: %s"
-msgstr "Сохранить ссылку в локальном репозитории"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s не установлено"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Не возможно найти %s в установленных"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Среда исполнения %s, ветка %s уже установлена"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Приложение %s, ветка %s уже установлено"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Заголовок удаленного репозитория не установлен"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Ветка по умолчанию в удалённом репозитории не установлена"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "Отсутствует путь к кэшу в сводной информации удалённого репозитория"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Нет записи для %s в сводной информации кэша flatpak"
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Неизвестный тип общего каталога %s, доступные типы: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Неизвестный тип политики %s, доступные типы: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Некорректное имя dbus %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Неизвестный тип сокета %s, доступные типы: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Неизвестный тип устройства %s, доступные типы: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Неизвестный тип функционала %s, доступные типы: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, fuzzy, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2567,153 +2311,437 @@ msgstr ""
 "Неизвестный путь файловой системы %s, доступные типы: host, home, xdg-"
 "*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Неверный формат переменной окружения %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Добавить общий каталог с хостом"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "ОБЩ_КАТАЛОГ"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Убрать общий каталог с хостом"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Пробросить сокет приложению"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "СОКЕТ"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Убрать проброс сокета приложению"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Пробросить устройство приложению"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "УСТРОЙСТВО"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Убрать проброс устройства приложению"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Разрешить функционал"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "ФУНКЦИОНАЛ"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Запретить функционал"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Пробросить файловую систему приложению (:ro только для чтения)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "ФАЙЛ_СИСТЕМА[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Не пробрасывать файловую систему для приложения"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "ФАЙЛ_СИСТЕМА"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Установить переменную окружения"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "ПЕРЕМЕННАЯ=ЗНАЧЕНИЕ"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Разрешить приложению владеть именем на сессионной шине"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr ""
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Разрешить приложению обмениваться с именем на сессионной шине"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Разрешить приложению владеть именем на системной шине"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Разрешить приложению обмениваться с именем на системной шине"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Добавить параметр обобщенной политики"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "ПОДСИСТЕМА.КЛЮЧ=ЗНАЧЕНИЕ"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Удалить параметр обобщенной политики"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Сохранять домашний каталог"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "ИМЯ_ФАЙЛА"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr ""
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Не найдено переопределений для %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Во время открытия репозитория %s:"
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Невозможно создать каталог для развёртывания"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Некорректная сумма sha256 для дополнительных данных по адресу %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Пустое имя для дополнительных данных по адресу %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Не поддерживаемые дополнительные данные по адресу %s"
+
+#: common/flatpak-dir.c:2661
+#, fuzzy, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Ошибка чтения зафиксированного изменения %s: "
+
+#: common/flatpak-dir.c:2664
+#, fuzzy, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Неправильный размер дополнительных данных по адресу %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Во время загрузки %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Неправильный размер дополнительных данных по адресу %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Некорректная контрольная сумма дополнительных данных по адресу %s"
+
+#: common/flatpak-dir.c:2756
+#, fuzzy
+msgid "Remote OCI index has no registry uri"
+msgstr "ПУТЬ является реестром oci"
+
+#: common/flatpak-dir.c:2976
+#, fuzzy, c-format
+msgid "%s commit %s already installed"
+msgstr "%s ветка %s уже установлено"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Во время получения %s из удалённого репозитория %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Не найден %s в удалённом репозитории %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Не достаточно памяти"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Ошибка чтения из экспортированного файла"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Во время получения отсоединённых метаданных:"
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Во время создания каталога с дополнительными данными:"
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Некорректная контрольная сумма sha256 для дополнительных данных"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Некорректный размер дополнительных данных"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Некорректная контрольная сумма для дополнительных данных"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Во время записи в файл дополнительных данных '%s': "
+
+#: common/flatpak-dir.c:5199
+#, fuzzy, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "скрипт apply_extra закончился с ошибкой"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Во время поиска назначения ссылки %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s не доступно"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s ветка %s уже установлено"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Ошибка чтения зафиксированного изменения %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Во время получения %s в %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Во время получения метаданных подкаталога "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Во время удаления существующего каталога с дополнительными данными: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Во время применения дополнительных данных: "
+
+#: common/flatpak-dir.c:5451
+#, fuzzy, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Неверный pid %s"
+
+#: common/flatpak-dir.c:5458
+#, fuzzy, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Неверный pid %s"
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr ""
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Указанная версия %s уже установлена"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Невозможно изменить удалённый репозиторий во время установки пакета"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s ветка %s не установлено"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s ветка %s не установлена"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Совпадений не обнаружено %s"
+
+#: common/flatpak-dir.c:8147
+#, fuzzy, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Невозможно найти %s%s%s%s%s в удалённом репозитории %s"
+
+#: common/flatpak-dir.c:8189
+#, fuzzy, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Ошибка: Не удалось %s %s: %s\n"
+
+#: common/flatpak-dir.c:8234
+#, fuzzy, c-format
+msgid "Error searching local repository: %s"
+msgstr "Сохранить ссылку в локальном репозитории"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s не установлено"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Не возможно найти %s в установленных"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Среда исполнения %s, ветка %s уже установлена"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Приложение %s, ветка %s уже установлено"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Заголовок удаленного репозитория не установлен"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Ветка по умолчанию в удалённом репозитории не установлена"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Отсутствует путь к кэшу в сводной информации удалённого репозитория"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Нет записи для %s в сводной информации кэша flatpak"
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Ошибка при открытии временного файла flatpak-info: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Ошибка при открытии временного файла: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Невозможно создать канал синхронизации"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Ошибка при открытии файла с информацией о приложении: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Ошибка при синхронизации с прокси dbus"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, fuzzy, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "скрипт apply_extra закончился с ошибкой"
@@ -2728,156 +2756,77 @@ msgstr "Обновление: %s из %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Ошибка: Не удалось %s %s: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Нет источников дополнительных данных"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr ""
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, fuzzy, c-format
 msgid "Downloading: %s/%s"
 msgstr "Показать ссылки"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, fuzzy, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Показать ссылки"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, fuzzy, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Показать ссылки"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
 #, fuzzy
-msgid "Install signed application"
-msgstr "Показать установленные приложения"
+#~ msgid "Install signed application"
+#~ msgstr "Показать установленные приложения"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr ""
-
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
 #, fuzzy
-msgid "Install signed runtime"
-msgstr "Показать установленные среды исполнения"
+#~ msgid "Install signed runtime"
+#~ msgstr "Показать установленные среды исполнения"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
 #, fuzzy
-msgid "Update signed application"
-msgstr "Показать установленные приложения"
+#~ msgid "Update signed application"
+#~ msgstr "Показать установленные приложения"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr ""
-
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
 #, fuzzy
-msgid "Update signed runtime"
-msgstr "Показать установленные среды исполнения"
+#~ msgid "Update signed runtime"
+#~ msgstr "Показать установленные среды исполнения"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
 #, fuzzy
-msgid "Update remote metadata"
-msgstr "ПУТЬ - Обновить метаданные репозитория"
+#~ msgid "Update remote metadata"
+#~ msgstr "ПУТЬ - Обновить метаданные репозитория"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr ""
-
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
 #, fuzzy
-msgid "Update system repository"
-msgstr "Обновить файл со сводной информацией в репозитории"
+#~ msgid "Update system repository"
+#~ msgstr "Обновить файл со сводной информацией в репозитории"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
-msgid "Authentication is required to update the system repository"
-msgstr ""
-
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
 #, fuzzy
-msgid "Install bundle"
-msgstr "установить пакет"
+#~ msgid "Install bundle"
+#~ msgstr "установить пакет"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
 #, fuzzy
-msgid "Uninstall runtime"
-msgstr "Показать установленные среды исполнения"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Показать установленные среды исполнения"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr ""
-
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
 #, fuzzy
-msgid "Uninstall app"
-msgstr "установить"
+#~ msgid "Uninstall app"
+#~ msgstr "установить"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
 #, fuzzy
-msgid "Configure Remote"
-msgstr "Удалить настроенный удалённый репозиторий"
+#~ msgid "Configure Remote"
+#~ msgstr "Удалить настроенный удалённый репозиторий"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr ""
-
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
 #, fuzzy
-msgid "Configure"
-msgstr "Удалить настроенный удалённый репозиторий"
+#~ msgid "Configure"
+#~ msgstr "Удалить настроенный удалённый репозиторий"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
-msgid "Authentication is required to configure software installation"
-msgstr ""
-
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
 #, fuzzy
-msgid "Update appstream"
-msgstr "Обновить ветку appstream для удалённого репозитория"
+#~ msgid "Update appstream"
+#~ msgstr "Обновить ветку appstream для удалённого репозитория"
 
 #~ msgid "No remote %s"
 #~ msgstr "Нет удалённого репозитория %s"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-01-23 18:19+0100\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: Slovak <gnome-sk-list@gnome.org>\n"
@@ -153,7 +153,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NÁZOV [UMIESTNENIE] - Pridanie vzdialeného repozitára"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "NÁZOV musí byť určený"
 
@@ -171,7 +171,7 @@ msgstr "UMIESTNENIE musí byť určené"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -239,7 +239,7 @@ msgstr ""
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Missing '=' in bind mount option '%s'"
 msgstr ""
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Nie je možné spustiť aplikáciu"
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "LOCATION and FILENAME must be specified"
 msgstr ""
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Architektúra , ktorá sa má použiť"
@@ -1100,128 +1100,154 @@ msgstr ""
 msgid "Can't switch uid"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Zobrazí referenciu"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Zobrazí začlenenie"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Zobrazí pôvod"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 #, fuzzy
 msgid "Show size"
 msgstr "Zobrazí referenciu"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Zobrazí voľby pomocníka"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+"Správa prístupu k súborom"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "CESTA"
+
+#: app/flatpak-builtins-info.c:62
 #, fuzzy
 msgid "Show extensions"
 msgstr "Zobrazí voľby pomocníka"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 #, fuzzy
 msgid "Branch:"
 msgstr "Vetva, ktorá sa má použiť"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Spustí aplikáciu"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 #, fuzzy
 msgid "Installed size:"
 msgstr "Nainštalovanie podpísaného prostredia"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 #, fuzzy
 msgid "Runtime:"
 msgstr "Prostredie. ktoré sa má použiť"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 #, fuzzy
 msgid "Extension:"
 msgstr "Zobrazí voľby pomocníka"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr ""
 
@@ -1247,37 +1273,42 @@ msgstr ""
 msgid "Show parent"
 msgstr "Zobrazí referenciu"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 #, fuzzy
 msgid "REMOTE and REF must be specified"
 msgstr "ADRESÁR musí byť určený"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "Zobrazí referenciu"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Zobrazí začlenenie"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1314,10 +1345,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr ""
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "CESTA"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1482,7 +1509,7 @@ msgstr ""
 msgid "Download size"
 msgstr "Zobrazí referenciu"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 #, fuzzy
 msgid "No ref information available in repository"
 msgstr "Vypíše informácie o verzii a skončí"
@@ -1692,40 +1719,40 @@ msgstr ""
 msgid "APP [args...] - Run an app"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "NÁZOV musí byť určený"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "Spustí aplikáciu"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Vetva, ktorá sa má použiť"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "Žiadny vzdialený repozitár %s"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Úplný popis"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "Nič nevyhovuje názvu %s"
@@ -1793,36 +1820,12 @@ msgstr ""
 msgid "Only update this subpath"
 msgstr ""
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr ""
-"Chyba počas aktualizácie metaúdajov navyše pre „%s“: %s\n"
-"\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr ""
-"Chyba počas aktualizácie metaúdajov navyše pre „%s“: %s\n"
-"\n"
-
-#: app/flatpak-builtins-update.c:113
-#, fuzzy, c-format
-msgid "Error updating: %s\n"
-msgstr "Aktualizovanie zhrnutia\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr ""
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 #, fuzzy
 msgid "[REF...] - Update applications or runtimes"
 msgstr "Podpíše aplikáciu alebo rozhranie"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 #, fuzzy
 msgid "Looking for updates...\n"
 msgstr "Žiadne aktualizácie.\n"
@@ -1839,6 +1842,30 @@ msgstr ""
 #: app/flatpak-builtins-utils.c:374
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
+msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr ""
+"Chyba počas aktualizácie metaúdajov navyše pre „%s“: %s\n"
+"\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr ""
+"Chyba počas aktualizácie metaúdajov navyše pre „%s“: %s\n"
+"\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, fuzzy, c-format
+msgid "Error updating: %s\n"
+msgstr "Aktualizovanie zhrnutia\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
 msgstr ""
 
 #. translators: please keep the leading space
@@ -1994,7 +2021,8 @@ msgid "Export a build dir to a repository"
 msgstr "Exportuje adresár zostavenia do repozitára"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Vytvorí balík z adresára zostavenia"
 
 #: app/flatpak-main.c:105
@@ -2070,22 +2098,22 @@ msgstr "NÁZOV_SÚBORU"
 msgid "Builtin Commands:"
 msgstr "Vstavané príkazy:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Neznámy príkaz „%s“"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Nebol určený žiadny príkaz"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "chyba:"
 
@@ -2118,9 +2146,9 @@ msgstr ""
 msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr ""
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2230,475 +2258,475 @@ msgstr ""
 msgid "One or more operations failed"
 msgstr "Jedna alebo viacero aktualizácií zlyhali"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr ""
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Počas otvárania repozitára %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr ""
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr ""
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr ""
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr ""
-
-#: common/flatpak-dir.c:2647
-#, fuzzy, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Zlyhalo čítanie začlenenia %s: "
-
-#: common/flatpak-dir.c:2650
-#, fuzzy, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Nesprávna veľkosť pre údaje navyše %s"
-
-#: common/flatpak-dir.c:2665
-#, fuzzy, c-format
-msgid "While downloading %s: "
-msgstr "Počas otvárania repozitára %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Nesprávna veľkosť pre údaje navyše %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr ""
-
-#: common/flatpak-dir.c:2742
-#, fuzzy
-msgid "Remote OCI index has no registry uri"
-msgstr "NÁZOV [UMIESTNENIE] - Pridanie vzdialeného repozitára"
-
-#: common/flatpak-dir.c:2958
-#, fuzzy, c-format
-msgid "%s commit %s already installed"
-msgstr "Aplikácia %s vetva %s je už nainštalovaná"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr ""
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Nedá sa nájsť %s vo vzdialenom repozitári %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Nedostatok pamäte"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Zlyhalo čítanie z exportovaného súboru"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr ""
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr ""
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr ""
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr ""
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr ""
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr ""
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr ""
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr ""
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "Aplikácia %s nie je dostupná"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "Aplikácia %s vetva %s je už nainštalovaná"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Zlyhalo čítanie začlenenia %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr ""
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr ""
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Počas pokusu o odstránenie existujúceho adresára navyše: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Počas pokusu o aplikáciu údajov navyše: "
-
-#: common/flatpak-dir.c:5433
-#, fuzzy, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Neplatný identifikátor pid %s"
-
-#: common/flatpak-dir.c:5440
-#, fuzzy, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Neplatný identifikátor pid %s"
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr ""
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Táto verzia aplikácie %s je už nainštalovaná"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr ""
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "Aplikácia %s vetva %s nie je nainštalovaná"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "Aplikácia %s vetva %s nie je nainštalovaná"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Nič nevyhovuje názvu %s"
-
-#: common/flatpak-dir.c:8119
-#, fuzzy, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Nedá sa nájsť %s%s%s%s%s vo vzdialenom repozitári %s"
-
-#: common/flatpak-dir.c:8161
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8206
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "Aplikácia %s %s nie je nainštalovaná"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Nepodarilo sa nájsť inštaláciu %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Prostredie %s, vetva %s je už nainštalovaná"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Aplikácia %s, vetva %s je už nainštalovaná"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr ""
-
-#: common/flatpak-dir.c:9597
-#, fuzzy
-msgid "Remote default-branch not set"
-msgstr "Vypíše predvolenú architektúru a skončí"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr ""
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr ""
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr ""
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr ""
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
 "*[/...], ~/dir, /dir"
 msgstr ""
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr ""
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Zdieľa s hostiteľom"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr ""
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr ""
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr ""
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOKET"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr ""
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr ""
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "ZARIADENIE"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr ""
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Umožní funkciu"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "FUNKCIA"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Neumožní funkciu"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr ""
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr ""
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr ""
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "SYSTÉM_SÚBOROV"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr ""
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr ""
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr ""
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "NÁZOV_DBUS"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr ""
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr ""
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr ""
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr ""
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr ""
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr ""
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr ""
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "NÁZOV_SÚBORU"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr ""
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr ""
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Počas otvárania repozitára %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr ""
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr ""
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr ""
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr ""
+
+#: common/flatpak-dir.c:2661
+#, fuzzy, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Zlyhalo čítanie začlenenia %s: "
+
+#: common/flatpak-dir.c:2664
+#, fuzzy, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Nesprávna veľkosť pre údaje navyše %s"
+
+#: common/flatpak-dir.c:2679
+#, fuzzy, c-format
+msgid "While downloading %s: "
+msgstr "Počas otvárania repozitára %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Nesprávna veľkosť pre údaje navyše %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr ""
+
+#: common/flatpak-dir.c:2756
+#, fuzzy
+msgid "Remote OCI index has no registry uri"
+msgstr "NÁZOV [UMIESTNENIE] - Pridanie vzdialeného repozitára"
+
+#: common/flatpak-dir.c:2976
+#, fuzzy, c-format
+msgid "%s commit %s already installed"
+msgstr "Aplikácia %s vetva %s je už nainštalovaná"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr ""
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Nedá sa nájsť %s vo vzdialenom repozitári %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Nedostatok pamäte"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Zlyhalo čítanie z exportovaného súboru"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr ""
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr ""
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr ""
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr ""
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr ""
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr ""
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr ""
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr ""
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "Aplikácia %s nie je dostupná"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "Aplikácia %s vetva %s je už nainštalovaná"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Zlyhalo čítanie začlenenia %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr ""
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr ""
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Počas pokusu o odstránenie existujúceho adresára navyše: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Počas pokusu o aplikáciu údajov navyše: "
+
+#: common/flatpak-dir.c:5451
+#, fuzzy, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Neplatný identifikátor pid %s"
+
+#: common/flatpak-dir.c:5458
+#, fuzzy, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Neplatný identifikátor pid %s"
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr ""
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Táto verzia aplikácie %s je už nainštalovaná"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr ""
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "Aplikácia %s vetva %s nie je nainštalovaná"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "Aplikácia %s vetva %s nie je nainštalovaná"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Nič nevyhovuje názvu %s"
+
+#: common/flatpak-dir.c:8147
+#, fuzzy, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Nedá sa nájsť %s%s%s%s%s vo vzdialenom repozitári %s"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "Aplikácia %s %s nie je nainštalovaná"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Nepodarilo sa nájsť inštaláciu %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Prostredie %s, vetva %s je už nainštalovaná"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Aplikácia %s, vetva %s je už nainštalovaná"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr ""
+
+#: common/flatpak-dir.c:9629
+#, fuzzy
+msgid "Remote default-branch not set"
+msgstr "Vypíše predvolenú architektúru a skončí"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr ""
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr ""
+
+#: common/flatpak-run.c:1450
 #, fuzzy, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Zlyhalo otvorenie dočasného súboru flatpak-info"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, fuzzy, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Zlyhalo otvorenie súboru temp"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr ""
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Zlyhalo otvorenie súboru s informáciami o aplikácii: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr ""
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr ""
@@ -2713,153 +2741,92 @@ msgstr "Aktualizovanie: %s z %s\n"
 msgid "Error during migration: %s\n"
 msgstr ""
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Žiadne zdroje údajov navyše"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr ""
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, fuzzy, c-format
 msgid "Downloading: %s/%s"
 msgstr "Zobrazí referenciu"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, fuzzy, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Zobrazí referenciu"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, fuzzy, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Zobrazí referenciu"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Nainštalovanie podpísanej aplikácie"
+#~ msgid "Install signed application"
+#~ msgstr "Nainštalovanie podpísanej aplikácie"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Na inštaláciu softvéru sa vyžaduje overenie totožnosti"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Na inštaláciu softvéru sa vyžaduje overenie totožnosti"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Nainštalovanie podpísaného prostredia"
+#~ msgid "Install signed runtime"
+#~ msgstr "Nainštalovanie podpísaného prostredia"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Aktualizovanie podpísanej aplikácie"
+#~ msgid "Update signed application"
+#~ msgstr "Aktualizovanie podpísanej aplikácie"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Na aktualizáciu softvéru sa vyžaduje overenie totožnosti"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Na aktualizáciu softvéru sa vyžaduje overenie totožnosti"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Aktualizovanie podpísaného prostredia"
+#~ msgid "Update signed runtime"
+#~ msgstr "Aktualizovanie podpísaného prostredia"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
 #, fuzzy
-msgid "Update remote metadata"
-msgstr "Použije alternatívny súbor pre metaúdaje"
+#~ msgid "Update remote metadata"
+#~ msgstr "Použije alternatívny súbor pre metaúdaje"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
 #, fuzzy
-msgid "Authentication is required to update remote info"
-msgstr "Na aktualizáciu softvéru sa vyžaduje overenie totožnosti"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Na aktualizáciu softvéru sa vyžaduje overenie totožnosti"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
 #, fuzzy
-msgid "Update system repository"
-msgstr "Aktualizuje súbor zhrnutia v repozitári"
+#~ msgid "Update system repository"
+#~ msgstr "Aktualizuje súbor zhrnutia v repozitári"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
 #, fuzzy
-msgid "Authentication is required to update the system repository"
-msgstr "Na aktualizáciu softvéru sa vyžaduje overenie totožnosti"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Na aktualizáciu softvéru sa vyžaduje overenie totožnosti"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Nainštalovanie balíka"
+#~ msgid "Install bundle"
+#~ msgstr "Nainštalovanie balíka"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Odinštalovanie prostredia"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Odinštalovanie prostredia"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Na odinštalovanie softvéru sa vyžaduje overenie totožnosti"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Na odinštalovanie softvéru sa vyžaduje overenie totožnosti"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
 #, fuzzy
-msgid "Uninstall app"
-msgstr "Odinštalovanie prostredia"
+#~ msgid "Uninstall app"
+#~ msgstr "Odinštalovanie prostredia"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Konfigurácia vzdialeného repozitára"
+#~ msgid "Configure Remote"
+#~ msgstr "Konfigurácia vzdialeného repozitára"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr ""
-"Na konfiguráciu softvérových repozitárov sa vyžaduje overenie totožnosti"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr ""
+#~ "Na konfiguráciu softvérových repozitárov sa vyžaduje overenie totožnosti"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
 #, fuzzy
-msgid "Configure"
-msgstr "Konfigurácia vzdialeného repozitára"
+#~ msgid "Configure"
+#~ msgstr "Konfigurácia vzdialeného repozitára"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
 #, fuzzy
-msgid "Authentication is required to configure software installation"
-msgstr ""
-"Na konfiguráciu softvérových repozitárov sa vyžaduje overenie totožnosti"
-
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr ""
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr ""
+#~ "Na konfiguráciu softvérových repozitárov sa vyžaduje overenie totožnosti"
 
 #~ msgid "No remote %s"
 #~ msgstr "Žiadny vzdialený repozitár %s"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-12-01 03:20+0100\n"
 "Last-Translator: Josef Andersson <josef.andersson@fripost.org>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -148,7 +148,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "NAMN PLATS - Lägg till ett fjärrförråd"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "NAMN måste anges"
 
@@ -166,7 +166,7 @@ msgstr "PLATS måste anges"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -232,7 +232,7 @@ msgstr "Arkitektur att skapa bunt för"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -392,7 +392,7 @@ msgstr "Ingen utökningspunkt matchar %s i %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Saknar ”=” i bindningsmonteringsargument ”%s”"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Kunde inte starta program"
 
@@ -786,7 +786,7 @@ msgstr "PLATS FILNAMN - Importera en filbunt in i ett lokalt arkiv"
 msgid "LOCATION and FILENAME must be specified"
 msgstr "PLATS och FILNAMN måste anges"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Ark att använda"
@@ -1104,124 +1104,150 @@ msgstr "Det går inte att byta gid"
 msgid "Can't switch uid"
 msgstr "Det går inte att byta uid"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Visa användarinstallationer"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Visa systeminstallationer"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Visa specifika systemomfattande installationer"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Visa ref"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Visa incheckning"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Visa ursprung"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Visa storlek"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Visa metadata"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Visa tillägg"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Hantera filåtkomst"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "SÖKVÄG"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Visa tillägg"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "NAMN [GREN] - Hämta information om installerat program och/eller "
 "exekveringsmiljö"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "ref fanns inte i källa"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Ref:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "ID:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Ark:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Gren:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Origin:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Samlings-ID"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr "Datum:"
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr "Ämne:"
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Aktiv incheckning:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Senaste incheckning:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Incheckning:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "alt-id:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr "Överordnad:"
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Plats:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Installerad storlek:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Exekvering:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Installerade underkataloger:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Tillägg:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Undersökvägar:"
 
@@ -1246,37 +1272,42 @@ msgstr "Visa logg"
 msgid "Show parent"
 msgstr "Visa överordnad"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 " REMOTE REF - visa information om ett program eller en exekveringsmiljö i "
 "ett fjärrförråd"
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "FJÄRRFÖRRÅD och REF måste anges"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 msgid "Download size:"
 msgstr "Hämtningsstorlek:"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 #, fuzzy
 msgid "History:\n"
 msgstr "Historik:"
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr " Ämne:"
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr " Datum:"
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 msgid " Commit:"
 msgstr " Incheckning:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1313,10 +1344,6 @@ msgstr "Kontrollera buntsignaturer med GPG-nyckel från FIL (- för standard in)
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Installera endast denna underkatalog"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "SÖKVÄG"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1479,7 +1506,7 @@ msgstr "Incheckning"
 msgid "Download size"
 msgstr "Hämtningsstorlek"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "Ingen ref-information tillgänglig i arkiv"
 
@@ -1689,35 +1716,35 @@ msgstr "Aktivera filvidarebefordran"
 msgid "APP [args...] - Run an app"
 msgstr "PROG [argument…] - Kör ett program"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr "TEXT - Sök i fjärrprogram/exekveringsmiljöer efter text"
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 msgid "TEXT must be specified"
 msgstr "TEXT måste anges"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 msgid "Application ID"
 msgstr "Program-ID"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr "Version"
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 msgid "Branch"
 msgstr "Gren"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 msgid "Remotes"
 msgstr "Fjärrförråd"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 msgid "Description"
 msgstr "Beskrivning"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 msgid "No matches found"
 msgstr "Inga träffar"
 
@@ -1783,31 +1810,11 @@ msgstr "Uppdatera appstream för fjärrförråd"
 msgid "Only update this subpath"
 msgstr "Uppdatera endast denna undersökväg"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Uppdatera appstream för fjärrförrådet %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Uppdatera appstream för fjärrförrådet %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, c-format
-msgid "Error updating: %s\n"
-msgstr "Fel vid uppdatering: %s\n"
-
-#: app/flatpak-builtins-update.c:143
-#, fuzzy, c-format
-msgid "Remote \"%s\" not found"
-msgstr "Data inte funnen"
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REF…]] - Uppdatera ett program eller exekveringsmiljö"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 msgid "Looking for updates...\n"
 msgstr "Söker efter uppdateringar...\n"
 
@@ -1825,6 +1832,26 @@ msgstr "Vilka vill du installera (0 för att avbryta)?"
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
 msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Uppdatera appstream för fjärrförrådet %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Uppdatera appstream för fjärrförrådet %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, c-format
+msgid "Error updating: %s\n"
+msgstr "Fel vid uppdatering: %s\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, fuzzy, c-format
+msgid "Remote \"%s\" not found"
+msgstr "Data inte funnen"
 
 #. translators: please keep the leading space
 #: app/flatpak-main.c:62
@@ -1977,7 +2004,8 @@ msgid "Export a build dir to a repository"
 msgstr "Exportera en byggkatalog till ett förråd"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Skapa en buntfil från en byggkatalog"
 
 #: app/flatpak-main.c:105
@@ -2051,22 +2079,22 @@ msgstr "NAMN"
 msgid "Builtin Commands:"
 msgstr "Inbyggda kommandon:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Okänt kommando ”%s”"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Inget kommando angivet"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "fel:"
 
@@ -2099,9 +2127,9 @@ msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr ""
 "Den krävda exekveringsmiljön %s hittades inte i konfigurerat fjärrförråd.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2207,323 +2235,38 @@ msgstr "Fel: Misslyckades med %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "En eller flera åtgärder misslyckades"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Inga åsidosättningar funna för %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Medan förråd %s öppnas: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Kan inte skapa distributionskatalog"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Ogiltig sha256 för extra data-uri %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Tomt namn för extra data-uri %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Extra data-uri som ej stöds %s"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Misslyckades med att läsa lokala extra data %s: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Fel storlek för extra data %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Medan %s hämtas: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Fel storlek för extra data %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Ogiltig kontrollsumma för extra data %s"
-
-#: common/flatpak-dir.c:2742
-msgid "Remote OCI index has no registry uri"
-msgstr "OCI-index för fjärrförråd har ingen register-uri"
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s incheckning %s redan installerat"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Medan %s hämtas från fjärrförrådet %s: "
-
-# sebras: how to translate in here?
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Kan inte hitta %s i fjärrförrådet %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Inte tillräckligt med minne"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Misslyckades med att läsa från exporterad fil"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Fel vid läsning av xml-fil för mimetyp"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Ogiltig xml-fil för mimetyp"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Under hämtning av frånkopplad metadata: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Under tiden extrakatalog skapas: "
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Ogiltigt sha256 för extradata"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Fel storlek för extra data"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Ogiltig kontrollsumma för extra data"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Fel vid skrivning av extra data-filen ”%s”: "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "misslyckades med skriptet apply_extra, avslutningsstatus %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Under upplösningsförsök för ref %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s är inte tillgängligt"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s gren %s redan installerat"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Misslyckades läsa incheckning %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Medan utcheckningsförsök av %s i %s: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Under utcheckningsförsök av metadataundersökväg: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Under försök att ta bort extra existerande katalog: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Under försök att tillämpa extra data: "
-
-#: common/flatpak-dir.c:5433
-#, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Ogiltig distribuerad ref %s: "
-
-#: common/flatpak-dir.c:5440
-#, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Ogiltig incheckningsref %s: "
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "Distribuerad ref %s matchar inte incheckning (%s)"
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "Distribuerad ref %s matchar inte incheckning (%s)"
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr "Ark för distribuerad ref %s matchar inte incheckning (%s)"
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "Distribuerad ref %s-gren matchar inte incheckning (%s)"
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "Distribuerad ref %s matchar inte incheckning (%s)"
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr "Distribuerad metadata matchar inte incheckning"
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Denna version av %s är redan installerad"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Kan inte ändra fjärrförråd under buntinstallering"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s gren %s är inte installerad"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s gren %s inte installerad"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr "Rensning av förråd misslyckades: %s"
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr "Flera grenar tillgängliga för %s, du måste ange en av: "
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Ingenting matchar %s"
-
-# sebras: how to translate in here?
-#: common/flatpak-dir.c:8119
-#, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Det går inte att hitta ref %s%s%s%s%s"
-
-#: common/flatpak-dir.c:8161
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Fel vid sökning av fjärrförråd %s: %s"
-
-#: common/flatpak-dir.c:8206
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr "Fel vid sökning i lokalt förråd: %s"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s inte installerad"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Kunde inte hitta installationen %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Exekveringsmiljö %s, gren %s är redan installerad"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Program %s, gren %s är redan installerad"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Titel för fjärrförråd inte angett"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Standardfjärrgren inte inställd"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "Ingen flatpak-cache i fjärrförrådets sammanfattning"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Ingen post för %s i sammanfattningen av fjärrförrådets flatpak-cache "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Okänd delningstyp %s, giltiga typer är: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Okänd policytyp %s, giltiga typer är: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Ogiltigt dbusnamn %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Okänd uttagstyp %s, giltiga typer är %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Okänd enhetstyp %s, giltiga typer är: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Okänd funktionstyp %s, giltiga typer är: %s"
 
 # sebras: can host and home be translated?
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2532,157 +2275,442 @@ msgstr ""
 "Okänd filsystemsplats %s, giltiga platser är: host, home, xdg-*[/…], ~/kat, /"
 "kat"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Ogiltigt miljöformat %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Dela med värd"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "DELA"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Avsluta delning med värd"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Exponera uttag för program"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "UTTAG"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Exponera inte detta uttag för program"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Exponera enhet för program"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "ENHET"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Exponera inte enhet till program"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Tillåt funktion"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "FUNKTION"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Tillåt inte funktion"
 
 # sebras: can ro be translated?
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Exponera filsystem för program (:ro för skrivskyddat)"
 
 # sebras: can ro be translated?
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "FILSYSTEM[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Exponera inte filsystem för program"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "FILSYSTEM"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Ställ in miljövariabel"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "VAR=VÄRDE"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Tillåt program att äga namn på sessionsbussen"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "DBUSNAMN"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Tillåt program att prata med namn på sessionsbussen"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Tillåt program att äga namn på systembussen"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Tillåt program att prata med namn på systembussen"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Lägg till alternativ för generell policy"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSYSTEM.KEY=VALUE"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Ta bort alternativet för generell policy"
 
 # sebras: persist or persistant?
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Beständig hemkatalog"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "FILNAMN"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Kräv inte en körande session (inget cgroups-skapande)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Inga åsidosättningar funna för %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Medan förråd %s öppnas: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Kan inte skapa distributionskatalog"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Ogiltig sha256 för extra data-uri %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Tomt namn för extra data-uri %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Extra data-uri som ej stöds %s"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Misslyckades med att läsa lokala extra data %s: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Fel storlek för extra data %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Medan %s hämtas: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Fel storlek för extra data %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Ogiltig kontrollsumma för extra data %s"
+
+#: common/flatpak-dir.c:2756
+msgid "Remote OCI index has no registry uri"
+msgstr "OCI-index för fjärrförråd har ingen register-uri"
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s incheckning %s redan installerat"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Medan %s hämtas från fjärrförrådet %s: "
+
+# sebras: how to translate in here?
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Kan inte hitta %s i fjärrförrådet %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Inte tillräckligt med minne"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Misslyckades med att läsa från exporterad fil"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Fel vid läsning av xml-fil för mimetyp"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Ogiltig xml-fil för mimetyp"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Under hämtning av frånkopplad metadata: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Under tiden extrakatalog skapas: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Ogiltigt sha256 för extradata"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Fel storlek för extra data"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Ogiltig kontrollsumma för extra data"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Fel vid skrivning av extra data-filen ”%s”: "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "misslyckades med skriptet apply_extra, avslutningsstatus %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Under upplösningsförsök för ref %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s är inte tillgängligt"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s gren %s redan installerat"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Misslyckades läsa incheckning %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Medan utcheckningsförsök av %s i %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Under utcheckningsförsök av metadataundersökväg: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Under försök att ta bort extra existerande katalog: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Under försök att tillämpa extra data: "
+
+#: common/flatpak-dir.c:5451
+#, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Ogiltig distribuerad ref %s: "
+
+#: common/flatpak-dir.c:5458
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Ogiltig incheckningsref %s: "
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "Distribuerad ref %s matchar inte incheckning (%s)"
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "Distribuerad ref %s matchar inte incheckning (%s)"
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr "Ark för distribuerad ref %s matchar inte incheckning (%s)"
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "Distribuerad ref %s-gren matchar inte incheckning (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "Distribuerad ref %s matchar inte incheckning (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Distribuerad metadata matchar inte incheckning"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Denna version av %s är redan installerad"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Kan inte ändra fjärrförråd under buntinstallering"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s gren %s är inte installerad"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s gren %s inte installerad"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr "Rensning av förråd misslyckades: %s"
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr "Flera grenar tillgängliga för %s, du måste ange en av: "
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Ingenting matchar %s"
+
+# sebras: how to translate in here?
+#: common/flatpak-dir.c:8147
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Det går inte att hitta ref %s%s%s%s%s"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Fel vid sökning av fjärrförråd %s: %s"
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Fel vid sökning i lokalt förråd: %s"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s inte installerad"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Kunde inte hitta installationen %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Exekveringsmiljö %s, gren %s är redan installerad"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Program %s, gren %s är redan installerad"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Titel för fjärrförråd inte angett"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Standardfjärrgren inte inställd"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Ingen flatpak-cache i fjärrförrådets sammanfattning"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Ingen post för %s i sammanfattningen av fjärrförrådets flatpak-cache "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Misslyckades med att öppna temporär flatpak-info-fil: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Misslyckades med att öppna temporärfil: %s"
 
 # sebras: sync?
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Kan inte skapa sync-rör"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Misslyckades med att öppna prog-info-fil: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Misslyckades med att synkronisera med dbus-proxy"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "misslyckades med ldconfig, avslutningsstatus %d"
@@ -2697,144 +2725,86 @@ msgstr "Migrerar %s till %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Fel vid migrering: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Inga extra data-källor"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Hämtar ned metadata: %u/(beräknad) %s"
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Hämtar: %s/%s"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Hämtar extra data: %s/%s"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Hämtar filer: %d/%d %s"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Installera signerat program"
+#~ msgid "Install signed application"
+#~ msgstr "Installera signerat program"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Autentisering krävs för att installera program"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Autentisering krävs för att installera program"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Installera signerad exekveringsmiljö"
+#~ msgid "Install signed runtime"
+#~ msgstr "Installera signerad exekveringsmiljö"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Uppdatera signerat program"
+#~ msgid "Update signed application"
+#~ msgstr "Uppdatera signerat program"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Autentisering krävs för att uppdatera program"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Autentisering krävs för att uppdatera program"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Uppdatera signerad exekveringsmiljö"
+#~ msgid "Update signed runtime"
+#~ msgstr "Uppdatera signerad exekveringsmiljö"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Uppdatera fjärrförrådmetadata"
+#~ msgid "Update remote metadata"
+#~ msgstr "Uppdatera fjärrförrådmetadata"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr "Autentisering krävs för att uppdatera fjärrförrådsinfo"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Autentisering krävs för att uppdatera fjärrförrådsinfo"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
-msgid "Update system repository"
-msgstr "Uppdaterar systemförråd"
+#~ msgid "Update system repository"
+#~ msgstr "Uppdaterar systemförråd"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
-msgid "Authentication is required to update the system repository"
-msgstr "Autentisering krävs för att uppdatera systemförrådet"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Autentisering krävs för att uppdatera systemförrådet"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Installera bunt"
+#~ msgid "Install bundle"
+#~ msgstr "Installera bunt"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Avinstallera exekveringsmiljö"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Avinstallera exekveringsmiljö"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Autentisering krävs för att avinstallera program"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Autentisering krävs för att avinstallera program"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Avinstallera program"
+#~ msgid "Uninstall app"
+#~ msgstr "Avinstallera program"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Konfigurera fjärrförråd"
+#~ msgid "Configure Remote"
+#~ msgstr "Konfigurera fjärrförråd"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "Autentisering krävs för att konfigurera programförråd"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr "Autentisering krävs för att konfigurera programförråd"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
-msgid "Configure"
-msgstr "Konfigurera"
+#~ msgid "Configure"
+#~ msgstr "Konfigurera"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
-msgid "Authentication is required to configure software installation"
-msgstr "Autentisering krävs för att konfigurera programinstallationen"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr "Autentisering krävs för att konfigurera programinstallationen"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Uppdatera appstream"
+#~ msgid "Update appstream"
+#~ msgstr "Uppdatera appstream"
 
 #~ msgid "No remote %s"
 #~ msgstr "Inget fjärrförråd %s"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-05-20 08:19+0300\n"
 "Last-Translator: Muhammet Kara <muhammetk@gmail.com>\n"
 "Language-Team: Türkçe <gnome-turk@gnome.org>\n"
@@ -151,7 +151,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "İSİM KONUM - Uzak bir arşiv ekle"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "İSİM belirtilmelidir"
 
@@ -169,7 +169,7 @@ msgstr "KONUM belirtilmelidir"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -235,7 +235,7 @@ msgstr "Paketleneceği mimari"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -393,7 +393,7 @@ msgstr "%s'e uyan eklenti noktası %s'te yok"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Bağlama noktası seçeneği '%s'te eksik '='"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Uygulama başlatılamadı"
 
@@ -789,7 +789,7 @@ msgstr "KONUM DOSYAADI - Bir yerel arşive dosya paketi içe aktar"
 msgid "LOCATION and FILENAME must be specified"
 msgstr "KONUM ve DOSYAADI belirtilmelidir"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Kullanılacak mimari"
@@ -1103,123 +1103,149 @@ msgstr "gid değiştirilemedi"
 msgid "Can't switch uid"
 msgstr "uid değiştirilemedi"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Kullanıcı yüklemelerini göster"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Sistem-geneli yüklemeleri göster"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Belirli sistem-geneli yüklemeleri göster"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Referansı göster"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Değişikliği göster"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Kökeni göster"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Boyut göster"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Üst veri göster"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Eklentileri göster"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+"Dosya erişimini yönet"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "VERİYOLU"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Eklentileri göster"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "İSİM [DAL] - Yüklü uygulamalar ve/veya çalışma ortamları hakkında bilgi edin"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Dal:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Bir uygulama çalıştır"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Yüklü boyut:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Çalışma zamanı:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Uzantı:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr ""
 
@@ -1245,36 +1271,41 @@ msgstr ""
 msgid "Show parent"
 msgstr "Referansı göster"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "UZAK ve REFERANS belirtilmelidir"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "İndirme boyutu"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Değişikliği göster"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1311,10 +1342,6 @@ msgstr "Paket imzalarını DOSYA'daki (stdin için -) GPG anahtarıyla kontrol e
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Sadece bu alt yolunu yükle "
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "VERİYOLU"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1475,7 +1502,7 @@ msgstr ""
 msgid "Download size"
 msgstr "İndirme boyutu"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 #, fuzzy
 msgid "No ref information available in repository"
 msgstr "Arşiv hakkında genel bilgileri yazdır"
@@ -1686,40 +1713,40 @@ msgstr ""
 msgid "APP [args...] - Run an app"
 msgstr "UYGULAMA [arg...] - Bir uygulamayı çalıştır"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "UZAK belirtilmelidir"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "Bir uygulama çalıştır"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Dal:"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "%s uzak yok"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Tam açıklama"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "%s için eşleşme yok"
@@ -1786,31 +1813,11 @@ msgstr "Appstream'i uzak için güncelle"
 msgid "Only update this subpath"
 msgstr "Sadece bu alt yolu güncelle"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Appstream uzak %s için güncelleniyor\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Appstream uzak %s için güncelleniyor\n"
-
-#: app/flatpak-builtins-update.c:113
-#, fuzzy, c-format
-msgid "Error updating: %s\n"
-msgstr "Özet güncelleniyor\n"
-
-#: app/flatpak-builtins-update.c:143
-#, c-format
-msgid "Remote \"%s\" not found"
-msgstr ""
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[REFERANS...] - Uygulamaları veya çalışma ortamlarını güncelle"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 #, fuzzy
 msgid "Looking for updates...\n"
 msgstr "Güncelleme yok.\n"
@@ -1828,6 +1835,26 @@ msgstr "Hangisini yüklemek istiyorsunuz (iptal etmek için 0)?"
 #: app/flatpak-builtins-utils.c:374
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
+msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Appstream uzak %s için güncelleniyor\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Appstream uzak %s için güncelleniyor\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, fuzzy, c-format
+msgid "Error updating: %s\n"
+msgstr "Özet güncelleniyor\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, c-format
+msgid "Remote \"%s\" not found"
 msgstr ""
 
 #. translators: please keep the leading space
@@ -1982,7 +2009,8 @@ msgid "Export a build dir to a repository"
 msgstr "Bir inşa dizinini bir arşive dışa aktar"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Bir inşa dizininden paket dosyası oluştur"
 
 #: app/flatpak-main.c:105
@@ -2055,22 +2083,22 @@ msgstr "İSİM"
 msgid "Builtin Commands:"
 msgstr "Yerleşik Komutlar:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Bilinmeyen komut '%s'"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Komut belirtilmemiş"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "hata:"
 
@@ -2102,9 +2130,9 @@ msgstr "%s için gerekli çalışma ortamı (%s) yüklü değil, aranıyor...\n"
 msgid "The required runtime %s was not found in a configured remote.\n"
 msgstr "Gerekli çalışma ortamı %s yapılandırılmış uzaklarda bulunamadı.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2210,321 +2238,37 @@ msgstr "Hata: %2$s'i %1$s başarılamadı: %3$s\n"
 msgid "One or more operations failed"
 msgstr "Bir veya daha fazla seçenek başarılamadı"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "%s için geçersiz kılma bulunamadı"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Arşiv %s'i açarken:"
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Dağıtım dizini oluşturulamadı"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Ek veri uri'si %s için geçersiz sha256 "
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Ek veri uri'si %s için boş isim"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Desteklenmeyen ek veri uri'si %s"
-
-#: common/flatpak-dir.c:2647
-#, fuzzy, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Değişiklik %s okunamadı:"
-
-#: common/flatpak-dir.c:2650
-#, fuzzy, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Ek veri %s için yanlış boyut"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "%s indirilirken:"
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Ek veri %s için yanlış boyut"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Ek veri %s için geçeresiz sağlama toplamı"
-
-#: common/flatpak-dir.c:2742
-#, fuzzy
-msgid "Remote OCI index has no registry uri"
-msgstr "KONUM'un bir oci sicili olduğunu varsay "
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s değişikliği %s zaten yüklü"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Uzak %2$s'ten %1$s çekerken:"
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Uzak %2$s'te %1$s bulunamadı"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Yeterli bellek yok"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Dışa aktarılmış dosyadan okunamadı"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr ""
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Ayrık üst veri alınırken:"
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Ek dizin oluşturulurken:"
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Ek veri için geçersiz sha256"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Ek veri için yanlış boyut"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Ek veri için geçersiz sağlama toplamı"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Ek veri dosyası '%s' yazılırken:"
-
-#: common/flatpak-dir.c:5181
-#, fuzzy, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "apply_extra betiği başarısız oldu"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Referans %s çözülmeye çalışılırken:"
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s mevcut değil"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "%s dalı %s zaten yüklü"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Değişiklik %s okunamadı:"
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "%s'i %s'e geçirmeye çalışırken:"
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Üst veri alt dizini geçirilmeye çalışılırken:"
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Var olan ek dizini kaldırmaya çalışırken:"
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Ek veriyi uygulamaya çalışırken:"
-
-#: common/flatpak-dir.c:5433
-#, fuzzy, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Geçersiz pid %s"
-
-#: common/flatpak-dir.c:5440
-#, fuzzy, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Geçersiz pid %s"
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr ""
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr ""
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "%s'in bu sürümü zaten yüklü"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Paket yüklemesi sırasında uzak değiştirilemedi"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s dalı %s yüklü değil"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s dalı %s yüklü değil"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr ""
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "%s için eşleşme yok"
-
-#: common/flatpak-dir.c:8119
-#, fuzzy, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "%s%s%s%s%s uzak %s'te bulunamadı"
-
-#: common/flatpak-dir.c:8161
-#, fuzzy, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Hata: %2$s'i %1$s başarılamadı: %3$s\n"
-
-#: common/flatpak-dir.c:8206
-#, fuzzy, c-format
-msgid "Error searching local repository: %s"
-msgstr "Referansı yerel arşivde sakla"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "%s %s yüklü değil"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Yükleme %s bulunamadı"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Çalışma ortamı %s, dal %s zaten yüklü"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Uygulama %s, dal %s zaten yüklü"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Uzak başlığı ayarlı değil"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Uzak öntanımlı dalı ayarlı değil"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "Uzak özetinde flatpak önbelleği yok"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Uzak özeti flatpak önbelleğinde %s için girdi yok"
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Bilinmeyen paylaşım tipi %s, geçerli tipler: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Bilinmeyen ilke tipi %s, geçerli tipler: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Geçersiz dbus ismi %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Bilinmeyen soket tipi %s, geçerli tipler: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Bilinmeyen cihaz tiği %s, geçerli tipler: %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Bilinmeyen özellik tipi %s, geçerli tipler: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2533,153 +2277,437 @@ msgstr ""
 "Bilinmeyen dosya sistemi konumu %s, geçerli konumlar: makina, home, xdg-"
 "*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Geçersiz env formatı %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Makinayla paylaş"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "PAYLAŞ"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Makinayla paylaşma"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Soketi uygulamaya göster"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "SOKET"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Soketi uygulamaya gösterme"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Cihazı uygulamaya göster"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "CİHAZ"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Cihazı uygulamaya gösterme"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Özelliğe izin ver"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "ÖZELLİK"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Özelliğe izin verme"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Dosya sistemini uygulamaya göster (salt-okuma için :ro)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "DOSYASİSTEMİ[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Dosya sistemini uygulamaya gösterme"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "DOSYASİSTEMİ"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Ortam değişkeni tanımla"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "DEĞİŞKEN=DEĞER"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Uygulamanın oturum veri yolunda kendi adı olmasına izin ver"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "DBUS_İSMİ"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Uygulamanın oturum veri yolunda isme konuşmasına izin ver"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Uygulamanın sistem veri yolunda kendi adı olmasına izin ver"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Uygulamanın sistem veri yolunda isme konuşmasına izin ver"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Genel ilke seçeneği ekle"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "ALTSİSTEM.ANAHTAR=DEĞER"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Genel ilke seçeneğini kaldır"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Ev dizinini koru"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "DOSYAİSMİ"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Çalışan oturum gerektirme (cgroups yaratımı yok)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "%s için geçersiz kılma bulunamadı"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Arşiv %s'i açarken:"
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Dağıtım dizini oluşturulamadı"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Ek veri uri'si %s için geçersiz sha256 "
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Ek veri uri'si %s için boş isim"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Desteklenmeyen ek veri uri'si %s"
+
+#: common/flatpak-dir.c:2661
+#, fuzzy, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Değişiklik %s okunamadı:"
+
+#: common/flatpak-dir.c:2664
+#, fuzzy, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Ek veri %s için yanlış boyut"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "%s indirilirken:"
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Ek veri %s için yanlış boyut"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Ek veri %s için geçeresiz sağlama toplamı"
+
+#: common/flatpak-dir.c:2756
+#, fuzzy
+msgid "Remote OCI index has no registry uri"
+msgstr "KONUM'un bir oci sicili olduğunu varsay "
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s değişikliği %s zaten yüklü"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Uzak %2$s'ten %1$s çekerken:"
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Uzak %2$s'te %1$s bulunamadı"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Yeterli bellek yok"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Dışa aktarılmış dosyadan okunamadı"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr ""
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Ayrık üst veri alınırken:"
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Ek dizin oluşturulurken:"
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Ek veri için geçersiz sha256"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Ek veri için yanlış boyut"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Ek veri için geçersiz sağlama toplamı"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Ek veri dosyası '%s' yazılırken:"
+
+#: common/flatpak-dir.c:5199
+#, fuzzy, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "apply_extra betiği başarısız oldu"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Referans %s çözülmeye çalışılırken:"
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s mevcut değil"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s dalı %s zaten yüklü"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Değişiklik %s okunamadı:"
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "%s'i %s'e geçirmeye çalışırken:"
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Üst veri alt dizini geçirilmeye çalışılırken:"
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Var olan ek dizini kaldırmaya çalışırken:"
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Ek veriyi uygulamaya çalışırken:"
+
+#: common/flatpak-dir.c:5451
+#, fuzzy, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Geçersiz pid %s"
+
+#: common/flatpak-dir.c:5458
+#, fuzzy, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Geçersiz pid %s"
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr ""
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr ""
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "%s'in bu sürümü zaten yüklü"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Paket yüklemesi sırasında uzak değiştirilemedi"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s dalı %s yüklü değil"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s dalı %s yüklü değil"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr ""
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "%s için eşleşme yok"
+
+#: common/flatpak-dir.c:8147
+#, fuzzy, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "%s%s%s%s%s uzak %s'te bulunamadı"
+
+#: common/flatpak-dir.c:8189
+#, fuzzy, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Hata: %2$s'i %1$s başarılamadı: %3$s\n"
+
+#: common/flatpak-dir.c:8234
+#, fuzzy, c-format
+msgid "Error searching local repository: %s"
+msgstr "Referansı yerel arşivde sakla"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "%s %s yüklü değil"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Yükleme %s bulunamadı"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Çalışma ortamı %s, dal %s zaten yüklü"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Uygulama %s, dal %s zaten yüklü"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Uzak başlığı ayarlı değil"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Uzak öntanımlı dalı ayarlı değil"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "Uzak özetinde flatpak önbelleği yok"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Uzak özeti flatpak önbelleğinde %s için girdi yok"
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Flatpak-info geçici dosyası açılamadı: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Geçici dosya açılamadı: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Eşzamanlama veri yolu yaratılamadı"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Uygulama bilgi dosyası açılamadı: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Dbus vekiliyle eşzamanlanamadı"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, fuzzy, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "apply_extra betiği başarısız oldu"
@@ -2694,149 +2722,91 @@ msgstr "Güncelleniyor: %2$s'ten %1$s\n"
 msgid "Error during migration: %s\n"
 msgstr "Hata: %2$s'i %1$s başarılamadı: %3$s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Ek veri kaynağı yok"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr ""
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, fuzzy, c-format
 msgid "Downloading: %s/%s"
 msgstr "İndirme boyutu"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, fuzzy, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "İndirme boyutu"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, fuzzy, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "İndirme boyutu"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "İmzalı uygulama yükle"
+#~ msgid "Install signed application"
+#~ msgstr "İmzalı uygulama yükle"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Uygulama yüklemek için kimlik denetimi gerekli"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Uygulama yüklemek için kimlik denetimi gerekli"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "İmzalı çalışma ortamı yükle"
+#~ msgid "Install signed runtime"
+#~ msgstr "İmzalı çalışma ortamı yükle"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "İmzalı uygulama güncelle"
+#~ msgid "Update signed application"
+#~ msgstr "İmzalı uygulama güncelle"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Uygulama güncellemek için kimlik denetimi gerekli"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Uygulama güncellemek için kimlik denetimi gerekli"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "İmzalı çalışma ortamı güncelle"
+#~ msgid "Update signed runtime"
+#~ msgstr "İmzalı çalışma ortamı güncelle"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Uzaktaki üst veriyi güncelle"
+#~ msgid "Update remote metadata"
+#~ msgstr "Uzaktaki üst veriyi güncelle"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
 #, fuzzy
-msgid "Authentication is required to update remote info"
-msgstr "Uygulama güncellemek için kimlik denetimi gerekli"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Uygulama güncellemek için kimlik denetimi gerekli"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
 #, fuzzy
-msgid "Update system repository"
-msgstr "Bir arşivdeki özet dosyasını güncelle"
+#~ msgid "Update system repository"
+#~ msgstr "Bir arşivdeki özet dosyasını güncelle"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
 #, fuzzy
-msgid "Authentication is required to update the system repository"
-msgstr "Uygulama güncellemek için kimlik denetimi gerekli"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Uygulama güncellemek için kimlik denetimi gerekli"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Paket yükle"
+#~ msgid "Install bundle"
+#~ msgstr "Paket yükle"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Çalışma ortamı kaldır"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Çalışma ortamı kaldır"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Uygulama kaldırmak için kimlik denetimi gerekli"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Uygulama kaldırmak için kimlik denetimi gerekli"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Uygulama kaldır"
+#~ msgid "Uninstall app"
+#~ msgstr "Uygulama kaldır"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Uzak Yapılandır"
+#~ msgid "Configure Remote"
+#~ msgstr "Uzak Yapılandır"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr "Yazılım arşivlerini yapılandırmak için kimlik denetimi gerekli"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr "Yazılım arşivlerini yapılandırmak için kimlik denetimi gerekli"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
 #, fuzzy
-msgid "Configure"
-msgstr "Uzak Yapılandır"
+#~ msgid "Configure"
+#~ msgstr "Uzak Yapılandır"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
 #, fuzzy
-msgid "Authentication is required to configure software installation"
-msgstr "Yazılım arşivlerini yapılandırmak için kimlik denetimi gerekli"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr "Yazılım arşivlerini yapılandırmak için kimlik denetimi gerekli"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Appstream'i güncelle"
+#~ msgid "Update appstream"
+#~ msgstr "Appstream'i güncelle"
 
 #~ msgid "No remote %s"
 #~ msgstr "%s uzak yok"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak master\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2017-12-15 13:30+0100\n"
+"POT-Creation-Date: 2018-02-09 09:50-0500\n"
 "PO-Revision-Date: 2017-10-23 20:15+0200\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -152,7 +152,7 @@ msgid "NAME LOCATION - Add a remote repository"
 msgstr "НАЗВА РОЗТАШУВАННЯ - Додати віддалене сховище"
 
 #: app/flatpak-builtins-add-remote.c:333
-#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:120
+#: app/flatpak-builtins-delete-remote.c:61 app/flatpak-builtins-info.c:125
 msgid "NAME must be specified"
 msgstr "Має бути вказано НАЗВУ"
 
@@ -170,7 +170,7 @@ msgstr "Слід вказати РОЗТАШУВАННЯ"
 #: app/flatpak-builtins-document-export.c:102
 #: app/flatpak-builtins-document-info.c:75
 #: app/flatpak-builtins-document-list.c:70
-#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:127
+#: app/flatpak-builtins-document-unexport.c:67 app/flatpak-builtins-info.c:132
 #: app/flatpak-builtins-install.c:267 app/flatpak-builtins-install.c:401
 #: app/flatpak-builtins-list.c:314 app/flatpak-builtins-list-remotes.c:61
 #: app/flatpak-builtins-ls-remote.c:107 app/flatpak-builtins-make-current.c:72
@@ -236,7 +236,7 @@ msgstr "Архітектура для пакунка"
 
 #: app/flatpak-builtins-build-bundle.c:56
 #: app/flatpak-builtins-build-export.c:55 app/flatpak-builtins-build-init.c:49
-#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-sign.c:41 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-info-remote.c:48 app/flatpak-builtins-install.c:57
 #: app/flatpak-builtins-list.c:46 app/flatpak-builtins-ls-remote.c:49
 #: app/flatpak-builtins-make-current.c:38 app/flatpak-builtins-run.c:52
@@ -397,7 +397,7 @@ msgstr "Немає точки розширення, яка відповідає 
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Пропущено «=» у параметрі монтування прив’язки «%s»"
 
-#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:5508
+#: app/flatpak-builtins-build.c:449 common/flatpak-run.c:3032
 msgid "Unable to start app"
 msgstr "Не вдалося запустити програму"
 
@@ -801,7 +801,7 @@ msgstr ""
 msgid "LOCATION and FILENAME must be specified"
 msgstr "Слід вказати РОЗТАШУВАННЯ і НАЗВУ ФАЙЛА"
 
-#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:48
+#: app/flatpak-builtins-build-init.c:49 app/flatpak-builtins-info.c:51
 #: app/flatpak-builtins-run.c:52
 msgid "Arch to use"
 msgstr "Архітектура, яку слід використовувати"
@@ -1122,124 +1122,150 @@ msgstr "Не вдалося перемкнути gid"
 msgid "Can't switch uid"
 msgstr "Не вдалося перемкнути uid"
 
-#: app/flatpak-builtins-info.c:49
+#: app/flatpak-builtins-info.c:52
 msgid "Show user installations"
 msgstr "Показати встановлення користувача"
 
-#: app/flatpak-builtins-info.c:50
+#: app/flatpak-builtins-info.c:53
 msgid "Show system-wide installations"
 msgstr "Показати загальносистемні встановлення"
 
-#: app/flatpak-builtins-info.c:51
+#: app/flatpak-builtins-info.c:54
 msgid "Show specific system-wide installations"
 msgstr "Показати вказані загальносистемні встановлення"
 
-#: app/flatpak-builtins-info.c:52 app/flatpak-builtins-info-remote.c:53
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-info-remote.c:53
 msgid "Show ref"
 msgstr "Показати посилання"
 
-#: app/flatpak-builtins-info.c:53 app/flatpak-builtins-info-remote.c:54
+#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:54
 msgid "Show commit"
 msgstr "Показати внесок"
 
-#: app/flatpak-builtins-info.c:54
+#: app/flatpak-builtins-info.c:57
 msgid "Show origin"
 msgstr "Показ початку координат"
 
-#: app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-info.c:58
 msgid "Show size"
 msgstr "Показ розміру"
 
-#: app/flatpak-builtins-info.c:56 app/flatpak-builtins-info-remote.c:56
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-info-remote.c:56
 msgid "Show metadata"
 msgstr "Показ метаданих"
 
-#: app/flatpak-builtins-info.c:57
+#: app/flatpak-builtins-info.c:60
+#, fuzzy
+msgid "Show permissions"
+msgstr "Показати розширення"
+
+#: app/flatpak-builtins-info.c:61
+#, fuzzy
+msgid "Query file access"
+msgstr ""
+"\n"
+" Керування доступом до файлів"
+
+#: app/flatpak-builtins-info.c:61 app/flatpak-builtins-install.c:68
+#: app/flatpak-builtins-update.c:64
+msgid "PATH"
+msgstr "ШЛЯХ"
+
+#: app/flatpak-builtins-info.c:62
 msgid "Show extensions"
 msgstr "Показати розширення"
 
-#: app/flatpak-builtins-info.c:113
+#: app/flatpak-builtins-info.c:118
 msgid "NAME [BRANCH] - Get info about installed app and/or runtime"
 msgstr ""
 "НАЗВА [ГІЛКА] - Отримати інформацію щодо встановленої програми і/або "
 "середовища виконання"
 
-#: app/flatpak-builtins-info.c:181
+#: app/flatpak-builtins-info.c:189
 msgid "ref not present in origin"
 msgstr "посилання немає у джерелі"
 
-#: app/flatpak-builtins-info.c:192 app/flatpak-builtins-info-remote.c:193
+#: app/flatpak-builtins-info.c:202 app/flatpak-builtins-info-remote.c:177
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr ""
+
+#: app/flatpak-builtins-info.c:209 app/flatpak-builtins-info-remote.c:200
 msgid "Ref:"
 msgstr "Джерело:"
 
-#: app/flatpak-builtins-info.c:193 app/flatpak-builtins-info.c:309
-#: app/flatpak-builtins-info-remote.c:194
+#: app/flatpak-builtins-info.c:210 app/flatpak-builtins-info.c:364
+#: app/flatpak-builtins-info-remote.c:201
 msgid "ID:"
 msgstr "Ід.:"
 
-#: app/flatpak-builtins-info.c:194 app/flatpak-builtins-info-remote.c:195
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:202
 msgid "Arch:"
 msgstr "Арх.:"
 
-#: app/flatpak-builtins-info.c:195 app/flatpak-builtins-info-remote.c:196
+#: app/flatpak-builtins-info.c:212 app/flatpak-builtins-info-remote.c:203
 msgid "Branch:"
 msgstr "Гілка:"
 
-#: app/flatpak-builtins-info.c:196 app/flatpak-builtins-info.c:310
+#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:365
 msgid "Origin:"
 msgstr "Походження:"
 
-#: app/flatpak-builtins-info.c:198 app/flatpak-builtins-info-remote.c:197
+#: app/flatpak-builtins-info.c:215 app/flatpak-builtins-info-remote.c:205
+#, fuzzy
+msgid "Collection ID:"
+msgstr "Ідентифікатор збірки"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info-remote.c:206
 msgid "Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:200 app/flatpak-builtins-info-remote.c:198
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info-remote.c:207
 msgid "Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:204
+#: app/flatpak-builtins-info.c:223
 msgid "Active commit:"
 msgstr "Активний внесок:"
 
-#: app/flatpak-builtins-info.c:205
+#: app/flatpak-builtins-info.c:224
 msgid "Latest commit:"
 msgstr "Останній внесок:"
 
-#: app/flatpak-builtins-info.c:208 app/flatpak-builtins-info.c:311
-#: app/flatpak-builtins-info-remote.c:199
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:366
+#: app/flatpak-builtins-info-remote.c:208
 msgid "Commit:"
 msgstr "Внесок:"
 
-#: app/flatpak-builtins-info.c:210
+#: app/flatpak-builtins-info.c:229
 msgid "alt-id:"
 msgstr "альт-ід.:"
 
-#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-info-remote.c:200
+#: app/flatpak-builtins-info.c:230 app/flatpak-builtins-info-remote.c:209
 msgid "Parent:"
 msgstr ""
 
-#: app/flatpak-builtins-info.c:212
+#: app/flatpak-builtins-info.c:231
 msgid "Location:"
 msgstr "Місце:"
 
-#: app/flatpak-builtins-info.c:213 app/flatpak-builtins-info.c:312
-#: app/flatpak-builtins-info-remote.c:202
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:367
+#: app/flatpak-builtins-info-remote.c:211
 msgid "Installed size:"
 msgstr "Розмір встановленого:"
 
-#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info-remote.c:207
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info-remote.c:216
 msgid "Runtime:"
 msgstr "Середовище виконання:"
 
-#: app/flatpak-builtins-info.c:223
+#: app/flatpak-builtins-info.c:242
 msgid "Installed subdirectories:"
 msgstr "Встановлені підкаталоги:"
 
-#: app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-info.c:363
 msgid "Extension:"
 msgstr "Суфікс:"
 
-#: app/flatpak-builtins-info.c:319
+#: app/flatpak-builtins-info.c:374
 msgid "Subpaths:"
 msgstr "Підшляхи:"
 
@@ -1265,37 +1291,42 @@ msgstr ""
 msgid "Show parent"
 msgstr "Показати посилання"
 
-#: app/flatpak-builtins-info-remote.c:121
+#: app/flatpak-builtins-info-remote.c:122
 #, fuzzy
 msgid ""
 " REMOTE REF - Show information about an application or runtime in a remote"
 msgstr "Встановити програму або середовище виконання із віддаленого сховища"
 
-#: app/flatpak-builtins-info-remote.c:132 app/flatpak-builtins-install.c:499
+#: app/flatpak-builtins-info-remote.c:133 app/flatpak-builtins-install.c:499
 msgid "REMOTE and REF must be specified"
 msgstr "Має бути вказано СХОВИЩЕ і НАЗВУ"
 
-#: app/flatpak-builtins-info-remote.c:201
+#: app/flatpak-builtins-info-remote.c:210
 #, fuzzy
 msgid "Download size:"
 msgstr "Розмір отриманого"
 
-#: app/flatpak-builtins-info-remote.c:214
+#: app/flatpak-builtins-info-remote.c:223
 msgid "History:\n"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:235
+#: app/flatpak-builtins-info-remote.c:244
 msgid " Subject:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:236
+#: app/flatpak-builtins-info-remote.c:245
 msgid " Date:"
 msgstr ""
 
-#: app/flatpak-builtins-info-remote.c:237
+#: app/flatpak-builtins-info-remote.c:246
 #, fuzzy
 msgid " Commit:"
 msgstr "Внесок:"
+
+#: app/flatpak-builtins-info-remote.c:292
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr ""
 
 #: app/flatpak-builtins-install.c:58
 msgid "Don't pull, only install from local cache"
@@ -1334,10 +1365,6 @@ msgstr ""
 #: app/flatpak-builtins-install.c:68
 msgid "Only install this subpath"
 msgstr "Встановити лише цей підшлях"
-
-#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-update.c:64
-msgid "PATH"
-msgstr "ШЛЯХ"
 
 #: app/flatpak-builtins-install.c:69 app/flatpak-builtins-update.c:65
 msgid "Automatically answer yes for all questions"
@@ -1500,7 +1527,7 @@ msgstr "Внесок"
 msgid "Download size"
 msgstr "Розмір отриманого"
 
-#: app/flatpak-builtins-ls-remote.c:301
+#: app/flatpak-builtins-ls-remote.c:304
 msgid "No ref information available in repository"
 msgstr "У сховищі немає даних щодо джерела"
 
@@ -1711,40 +1738,40 @@ msgstr "Увімкнути переспрямовування файлів"
 msgid "APP [args...] - Run an app"
 msgstr "ПРОГРАМА [аргументи...] - Виконати програму"
 
-#: app/flatpak-builtins-search.c:212
+#: app/flatpak-builtins-search.c:216
 msgid "TEXT - Search remote apps/runtimes for text"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:220
+#: app/flatpak-builtins-search.c:225
 #, fuzzy
 msgid "TEXT must be specified"
 msgstr "Має бути вказано СХОВИЩЕ"
 
-#: app/flatpak-builtins-search.c:270
+#: app/flatpak-builtins-search.c:279
 #, fuzzy
 msgid "Application ID"
 msgstr "Ідентифікатор збірки"
 
-#: app/flatpak-builtins-search.c:271
+#: app/flatpak-builtins-search.c:280
 msgid "Version"
 msgstr ""
 
-#: app/flatpak-builtins-search.c:273
+#: app/flatpak-builtins-search.c:282
 #, fuzzy
 msgid "Branch"
 msgstr "Гілка:"
 
-#: app/flatpak-builtins-search.c:275
+#: app/flatpak-builtins-search.c:284
 #, fuzzy
 msgid "Remotes"
 msgstr "Немає сховища %s"
 
-#: app/flatpak-builtins-search.c:276
+#: app/flatpak-builtins-search.c:285
 #, fuzzy
 msgid "Description"
 msgstr "Повний опис"
 
-#: app/flatpak-builtins-search.c:285
+#: app/flatpak-builtins-search.c:294
 #, fuzzy
 msgid "No matches found"
 msgstr "Немає відповідників %s"
@@ -1811,31 +1838,11 @@ msgstr "Оновити дані appstream для віддаленого схов
 msgid "Only update this subpath"
 msgstr "Оновити лише вказаний підшлях"
 
-#: app/flatpak-builtins-update.c:107
-#, fuzzy, c-format
-msgid "Updating appstream data for user remote %s\n"
-msgstr "Оновлюємо appstream для віддаленого сховища %s\n"
-
-#: app/flatpak-builtins-update.c:109
-#, fuzzy, c-format
-msgid "Updating appstream data for remote %s\n"
-msgstr "Оновлюємо appstream для віддаленого сховища %s\n"
-
-#: app/flatpak-builtins-update.c:113
-#, c-format
-msgid "Error updating: %s\n"
-msgstr "Помилка під час спроби оновлення: %s\n"
-
-#: app/flatpak-builtins-update.c:143
-#, fuzzy, c-format
-msgid "Remote \"%s\" not found"
-msgstr "Дані не знайдено"
-
-#: app/flatpak-builtins-update.c:163
+#: app/flatpak-builtins-update.c:83
 msgid "[REF...] - Update applications or runtimes"
 msgstr "[НАЗВА…] - Оновити програми або середовища виконання"
 
-#: app/flatpak-builtins-update.c:196
+#: app/flatpak-builtins-update.c:119
 msgid "Looking for updates...\n"
 msgstr "Шукаємо оновлення...\n"
 
@@ -1853,6 +1860,26 @@ msgstr "Який з пакунків встановити (0 — перерва�
 #, c-format
 msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
 msgstr ""
+
+#: app/flatpak-builtins-utils.c:479 app/flatpak-builtins-utils.c:481
+#, fuzzy, c-format
+msgid "Updating appstream data for user remote %s\n"
+msgstr "Оновлюємо appstream для віддаленого сховища %s\n"
+
+#: app/flatpak-builtins-utils.c:486 app/flatpak-builtins-utils.c:488
+#, fuzzy, c-format
+msgid "Updating appstream data for remote %s\n"
+msgstr "Оновлюємо appstream для віддаленого сховища %s\n"
+
+#: app/flatpak-builtins-utils.c:493
+#, c-format
+msgid "Error updating: %s\n"
+msgstr "Помилка під час спроби оновлення: %s\n"
+
+#: app/flatpak-builtins-utils.c:526
+#, fuzzy, c-format
+msgid "Remote \"%s\" not found"
+msgstr "Дані не знайдено"
 
 #. translators: please keep the leading space
 #: app/flatpak-main.c:62
@@ -2007,7 +2034,8 @@ msgid "Export a build dir to a repository"
 msgstr "Експортувати каталог збирання до сховища"
 
 #: app/flatpak-main.c:104
-msgid "Create a bundle file from a build directory"
+#, fuzzy
+msgid "Create a bundle file from a ref in a local repository"
 msgstr "Створити файл пакунка з каталогу збирання"
 
 #: app/flatpak-main.c:105
@@ -2081,22 +2109,22 @@ msgstr "НАЗВА"
 msgid "Builtin Commands:"
 msgstr "Вбудовані команди:"
 
-#: app/flatpak-main.c:367
+#: app/flatpak-main.c:370
 msgid ""
-"The --installation option was used multiple timesfor a command that works on "
-"one installation"
+"The --installation option was used multiple times for a command that works "
+"on one installation"
 msgstr ""
 
-#: app/flatpak-main.c:486
+#: app/flatpak-main.c:489
 #, c-format
 msgid "Unknown command '%s'"
 msgstr "Невідома команда «%s»"
 
-#: app/flatpak-main.c:494
+#: app/flatpak-main.c:497
 msgid "No command specified"
 msgstr "Команду не вказано"
 
-#: app/flatpak-main.c:612
+#: app/flatpak-main.c:615
 msgid "error:"
 msgstr "помилка:"
 
@@ -2130,9 +2158,9 @@ msgstr ""
 "Потрібного середовища виконання %s у налаштованому віддаленому сховищі не "
 "знайдено.\n"
 
-#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1157
-#: common/flatpak-dir.c:1476 common/flatpak-dir.c:1499
-#: common/flatpak-dir.c:1521 common/flatpak-dir.c:10508
+#: app/flatpak-transaction.c:506 common/flatpak-dir.c:1160
+#: common/flatpak-dir.c:1479 common/flatpak-dir.c:1502
+#: common/flatpak-dir.c:1524 common/flatpak-dir.c:10545
 #: common/flatpak-utils.c:1311 common/flatpak-utils.c:1405
 #, c-format
 msgid "%s not installed"
@@ -2238,322 +2266,37 @@ msgstr "Помилка: не вдалося виконати дію %s %s: %s\n"
 msgid "One or more operations failed"
 msgstr "Помилка під час виконання однієї або декількох дій"
 
-#: common/flatpak-dir.c:1041
-#, c-format
-msgid "No overrides found for %s"
-msgstr "Не знайдено перевизначень для %s"
-
-#: common/flatpak-dir.c:1667
-#, c-format
-msgid "While opening repository %s: "
-msgstr "Під час спроби відкрити сховище %s: "
-
-#: common/flatpak-dir.c:1901 common/flatpak-dir.c:5301
-msgid "Can't create deploy directory"
-msgstr "Не вдалося створити каталог розгортання"
-
-#: common/flatpak-dir.c:2621
-#, c-format
-msgid "Invalid sha256 for extra data uri %s"
-msgstr "Некоректна сума sha256 для адреси додаткових даних %s"
-
-#: common/flatpak-dir.c:2626
-#, c-format
-msgid "Empty name for extra data uri %s"
-msgstr "Порожня назва для адреси додаткових даних %s"
-
-#: common/flatpak-dir.c:2633
-#, c-format
-msgid "Unsupported extra data uri %s"
-msgstr "Непідтримувана адреса додаткових даних %s"
-
-#: common/flatpak-dir.c:2647
-#, c-format
-msgid "Failed to load local extra-data %s: %s"
-msgstr "Не вдалося завантажити локальні додаткові дані %s: %s"
-
-#: common/flatpak-dir.c:2650
-#, c-format
-msgid "Wrong size for extra-data %s"
-msgstr "Помилковий розмір додаткових даних %s"
-
-#: common/flatpak-dir.c:2665
-#, c-format
-msgid "While downloading %s: "
-msgstr "Під час спроби отримання %s: "
-
-#: common/flatpak-dir.c:2672
-#, c-format
-msgid "Wrong size for extra data %s"
-msgstr "Помилковий розмір додаткових даних %s"
-
-#: common/flatpak-dir.c:2683
-#, c-format
-msgid "Invalid checksum for extra data %s"
-msgstr "Некоректна контрольна сума додаткових даних, %s"
-
-#: common/flatpak-dir.c:2742
-#, fuzzy
-msgid "Remote OCI index has no registry uri"
-msgstr "НАЗВА [РОЗТАШУВАННЯ] - Додати віддалене сховище"
-
-#: common/flatpak-dir.c:2958
-#, c-format
-msgid "%s commit %s already installed"
-msgstr "%s, внесок %s вже встановлено"
-
-#: common/flatpak-dir.c:3300 common/flatpak-dir.c:3614
-#, c-format
-msgid "While pulling %s from remote %s: "
-msgstr "Під час отримання %s з віддаленого сховища %s: "
-
-#: common/flatpak-dir.c:3499
-#, c-format
-msgid "Can't find %s in remote %s"
-msgstr "Не вдалося знайти %s у віддаленому сховищі %s"
-
-#: common/flatpak-dir.c:4172
-msgid "Not enough memory"
-msgstr "Не вистачає пам'яті"
-
-#: common/flatpak-dir.c:4191
-msgid "Failed to read from exported file"
-msgstr "Не вдалося виконати читання з експортованого файла"
-
-#: common/flatpak-dir.c:4382
-msgid "Error reading mimetype xml file"
-msgstr "Помилка під час читання файла xml типу MIME"
-
-#: common/flatpak-dir.c:4387
-msgid "Invalid mimetype xml file"
-msgstr "Некоректний файл xml типу MIME"
-
-#: common/flatpak-dir.c:4930
-msgid "While getting detached metadata: "
-msgstr "Під час спроби отримання від’єднаних метаданих: "
-
-#: common/flatpak-dir.c:4948
-msgid "While creating extradir: "
-msgstr "Під час створення каталогу додаткових даних: "
-
-#: common/flatpak-dir.c:4969
-msgid "Invalid sha256 for extra data"
-msgstr "Некоректна контрольна сума sha256 для додаткових даних"
-
-#: common/flatpak-dir.c:4998
-msgid "Wrong size for extra data"
-msgstr "Помилковий розмір додаткових даних"
-
-#: common/flatpak-dir.c:5002
-msgid "Invalid checksum for extra data"
-msgstr "Некоректна контрольна сума додаткових даних"
-
-#: common/flatpak-dir.c:5011
-#, c-format
-msgid "While writing extra data file '%s': "
-msgstr "Під час записування файла додаткових даних «%s»: "
-
-#: common/flatpak-dir.c:5181
-#, c-format
-msgid "apply_extra script failed, exit status %d"
-msgstr "Помилка скрипту apply_extra, стан виходу %d"
-
-#: common/flatpak-dir.c:5260
-#, c-format
-msgid "While trying to resolve ref %s: "
-msgstr "Під час спроби визначити посилання %s: "
-
-#: common/flatpak-dir.c:5275
-#, c-format
-msgid "%s is not available"
-msgstr "%s недоступний"
-
-#: common/flatpak-dir.c:5290 common/flatpak-dir.c:5722
-#: common/flatpak-dir.c:6504 common/flatpak-dir.c:6517
-#: common/flatpak-dir.c:6593
-#, c-format
-msgid "%s branch %s already installed"
-msgstr "Гілку %s %s вже встановлено"
-
-#: common/flatpak-dir.c:5309
-#, c-format
-msgid "Failed to read commit %s: "
-msgstr "Не вдалося прочитати внесок %s: "
-
-#: common/flatpak-dir.c:5329
-#, c-format
-msgid "While trying to checkout %s into %s: "
-msgstr "Під час спроби вивантаження %s до %s: "
-
-#: common/flatpak-dir.c:5354 common/flatpak-dir.c:5385
-msgid "While trying to checkout metadata subpath: "
-msgstr "Під час спроби вивантаження підшляху метаданих: "
-
-#: common/flatpak-dir.c:5395
-msgid "While trying to remove existing extra dir: "
-msgstr "Під час спроби вилучення наявного додаткового каталогу: "
-
-#: common/flatpak-dir.c:5406
-msgid "While trying to apply extra data: "
-msgstr "Під час спроби застосування додаткових даних: "
-
-#: common/flatpak-dir.c:5433
-#, c-format
-msgid "Invalid deployed ref %s: "
-msgstr "Некоректне посилання на розгортання %s: "
-
-#: common/flatpak-dir.c:5440
-#, c-format
-msgid "Invalid commit ref %s: "
-msgstr "Некоректне посилання на внесок %s: "
-
-#: common/flatpak-dir.c:5448
-#, c-format
-msgid "Deployed ref %s kind does not match commit (%s)"
-msgstr "Тип розміщеного посилання %s не відповідає внеску (%s)"
-
-#: common/flatpak-dir.c:5456
-#, c-format
-msgid "Deployed ref %s name does not match commit (%s)"
-msgstr "Назва розміщеного посилання %s не відповідає внеску (%s)"
-
-#: common/flatpak-dir.c:5464
-#, c-format
-msgid "Deployed ref %s arch does not match commit (%s)"
-msgstr "Архітектура розміщеного посилання %s не відповідає внеску (%s)"
-
-#: common/flatpak-dir.c:5470
-#, c-format
-msgid "Deployed ref %s branch does not match commit (%s)"
-msgstr "Гілка розміщеного посилання %s не відповідає внеску (%s)"
-
-#: common/flatpak-dir.c:5476
-#, c-format
-msgid "Deployed ref %s does not match commit (%s)"
-msgstr "Розміщене джерело %s не відповідає внеску (%s)"
-
-#: common/flatpak-dir.c:5495
-msgid "Deployed metadata does not match commit"
-msgstr "Розміщені метадані не відповідають внеску"
-
-#: common/flatpak-dir.c:6365
-#, c-format
-msgid "This version of %s is already installed"
-msgstr "Цю версію %s вже встановлено"
-
-#: common/flatpak-dir.c:6372
-msgid "Can't change remote during bundle install"
-msgstr "Не можна змінювати сховище під час встановлення пакунка"
-
-#: common/flatpak-dir.c:6927
-#, c-format
-msgid "%s branch %s is not installed"
-msgstr "%s, гілка %s не встановлено"
-
-#: common/flatpak-dir.c:7171
-#, c-format
-msgid "%s branch %s not installed"
-msgstr "%s, гілка %s не встановлено"
-
-#: common/flatpak-dir.c:7489
-#, c-format
-msgid "Pruning repo failed: %s"
-msgstr "Не вдалося спорожнити сховище: %s"
-
-#: common/flatpak-dir.c:8016
-#, c-format
-msgid "Multiple branches available for %s, you must specify one of: "
-msgstr ""
-"Доступними є декілька гілок %s, вам слід вказати одне з таких значень: "
-
-#: common/flatpak-dir.c:8037
-#, c-format
-msgid "Nothing matches %s"
-msgstr "Немає відповідників %s"
-
-#: common/flatpak-dir.c:8119
-#, c-format
-msgid "Can't find ref %s%s%s%s%s"
-msgstr "Не вдалося знайти посилання %s%s%s%s%s"
-
-#: common/flatpak-dir.c:8161
-#, c-format
-msgid "Error searching remote %s: %s"
-msgstr "Помилка під час пошуку у віддаленому сховищі %s: %s"
-
-#: common/flatpak-dir.c:8206
-#, c-format
-msgid "Error searching local repository: %s"
-msgstr "Помилка під час пошуку у локальному сховищі: %s"
-
-#: common/flatpak-dir.c:8332
-#, c-format
-msgid "%s %s not installed"
-msgstr "Не встановлено %s %s"
-
-#: common/flatpak-dir.c:8499
-#, c-format
-msgid "Could not find installation %s"
-msgstr "Не вдалося знайти встановлення %s"
-
-#: common/flatpak-dir.c:9094
-#, c-format
-msgid "Runtime %s, branch %s is already installed"
-msgstr "Середовище виконання %s, гілка %s вже встановлено"
-
-#: common/flatpak-dir.c:9095
-#, c-format
-msgid "App %s, branch %s is already installed"
-msgstr "Програму %s, гілка %s вже встановлено"
-
-#: common/flatpak-dir.c:9575
-msgid "Remote title not set"
-msgstr "Заголовок віддаленого сховища не встановлено"
-
-#: common/flatpak-dir.c:9597
-msgid "Remote default-branch not set"
-msgstr "Не встановлено типову гілку віддаленого сховища"
-
-#: common/flatpak-dir.c:10185
-msgid "No flatpak cache in remote summary"
-msgstr "У резюме сховища немає кешу flatpak"
-
-#: common/flatpak-dir.c:10195
-#, c-format
-msgid "No entry for %s in remote summary flatpak cache "
-msgstr "Немає запису %s у кеші flatpak резюме сховища "
-
-#: common/flatpak-run.c:258
+#: common/flatpak-context.c:174
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Невідомий тип спільного ресурсу %s, коректними типами є такі: %s"
 
-#: common/flatpak-run.c:293
+#: common/flatpak-context.c:209
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Невідомий тип правил %s, коректними типами є такі: %s"
 
-#: common/flatpak-run.c:331
+#: common/flatpak-context.c:247
 #, c-format
 msgid "Invalid dbus name %s\n"
 msgstr "Некоректна назва D-Bus, %s\n"
 
-#: common/flatpak-run.c:344
+#: common/flatpak-context.c:260
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Невідомий тип сокета, %s, коректними типами є такі: %s"
 
-#: common/flatpak-run.c:373
+#: common/flatpak-context.c:289
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Невідомий тип пристрою, %s. Коректними типами є %s"
 
-#: common/flatpak-run.c:401
+#: common/flatpak-context.c:317
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Невідомий тип можливості %s, коректними типами є такі: %s"
 
-#: common/flatpak-run.c:774
+#: common/flatpak-context.c:690
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, home, xdg-"
@@ -2562,153 +2305,438 @@ msgstr ""
 "Невідоме розташування файлової системи, %s, коректними розташуваннями є "
 "такі: host, home, xdg-*[/...], ~/dir, /dir"
 
-#: common/flatpak-run.c:1040
+#: common/flatpak-context.c:956
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Некоректне форматування середовища, %s"
 
-#: common/flatpak-run.c:1180
+#: common/flatpak-context.c:1096
 msgid "Share with host"
 msgstr "Надати спільний доступ вузлу"
 
-#: common/flatpak-run.c:1180 common/flatpak-run.c:1181
+#: common/flatpak-context.c:1096 common/flatpak-context.c:1097
 msgid "SHARE"
 msgstr "СПІЛЬНИЙ РЕСУРС"
 
-#: common/flatpak-run.c:1181
+#: common/flatpak-context.c:1097
 msgid "Unshare with host"
 msgstr "Скасувати надання спільного ресурсу вузлу"
 
-#: common/flatpak-run.c:1182
+#: common/flatpak-context.c:1098
 msgid "Expose socket to app"
 msgstr "Відкрити сокет програмі"
 
-#: common/flatpak-run.c:1182 common/flatpak-run.c:1183
+#: common/flatpak-context.c:1098 common/flatpak-context.c:1099
 msgid "SOCKET"
 msgstr "СОКЕТ"
 
-#: common/flatpak-run.c:1183
+#: common/flatpak-context.c:1099
 msgid "Don't expose socket to app"
 msgstr "Не відкривати сокет програми"
 
-#: common/flatpak-run.c:1184
+#: common/flatpak-context.c:1100
 msgid "Expose device to app"
 msgstr "Відкрити пристрій програмі"
 
-#: common/flatpak-run.c:1184 common/flatpak-run.c:1185
+#: common/flatpak-context.c:1100 common/flatpak-context.c:1101
 msgid "DEVICE"
 msgstr "ПРИСТРІЙ"
 
-#: common/flatpak-run.c:1185
+#: common/flatpak-context.c:1101
 msgid "Don't expose device to app"
 msgstr "Не відкривати пристрій програмі"
 
-#: common/flatpak-run.c:1186
+#: common/flatpak-context.c:1102
 msgid "Allow feature"
 msgstr "Увімкнути можливість"
 
-#: common/flatpak-run.c:1186 common/flatpak-run.c:1187
+#: common/flatpak-context.c:1102 common/flatpak-context.c:1103
 msgid "FEATURE"
 msgstr "МОЖЛИВІСТЬ"
 
-#: common/flatpak-run.c:1187
+#: common/flatpak-context.c:1103
 msgid "Don't allow feature"
 msgstr "Вимкнути можливість"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Відкрити файлову систему програмі (:ro — лише для читання)"
 
-#: common/flatpak-run.c:1188
+#: common/flatpak-context.c:1104
 msgid "FILESYSTEM[:ro]"
 msgstr "ФАЙЛОВА_СИСТЕМА[:ro]"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "Don't expose filesystem to app"
 msgstr "Не відкривати файлову систему програмі"
 
-#: common/flatpak-run.c:1189
+#: common/flatpak-context.c:1105
 msgid "FILESYSTEM"
 msgstr "ФАЙЛОВА СИСТЕМА"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "Set environment variable"
 msgstr "Встановити змінну середовища"
 
-#: common/flatpak-run.c:1190
+#: common/flatpak-context.c:1106
 msgid "VAR=VALUE"
 msgstr "ЗМІННА=ЗНАЧЕННЯ"
 
-#: common/flatpak-run.c:1191
+#: common/flatpak-context.c:1107
 msgid "Allow app to own name on the session bus"
 msgstr "Дозволити програмі бути власником назви на каналі сеансу"
 
-#: common/flatpak-run.c:1191 common/flatpak-run.c:1192
-#: common/flatpak-run.c:1193 common/flatpak-run.c:1194
+#: common/flatpak-context.c:1107 common/flatpak-context.c:1108
+#: common/flatpak-context.c:1109 common/flatpak-context.c:1110
 msgid "DBUS_NAME"
 msgstr "НАЗВА_DBUS"
 
-#: common/flatpak-run.c:1192
+#: common/flatpak-context.c:1108
 msgid "Allow app to talk to name on the session bus"
 msgstr "Дозволити програмі обмінюватися даними з назвою на каналі сеансу"
 
-#: common/flatpak-run.c:1193
+#: common/flatpak-context.c:1109
 msgid "Allow app to own name on the system bus"
 msgstr "Дозволити програмі бути власником назви на каналі системи"
 
-#: common/flatpak-run.c:1194
+#: common/flatpak-context.c:1110
 msgid "Allow app to talk to name on the system bus"
 msgstr "Дозволити програмі обмінюватися даними з назвою на каналі системи"
 
-#: common/flatpak-run.c:1195
+#: common/flatpak-context.c:1111
 msgid "Add generic policy option"
 msgstr "Додати параметр загальних правил"
 
-#: common/flatpak-run.c:1195 common/flatpak-run.c:1196
+#: common/flatpak-context.c:1111 common/flatpak-context.c:1112
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "ПІДСИСТЕМА.КЛЮЧ=ЗНАЧЕННЯ"
 
-#: common/flatpak-run.c:1196
+#: common/flatpak-context.c:1112
 msgid "Remove generic policy option"
 msgstr "Вилучити параметр загальних правил"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "Persist home directory"
 msgstr "Примусово встановити домашній каталог"
 
-#: common/flatpak-run.c:1197
+#: common/flatpak-context.c:1113
 msgid "FILENAME"
 msgstr "НАЗВА ФАЙЛА"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-run.c:1199
+#: common/flatpak-context.c:1115
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Не вимагати запущеного сеансу (без створення cgroup)"
 
-#: common/flatpak-run.c:3790
+#: common/flatpak-dir.c:1044
+#, c-format
+msgid "No overrides found for %s"
+msgstr "Не знайдено перевизначень для %s"
+
+#: common/flatpak-dir.c:1674
+#, c-format
+msgid "While opening repository %s: "
+msgstr "Під час спроби відкрити сховище %s: "
+
+#: common/flatpak-dir.c:1908 common/flatpak-dir.c:5319
+msgid "Can't create deploy directory"
+msgstr "Не вдалося створити каталог розгортання"
+
+#: common/flatpak-dir.c:2635
+#, c-format
+msgid "Invalid sha256 for extra data uri %s"
+msgstr "Некоректна сума sha256 для адреси додаткових даних %s"
+
+#: common/flatpak-dir.c:2640
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "Порожня назва для адреси додаткових даних %s"
+
+#: common/flatpak-dir.c:2647
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Непідтримувана адреса додаткових даних %s"
+
+#: common/flatpak-dir.c:2661
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Не вдалося завантажити локальні додаткові дані %s: %s"
+
+#: common/flatpak-dir.c:2664
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "Помилковий розмір додаткових даних %s"
+
+#: common/flatpak-dir.c:2679
+#, c-format
+msgid "While downloading %s: "
+msgstr "Під час спроби отримання %s: "
+
+#: common/flatpak-dir.c:2686
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "Помилковий розмір додаткових даних %s"
+
+#: common/flatpak-dir.c:2697
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "Некоректна контрольна сума додаткових даних, %s"
+
+#: common/flatpak-dir.c:2756
+#, fuzzy
+msgid "Remote OCI index has no registry uri"
+msgstr "НАЗВА [РОЗТАШУВАННЯ] - Додати віддалене сховище"
+
+#: common/flatpak-dir.c:2976
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s, внесок %s вже встановлено"
+
+#: common/flatpak-dir.c:3318 common/flatpak-dir.c:3632
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "Під час отримання %s з віддаленого сховища %s: "
+
+#: common/flatpak-dir.c:3517
+#, c-format
+msgid "Can't find %s in remote %s"
+msgstr "Не вдалося знайти %s у віддаленому сховищі %s"
+
+#: common/flatpak-dir.c:4190
+msgid "Not enough memory"
+msgstr "Не вистачає пам'яті"
+
+#: common/flatpak-dir.c:4209
+msgid "Failed to read from exported file"
+msgstr "Не вдалося виконати читання з експортованого файла"
+
+#: common/flatpak-dir.c:4400
+msgid "Error reading mimetype xml file"
+msgstr "Помилка під час читання файла xml типу MIME"
+
+#: common/flatpak-dir.c:4405
+msgid "Invalid mimetype xml file"
+msgstr "Некоректний файл xml типу MIME"
+
+#: common/flatpak-dir.c:4948
+msgid "While getting detached metadata: "
+msgstr "Під час спроби отримання від’єднаних метаданих: "
+
+#: common/flatpak-dir.c:4966
+msgid "While creating extradir: "
+msgstr "Під час створення каталогу додаткових даних: "
+
+#: common/flatpak-dir.c:4987
+msgid "Invalid sha256 for extra data"
+msgstr "Некоректна контрольна сума sha256 для додаткових даних"
+
+#: common/flatpak-dir.c:5016
+msgid "Wrong size for extra data"
+msgstr "Помилковий розмір додаткових даних"
+
+#: common/flatpak-dir.c:5020
+msgid "Invalid checksum for extra data"
+msgstr "Некоректна контрольна сума додаткових даних"
+
+#: common/flatpak-dir.c:5029
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "Під час записування файла додаткових даних «%s»: "
+
+#: common/flatpak-dir.c:5199
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "Помилка скрипту apply_extra, стан виходу %d"
+
+#: common/flatpak-dir.c:5278
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "Під час спроби визначити посилання %s: "
+
+#: common/flatpak-dir.c:5293
+#, c-format
+msgid "%s is not available"
+msgstr "%s недоступний"
+
+#: common/flatpak-dir.c:5308 common/flatpak-dir.c:5740
+#: common/flatpak-dir.c:6522 common/flatpak-dir.c:6535
+#: common/flatpak-dir.c:6611
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "Гілку %s %s вже встановлено"
+
+#: common/flatpak-dir.c:5327
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "Не вдалося прочитати внесок %s: "
+
+#: common/flatpak-dir.c:5347
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "Під час спроби вивантаження %s до %s: "
+
+#: common/flatpak-dir.c:5372 common/flatpak-dir.c:5403
+msgid "While trying to checkout metadata subpath: "
+msgstr "Під час спроби вивантаження підшляху метаданих: "
+
+#: common/flatpak-dir.c:5413
+msgid "While trying to remove existing extra dir: "
+msgstr "Під час спроби вилучення наявного додаткового каталогу: "
+
+#: common/flatpak-dir.c:5424
+msgid "While trying to apply extra data: "
+msgstr "Під час спроби застосування додаткових даних: "
+
+#: common/flatpak-dir.c:5451
+#, c-format
+msgid "Invalid deployed ref %s: "
+msgstr "Некоректне посилання на розгортання %s: "
+
+#: common/flatpak-dir.c:5458
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr "Некоректне посилання на внесок %s: "
+
+#: common/flatpak-dir.c:5466
+#, c-format
+msgid "Deployed ref %s kind does not match commit (%s)"
+msgstr "Тип розміщеного посилання %s не відповідає внеску (%s)"
+
+#: common/flatpak-dir.c:5474
+#, c-format
+msgid "Deployed ref %s name does not match commit (%s)"
+msgstr "Назва розміщеного посилання %s не відповідає внеску (%s)"
+
+#: common/flatpak-dir.c:5482
+#, c-format
+msgid "Deployed ref %s arch does not match commit (%s)"
+msgstr "Архітектура розміщеного посилання %s не відповідає внеску (%s)"
+
+#: common/flatpak-dir.c:5488
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "Гілка розміщеного посилання %s не відповідає внеску (%s)"
+
+#: common/flatpak-dir.c:5494
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "Розміщене джерело %s не відповідає внеску (%s)"
+
+#: common/flatpak-dir.c:5513
+msgid "Deployed metadata does not match commit"
+msgstr "Розміщені метадані не відповідають внеску"
+
+#: common/flatpak-dir.c:6383
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "Цю версію %s вже встановлено"
+
+#: common/flatpak-dir.c:6390
+msgid "Can't change remote during bundle install"
+msgstr "Не можна змінювати сховище під час встановлення пакунка"
+
+#: common/flatpak-dir.c:6948
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s, гілка %s не встановлено"
+
+#: common/flatpak-dir.c:7193
+#, c-format
+msgid "%s branch %s not installed"
+msgstr "%s, гілка %s не встановлено"
+
+#: common/flatpak-dir.c:7517
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr "Не вдалося спорожнити сховище: %s"
+
+#: common/flatpak-dir.c:8044
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+"Доступними є декілька гілок %s, вам слід вказати одне з таких значень: "
+
+#: common/flatpak-dir.c:8065
+#, c-format
+msgid "Nothing matches %s"
+msgstr "Немає відповідників %s"
+
+#: common/flatpak-dir.c:8147
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "Не вдалося знайти посилання %s%s%s%s%s"
+
+#: common/flatpak-dir.c:8189
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "Помилка під час пошуку у віддаленому сховищі %s: %s"
+
+#: common/flatpak-dir.c:8234
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Помилка під час пошуку у локальному сховищі: %s"
+
+#: common/flatpak-dir.c:8360
+#, c-format
+msgid "%s %s not installed"
+msgstr "Не встановлено %s %s"
+
+#: common/flatpak-dir.c:8527
+#, c-format
+msgid "Could not find installation %s"
+msgstr "Не вдалося знайти встановлення %s"
+
+#: common/flatpak-dir.c:9126
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "Середовище виконання %s, гілка %s вже встановлено"
+
+#: common/flatpak-dir.c:9127
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "Програму %s, гілка %s вже встановлено"
+
+#: common/flatpak-dir.c:9607
+msgid "Remote title not set"
+msgstr "Заголовок віддаленого сховища не встановлено"
+
+#: common/flatpak-dir.c:9629
+msgid "Remote default-branch not set"
+msgstr "Не встановлено типову гілку віддаленого сховища"
+
+#: common/flatpak-dir.c:10222
+msgid "No flatpak cache in remote summary"
+msgstr "У резюме сховища немає кешу flatpak"
+
+#: common/flatpak-dir.c:10232
+#, c-format
+msgid "No entry for %s in remote summary flatpak cache "
+msgstr "Немає запису %s у кеші flatpak резюме сховища "
+
+#: common/flatpak-run.c:1450
 #, c-format
 msgid "Failed to open flatpak-info temp file: %s"
 msgstr "Не вдалося відкрити тимчасовий файл flatpak-info: %s"
 
-#: common/flatpak-run.c:3864 common/flatpak-run.c:3874
+#: common/flatpak-run.c:1524 common/flatpak-run.c:1534
 #, c-format
 msgid "Failed to open temp file: %s"
 msgstr "Не вдалося відкрити тимчасовий файл: %s"
 
-#: common/flatpak-run.c:4214
+#: common/flatpak-run.c:1877
 msgid "Unable to create sync pipe"
 msgstr "Не вдалося створити канал синхронізації"
 
-#: common/flatpak-run.c:4241
+#: common/flatpak-run.c:1904
 #, c-format
 msgid "Failed to open app info file: %s"
 msgstr "Не вдалося відкрити файл інформації щодо програми: %s"
 
-#: common/flatpak-run.c:4271
+#: common/flatpak-run.c:1934
 msgid "Failed to sync with dbus proxy"
 msgstr "Не вдалося виконати синхронізацію із проміжним D-Bus"
 
-#: common/flatpak-run.c:5170
+#: common/flatpak-run.c:2694
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "Помилка ldconfig, стан виходу %d"
@@ -2723,147 +2751,90 @@ msgstr "Переносимо %s на %s\n"
 msgid "Error during migration: %s\n"
 msgstr "Помилка під час перенесення: %s\n"
 
-#: common/flatpak-utils.c:2939
+#: common/flatpak-utils.c:2987
 msgid "No extra data sources"
 msgstr "Немає джерел додаткових даних"
 
-#: common/flatpak-utils.c:6522
+#: common/flatpak-utils.c:6577
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Отримуємо метадані: %u/(оцінка) %s"
 
-#: common/flatpak-utils.c:6546
+#: common/flatpak-utils.c:6601
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Отримуємо: %s/%s"
 
-#: common/flatpak-utils.c:6566
+#: common/flatpak-utils.c:6621
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Отримуємо додаткові дані: %s з %s"
 
-#: common/flatpak-utils.c:6571
+#: common/flatpak-utils.c:6626
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Отримуємо файли: %d з %d %s"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:23
-msgid "Install signed application"
-msgstr "Встановлення підписаної програми"
+#~ msgid "Install signed application"
+#~ msgstr "Встановлення підписаної програми"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:24
-#: system-helper/org.freedesktop.Flatpak.policy.in:41
-#: system-helper/org.freedesktop.Flatpak.policy.in:118
-msgid "Authentication is required to install software"
-msgstr "Для встановлення програмного забезпечення слід пройти розпізнавання"
+#~ msgid "Authentication is required to install software"
+#~ msgstr "Для встановлення програмного забезпечення слід пройти розпізнавання"
 
-#. SECURITY:
-#. - Normal users do not need authentication to install signed applications
-#. from signed repositories, as this cannot exploit a system.
-#. - Paranoid users (or parents!) can change this to 'auth_admin' or
-#. 'auth_admin_keep'.
-#: system-helper/org.freedesktop.Flatpak.policy.in:40
-msgid "Install signed runtime"
-msgstr "Встановлення підписаного середовища виконання"
+#~ msgid "Install signed runtime"
+#~ msgstr "Встановлення підписаного середовища виконання"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update an
-#. app as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:58
-msgid "Update signed application"
-msgstr "Оновлення підписаної програми"
+#~ msgid "Update signed application"
+#~ msgstr "Оновлення підписаної програми"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:59
-#: system-helper/org.freedesktop.Flatpak.policy.in:77
-#: system-helper/org.freedesktop.Flatpak.policy.in:180
-msgid "Authentication is required to update software"
-msgstr "Для оновлення програмного забезпечення слід пройти розпізнавання"
+#~ msgid "Authentication is required to update software"
+#~ msgstr "Для оновлення програмного забезпечення слід пройти розпізнавання"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update a
-#. runtime as the commit will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:76
-msgid "Update signed runtime"
-msgstr "Оновлення підписаного середовища виконання"
+#~ msgid "Update signed runtime"
+#~ msgstr "Оновлення підписаного середовища виконання"
 
-#. SECURITY:
-#. - Normal users do not need authentication to update metadata
-#. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:91
-msgid "Update remote metadata"
-msgstr "Оновити віддалені метадані"
+#~ msgid "Update remote metadata"
+#~ msgstr "Оновити віддалені метадані"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:92
-msgid "Authentication is required to update remote info"
-msgstr "Для оновлення даних віддаленого сховища слід пройти розпізнавання"
+#~ msgid "Authentication is required to update remote info"
+#~ msgstr "Для оновлення даних віддаленого сховища слід пройти розпізнавання"
 
-#. SECURITY:
-#. - Normal users do not need authentication to modify the
-#. OSTree repository
-#: system-helper/org.freedesktop.Flatpak.policy.in:106
-msgid "Update system repository"
-msgstr "Оновлення загальносистемного сховища"
+#~ msgid "Update system repository"
+#~ msgstr "Оновлення загальносистемного сховища"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:107
-msgid "Authentication is required to update the system repository"
-msgstr "Для оновлення загальносистемного сховища слід пройти розпізнавання"
+#~ msgid "Authentication is required to update the system repository"
+#~ msgstr "Для оновлення загальносистемного сховища слід пройти розпізнавання"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:117
-msgid "Install bundle"
-msgstr "Встановити пакунок"
+#~ msgid "Install bundle"
+#~ msgstr "Встановити пакунок"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:128
-msgid "Uninstall runtime"
-msgstr "Вилучення середовища виконання"
+#~ msgid "Uninstall runtime"
+#~ msgstr "Вилучення середовища виконання"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:129
-#: system-helper/org.freedesktop.Flatpak.policy.in:140
-msgid "Authentication is required to uninstall software"
-msgstr "Для вилучення програмного забезпечення слід пройти розпізнавання"
+#~ msgid "Authentication is required to uninstall software"
+#~ msgstr "Для вилучення програмного забезпечення слід пройти розпізнавання"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:139
-msgid "Uninstall app"
-msgstr "Вилучити програму"
+#~ msgid "Uninstall app"
+#~ msgstr "Вилучити програму"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:150
-msgid "Configure Remote"
-msgstr "Налаштовування сховищ"
+#~ msgid "Configure Remote"
+#~ msgstr "Налаштовування сховищ"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:151
-msgid "Authentication is required to configure software repositories"
-msgstr ""
-"Для налаштовування сховищ програмного забезпечення слід пройти розпізнавання"
+#~ msgid "Authentication is required to configure software repositories"
+#~ msgstr ""
+#~ "Для налаштовування сховищ програмного забезпечення слід пройти "
+#~ "розпізнавання"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
-msgid "Configure"
-msgstr "Налаштувати"
+#~ msgid "Configure"
+#~ msgstr "Налаштувати"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
-msgid "Authentication is required to configure software installation"
-msgstr ""
-"Для налаштовування встановлення програмного забезпечення слід пройти "
-"розпізнавання"
+#~ msgid "Authentication is required to configure software installation"
+#~ msgstr ""
+#~ "Для налаштовування встановлення програмного забезпечення слід пройти "
+#~ "розпізнавання"
 
-#. SECURITY:
-#. - Normal users do not require admin authentication to update
-#. appstream data as it will be signed, and the action is required
-#. to update the system when unattended.
-#. - Changing this to anything other than 'yes' will break unattended
-#. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:179
-msgid "Update appstream"
-msgstr "Оновлення appstream"
+#~ msgid "Update appstream"
+#~ msgstr "Оновлення appstream"
 
 #~ msgid "No remote %s"
 #~ msgstr "Немає сховища %s"


### PR DESCRIPTION
(vbatts) but removing the XCB stuffs
this now works when PULSE_SERVER is set.

On slackware for example PULSE_SERVER is not set in a user session, but
it is for the X session `xprop  -root | grep -i ^PULSE_SERVER`

so manually exporting that variable then brings the pulseaudio socket
into the bwrap container and works fine. So maybe there could be yet
another check for whether the env or socket has not been found, else
shell out to xprop for that variable? gross, but maybe better than
linking to xlib.

Rebase and update of https://github.com/flatpak/flatpak/pull/1208 cc @valentindavid 

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>