### PR TITLE
.gitignore: Ignore flatpak-document-dbus.[ch]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ flatpak-builder
 *~
 profile/flatpak.sh
 flatpak-dbus.[ch]
+flatpak-document-dbus.[ch]
 flatpak-systemd-dbus.[ch]
 flatpak-resources.[ch]
 flatpak-dbus-proxy


### PR DESCRIPTION
These targets were added in commit f2a6c1db8 and don't need to be
tracked by git.