### PR TITLE
build-init: Add support for tagged extension names

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -74,14 +74,20 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_branch,
   for (i = 0; src_extensions[i] != NULL; i++)
     {
       const char *requested_extension = src_extensions[i];
+      g_autofree char *requested_extension_name = NULL;
       gboolean found = FALSE;
+
+      /* Remove any '@' from the name */
+      flatpak_parse_extension_with_tag (requested_extension,
+                                        &requested_extension_name,
+                                        NULL);
 
       for (l = extensions; l != NULL; l = l->next)
         {
           FlatpakExtension *ext = l->data;
 
-          if (strcmp (ext->installed_id, requested_extension) == 0 ||
-              strcmp (ext->id, requested_extension) == 0)
+          if (strcmp (ext->installed_id, requested_extension_name) == 0 ||
+              strcmp (ext->id, requested_extension_name) == 0)
             {
               if (!ext->is_unmaintained)
                 {
@@ -128,7 +134,7 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_branch,
       if (!found)
         {
           g_list_free_full (extensions, (GDestroyNotify) flatpak_extension_free);
-          return flatpak_fail (error, _("Requested extension %s not installed"), requested_extension);
+          return flatpak_fail (error, _("Requested extension %s not installed"), requested_extension_name);
         }
     }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10586,11 +10586,12 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
       groups = g_key_file_get_groups (metakey, NULL);
       for (i = 0; groups[i] != NULL; i++)
         {
-          char *extension;
+          char *tagged_extension;
 
           if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
-              *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
+              *(tagged_extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
             {
+              g_autofree char *extension = NULL;
               g_autofree char *version = g_key_file_get_string (metakey, groups[i],
                                                                 FLATPAK_METADATA_KEY_VERSION, NULL);
               gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
@@ -10607,6 +10608,9 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
               const char *branch;
               g_autofree char *extension_ref = NULL;
               g_autofree char *checksum = NULL;
+
+              /* Parse actual extension name */
+              flatpak_parse_extension_with_tag (tagged_extension, &extension, NULL);
 
               if (version)
                 branch = version;
@@ -10750,11 +10754,12 @@ flatpak_dir_find_local_related (FlatpakDir *self,
       groups = g_key_file_get_groups (metakey, NULL);
       for (i = 0; groups[i] != NULL; i++)
         {
-          char *extension;
+          char *tagged_extension;
 
           if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
-              *(extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
+              *(tagged_extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
             {
+              g_autofree char *extension = NULL;
               g_autofree char *version = g_key_file_get_string (metakey, groups[i],
                                                                 FLATPAK_METADATA_KEY_VERSION, NULL);
               gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
@@ -10772,6 +10777,9 @@ flatpak_dir_find_local_related (FlatpakDir *self,
               g_autofree char *prefixed_extension_ref = NULL;
               g_autofree char *checksum = NULL;
               g_autofree char *extension_collection_id = NULL;
+
+              /* Parse actual extension name */
+              flatpak_parse_extension_with_tag (tagged_extension, &extension, NULL);
 
               if (version)
                 branch = version;

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -101,6 +101,7 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_GROUP_EXTENSION_OF "ExtensionOf"
 #define FLATPAK_METADATA_KEY_PRIORITY "priority"
 #define FLATPAK_METADATA_KEY_REF "ref"
+#define FLATPAK_METADATA_KEY_TAG "tag"
 
 
 typedef enum {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3955,6 +3955,31 @@ add_extension (GKeyFile   *metakey,
   return res;
 }
 
+void
+flatpak_parse_extension_with_tag (const char  *extension,
+                                  char       **name,
+                                  char       **tag)
+{
+  const char *tag_chr = strchr (extension, '@');
+
+  if (tag_chr)
+    {
+      if (name != NULL)
+        *name = g_strndup (extension, tag_chr - extension);
+
+      /* Everything after the @ */
+      if (tag != NULL)
+        *tag = g_strdup (tag_chr + 1);
+
+      return;
+    }
+
+  if (name != NULL)
+    *name = g_strdup (extension);
+
+  if (tag != NULL)
+    *tag = NULL;
+}
 
 GList *
 flatpak_list_extensions (GKeyFile   *metakey,
@@ -3984,8 +4009,11 @@ flatpak_list_extensions (GKeyFile   *metakey,
           g_auto(GStrv) versions = g_key_file_get_string_list (metakey, groups[i],
                                                                FLATPAK_METADATA_KEY_VERSIONS,
                                                                NULL, NULL);
+          g_autofree char *name = NULL;
           const char *default_branches[] = { default_branch, NULL};
           const char **branches;
+
+          flatpak_parse_extension_with_tag (extension, &name, NULL);
 
           if (versions)
             branches = (const char **)versions;
@@ -3997,7 +4025,7 @@ flatpak_list_extensions (GKeyFile   *metakey,
             }
 
           for (j = 0; branches[j] != NULL; j++)
-            res = add_extension (metakey, groups[i], extension, arch, branches[j], res);
+            res = add_extension (metakey, groups[i], name, arch, branches[j], res);
         }
     }
 

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -394,6 +394,10 @@ typedef struct
 
 void flatpak_extension_free (FlatpakExtension *extension);
 
+void flatpak_parse_extension_with_tag (const char  *extension,
+                                       char       **name,
+                                       char       **tag);
+
 GList *flatpak_list_extensions (GKeyFile   *metakey,
                                 const char *arch,
                                 const char *branch);

--- a/doc/flatpak-build-init.xml
+++ b/doc/flatpak-build-init.xml
@@ -179,6 +179,15 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--extension-tag=EXTENSION_TAG</option></term>
+
+                <listitem><para>
+                    If building an extension, the tag to use when searching for
+                    the mount point of the extension.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--verbose</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -542,7 +542,11 @@
                 inside the sandbox when they are present on the system. Typical uses
                 for extension points include translations for applications, or debuginfo
                 for sdks. The name of the extension point is specified as part of the
-                group heading.
+                group heading. Since 0.11.4, the name may optionally include a tag
+                in the NAME in the name@tag ref syntax if you wish to use different
+                configurations (eg, versions) of the same extension concurrently.
+                The "tag" is effectively ignored, but is necessary in order to allow
+                the same extension name to be specified more than once.
             </para>
             <variablelist>
                 <varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -694,6 +694,13 @@
                         backported to the 0.8.x branch in 0.8.3.
                     </para></listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term><option>tag</option> (string)</term>
+                    <listitem><para>
+                        The tag name to use when searching for this extension's mount
+                        point in the parent flatpak. Available since 0.11.4.
+                    </para></listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
         <refsect2>


### PR DESCRIPTION
This allows us to mount an extension more than once by adding an ignored "tag" to the end of the section name (eg foo@tag-1, foo@tag-2) and specifying the version as a key in the section.