### PR TITLE
remote-ls: Skip disabled remotes

### DIFF
--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -145,6 +145,9 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
               RemoteDirPair *remote_dir_pair = NULL;
               const char *remote_name = remotes[j];
 
+              if (flatpak_dir_get_remote_disabled (dir, remote_name))
+                continue;
+
               if (!flatpak_dir_list_remote_refs (dir,
                                                  remote_name,
                                                  &refs,


### PR DESCRIPTION
The remote-ls command should skip remotes that have "xa.disable" set to
true or have no URL set, which can happen for remotes added for flatpak
bundle files.

Fixes https://github.com/flatpak/flatpak/issues/1427