### PR TITLE
update: Don't do a full update given --appstream

### DIFF
--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -103,6 +103,8 @@ flatpak_builtin_update (int           argc,
           if (!update_appstream (dirs, argc >= 2 ? argv[1] : NULL, arches[i], 0, FALSE, cancellable, error))
             return FALSE;
         }
+
+      return TRUE;
     }
 
   prefs = &argv[1];


### PR DESCRIPTION
Until recently, "flatpak update --appstream" caused flatpak to only
update appstream data. Then commit 20c842012 accidentally made flatpak
also do a full update after updating appstream data, so this commit
fixes the regression.