### PR TITLE
uninstall: Pick installation automatically

### DIFF
--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -32,6 +32,7 @@
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"
 #include "flatpak-utils.h"
+#include "flatpak-error.h"
 
 static char *opt_arch;
 static gboolean opt_keep_ref;
@@ -50,32 +51,79 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
+typedef struct {
+  FlatpakDir *dir;
+  GHashTable *refs_hash;
+  GPtrArray *refs;
+} UninstallDir;
+
+static UninstallDir *
+uninstall_dir_new (FlatpakDir *dir)
+{
+  UninstallDir *udir = g_new0 (UninstallDir, 1);
+
+  udir->dir = g_object_ref (dir);
+  udir->refs = g_ptr_array_new_with_free_func (g_free);
+  udir->refs_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  return udir;
+}
+
+static void
+uninstall_dir_free (UninstallDir *udir)
+{
+  g_object_unref (udir->dir);
+  g_hash_table_unref (udir->refs_hash);
+  g_ptr_array_unref (udir->refs);
+  g_free (udir);
+}
+
+static void
+uninstall_dir_add_ref (UninstallDir *udir,
+                       const char *ref)
+{
+  if (g_hash_table_insert (udir->refs_hash, g_strdup (ref), NULL))
+    g_ptr_array_add (udir->refs, g_strdup (ref));
+}
+
+static UninstallDir *
+uninstall_dir_ensure (GHashTable *uninstall_dirs,
+                      FlatpakDir *dir)
+{
+  UninstallDir *udir;
+
+  udir = g_hash_table_lookup (uninstall_dirs, dir);
+  if (udir == NULL)
+    {
+      udir = uninstall_dir_new (dir);
+      g_hash_table_insert (uninstall_dirs, udir->dir, udir);
+    }
+
+  return udir;
+}
+
+
 gboolean
 flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GPtrArray) dirs = NULL;
-  FlatpakDir *dir;
   char **prefs = NULL;
-  int i, j, n_prefs;
+  int i, j, k, n_prefs;
   const char *default_branch = NULL;
-  g_autofree char *ref = NULL;
   FlatpakHelperUninstallFlags flags = 0;
   g_autoptr(GPtrArray) related = NULL;
   FlatpakKinds kinds;
   FlatpakKinds kind;
-  g_autoptr(GHashTable) uninstall_refs_hash = NULL;
-  g_autoptr(GPtrArray) uninstall_refs = NULL;
+  g_autoptr(GHashTable) uninstall_dirs = NULL;
 
   context = g_option_context_new (_("REF... - Uninstall an application"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,
-                                     FLATPAK_BUILTIN_FLAG_ONE_DIR,
+                                     FLATPAK_BUILTIN_FLAG_STANDARD_DIRS,
                                      &dirs, cancellable, error))
     return FALSE;
-
-  dir = g_ptr_array_index (dirs, 0);
 
   if (argc < 2)
     return usage_error (context, _("Must specify at least one REF"), error);
@@ -91,8 +139,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
     }
 
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
-  uninstall_refs = g_ptr_array_new_with_free_func (g_free);
-  uninstall_refs_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  uninstall_dirs = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)uninstall_dir_free);
 
   for (j = 0; j < n_prefs; j++)
     {
@@ -102,7 +149,11 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
       g_autofree char *arch = NULL;
       g_autofree char *branch = NULL;
       g_autoptr(GError) local_error = NULL;
+      g_autoptr(GError) first_error = NULL;
+      g_autofree char *first_ref = NULL;
       g_autofree char *origin = NULL;
+      g_autoptr(GPtrArray) dirs_with_ref = NULL;
+      UninstallDir *udir = NULL;
 
       pref = prefs[j];
 
@@ -110,24 +161,77 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
                                           &matched_kinds, &id, &arch, &branch, error))
         return FALSE;
 
-      ref = flatpak_dir_find_installed_ref (dir, id, branch, arch,
-                                            kinds, &kind, error);
-      if (ref == NULL)
-        return FALSE;
+      dirs_with_ref = g_ptr_array_new ();
+      for (k = 0; k < dirs->len; k++)
+        {
+          FlatpakDir *dir = g_ptr_array_index (dirs, k);
+          g_autofree char *ref = NULL;
 
-      if (g_hash_table_insert (uninstall_refs_hash, g_strdup (ref), NULL))
-        g_ptr_array_add (uninstall_refs, g_strdup (ref));
+          ref = flatpak_dir_find_installed_ref (dir, id, branch, arch,
+                                                kinds, &kind, &local_error);
+          if (ref == NULL)
+            {
+              if (g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED))
+                {
+                  if (first_error == NULL)
+                    first_error = g_steal_pointer (&local_error);
+                  g_clear_error (&local_error);
+                }
+              else
+                {
+                  g_propagate_error (error, g_steal_pointer (&local_error));
+                  return FALSE;
+                }
+            }
+          else
+            {
+              g_ptr_array_add (dirs_with_ref, dir);
+              if (first_ref == NULL)
+                first_ref = g_strdup (ref);
+            }
+        }
+
+      if (dirs_with_ref->len == 0)
+        {
+          g_assert (first_error != NULL);
+          /* No match anywhere, return the first NOT_INSTALLED error */
+          g_propagate_error (error, g_steal_pointer (&first_error));
+          return FALSE;
+        }
+
+      if (dirs_with_ref->len > 1)
+        {
+          g_autoptr(GString) dir_names = g_string_new ("");
+          for (k = 0; k < dirs_with_ref->len; k++)
+            {
+              FlatpakDir *dir = g_ptr_array_index (dirs_with_ref, k);
+              g_autofree char *dir_name = flatpak_dir_get_name (dir);
+              if (k > 0)
+                g_string_append (dir_names, ", ");
+              g_string_append (dir_names, dir_name);
+            }
+
+          return flatpak_fail (error,
+                               _("Ref ‘%s’ found in multiple installations: %s. You must specify one."),
+                               pref, dir_names->str);
+        }
+
+      udir = uninstall_dir_ensure (uninstall_dirs, g_ptr_array_index (dirs_with_ref, 0));
+
+      g_assert (first_ref);
+
+      uninstall_dir_add_ref (udir, first_ref);
 
       /* TODO: when removing runtimes, look for apps that use it, require --force */
 
       if (opt_no_related)
         continue;
 
-      origin = flatpak_dir_get_origin (dir, ref, NULL, NULL);
+      origin = flatpak_dir_get_origin (udir->dir, first_ref, NULL, NULL);
       if (origin == NULL)
         continue;
 
-      related = flatpak_dir_find_local_related (dir, ref, origin,
+      related = flatpak_dir_find_local_related (udir->dir, first_ref, origin,
                                                 NULL, &local_error);
       if (related == NULL)
         {
@@ -144,11 +248,9 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
           if (!rel->delete)
             continue;
 
-          deploy_data = flatpak_dir_get_deploy_data (dir, rel->ref, NULL, NULL);
-
-          if (deploy_data != NULL &&
-              g_hash_table_insert (uninstall_refs_hash, g_strdup (rel->ref), NULL))
-            g_ptr_array_add (uninstall_refs, g_strdup (rel->ref));
+          deploy_data = flatpak_dir_get_deploy_data (udir->dir, rel->ref, NULL, NULL);
+          if (deploy_data != NULL)
+            uninstall_dir_add_ref (udir, rel->ref);
         }
     }
 
@@ -157,14 +259,21 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
   if (opt_force_remove)
     flags |= FLATPAK_HELPER_UNINSTALL_FLAGS_FORCE_REMOVE;
 
-  for (i = 0; i < uninstall_refs->len; i++)
+  GLNX_HASH_TABLE_FOREACH_V (uninstall_dirs, UninstallDir *, udir)
     {
-      const char *ref = (char *)g_ptr_array_index (uninstall_refs, i);
-      const char *pref = strchr (ref, '/') + 1;
-      g_print (_("Uninstalling: %s\n"), pref);
-      if (!flatpak_dir_uninstall (dir, ref, flags,
-                                  cancellable, error))
-        return FALSE;
+      g_autofree char *dir_name = flatpak_dir_get_name (udir->dir);
+
+      for (i = 0; i < udir->refs->len; i++)
+        {
+          const char *ref = (char *)g_ptr_array_index (udir->refs, i);
+          const char *pref = strchr (ref, '/') + 1;
+
+          g_print (_("Uninstalling: %s from %s\n"), pref, dir_name);
+
+          if (!flatpak_dir_uninstall (udir->dir, ref, flags,
+                                      cancellable, error))
+            return FALSE;
+        }
     }
 
   return TRUE;
@@ -175,15 +284,13 @@ flatpak_complete_uninstall (FlatpakCompletion *completion)
 {
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GPtrArray) dirs = NULL;
-  FlatpakDir *dir;
+  int i;
   FlatpakKinds kinds;
 
   context = g_option_context_new ("");
   if (!flatpak_option_context_parse (context, options, &completion->argc, &completion->argv,
-                                     FLATPAK_BUILTIN_FLAG_ONE_DIR, &dirs, NULL, NULL))
+                                     FLATPAK_BUILTIN_FLAG_STANDARD_DIRS, &dirs, NULL, NULL))
     return FALSE;
-
-  dir = g_ptr_array_index (dirs, 0);
 
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
 
@@ -194,7 +301,13 @@ flatpak_complete_uninstall (FlatpakCompletion *completion)
       flatpak_complete_options (completion, global_entries);
       flatpak_complete_options (completion, options);
       flatpak_complete_options (completion, user_entries);
-      flatpak_complete_partial_ref (completion, kinds, opt_arch, dir, NULL);
+
+      for (i = 0; i < dirs->len; i++)
+        {
+          FlatpakDir *dir = g_ptr_array_index (dirs, i);
+          flatpak_complete_partial_ref (completion, kinds, opt_arch, dir, NULL);
+        }
+
       break;
     }
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -94,9 +94,11 @@ export ARCH=`flatpak --default-arch`
 if [ x${USE_SYSTEMDIR-} == xyes ] ; then
     export FL_DIR=${SYSTEMDIR}
     export U=
+    export INVERT_U=--user
 else
     export FL_DIR=${USERDIR}
     export U="--user"
+    export INVERT_U=--system
 fi
 
 if [ x${USE_DELTAS-} == xyes ] ; then

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -28,7 +28,7 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-
     skip_without_p2p
 fi
 
-echo "1..12"
+echo "1..13"
 
 #Regular repo
 setup_repo
@@ -139,9 +139,16 @@ update_repo test-gpg3 org.test.Collection.test
 ${FLATPAK} ${U} install test-repo org.test.Hello
 assert_file_has_content $FL_DIR/app/org.test.Hello/$ARCH/master/active/files/bin/hello.sh UPDATED
 
-${FLATPAK} ${U} uninstall org.test.Platform org.test.Hello
-
 echo "ok redirect url and gpg key"
+
+if ${FLATPAK} ${INVERT_U} uninstall org.test.Platform org.test.Hello; then
+    assert_not_reached "Should not be able to uninstall ${INVERT_U} when installed ${U}"
+fi
+
+# Test that unspecified --user/--system finds the right one, so no ${U}
+${FLATPAK} uninstall org.test.Platform org.test.Hello
+
+echo "ok uninstall vs installations"
 
 # Test that remote-ls works in all of the following cases:
 # * system remote, and --system is used


### PR DESCRIPTION
When uninstalling, if no specific installation was specified with e.g.
--user or --system, automatically chose any unique match, or error
out if there are multiple alternatives.