### PR TITLE
dir: Regenerate summary in child repo in more cases

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2233,6 +2233,13 @@ flatpak_dir_update_appstream (FlatpakDir          *self,
                                  progress, cancellable, error))
             return FALSE;
 
+          /* Regenerate the summary in the child repo because the
+           * flatpak_dir_pull() call above might not copy the remote summary
+           * into the repo if the "branches" key is set on the remote. */
+          if (collection_id != NULL &&
+              !ostree_repo_regenerate_summary (child_repo, NULL, cancellable, error))
+            return FALSE;
+
           if (summary_copy != NULL)
             {
               summary_file = g_file_get_child (ostree_repo_get_path (child_repo), "summary");
@@ -9890,6 +9897,13 @@ flatpak_dir_fetch_remote_repo_metadata (FlatpakDir    *self,
                                  flatpak_flags,
                                  OSTREE_REPO_PULL_FLAGS_MIRROR,
                                  NULL, cancellable, error))
+            return FALSE;
+
+          /* Regenerate the summary in the child repo because the
+           * flatpak_dir_pull() call above might not copy the remote summary
+           * into the repo if the "branches" key is set on the remote. */
+          if (collection_id != NULL &&
+              !ostree_repo_regenerate_summary (child_repo, NULL, cancellable, error))
             return FALSE;
 
           child_repo_path = g_file_get_path (ostree_repo_get_path (child_repo));


### PR DESCRIPTION
Similarly to commit 272af0f8c, this commit makes sure the child repo
used by the system helper has an accurate summary file so it can be
pulled from. This time it's for the fetches of the ostree-metadata ref
and the appstream data.

This fixes a bug that occurs if a remote has a collection ID set and
uses the "branches" key as well. Under those conditions, `flatpak
remote-ls -d REMOTE` and `flatpak update --appstream REMOTE` can fail
with "Error pulling from repo: No summary found".

Until recently, the /ostree/repo/config in Endless contained a remote
that was shared between flatpak and ostree, which had "branches" set. So
that's a use case where this helps.

Fixes https://github.com/flatpak/flatpak/issues/1440