### PR TITLE
Various updates to appdata support

### DIFF
--- a/app/flatpak-builtins-build-bundle.c
+++ b/app/flatpak-builtins-build-bundle.c
@@ -190,7 +190,7 @@ build_bundle (OstreeRepo *repo, GFile *file,
       if (flatpak_appstream_xml_migrate (xml_root, appstream_root,
                                          full_branch, name, keyfile))
         {
-          g_autoptr(GBytes) xml_data = flatpak_appstream_xml_root_to_data (appstream_root, error);
+          g_autoptr(GBytes) xml_data = NULL;
           int i;
           g_autoptr(GFile) icons_dir =
             g_file_resolve_relative_path (root,
@@ -199,7 +199,7 @@ build_bundle (OstreeRepo *repo, GFile *file,
           const char *icon_sizes_key[] = { "icon-64", "icon-128" };
           g_autofree char *icon_name = g_strconcat (name, ".png", NULL);
 
-          if (xml_data == NULL)
+          if (!flatpak_appstream_xml_root_to_data (appstream_root, NULL, &xml_data, error))
             return FALSE;
 
           g_variant_builder_add (&metadata_builder, "{sv}", "appdata",

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -79,8 +79,6 @@ flatpak_builtin_update (int           argc,
   const char *default_branch = NULL;
   FlatpakKinds kinds;
   g_autoptr(GPtrArray) transactions = NULL;
-  const char *opt_arches[2] = {NULL, NULL};
-  const char **arches = flatpak_get_arches ();
 
   context = g_option_context_new (_("[REF...] - Update applications or runtimes"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
@@ -90,19 +88,10 @@ flatpak_builtin_update (int           argc,
                                      &dirs, cancellable, error))
     return FALSE;
 
-  if (opt_arch)
-    {
-      opt_arches[0] = opt_arch;
-      arches = opt_arches;
-    }
-
   if (opt_appstream)
     {
-      for (i = 0; arches[i] != NULL; i++)
-        {
-          if (!update_appstream (dirs, argc >= 2 ? argv[1] : NULL, arches[i], 0, FALSE, cancellable, error))
-            return FALSE;
-        }
+      if (!update_appstream (dirs, argc >= 2 ? argv[1] : NULL, opt_arch, 0, FALSE, cancellable, error))
+        return FALSE;
 
       return TRUE;
     }
@@ -243,11 +232,8 @@ flatpak_builtin_update (int           argc,
 
   if (n_prefs == 0)
     {
-      for (i = 0; arches[i] != NULL; i++)
-        {
-          if (!update_appstream (dirs, NULL, arches[i], FLATPAK_APPSTREAM_TTL, TRUE, cancellable, error))
-            return FALSE;
-        }
+      if (!update_appstream (dirs, NULL, opt_arch, FLATPAK_APPSTREAM_TTL, TRUE, cancellable, error))
+        return FALSE;
     }
 
   return TRUE;

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -448,7 +448,9 @@ update_appstream (GPtrArray    *dirs,
   int i, j;
 
   g_return_val_if_fail (dirs != NULL, FALSE);
-  g_return_val_if_fail (arch != NULL, FALSE);
+
+  if (arch == NULL)
+    arch = flatpak_get_arch ();
 
   if (remote == NULL)
     {

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -468,8 +468,7 @@ update_appstream (GPtrArray    *dirs,
                 g_debug ("%s age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, ts_file_path, ts_file_age, ttl);
 
               if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
-                  flatpak_dir_get_remote_noenumerate (dir, remotes[i]) ||
-                  !flatpak_dir_check_for_appstream_update (dir, remotes[i], arch, &local_error))
+                  flatpak_dir_get_remote_noenumerate (dir, remotes[i]))
                 {
                   if (local_error)
                     {
@@ -528,19 +527,6 @@ update_appstream (GPtrArray    *dirs,
               g_autoptr(GError) local_error = NULL;
 
               found = TRUE;
-
-              /* Early bail out check */
-              if (!flatpak_dir_check_for_appstream_update (dir, remote, arch, &local_error))
-                {
-                  if (local_error)
-                    {
-                      if (quiet)
-                        g_debug ("%s: %s", _("Error updating"), local_error->message);
-                      else
-                        g_printerr ("%s: %s\n", _("Error updating"), local_error->message);
-                    }
-                  continue;
-                }
 
               progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
               res = flatpak_dir_update_appstream (dir, remote, arch, &changed,

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -536,7 +536,6 @@ update_appstream (GPtrArray    *dirs,
           if (flatpak_dir_has_remote (dir, remote))
             {
               g_autoptr(OstreeAsyncProgress) progress = NULL;
-              g_autoptr(GError) local_error = NULL;
               guint64 ts_file_age;
 
               found = TRUE;

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -418,6 +418,22 @@ no_progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
 {
 }
 
+static guint64
+get_appstream_timestamp (FlatpakDir *dir,
+                         const char *remote,
+                         const char *arch)
+{
+  g_autoptr(GFile) ts_file = NULL;
+  g_autofree char *ts_file_path = NULL;
+  g_autofree char *subdir = NULL;
+
+  subdir = g_strdup_printf ("appstream/%s/%s/.timestamp", remote, arch);
+  ts_file = g_file_resolve_relative_path (flatpak_dir_get_path (dir), subdir);
+  ts_file_path = g_file_get_path (ts_file);
+  return get_file_age (ts_file);
+}
+
+
 gboolean
 update_appstream (GPtrArray    *dirs,
                   const char   *remote,
@@ -450,22 +466,16 @@ update_appstream (GPtrArray    *dirs,
             {
               g_autoptr(GError) local_error = NULL;
               g_autoptr(OstreeAsyncProgress) progress = NULL;
-              g_autoptr(GFile) ts_file = NULL;
-              g_autofree char *ts_file_path = NULL;
-              g_autofree char *subdir = NULL;
               guint64 ts_file_age;
 
-              subdir = g_strdup_printf ("appstream/%s/%s/.timestamp", remotes[i], arch);
-              ts_file = g_file_resolve_relative_path (flatpak_dir_get_path (dir), subdir);
-              ts_file_path = g_file_get_path (ts_file);
-              ts_file_age = get_file_age (ts_file);
+              ts_file_age = get_appstream_timestamp (dir, remotes[i], arch);
               if (ts_file_age < ttl)
                 {
-                  g_debug ("%s age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, ts_file_path, ts_file_age, ttl);
+                  g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, remotes[i], arch, ts_file_age, ttl);
                   continue;
                 }
               else
-                g_debug ("%s age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, ts_file_path, ts_file_age, ttl);
+                g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, remotes[i], arch, ts_file_age, ttl);
 
               if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
                   flatpak_dir_get_remote_noenumerate (dir, remotes[i]))
@@ -525,8 +535,18 @@ update_appstream (GPtrArray    *dirs,
             {
               g_autoptr(OstreeAsyncProgress) progress = NULL;
               g_autoptr(GError) local_error = NULL;
+              guint64 ts_file_age;
 
               found = TRUE;
+
+              ts_file_age = get_appstream_timestamp (dir, remote, arch);
+              if (ts_file_age < ttl)
+                {
+                  g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, remote, arch, ts_file_age, ttl);
+                  continue;
+                }
+              else
+                g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, remote, arch, ts_file_age, ttl);
 
               progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
               res = flatpak_dir_update_appstream (dir, remote, arch, &changed,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -399,10 +399,6 @@ gboolean    flatpak_dir_deploy_appstream (FlatpakDir          *self,
                                           gboolean            *out_changed,
                                           GCancellable        *cancellable,
                                           GError             **error);
-gboolean    flatpak_dir_check_for_appstream_update (FlatpakDir          *self,
-                                                    const char          *remote,
-                                                    const char          *arch,
-                                                    GError             **error);
 gboolean    flatpak_dir_update_appstream (FlatpakDir          *self,
                                           const char          *remote,
                                           const char          *arch,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -604,8 +604,10 @@ gboolean   flatpak_appstream_xml_migrate (FlatpakXml *source,
                                           const char *ref,
                                           const char *id,
                                           GKeyFile   *metadata);
-GBytes *flatpak_appstream_xml_root_to_data (FlatpakXml *appstream_root,
-                                            GError    **error);
+gboolean flatpak_appstream_xml_root_to_data (FlatpakXml *appstream_root,
+                                             GBytes **uncompressed,
+                                             GBytes **compressed,
+                                             GError    **error);
 gboolean   flatpak_repo_generate_appstream (OstreeRepo   *repo,
                                             const char  **gpg_key_ids,
                                             const char   *gpg_homedir,

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -37,8 +37,14 @@ setup_repo
 if ! ostree show --repo=repos/test appstream/${ARCH} > /dev/null; then
     assert_not_reached "No appstream branch"
 fi
+if ! ostree show --repo=repos/test appstream2/${ARCH} > /dev/null; then
+    assert_not_reached "No appstream2 branch"
+fi
 ostree cat --repo=repos/test appstream/${ARCH} /appstream.xml.gz | gunzip -d > appdata.xml
 assert_file_has_content appdata.xml "<id>org.test.Hello.desktop</id>"
+
+ostree cat --repo=repos/test appstream2/${ARCH} /appstream.xml > appdata2.xml
+assert_file_has_content appdata2.xml "<id>org.test.Hello.desktop</id>"
 
 # Unsigned repo (not supported with collections; client-side use of collections requires GPG)
 if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] ; then

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -28,7 +28,7 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-
     skip_without_p2p
 fi
 
-echo "1..18"
+echo "1..19"
 
 #Regular repo
 setup_repo
@@ -59,6 +59,8 @@ elif [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
 else
     GPGPUBKEY="" GPGARGS="" setup_repo test-no-gpg
 fi
+
+flatpak remote-add ${U} --no-gpg-verify local-test-no-gpg-repo `pwd`/repos/test-no-gpg
 
 #alternative gpg key repo
 GPGPUBKEY="${FL_GPG_HOMEDIR2}/pubring.gpg" GPGARGS="${FL_GPGARGS2}" setup_repo test-gpg2 org.test.Collection.Gpg2
@@ -115,6 +117,12 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} != xyes ] ; then
 else
     echo "ok install without gpg key # skip not supported for collections"
 fi
+
+install_repo local-test-no-gpg
+${FLATPAK} ${U} uninstall org.test.Platform org.test.Hello
+${FLATPAK} ${U} update --appstream local-test-no-gpg-repo
+
+echo "ok local without gpg key"
 
 install_repo test-gpg2
 echo "ok with alternative gpg key"

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -60,10 +60,12 @@ ostree --repo=repos/test refs > refs
 assert_file_has_content refs "^app/org.test.App/$ARCH/master$"
 assert_file_has_content refs '^ostree-metadata$'
 assert_file_has_content refs "^appstream/${ARCH}$"
+assert_file_has_content refs "^appstream2/${ARCH}$"
 ostree --repo=repos/test refs --collections > refs-collections
 assert_file_has_content refs-collections "^(org.test.Collection, app/org.test.App/$ARCH/master)$"
 assert_file_has_content refs-collections '^(org.test.Collection, ostree-metadata)$'
 assert_file_has_content refs-collections "^(org.test.Collection, appstream/${ARCH})$"
+assert_file_has_content refs-collections "^(org.test.Collection, appstream2/${ARCH})$"
 assert_has_file repos/test/summary.sig
 ostree --repo=repos/test summary --view > summary
 assert_file_has_content summary '^Collection ID (ostree.summary.collection-id): org.test.Collection$'


### PR DESCRIPTION
This has a few basic fixes and tests.
Additionally, it has these changes in behaviour:
 * The appstream for an arch contains refs from compatible arches, if those don't exist for the main arch. I.e. an i386-only app would be in the x86-64 appstream
 * With the above, we now only pull and search the main arch by default
 * We have a new appstream branch called appstream2/$arch which has the same content, but the appdata file is not compressed. This allows updates to the appstream branch to delta better, and to improve deltas further we now sort the appstream by ref.
 * When we update appstream data we prefere the new branch and fall back if not in the remote
 * We now support appstream system-wide updates from non-gpg remotes from local repos.