### PR TITLE
doc: Fix a few mistakes and inaccuracies

### DIFF
--- a/doc/flatpak-uninstall.xml
+++ b/doc/flatpak-uninstall.xml
@@ -58,7 +58,7 @@
         </para>
         <para>
             Normally, this command removes the ref for this application/runtime from the
-            local OSTree repository and purges and objects that are no longer
+            local OSTree repository and purges any objects that are no longer
             needed to free up disk space. If the same application is later
             reinstalled, the objects will be pulled from the remote repository
             again. The --keep-ref option can be used to prevent this.
@@ -68,8 +68,10 @@
             also purges the data directory for the application.
         </para>
         <para>
-            Unless overridden with the --user or the --installation option, this command updates
-            the default system-wide installation.
+            Unless overridden with the --system, --user, or --installation
+            options, this command searches both the system-wide installation
+            and the per-user one for <arg choice="plain">REF</arg> and errors
+            out if it exists in more than one.
         </para>
 
     </refsect1>
@@ -102,7 +104,7 @@
                 <term><option>--user</option></term>
 
                 <listitem><para>
-                    Updates a per-user installation.
+                    Uninstalls from a per-user installation.
                 </para></listitem>
             </varlistentry>
 
@@ -110,7 +112,7 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Updates the default system-wide installation.
+                    Uninstalls from the default system-wide installation.
                 </para></listitem>
             </varlistentry>
 
@@ -118,10 +120,11 @@
                 <term><option>--installation=NAME</option></term>
 
                 <listitem><para>
-                    Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
-                    among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Uninstalls from a system-wide installation specified by
+                    <arg choice="plain">NAME</arg> among those defined in
+                    <filename>/etc/flatpak/installations.d/</filename>.  Using
+                    <arg choice="plain">--installation=default</arg> is
+                    equivalent to using <arg choice="plain">--system</arg>.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
The flatpak-uninstall command now automatically chooses which
installation to use, so document that in the man page, and fix a few
other minor mistakes.