### PR TITLE
End-of-life minimal viable implementation

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -47,10 +47,10 @@ static char *opt_timestamp;
 
 static GOptionEntry options[] = {
   { "src-repo", 's', 0, G_OPTION_ARG_STRING, &opt_src_repo, N_("Source repo dir"), N_("SRC-REPO") },
-  { "src-ref", 's', 0, G_OPTION_ARG_STRING, &opt_src_ref, N_("Source repo ref"), N_("SRC-REF") },
+  { "src-ref", 0, 0, G_OPTION_ARG_STRING, &opt_src_ref, N_("Source repo ref"), N_("SRC-REF") },
   { "untrusted", 0, 0, G_OPTION_ARG_NONE, &opt_untrusted, "Do not trust SRC-REPO", NULL },
   { "force", 0, 0, G_OPTION_ARG_NONE, &opt_force, "Always commit, even if same content", NULL },
-  { "subject", 's', 0, G_OPTION_ARG_STRING, &opt_subject, N_("One line subject"), N_("SUBJECT") },
+  { "subject", 0, 0, G_OPTION_ARG_STRING, &opt_subject, N_("One line subject"), N_("SUBJECT") },
   { "body", 'b', 0, G_OPTION_ARG_STRING, &opt_body, N_("Full description"), N_("BODY") },
   { "update-appstream", 0, 0, G_OPTION_ARG_NONE, &opt_update_appstream, N_("Update the appstream branch"), NULL },
   { "no-update-summary", 0, 0, G_OPTION_ARG_NONE, &opt_no_update_summary, N_("Don't update the summary"), NULL },

--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -46,6 +46,7 @@ static char *opt_gpg_homedir;
 static char *opt_files;
 static char *opt_metadata;
 static char *opt_timestamp = NULL;
+static char *opt_endoflife;
 #ifdef FLATPAK_ENABLE_P2P
 static char *opt_collection_id = NULL;
 #endif  /* FLATPAK_ENABLE_P2P */
@@ -63,6 +64,7 @@ static GOptionEntry options[] = {
   { "exclude", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_exclude, N_("Files to exclude"), N_("PATTERN") },
   { "include", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_include, N_("Excluded files to include"), N_("PATTERN") },
   { "gpg-homedir", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_homedir, N_("GPG Homedir to use when looking for keyrings"), N_("HOMEDIR") },
+  { "end-of-life", 0, 0, G_OPTION_ARG_STRING, &opt_endoflife, N_("Mark build as end-of-life"), N_("REASON") },
   { "timestamp", 0, 0, G_OPTION_ARG_STRING, &opt_timestamp, N_("Override the timestamp of the commit"), N_("TIMESTAMP") },
 #ifdef FLATPAK_ENABLE_P2P
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id, N_("Collection ID"), "COLLECTION-ID" },
@@ -895,6 +897,10 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
   g_variant_dict_insert_value (&metadata_dict, "xa.metadata", g_variant_new_string (metadata_contents));
   g_variant_dict_insert_value (&metadata_dict, "xa.installed-size", g_variant_new_uint64 (GUINT64_TO_BE (installed_size)));
   g_variant_dict_insert_value (&metadata_dict, "xa.download-size", g_variant_new_uint64 (GUINT64_TO_BE (download_size)));
+
+  if (opt_endoflife && *opt_endoflife)
+    g_variant_dict_insert_value (&metadata_dict, OSTREE_COMMIT_META_KEY_ENDOFLIFE,
+                                 g_variant_new_string (opt_endoflife));
 
   metadata_dict_v = g_variant_ref_sink (g_variant_dict_end (&metadata_dict));
 

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -100,6 +100,8 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
   g_autoptr(GKeyFile) metakey = NULL;
   const char *commit = NULL;
   const char *alt_id = NULL;
+  const char *eol;
+  const char *eol_rebase;
   const char *pref = NULL;
   const char *default_branch = NULL;
   const char *origin = NULL;
@@ -165,6 +167,8 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
   formatted = g_format_size (size);
   path = g_file_get_path (flatpak_deploy_get_dir (deploy));
   subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
+  eol = flatpak_deploy_data_get_eol (deploy_data);
+  eol_rebase = flatpak_deploy_data_get_eol_rebase (deploy_data);
 
   metakey = flatpak_deploy_get_metadata (deploy);
 
@@ -230,6 +234,10 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       g_print ("%s%s%s %s\n", on, _("Parent:"), off, parent ? parent : "-");
       g_print ("%s%s%s %s\n", on, _("Location:"), off, path);
       g_print ("%s%s%s %s\n", on, _("Installed size:"), off, formatted);
+      if (eol)
+        g_print ("%s%s%s %s\n", on, _("end-of-life:"), off, eol);
+      if (eol_rebase)
+        g_print ("%s%s%s %s\n", on, _("end-of-life-rebase:"), off, eol_rebase);
       if (strcmp (parts[0], "app") == 0)
         {
           g_autofree char *runtime = NULL;

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -159,6 +159,8 @@ print_table_for_refs (gboolean print_apps, GPtrArray* refs_array, const char *ar
           g_autoptr(GVariant) deploy_data = NULL;
           const char *active;
           const char *alt_id;
+          const char *eol;
+          const char *eol_rebase;
           g_autofree char *latest = NULL;
           g_autofree char *size_s = NULL;
           guint64 size = 0;
@@ -195,6 +197,8 @@ print_table_for_refs (gboolean print_apps, GPtrArray* refs_array, const char *ar
 
           active = flatpak_deploy_data_get_commit (deploy_data);
           alt_id = flatpak_deploy_data_get_alt_id (deploy_data);
+          eol = flatpak_deploy_data_get_eol (deploy_data);
+          eol_rebase = flatpak_deploy_data_get_eol_rebase (deploy_data);
 
           latest = flatpak_dir_read_latest (dir, repo, ref, NULL, NULL, NULL);
           if (latest)
@@ -237,10 +241,7 @@ print_table_for_refs (gboolean print_apps, GPtrArray* refs_array, const char *ar
             }
 
           if (alt_id)
-            {
-              g_autofree char *alt_id_str = g_strdup_printf ("alt-id=%.12s", alt_id);
-              flatpak_table_printer_append_with_comma (printer, alt_id_str);
-            }
+            flatpak_table_printer_append_with_comma_printf (printer, "alt-id=%.12s", alt_id);
 
           if (strcmp (parts[0], "app") == 0)
             {
@@ -261,6 +262,12 @@ print_table_for_refs (gboolean print_apps, GPtrArray* refs_array, const char *ar
             {
               flatpak_table_printer_append_with_comma (printer, "partial");
             }
+
+          if (eol)
+            flatpak_table_printer_append_with_comma_printf (printer, "eol=%s", eol);
+          if (eol_rebase)
+            flatpak_table_printer_append_with_comma_printf (printer, "eol-rebase=%s", eol_rebase);
+
           flatpak_table_printer_finish_row (printer);
         }
     }

--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -82,7 +82,9 @@ static void
 print_branches (GVariant *meta)
 {
   g_autoptr(GVariant) cache = NULL;
+  g_autoptr(GVariant) sparse_cache = NULL;
 
+  g_variant_lookup (meta, "xa.sparse-cache", "@a{sa{sv}}", &sparse_cache);
   cache = g_variant_lookup_value (meta, "xa.cache", NULL);
   if (cache)
     {
@@ -98,6 +100,7 @@ print_branches (GVariant *meta)
       flatpak_table_printer_set_column_title (printer, 0, _("Ref"));
       flatpak_table_printer_set_column_title (printer, 1, _("Installed"));
       flatpak_table_printer_set_column_title (printer, 2, _("Download"));
+      flatpak_table_printer_set_column_title (printer, 3, _("Options"));
 
       refdata = g_variant_get_variant (cache);
       g_variant_iter_init (&iter, refdata);
@@ -109,6 +112,22 @@ print_branches (GVariant *meta)
           flatpak_table_printer_add_column (printer, ref);
           flatpak_table_printer_add_decimal_column (printer, installed);
           flatpak_table_printer_add_decimal_column (printer, download);
+
+          flatpak_table_printer_add_column (printer, ""); /* Options */
+
+          if (sparse_cache)
+            {
+              g_autoptr(GVariant) sparse = NULL;
+              if (g_variant_lookup (sparse_cache, ref, "@a{sv}", &sparse))
+                {
+                  const char *eol;
+                  if (g_variant_lookup (sparse, "eol", "&s", &eol))
+                    flatpak_table_printer_append_with_comma_printf (printer, "eol=%s", eol);
+                  if (g_variant_lookup (sparse, "eolr", "&s", &eol))
+                    flatpak_table_printer_append_with_comma_printf (printer, "eol-rebase=%s", eol);
+                }
+            }
+
           flatpak_table_printer_finish_row (printer);
         }
 

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -829,6 +829,24 @@ flatpak_transaction_run (FlatpakTransaction *self,
       else
         g_assert_not_reached ();
 
+      if (res)
+        {
+          g_autoptr(GVariant) deploy_data = NULL;
+          deploy_data = flatpak_dir_get_deploy_data (self->dir, op->ref, NULL, NULL);
+
+          const char *eol =  flatpak_deploy_data_get_eol (deploy_data);
+          const char *eol_rebase = flatpak_deploy_data_get_eol_rebase (deploy_data);
+
+          if (eol_rebase)
+            {
+              g_printerr ("Warning: %s is end-of-line, in preference of %s\n", op->ref, eol_rebase);
+            }
+          else if (eol)
+            {
+              g_printerr ("Warning: %s is end-of-line, with reason: %s\n", op->ref, eol);
+            }
+        }
+
       if (!res)
         {
           if (op->non_fatal)

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -186,6 +186,8 @@ const char *        flatpak_deploy_data_get_commit (GVariant *deploy_data);
 const char **       flatpak_deploy_data_get_subpaths (GVariant *deploy_data);
 guint64             flatpak_deploy_data_get_installed_size (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_alt_id (GVariant *deploy_data);
+const char *        flatpak_deploy_data_get_eol (GVariant *deploy_data);
+const char *        flatpak_deploy_data_get_eol_rebase (GVariant *deploy_data);
 
 GFile *        flatpak_deploy_get_dir (FlatpakDeploy *deploy);
 GVariant *     flatpak_load_deploy_data (GFile *deploy_dir,

--- a/common/flatpak-table-printer.c
+++ b/common/flatpak-table-printer.c
@@ -152,6 +152,23 @@ flatpak_table_printer_append_with_comma (FlatpakTablePrinter *printer,
   cell->text = new;
 }
 
+void
+flatpak_table_printer_append_with_comma_printf  (FlatpakTablePrinter *printer,
+                                                 const char          *format,
+                                                 ...)
+{
+  va_list var_args;
+  g_autofree char *s = NULL;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+  va_start (var_args, format);
+  s = g_strdup_vprintf (format, var_args);
+  va_end (var_args);
+#pragma GCC diagnostic pop
+
+  flatpak_table_printer_append_with_comma (printer, s);
+}
 
 void
 flatpak_table_printer_finish_row (FlatpakTablePrinter *printer)

--- a/common/flatpak-table-printer.h
+++ b/common/flatpak-table-printer.h
@@ -42,6 +42,9 @@ void                flatpak_table_printer_add_column_len     (FlatpakTablePrinte
                                                               gsize                len);
 void                flatpak_table_printer_append_with_comma  (FlatpakTablePrinter *printer,
                                                               const char          *text);
+void                flatpak_table_printer_append_with_comma_printf  (FlatpakTablePrinter *printer,
+                                                                     const char          *format,
+                                                                     ...);
 void                flatpak_table_printer_finish_row         (FlatpakTablePrinter *printer);
 void                flatpak_table_printer_print              (FlatpakTablePrinter *printer);
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3399,16 +3399,16 @@ extract_appstream (OstreeRepo   *repo,
               continue;
             }
 
-          g_print ("Extracting icons for component %s\n", component_id_text);
+          g_print (_("Extracting icons for component %s\n"), component_id_text);
 
           if (!copy_icon (component_id_text, root, dest, "64x64", &my_error))
             {
-              g_print ("Error copying 64x64 icon: %s\n", my_error->message);
+              g_print (_("Error copying 64x64 icon: %s\n"), my_error->message);
               g_clear_error (&my_error);
             }
           if (!copy_icon (component_id_text, root, dest, "128x128", &my_error))
             {
-              g_print ("Error copying 128x128 icon: %s\n", my_error->message);
+              g_print (_("Error copying 128x128 icon: %s\n"), my_error->message);
               g_clear_error (&my_error);
             }
 
@@ -3557,7 +3557,7 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
                                   cancellable, &my_error))
             {
               if (g_str_has_prefix (ref, "app/"))
-                g_print ("No appstream data for %s: %s\n", ref, my_error->message);
+                g_print (_("No appstream data for %s: %s\n"), ref, my_error->message);
               continue;
             }
         }

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4251,7 +4251,6 @@ flatpak_bundle_get_installed_size (GVariant *bundle, gboolean byte_swap)
 
   g_variant_get_child (bundle, 6, "@a" OSTREE_STATIC_DELTA_META_ENTRY_FORMAT, &meta_entries);
   n_parts = g_variant_n_children (meta_entries);
-  g_print ("Number of parts: %u\n", n_parts);
 
   for (i = 0; i < n_parts; i++)
     {

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -73,5 +73,5 @@ fi
 
 flatpak build-finish --command=hello.sh ${DIR}
 mkdir -p repos
-flatpak build-export ${collection_args} ${GPGARGS-} repos/${REPONAME} ${DIR}
+flatpak build-export ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} repos/${REPONAME} ${DIR}
 rm -rf ${DIR}

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -33,6 +33,13 @@ echo "1..13"
 #Regular repo
 setup_repo
 
+# Ensure we have appdata
+if ! ostree show --repo=repos/test appstream/${ARCH} > /dev/null; then
+    assert_not_reached "No appstream branch"
+fi
+ostree cat --repo=repos/test appstream/${ARCH} /appstream.xml.gz | gunzip -d > appdata.xml
+assert_file_has_content appdata.xml "<id>org.test.Hello.desktop</id>"
+
 # Unsigned repo (not supported with collections; client-side use of collections requires GPG)
 if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] ; then
     if GPGPUBKEY=" " GPGARGS=" " setup_repo test-no-gpg org.test.Collection.NoGpg; then

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -28,7 +28,7 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-
     skip_without_p2p
 fi
 
-echo "1..13"
+echo "1..15"
 
 #Regular repo
 setup_repo
@@ -129,6 +129,53 @@ ${FLATPAK} ${U} remotes -d | grep ^test-repo > repo-info
 assert_file_has_content repo-info "new-title"
 
 echo "ok update metadata"
+
+ostree init --repo=repos/test-copy --mode=archive-z2
+${FLATPAK} build-commit-from --end-of-life=Reason1 --src-repo=repos/test repos/test-copy app/org.test.Hello/$ARCH/master
+update_repo test-copy
+
+# Ensure we have no eol app in appdata
+if ! ostree show --repo=repos/test-copy appstream/${ARCH} > /dev/null; then
+    assert_not_reached "No appstream branch"
+fi
+ostree cat --repo=repos/test-copy appstream/${ARCH} /appstream.xml.gz | gunzip -d > appdata.xml
+assert_not_file_has_content appdata.xml "org.test.Hello.desktop"
+
+${FLATPAK} repo --branches repos/test-copy > branches-log
+assert_file_has_content branches-log "^app/org.test.Hello/.*eol=Reason1"
+
+echo "ok eol build-commit-from"
+
+${FLATPAK} ${U} install -y test-repo org.test.Hello
+
+EXPORT_ARGS="--end-of-life=Reason2" make_updated_app
+
+# Ensure we have no eol app in appdata
+if ! ostree show --repo=repos/test appstream/${ARCH} > /dev/null; then
+    assert_not_reached "No appstream branch"
+fi
+ostree cat --repo=repos/test appstream/${ARCH} /appstream.xml.gz | gunzip -d > appdata.xml
+assert_not_file_has_content appdata.xml "org.test.Hello.desktop"
+
+${FLATPAK} repo --branches repos/test > branches-log
+assert_file_has_content branches-log "^app/org.test.Hello/.*eol=Reason2"
+
+${FLATPAK} ${U} remote-ls -d test-repo > remote-ls-log
+assert_file_has_content remote-ls-log "^app/org.test.Hello/.*eol=Reason2"
+
+${FLATPAK} ${U} update org.test.Hello 2> update-log
+assert_file_has_content update-log "app/org.test.Hello/.*Reason2"
+
+${FLATPAK} ${U} info org.test.Hello > info-log
+assert_file_has_content info-log "end-of-life: Reason2"
+
+${FLATPAK} ${U} list -d > list-log
+assert_file_has_content list-log "^org.test.Hello/.*eol=Reason2"
+
+${FLATPAK} ${U} uninstall org.test.Hello
+
+echo "ok eol build-export"
+
 
 port=$(cat httpd-port-main)
 UPDATE_REPO_ARGS="--redirect-url=http://127.0.0.1:${port}/test-gpg3 --gpg-import=${FL_GPG_HOMEDIR2}/pubring.gpg" update_repo

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -130,9 +130,17 @@ assert_file_has_content repo-info "new-title"
 
 echo "ok update metadata"
 
-ostree init --repo=repos/test-copy --mode=archive-z2
+if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
+    COPY_COLLECTION_ID=org.test.Collection.test
+    copy_collection_args=--collection-id=${COLLECTION_ID}
+else
+    COPY_COLLECTION_ID=
+    copy_collection_args=
+fi
+
+ostree init --repo=repos/test-copy --mode=archive-z2 ${copy_collection_args}
 ${FLATPAK} build-commit-from --end-of-life=Reason1 --src-repo=repos/test repos/test-copy app/org.test.Hello/$ARCH/master
-update_repo test-copy
+update_repo test-copy ${COPY_COLLECTION_ID}
 
 # Ensure we have no eol app in appdata
 if ! ostree show --repo=repos/test-copy appstream/${ARCH} > /dev/null; then


### PR DESCRIPTION
This is a minimum viable implementation of end-of-life. It implements:

 * Support in build-commit-from and build-export to set eol (not eol-rebase atm)
 * Appstream generation ignores eol and eol-rebase ref
 * The eol and eol-rebase info is stored in the summary
 * On deployment, eol and eol-rebase info is stored in the deploy data
 * On install/update warnings are printed about eol and eol-rebase refs
 * Print eol status in: repo --branches, remote-ls -d, list -d, info