### PR TITLE
update: Fix updates of non-primary arches

### DIFF
--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -29,9 +29,6 @@
 #include "flatpak-table-printer.h"
 #include "flatpak-utils.h"
 
-/* Appstream data expires after a day */
-#define FLATPAK_APPSTREAM_TTL 86400
-
 static GPtrArray *
 get_remote_stores (GPtrArray *dirs, GCancellable *cancellable)
 {

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -26,6 +26,9 @@
 #include "flatpak-utils.h"
 #include "flatpak-dir.h"
 
+/* Appstream data expires after a day */
+#define FLATPAK_APPSTREAM_TTL 86400
+
 gboolean    looks_like_branch (const char  *branch);
 GBytes *    download_uri      (const char  *url,
                                GError     **error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2089,7 +2089,8 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
 gboolean
 flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
                                         const char          *remote,
-                                        const char          *arch)
+                                        const char          *arch,
+                                        GError             **error)
 {
   const char *old_checksum = NULL;
   g_autofree char *new_checksum = NULL;
@@ -2119,14 +2120,11 @@ flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
   if (!flatpak_dir_find_latest_rev (self, remote, branch, NULL, &new_checksum,
                                     NULL, NULL, &local_error))
     {
-      if (g_strcmp0 (arch, flatpak_get_arch ()) == 0)
-        g_printerr (_("Failed to find latest revision for ref %s from remote %s: %s\n"),
+      flatpak_fail (error, _("Failed to find latest revision for ref %s from remote %s: %s"),
                     branch, remote, local_error->message);
-      else
-        g_debug (_("Failed to find latest revision for ref %s from remote %s: %s\n"),
-                 branch, remote, local_error->message);
       new_checksum = NULL;
     }
+
   if (new_checksum == NULL)
     {
       g_debug ("No %s branch for remote %s, ignoring", branch, remote);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -353,7 +353,8 @@ gboolean    flatpak_dir_find_latest_rev (FlatpakDir               *self,
                                          GError                  **error);
 gboolean    flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
                                                     const char          *remote,
-                                                    const char          *arch);
+                                                    const char          *arch,
+                                                    GError             **error);
 gboolean    flatpak_dir_update_appstream (FlatpakDir          *self,
                                           const char          *remote,
                                           const char          *arch,


### PR DESCRIPTION
When updating with no arch is specified we now update
appdata for all supported arches, and we don't look for
updates only of the primary arch.