### PR TITLE
build-finish: Also export .service files for names that we are allowed to own

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -415,6 +415,22 @@ flatpak_context_set_session_bus_policy (FlatpakContext *context,
   g_hash_table_insert (context->session_bus_policy, g_strdup (name), GINT_TO_POINTER (policy));
 }
 
+GStrv
+flatpak_context_get_session_bus_policy_allowed_own_names (FlatpakContext *context)
+{
+  GHashTableIter iter;
+  gpointer key, value;
+  g_autoptr(GPtrArray) names = g_ptr_array_new_with_free_func (g_free);
+
+  g_hash_table_iter_init (&iter, context->session_bus_policy);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    if (GPOINTER_TO_INT (value) == FLATPAK_POLICY_OWN)
+      g_ptr_array_add (names, g_strdup (key));
+
+  g_ptr_array_add (names, NULL);
+  return (GStrv) g_ptr_array_free (g_steal_pointer (&names), FALSE);
+}
+
 void
 flatpak_context_set_system_bus_policy (FlatpakContext *context,
                                        const char     *name,

--- a/common/flatpak-context.h
+++ b/common/flatpak-context.h
@@ -93,6 +93,7 @@ void           flatpak_context_allow_host_fs (FlatpakContext *context);
 void           flatpak_context_set_session_bus_policy (FlatpakContext *context,
                                                        const char     *name,
                                                        FlatpakPolicy   policy);
+GStrv          flatpak_context_get_session_bus_policy_allowed_own_names (FlatpakContext *context);
 void           flatpak_context_set_system_bus_policy (FlatpakContext *context,
                                                       const char     *name,
                                                       FlatpakPolicy   policy);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4888,15 +4888,56 @@ out:
   return ret;
 }
 
+typedef gboolean (*MultiplePrefixesComparisonFunc) (const char         *path,
+                                                    const char * const *prefixes);
+
+static GStrv
+get_permissible_prefixes (FlatpakContext                  *context,
+                          const char                      *source_path,
+                          const char                      *app_id,
+                          MultiplePrefixesComparisonFunc  *out_match_prefixes_func,
+                          GError                         **error)
+{
+  g_autoptr(GPtrArray) prefixes = NULL;
+
+  g_return_val_if_fail (out_match_prefixes_func != NULL, FALSE);
+
+  prefixes = g_ptr_array_new_with_free_func (g_free);
+
+  /* Create a new pointer array with prefixes including the app
+   * ID and in the case of d-bus service files, the allowed own
+   * names. */
+  g_ptr_array_add (prefixes, g_strdup (app_id));
+
+  if (flatpak_has_path_prefix (source_path, "share/dbus-1/services"))
+    {
+      g_auto(GStrv) owned_dbus_names =
+        flatpak_context_get_session_bus_policy_allowed_own_names (context);
+      GStrv iter = owned_dbus_names;
+
+      for (; *iter != NULL; ++iter)
+        g_ptr_array_add (prefixes, g_strdup (*iter));
+
+      *out_match_prefixes_func = flatpak_name_matches_one_wildcard_prefix;
+    }
+
+  g_ptr_array_add (prefixes, NULL);
+
+  *out_match_prefixes_func = flatpak_name_matches_one_prefix;
+  return (GStrv) g_ptr_array_free (g_steal_pointer (&prefixes), FALSE);
+}
+
 static gboolean
-rewrite_export_dir (const char   *app,
-                    const char   *branch,
-                    const char   *arch,
-                    GKeyFile     *metadata,
-                    int           source_parent_fd,
-                    const char   *source_name,
-                    GCancellable *cancellable,
-                    GError      **error)
+rewrite_export_dir (const char     *app,
+                    const char     *branch,
+                    const char     *arch,
+                    GKeyFile       *metadata,
+                    FlatpakContext *context,
+                    int             source_parent_fd,
+                    const char     *source_name,
+                    const char     *source_path,
+                    GCancellable   *cancellable,
+                    GError        **error)
 {
   gboolean ret = FALSE;
 
@@ -4940,16 +4981,27 @@ rewrite_export_dir (const char   *app,
 
       if (S_ISDIR (stbuf.st_mode))
         {
-          if (!rewrite_export_dir (app, branch, arch, metadata,
+          g_autofree char *path = g_build_filename (source_path, dent->d_name, NULL);
+
+          if (!rewrite_export_dir (app, branch, arch, metadata, context,
                                    source_iter.fd, dent->d_name,
-                                   cancellable, error))
+                                   path, cancellable, error))
             goto out;
         }
       else if (S_ISREG (stbuf.st_mode))
         {
+          MultiplePrefixesComparisonFunc match_prefixes_func;
+          g_auto(GStrv) permissible_prefixes = get_permissible_prefixes (context,
+                                                                         source_path,
+                                                                         app,
+                                                                         &match_prefixes_func,
+                                                                         error);
           g_autofree gchar *new_name = NULL;
 
-          if (!flatpak_has_name_prefix (dent->d_name, app))
+          if (permissible_prefixes == NULL)
+            return FALSE;
+
+          if (!match_prefixes_func (dent->d_name, (const char * const *) permissible_prefixes))
             {
               g_warning ("Non-prefixed filename %s in app %s, removing.", dent->d_name, app);
               if (unlinkat (source_iter.fd, dent->d_name, 0) != 0 && errno != ENOENT)
@@ -5021,10 +5073,15 @@ flatpak_rewrite_export_dir (const char   *app,
                             GError      **error)
 {
   gboolean ret = FALSE;
+  g_autofree char *name = g_file_get_basename (source);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+
+  if (!flatpak_context_load_metadata (context, metadata, error))
+    return FALSE;
 
   /* The fds are closed by this call */
-  if (!rewrite_export_dir (app, branch, arch, metadata,
-                           AT_FDCWD, flatpak_file_get_path_cached (source),
+  if (!rewrite_export_dir (app, branch, arch, metadata, context,
+                           AT_FDCWD, name, name,
                            cancellable, error))
     goto out;
 

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -102,7 +102,6 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_PRIORITY "priority"
 #define FLATPAK_METADATA_KEY_REF "ref"
 
-
 typedef enum {
   FLATPAK_RUN_FLAG_DEVEL              = (1 << 0),
   FLATPAK_RUN_FLAG_BACKGROUND         = (1 << 1),

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -750,6 +750,46 @@ flatpak_has_name_prefix (const char *string,
     !is_valid_name_character (*rest, FALSE);
 }
 
+gboolean
+flatpak_name_matches_one_prefix (const char         *path,
+                                 const char * const *prefixes)
+{
+  const char * const *iter = prefixes;
+
+  for (; *iter != NULL; ++iter)
+    if (flatpak_has_name_prefix (path, *iter))
+      return TRUE;
+
+  return FALSE;
+}
+
+gboolean
+flatpak_name_matches_one_wildcard_prefix (const char         *path,
+                                          const char * const *wildcarded_prefixes)
+{
+  const char * const *iter = wildcarded_prefixes;
+
+  for (; *iter != NULL; ++iter)
+    {
+      const char *maybe_wildcarded_prefix = *iter;
+
+      if (g_str_has_suffix (maybe_wildcarded_prefix, ".*"))
+        {
+          g_autofree char *truncated_wildcarded_prefix = g_strndup (maybe_wildcarded_prefix,
+                                                                    strlen (maybe_wildcarded_prefix) - 2);
+
+          if (flatpak_has_name_prefix (path, truncated_wildcarded_prefix))
+            return TRUE;
+        }
+      else if (flatpak_has_name_prefix (path, maybe_wildcarded_prefix))
+        {
+          return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
 static gboolean
 is_valid_initial_branch_character (gint c)
 {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -751,37 +751,43 @@ flatpak_has_name_prefix (const char *string,
 }
 
 gboolean
-flatpak_name_matches_one_prefix (const char         *path,
+flatpak_name_matches_one_prefix (const char         *name,
                                  const char * const *prefixes)
 {
   const char * const *iter = prefixes;
 
   for (; *iter != NULL; ++iter)
-    if (flatpak_has_name_prefix (path, *iter))
+    if (flatpak_has_name_prefix (name, *iter))
       return TRUE;
 
   return FALSE;
 }
 
 gboolean
-flatpak_name_matches_one_wildcard_prefix (const char         *path,
+flatpak_name_matches_one_wildcard_prefix (const char         *name,
                                           const char * const *wildcarded_prefixes)
 {
   const char * const *iter = wildcarded_prefixes;
+  g_autofree char *name_without_suffix = g_strdup (name);
+
+  char *first_dot = strrchr (name_without_suffix, '.');
+  *first_dot = '\0';
 
   for (; *iter != NULL; ++iter)
     {
       const char *maybe_wildcarded_prefix = *iter;
+
+      g_message ("Checking if name matches %s %s", name_without_suffix, maybe_wildcarded_prefix);
 
       if (g_str_has_suffix (maybe_wildcarded_prefix, ".*"))
         {
           g_autofree char *truncated_wildcarded_prefix = g_strndup (maybe_wildcarded_prefix,
                                                                     strlen (maybe_wildcarded_prefix) - 2);
 
-          if (flatpak_has_name_prefix (path, truncated_wildcarded_prefix))
+          if (flatpak_has_name_prefix (name_without_suffix, truncated_wildcarded_prefix))
             return TRUE;
         }
-      else if (flatpak_has_name_prefix (path, maybe_wildcarded_prefix))
+      else if (g_strcmp0 (name_without_suffix, maybe_wildcarded_prefix) == 0)
         {
           return TRUE;
         }

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -142,6 +142,10 @@ gboolean flatpak_summary_lookup_ref (GVariant    *summary,
 
 gboolean flatpak_has_name_prefix (const char *string,
                                   const char *name);
+gboolean flatpak_name_matches_one_prefix (const char         *string,
+                                          const char * const *prefixes);
+gboolean flatpak_name_matches_one_wildcard_prefix (const char         *string,
+                                                   const char * const *maybe_wildcard_prefixes);
 gboolean flatpak_is_valid_name (const char *string,
                                 GError **error);
 gboolean flatpak_is_valid_branch (const char *string,


### PR DESCRIPTION
Previously we only allowed exporting files which matched the prefix of the flatpak app ID. But it is perfectly possible to own any D-Bus name we want in the flatpak by passing `--own-name=` to build-finish, so export those `.service` files too.