### PR TITLE
metadata: allow [Extension name//ref]

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4459,32 +4459,45 @@ flatpak_list_extensions (GKeyFile   *metakey,
   groups = g_key_file_get_groups (metakey, NULL);
   for (i = 0; groups[i] != NULL; i++)
     {
-      char *extension;
+      if (!g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))
+        continue;
 
-      if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
-          *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
+      char *extension = groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION);
+
+      if (!extension)
+        continue;
+
+      g_autofree char *name = NULL;
+      g_autofree char *branch = NULL;
+      g_autoptr(GError) error = NULL;
+
+      if (!flatpak_split_partial_ref_arg (extension, FLATPAK_KINDS_RUNTIME, arch, default_branch,
+                                          NULL, &name, NULL, &branch, &error))
         {
-          g_autofree char *version = g_key_file_get_string (metakey, groups[i],
-                                                            FLATPAK_METADATA_KEY_VERSION,
-                                                            NULL);
-          g_auto(GStrv) versions = g_key_file_get_string_list (metakey, groups[i],
-                                                               FLATPAK_METADATA_KEY_VERSIONS,
-                                                               NULL, NULL);
-          const char *default_branches[] = { default_branch, NULL};
-          const char **branches;
-
-          if (versions)
-            branches = (const char **)versions;
-          else
-            {
-              if (version)
-                default_branches[0] = version;
-              branches = default_branches;
-            }
-
-          for (j = 0; branches[j] != NULL; j++)
-            res = add_extension (metakey, groups[i], extension, arch, branches[j], res);
+          g_debug ("couldn't parse extension name %s: %s", extension, error->message);
+          continue;
         }
+
+      g_autofree char *version = g_key_file_get_string (metakey, groups[i],
+                                                        FLATPAK_METADATA_KEY_VERSION,
+                                                        NULL);
+      g_auto(GStrv) versions = g_key_file_get_string_list (metakey, groups[i],
+                                                           FLATPAK_METADATA_KEY_VERSIONS,
+                                                           NULL, NULL);
+      const char *default_branches[] = { branch, NULL };
+      const char **branches;
+
+      if (versions)
+        branches = (const char **)versions;
+      else
+        {
+          if (version)
+            default_branches[0] = version;
+          branches = default_branches;
+        }
+
+      for (j = 0; branches[j] != NULL; j++)
+        res = add_extension (metakey, groups[i], name, arch, branches[j], res);
     }
 
   return g_list_sort (g_list_reverse (res), flatpak_extension_compare);

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -542,7 +542,10 @@
                 inside the sandbox when they are present on the system. Typical uses
                 for extension points include translations for applications, or debuginfo
                 for sdks. The name of the extension point is specified as part of the
-                group heading.
+                group heading. Since 0.11.4, the name may optionally include a branch
+                in the name//branch ref syntax if you wish to use different versions
+                of the same extension at same time. If specified, the architecture
+                part of the ref is currently ignored.
             </para>
             <variablelist>
                 <varlistentry>


### PR DESCRIPTION
Group names must be unique in GKeyFiles, which means that even though
flatpak run allows the same extension with different versions to be
used by a flatpak, it cannot be specified in the metadata. Add this
syntax so that the group names can vary by version, allowing an app
to load different versions of the same extension at different paths.