### PR TITLE
run: Add --no-document-portal option

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -45,6 +45,7 @@ static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
 static gboolean opt_log_a11y_bus;
 static gboolean opt_no_a11y_bus;
+static gboolean opt_no_documents_portal;
 static gboolean opt_file_forwarding;
 static gboolean opt_sandbox;
 static char *opt_runtime;
@@ -63,6 +64,7 @@ static GOptionEntry options[] = {
   { "log-system-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_system_bus, N_("Log system bus calls"), NULL },
   { "log-a11y-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_a11y_bus, N_("Log accessibility bus calls"), NULL },
   { "no-a11y-bus", 0, 0, G_OPTION_ARG_NONE, &opt_no_a11y_bus, N_("Don't proxy accessibility bus calls"), NULL },
+  { "no-documents-portal", 0, 0, G_OPTION_ARG_NONE, &opt_no_documents_portal, N_("Don't start portals"), NULL },
   { "file-forwarding", 0, 0, G_OPTION_ARG_NONE, &opt_file_forwarding, N_("Enable file forwarding"), NULL },
   { "commit", 0, 0, G_OPTION_ARG_STRING, &opt_commit, N_("Run specified commit"), NULL },
   { "runtime-commit", 0, 0, G_OPTION_ARG_STRING, &opt_runtime_commit, N_("Use specified runtime commit"), NULL },
@@ -190,7 +192,8 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
                         (opt_log_system_bus ? FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS : 0) |
                         (opt_log_a11y_bus ? FLATPAK_RUN_FLAG_LOG_A11Y_BUS : 0) |
                         (opt_file_forwarding ? FLATPAK_RUN_FLAG_FILE_FORWARDING : 0) |
-                        (opt_no_a11y_bus ? FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY : 0),
+                        (opt_no_a11y_bus ? FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY : 0) |
+                        (opt_no_documents_portal ? FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL : 0),
                         opt_command,
                         &argv[rest_argv_start + 1],
                         rest_argc - 1,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4716,6 +4716,8 @@ format_flatpak_run_args_from_run_opts (GStrv flatpak_run_args)
     {
       if (g_strcmp0 (*iter, "no-a11y-bus") == 0)
         g_string_append_printf (str, " --no-a11y-bus");
+      else if (g_strcmp0 (*iter, "no-documents-portal") == 0)
+        g_string_append_printf (str, " --no-documents-portal");
     }
 
   return g_string_free (str, FALSE);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3014,7 +3014,7 @@ flatpak_run_app (const char     *app_ref,
                                       &app_info_path, error))
     return FALSE;
 
-  if (!sandboxed)
+  if (!sandboxed && !(flags & FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL))
     add_document_portal_args (bwrap, app_ref_parts[1], &doc_mount_path);
 
   if (!flatpak_run_add_environment_args (bwrap, app_info_path, flags,

--- a/common/flatpak-run.h
+++ b/common/flatpak-run.h
@@ -119,6 +119,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_LOG_A11Y_BUS       = (1 << 12),
   FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY  = (1 << 13),
   FLATPAK_RUN_FLAG_SANDBOX            = (1 << 14),
+  FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL = (1 << 15),
 } FlatpakRunFlags;
 
 gboolean  flatpak_run_add_extension_args (FlatpakBwrap   *bwrap,


### PR DESCRIPTION
This prevents flatpak from trying to talk to the documents portal
on startup.