### PR TITLE
Remove unused FUSE build-dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,8 +222,6 @@ fi
 
 PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
 
-PKG_CHECK_MODULES(FUSE, [fuse])
-
 PKG_CHECK_MODULES(JSON, [json-glib-1.0])
 
 PKG_CHECK_MODULES(APPSTREAM_GLIB, [appstream-glib >= 0.5.10])


### PR DESCRIPTION
This was needed for the document portal, which has been removed.

---

Not suitable for 0.10.x, for which I'll open a separate PR.