### PR TITLE
dir: Add support for X-Flatpak-RunArguments in exported desktop files

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4616,6 +4616,24 @@ export_mime_file (int           parent_fd,
   return TRUE;
 }
 
+static char *
+format_flatpak_run_args_from_run_opts (GStrv flatpak_run_args)
+{
+  GString *str = g_string_new ("");
+  GStrv iter = flatpak_run_args;
+
+  if (flatpak_run_args == NULL)
+    return NULL;
+
+  for (; *iter != NULL; ++iter)
+    {
+      if (g_strcmp0 (*iter, "no-a11y-bus") == 0)
+        g_string_append_printf (str, " --no-a11y-bus");
+    }
+
+  return g_string_free (str, FALSE);
+}
+
 static gboolean
 export_desktop_file (const char   *app,
                      const char   *branch,
@@ -4695,13 +4713,23 @@ export_desktop_file (const char   *app,
 
   for (i = 0; groups[i] != NULL; i++)
     {
+      g_auto(GStrv) flatpak_run_opts = g_key_file_get_string_list (keyfile, groups[i], "X-Flatpak-RunOptions", NULL, NULL);
+      g_autofree char *flatpak_run_args = format_flatpak_run_args_from_run_opts (flatpak_run_opts);
+
+      g_key_file_remove_key (keyfile, groups[i], "X-Flatpak-RunOptions", NULL);
       g_key_file_remove_key (keyfile, groups[i], "TryExec", NULL);
 
       /* Remove this to make sure nothing tries to execute it outside the sandbox*/
       g_key_file_remove_key (keyfile, groups[i], "X-GNOME-Bugzilla-ExtraInfoScript", NULL);
 
       new_exec = g_string_new ("");
-      g_string_append_printf (new_exec, FLATPAK_BINDIR "/flatpak run --branch=%s --arch=%s", escaped_branch, escaped_arch);
+      g_string_append_printf (new_exec,
+                              FLATPAK_BINDIR "/flatpak run --branch=%s --arch=%s",
+                              escaped_branch,
+                              escaped_arch);
+
+      if (flatpak_run_args != NULL)
+        g_string_append_printf (new_exec, "%s", flatpak_run_args);
 
       old_exec = g_key_file_get_string (keyfile, groups[i], "Exec", NULL);
       if (old_exec && g_shell_parse_argv (old_exec, &old_argc, &old_argv, NULL) && old_argc >= 1)


### PR DESCRIPTION
A desktop file can specify this key to add additional arguments
to flatpak run (for instance --no-desktop, --no-a11y-bus).

This is needed for flatpaks that might get auto-activated on a dbus session bus which does not have a running X Server