### PR TITLE
lib/remote: Make gpg-verify-summary dependent on collection-id

### DIFF
--- a/lib/flatpak-remote.c
+++ b/lib/flatpak-remote.c
@@ -823,17 +823,16 @@ flatpak_remote_commit (FlatpakRemote   *self,
         }
       else
         {
+          g_autoptr(GError) local_error = NULL;
           gboolean gpg_verify_value;
 
           g_key_file_remove_key (config, group, "collection-id", NULL);
 
           /* Without a collection ID gpg-verify-summary should go back to
            * matching gpg-verify. */
-          gpg_verify_value = g_key_file_get_boolean (config, group, "gpg-verify", error);
-          if (*error == NULL)
+          gpg_verify_value = g_key_file_get_boolean (config, group, "gpg-verify", &local_error);
+          if (local_error == NULL)
             g_key_file_set_boolean (config, group, "gpg-verify-summary", gpg_verify_value);
-          else
-            g_clear_error (error);
         }
     }
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -12,10 +12,11 @@ else
 AM_TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
 endif
 
-testlibrary_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
+testlibrary_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS)
 testlibrary_LDADD = \
              $(AM_LDADD) \
              $(BASE_LIBS) \
+             $(OSTREE_LIBS) \
              libglnx.la \
              libflatpak.la \
              $(NULL)

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -5,6 +5,7 @@
 #include <sys/wait.h>
 
 #include <glib.h>
+#include <ostree.h>
 
 #include "libglnx/libglnx.h"
 #include "flatpak.h"
@@ -273,6 +274,10 @@ test_remote (void)
   g_autoptr(FlatpakInstallation) inst = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(FlatpakRemote) remote = NULL;
+  g_autoptr(GFile) inst_file = NULL;
+  g_autoptr(GFile) repo_file = NULL;
+  g_autoptr(OstreeRepo) repo = NULL;
+  g_autofree char *gpg_verify_summary = NULL;
   gboolean res;
 
   inst = flatpak_installation_new_user (NULL, &error);
@@ -285,9 +290,36 @@ test_remote (void)
   g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, NULL);
   flatpak_remote_set_collection_id (remote, "org.example.CollectionID");
   g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, "org.example.CollectionID");
+
+  /* Flatpak doesn't provide access to gpg-verify-summary, so use ostree */
+  res = flatpak_installation_modify_remote (inst, remote, NULL, &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  inst_file = flatpak_installation_get_path (inst);
+  repo_file = g_file_get_child (inst_file, "repo");
+  repo = ostree_repo_new (repo_file);
+  res = ostree_repo_open (repo, NULL, &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  res = ostree_repo_get_remote_option (repo, repo_name, "gpg-verify-summary", NULL, &gpg_verify_summary, &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  g_assert_cmpstr (gpg_verify_summary, ==, "false");
+
   /* Don’t leave the collection ID set since the repos aren’t configured with one. */
   flatpak_remote_set_collection_id (remote, NULL);
   g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, NULL);
+
+  res = flatpak_installation_modify_remote (inst, remote, NULL, &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  res = ostree_repo_reload_config (repo, NULL, &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  res = ostree_repo_get_remote_option (repo, repo_name, "gpg-verify-summary", NULL, &gpg_verify_summary, &error);
+  g_assert_true (res);
+  g_assert_no_error (error);
+  g_assert_cmpstr (gpg_verify_summary, ==, "true");
 #endif  /* FLATPAK_ENABLE_P2P */
 
   g_assert_cmpstr (flatpak_remote_get_title (remote), ==, NULL);

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -331,8 +331,8 @@ test_remote (void)
   g_assert_cmpint (flatpak_remote_get_prio (remote), ==, 15);
 
   res = flatpak_installation_modify_remote (inst, remote, NULL, &error);
-  g_assert_true (res);
   g_assert_no_error (error);
+  g_assert_true (res);
 
   g_clear_object (&remote);
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -277,7 +277,7 @@ test_remote (void)
   g_autoptr(GFile) inst_file = NULL;
   g_autoptr(GFile) repo_file = NULL;
   g_autoptr(OstreeRepo) repo = NULL;
-  g_autofree char *gpg_verify_summary = NULL;
+  gboolean gpg_verify_summary;
   gboolean res;
 
   inst = flatpak_installation_new_user (NULL, &error);
@@ -293,33 +293,33 @@ test_remote (void)
 
   /* Flatpak doesn't provide access to gpg-verify-summary, so use ostree */
   res = flatpak_installation_modify_remote (inst, remote, NULL, &error);
-  g_assert_true (res);
   g_assert_no_error (error);
+  g_assert_true (res);
   inst_file = flatpak_installation_get_path (inst);
   repo_file = g_file_get_child (inst_file, "repo");
   repo = ostree_repo_new (repo_file);
   res = ostree_repo_open (repo, NULL, &error);
-  g_assert_true (res);
   g_assert_no_error (error);
-  res = ostree_repo_get_remote_option (repo, repo_name, "gpg-verify-summary", NULL, &gpg_verify_summary, &error);
   g_assert_true (res);
+  res = ostree_repo_get_remote_boolean_option (repo, repo_name, "gpg-verify-summary", TRUE, &gpg_verify_summary, &error);
   g_assert_no_error (error);
-  g_assert_cmpstr (gpg_verify_summary, ==, "false");
+  g_assert_true (res);
+  g_assert_false (gpg_verify_summary);
 
   /* Don’t leave the collection ID set since the repos aren’t configured with one. */
   flatpak_remote_set_collection_id (remote, NULL);
   g_assert_cmpstr (flatpak_remote_get_collection_id (remote), ==, NULL);
 
   res = flatpak_installation_modify_remote (inst, remote, NULL, &error);
-  g_assert_true (res);
   g_assert_no_error (error);
+  g_assert_true (res);
   res = ostree_repo_reload_config (repo, NULL, &error);
-  g_assert_true (res);
   g_assert_no_error (error);
-  res = ostree_repo_get_remote_option (repo, repo_name, "gpg-verify-summary", NULL, &gpg_verify_summary, &error);
   g_assert_true (res);
+  res = ostree_repo_get_remote_boolean_option (repo, repo_name, "gpg-verify-summary", FALSE, &gpg_verify_summary, &error);
   g_assert_no_error (error);
-  g_assert_cmpstr (gpg_verify_summary, ==, "true");
+  g_assert_true (res);
+  g_assert_true (gpg_verify_summary);
 #endif  /* FLATPAK_ENABLE_P2P */
 
   g_assert_cmpstr (flatpak_remote_get_title (remote), ==, NULL);


### PR DESCRIPTION
When a collection ID is set on a remote configuration,
gpg-verify-summary should be set to FALSE because flatpak uses signed
per-repo and per-commit metadata instead. The flatpak command line
already does this (use flatpak remote-modify --collection-id=... and
notice that gpg-verify-summary is then set to false). This commit
changes libflatpak to have the same behavior. Specifically, with a
collection ID set gpg-verify-summary is set to false and otherwise its
value matches that of gpg-verify. This commit also adds a test for this
in testlibrary.c.

Fixes https://github.com/flatpak/flatpak/issues/1479