### PR TITLE
dir: Improve "Can't find ref" error message

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3671,8 +3671,13 @@ flatpak_dir_pull_untrusted_local (FlatpakDir          *self,
                                    ref,
                                    &checksum, NULL))
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   _("Can't find %s in remote %s"), ref, remote_name);
+      if (collection_id != NULL)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                     _("No such ref (%s, %s) in remote %s"), collection_id, ref, remote_name);
+      else
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                     _("No such ref '%s' in remote %s"), ref, remote_name);
+
       return FALSE;
     }
 


### PR DESCRIPTION
This commit adds the collection ID (if any) to the "Can't find ref"
error message produced by flatpak_dir_pull_untrusted_local(). This makes
the message more helpful if for example you run `flatpak update` when
some of the remotes are configured with the wrong collection IDs. It
also changes the wording to be consistent with other similar errors.