### PR TITLE
appdata: Remove unnecessary spew when generating appdata

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3917,8 +3917,6 @@ extract_appstream (OstreeRepo   *repo,
 
           if (!g_str_has_prefix (component_id_text, id))
             {
-              g_print ("Skipping mismatched appstream component %s for app %s\n",
-                       component_id_text, id);
               component = component->next_sibling;
               continue;
             }


### PR DESCRIPTION
The process was printing a line for every mismatching component id
in the xml for each app, which is starting to get very large log files
on flathub.