### PR TITLE
Add fallback-x11 socket permission

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -58,6 +58,7 @@ const char *flatpak_context_sockets[] = {
   "pulseaudio",
   "session-bus",
   "system-bus",
+  "fallback-x11",
   NULL
 };
 
@@ -815,6 +816,9 @@ option_socket_cb (const gchar *option_name,
   if (socket == 0)
     return FALSE;
 
+  if (socket == FLATPAK_CONTEXT_SOCKET_FALLBACK_X11)
+    socket |= FLATPAK_CONTEXT_SOCKET_X11;
+
   flatpak_context_add_sockets (context, socket);
 
   return TRUE;
@@ -832,6 +836,9 @@ option_nosocket_cb (const gchar *option_name,
   socket = flatpak_context_socket_from_string (value, error);
   if (socket == 0)
     return FALSE;
+
+  if (socket == FLATPAK_CONTEXT_SOCKET_FALLBACK_X11)
+    socket |= FLATPAK_CONTEXT_SOCKET_X11;
 
   flatpak_context_remove_sockets (context, socket);
 

--- a/common/flatpak-context.h
+++ b/common/flatpak-context.h
@@ -39,6 +39,7 @@ typedef enum {
   FLATPAK_CONTEXT_SOCKET_PULSEAUDIO  = 1 << 2,
   FLATPAK_CONTEXT_SOCKET_SESSION_BUS = 1 << 3,
   FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS  = 1 << 4,
+  FLATPAK_CONTEXT_SOCKET_FALLBACK_X11 = 1 << 5, /* For backwards compat, also set SOCKET_X11 */
 } FlatpakContextSockets;
 
 typedef enum {

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -122,7 +122,7 @@
                 <listitem><para>
                     Expose a well known socket to the application. This updates
                     the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -133,7 +133,7 @@
                 <listitem><para>
                     Don't expose a well known socket to the application. This updates
                     the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -140,7 +140,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -151,7 +151,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -142,7 +142,7 @@
                     <term><option>sockets</option> (list)</term>
                     <listitem><para>
                         List of well-known sockets to make available in the sandbox.
-                        Possible sockets: x11, wayland, pulseaudio, session-bus, system-bus.
+                        Possible sockets: x11, wayland, fallback-x11, pulseaudio, session-bus, system-bus.
                         When making a socket available, flatpak also sets
                         well-known environment variables like DISPLAY or
                         DBUS_SYSTEM_BUS_ADDRESS to let the application

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -130,7 +130,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -141,7 +141,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -181,7 +181,7 @@
                 <listitem><para>
                     Expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -192,7 +192,7 @@
                 <listitem><para>
                     Don't expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This means use x11 if no alternative is present, and should be used
for applications that support both X11 and wayland, but want to be
sandboxed when running under a wayland compositor (but still want to
run under an X server).