### PR TITLE
Make flatpak remove an alias to flatpak uninstall

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -63,6 +63,8 @@ static FlatpakCommand commands[] = {
   { "install", N_("Install an application or runtime"), flatpak_builtin_install, flatpak_complete_install },
   { "update", N_("Update an installed application or runtime"), flatpak_builtin_update, flatpak_complete_update },
   { "uninstall", N_("Uninstall an installed application or runtime"), flatpak_builtin_uninstall, flatpak_complete_uninstall },
+  /* Alias remove to uninstall to help users of yum/dnf/apt */
+  { "remove", NULL, flatpak_builtin_uninstall, flatpak_complete_uninstall, TRUE },
   { "list", N_("List installed apps and/or runtimes"), flatpak_builtin_list, flatpak_complete_list },
   { "info", N_("Show info for installed app or runtime"), flatpak_builtin_info, flatpak_complete_info },
   { "config", N_("Configure flatpak"), flatpak_builtin_config, flatpak_complete_config },


### PR DESCRIPTION
Yum, dnf and apt all use "remove" as the opposite of install, so
to make it easier for people coming from these.