### PR TITLE
Fix persisted directories on atomic

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1918,10 +1918,7 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext *context,
 
           g_mkdir_with_parents (src, 0755);
 
-          /* We stick to flatpak_bwrap_add_args instead of flatpak_bwrap_add_bind_arg because persisted
-           * folders don't need to exist outside the chroot.
-           */
-          flatpak_bwrap_add_args (bwrap, "--bind", src, dest, NULL);
+          flatpak_bwrap_add_bind_arg (bwrap, "--bind", src, dest);
         }
     }
 


### PR DESCRIPTION
On atomic /home is a symlink to /var/home, so when we bind-mount
the persistent directories we need to early-resolve the symlinks
to avoid running into issues with /newroot.

In most cases we do this already by calling flatpak_bwrap_add_bind_arg,
but the persistent dir case did not, because that function required
the target to exist, and the persistent directoried might not.
However, these days flatpak_bwrap_add_bind_arg is fine if the base
dir doesn't exists but the target does, which is the case here,
so we can use it now.

This fixes e.g. steam: https://github.com/flatpak/flatpak/issues/1278