### PR TITLE
dir: Fix handling of empty dirs when listing installed refs

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4041,13 +4041,14 @@ flatpak_dir_list_refs_for_name (FlatpakDir   *self,
 
       while ((child_info2 = g_file_enumerator_next_file (dir_enum2, cancellable, &temp_error)))
         {
-          const char *branch;
+          const char *branch = g_file_info_get_name (child_info2);
 
           if (g_file_info_get_file_type (child_info2) == G_FILE_TYPE_DIRECTORY)
             {
-              branch = g_file_info_get_name (child_info2);
-              g_ptr_array_add (refs,
-                               g_strdup_printf ("%s/%s/%s/%s", kind, name, arch, branch));
+              g_autoptr(GFile) deploy = flatpak_build_file (child, branch, "active/deploy", NULL);
+              if (g_file_query_exists (deploy, NULL))
+                g_ptr_array_add (refs,
+                                 g_strdup_printf ("%s/%s/%s/%s", kind, name, arch, branch));
             }
 
           g_clear_object (&child_info2);


### PR DESCRIPTION
Before, we would list a ref as installed if the directory for the
ref was in the installation. However, if that was empty then we
would still consider that as installed. We also now require
there to be an active symlink with a deploy file in it.

This caused issues for me on update, because we listed some app
as installed, but then failed to update it.