### PR TITLE
app: Do not share the GError object in all completion tasks

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -381,7 +381,6 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(FlatpakDir) user_dir = NULL;
   g_autoptr(FlatpakDir) system_dir = NULL;
-  g_autoptr(GError) error = NULL;
   int i;
 
   context = g_option_context_new ("");
@@ -407,6 +406,7 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
     case 4: /* SDK */
       user_dir = flatpak_dir_get_user ();
       {
+        g_autoptr(GError) error = NULL;
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (user_dir, NULL, NULL, opt_arch,
                                                               FLATPAK_KINDS_RUNTIME, &error);
         if (refs == NULL)
@@ -421,6 +421,7 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
 
       system_dir = flatpak_dir_get_system_default ();
       {
+        g_autoptr(GError) error = NULL;
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, NULL, NULL, opt_arch,
                                                               FLATPAK_KINDS_RUNTIME, &error);
         if (refs == NULL)
@@ -438,6 +439,7 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
     case 5: /* BRANCH */
       user_dir = flatpak_dir_get_user ();
       {
+        g_autoptr(GError) error = NULL;
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (user_dir, completion->argv[3], NULL, opt_arch,
                                                               FLATPAK_KINDS_RUNTIME, &error);
         if (refs == NULL)
@@ -452,6 +454,7 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
 
       system_dir = flatpak_dir_get_system_default ();
       {
+        g_autoptr(GError) error = NULL;
         g_auto(GStrv) refs = flatpak_dir_find_installed_refs (system_dir, completion->argv[3], NULL, opt_arch,
                                                               FLATPAK_KINDS_RUNTIME, &error);
         if (refs == NULL)


### PR DESCRIPTION
Completion on my system was triggering an assertion error:
`ostree_repo_open: assertion 'error == NULL || *error == NULL' failed`

command:
`flatpak build-init build-dir bar.foo.Baz org.freedesktop.Sdk//1.6 org.freedesktop.Platform//1.6`