### PR TITLE
common: Include sys/mman.h for memfd_create()

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/file.h>
+#include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
Versions of glibc starting with 2.27 include support for memfd_create()
in sys/mman.h, and the included libglnx then drops its internal define.