### PR TITLE
Collection IDs and dynamic remotes

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -430,7 +430,7 @@ install_from (FlatpakDir *dir,
   if (!handle_runtime_repo_deps_from_keyfile (dir, file_data, error))
     return FALSE;
 
-  if (!flatpak_dir_create_remote_for_ref_file (dir, file_data, opt_arch, &remote, &ref, error))
+  if (!flatpak_dir_create_remote_for_ref_file (dir, file_data, opt_arch, &remote, NULL, &ref, error))
     return FALSE;
 
   /* Need to pick up the new config, in case it was applied in the system helper. */

--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -117,9 +117,16 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
       g_autoptr(GHashTable) refs = NULL;
       RemoteDirPair *remote_dir_pair = NULL;
       g_autoptr(FlatpakRemoteState) state = NULL;
+      gboolean is_local = FALSE;
 
-      if (!flatpak_resolve_duplicate_remotes (dirs, argv[1], &preferred_dir, cancellable, error))
-        return FALSE;
+      is_local = g_str_has_prefix (argv[1], "file:");
+      if (is_local)
+        preferred_dir = flatpak_dir_get_system_default ();
+      else
+        {
+          if (!flatpak_resolve_duplicate_remotes (dirs, argv[1], &preferred_dir, cancellable, error))
+            return FALSE;
+        }
 
       state = flatpak_dir_get_remote_state (preferred_dir, argv[1], cancellable, error);
       if (state == NULL)

--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -96,7 +96,7 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
   g_autoptr(GHashTable) pref_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   g_autoptr(GHashTable) refs_hash = g_hash_table_new_full(g_direct_hash, g_direct_equal, (GDestroyNotify)g_hash_table_unref, (GDestroyNotify)remote_dir_pair_free);
 
-  context = g_option_context_new (_(" [REMOTE] - Show available runtimes and applications"));
+  context = g_option_context_new (_(" [REMOTE or URI] - Show available runtimes and applications"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,

--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -206,7 +206,8 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
       g_hash_table_iter_init (&iter, refs);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          char *ref = key;
+          FlatpakCollectionRef *coll_ref = key;
+          char *ref = coll_ref->ref_name;
           char *partial_ref;
           const char *slash = strchr (ref, '/');
 
@@ -223,7 +224,8 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
       g_hash_table_iter_init (&iter, refs);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          const char *ref = key;
+          FlatpakCollectionRef *coll_ref = key;
+          const char *ref = coll_ref->ref_name;
           const char *checksum = value;
           const char *name = NULL;
           g_auto(GStrv) parts = NULL;
@@ -283,7 +285,8 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
               strcmp (arches[0], parts[2]) != 0)
             {
               g_autofree char *alt_arch_ref = g_strconcat (parts[0], "/", parts[1], "/", arches[0], "/", parts[3], NULL);
-              if (g_hash_table_lookup (refs, alt_arch_ref))
+              g_autoptr(FlatpakCollectionRef) alt_arch_coll_ref = flatpak_collection_ref_new (coll_ref->collection_id, alt_arch_ref);
+              if (g_hash_table_lookup (refs, alt_arch_coll_ref))
                 continue;
             }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8215,51 +8215,49 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
         }
     }
 
-  if (state->summary != NULL) /* In the optional case we might not have a summary */
+  if (state->collection_id == NULL)
     {
-      if (state->collection_id == NULL)
-        {
-          state->metadata = g_variant_get_child_value (state->summary, 1);
-        }
-      else
-        {
+      if (state->summary != NULL) /* In the optional case we might not have a summary */
+        state->metadata = g_variant_get_child_value (state->summary, 1);
+    }
+  else
+    {
 #ifdef FLATPAK_ENABLE_P2P
-          g_autofree char *latest_rev = NULL;
-          g_autoptr(GVariant) commit_v = NULL;
-          g_autoptr(GError) local_error = NULL;
+      g_autofree char *latest_rev = NULL;
+      g_autoptr(GVariant) commit_v = NULL;
+      g_autoptr(GError) local_error = NULL;
 
-          /* Make sure the branch is up to date. */
-          if (!_flatpak_dir_fetch_remote_state_metadata_branch (self, state, cancellable, &local_error))
+      /* Make sure the branch is up to date. */
+      if (!_flatpak_dir_fetch_remote_state_metadata_branch (self, state, cancellable, &local_error))
+        {
+          if (optional)
             {
-              if (optional)
-                {
-                  /* This happens for instance in the case where a p2p remote is invalid (wrong signature)
-                     and we should just silently fail to update to it. */
-                  g_debug ("Failed to download optional metadata");
-                }
-              else
-                {
-                  g_propagate_error (error, g_steal_pointer (&local_error));
-                  return NULL;
-                }
+              /* This happens for instance in the case where a p2p remote is invalid (wrong signature)
+                 and we should just silently fail to update to it. */
+              g_debug ("Failed to download optional metadata");
             }
           else
             {
-              /* Look up the commit containing the latest repository metadata. */
-              latest_rev = flatpak_dir_read_latest (self, remote, OSTREE_REPO_METADATA_REF,
-                                                    NULL, cancellable, error);
-              if (latest_rev == NULL)
-                return NULL;
-
-              if (!ostree_repo_load_commit (self->repo, latest_rev, &commit_v, NULL, error))
-                return NULL;
-
-              state->metadata = g_variant_get_child_value (commit_v, 0);
+              g_propagate_error (error, g_steal_pointer (&local_error));
+              return NULL;
             }
-#else  /* if !FLATPAK_ENABLE_P2P */
-          g_assert_not_reached ();
-#endif  /* !FLATPAK_ENABLE_P2P */
         }
+      else
+        {
+          /* Look up the commit containing the latest repository metadata. */
+          latest_rev = flatpak_dir_read_latest (self, remote, OSTREE_REPO_METADATA_REF,
+                                                NULL, cancellable, error);
+          if (latest_rev == NULL)
+            return NULL;
+
+          if (!ostree_repo_load_commit (self->repo, latest_rev, &commit_v, NULL, error))
+            return NULL;
+
+          state->metadata = g_variant_get_child_value (commit_v, 0);
+        }
+#else  /* if !FLATPAK_ENABLE_P2P */
+      g_assert_not_reached ();
+#endif  /* !FLATPAK_ENABLE_P2P */
     }
 
   return g_steal_pointer (&state);
@@ -10177,8 +10175,10 @@ _flatpak_dir_fetch_remote_state_metadata_branch (FlatpakDir    *self,
   /* Look up the checksum as advertised by the summary file. If it differs from
    * what we currently have on disk, try and pull the updated ostree-metadata ref.
    * This is how we implement caching. Ignore failure and pull the ref anyway. */
-  if (!flatpak_summary_lookup_ref (state->summary, state->collection_id, OSTREE_REPO_METADATA_REF, &checksum_from_summary, NULL))
-    return flatpak_fail (error, "No such ref (%s, %s) in remote %s", state->collection_id, OSTREE_REPO_METADATA_REF, state->remote_name);
+  if (state->summary != NULL)
+    flatpak_summary_lookup_ref (state->summary, state->collection_id,
+                                OSTREE_REPO_METADATA_REF,
+                                &checksum_from_summary, NULL);
 
   refspec = g_strdup_printf ("%s:%s", state->remote_name, OSTREE_REPO_METADATA_REF);
   if (!ostree_repo_resolve_rev (self->repo, refspec, TRUE, &checksum_from_repo, error))

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8327,6 +8327,40 @@ flatpak_dir_remote_has_ref (FlatpakDir   *self,
   return rev != NULL;
 }
 
+static void
+populate_hash_table_from_refs_map (GHashTable *ret_all_refs, GVariant *ref_map,
+                                   const gchar *collection_id)
+{
+  GVariant *value;
+  GVariantIter ref_iter;
+  g_variant_iter_init (&ref_iter, ref_map);
+  while ((value = g_variant_iter_next_value (&ref_iter)) != NULL)
+    {
+      /* helper for being able to auto-free the value */
+      g_autoptr(GVariant) child = value;
+      const char *ref_name = NULL;
+
+      g_variant_get_child (child, 0, "&s", &ref_name);
+      if (ref_name == NULL)
+        continue;
+
+      g_autoptr(GVariant) csum_v = NULL;
+      char tmp_checksum[65];
+      const guchar *csum_bytes;
+      FlatpakCollectionRef *ref;
+
+      g_variant_get_child (child, 1, "(t@aya{sv})", NULL, &csum_v, NULL);
+      csum_bytes = ostree_checksum_bytes_peek_validate (csum_v, NULL);
+      if (csum_bytes == NULL)
+        continue;
+
+      ref = flatpak_collection_ref_new (collection_id, ref_name);
+      ostree_checksum_inplace_from_bytes (csum_bytes, tmp_checksum);
+
+      g_hash_table_insert (ret_all_refs, ref, g_strdup (tmp_checksum));
+    }
+}
+
 /* This duplicates ostree_repo_remote_list_refs so it can use
  * flatpak_remote_state_ensure_summary and get caching. */
 /* FIXME: For command line completion support for collection–refs over P2P,
@@ -8340,42 +8374,37 @@ flatpak_dir_remote_list_refs (FlatpakDir         *self,
 {
   g_autoptr(GHashTable) ret_all_refs = NULL;
   g_autoptr(GVariant) ref_map = NULL;
+  g_autoptr(GVariant) exts = NULL;
+  g_autoptr(GVariant) collection_map = NULL;
+  const gchar *collection_id;
   GVariantIter iter;
-  GVariant *child;
 
   if (!flatpak_remote_state_ensure_summary (state, error))
     return FALSE;
 
-  ret_all_refs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  ret_all_refs = g_hash_table_new_full (flatpak_collection_ref_hash,
+                                        flatpak_collection_ref_equal,
+                                        (GDestroyNotify) flatpak_collection_ref_free,
+                                        g_free);
 
+  /* refs that match the main collection-id */
   ref_map = g_variant_get_child_value (state->summary, 0);
 
-  g_variant_iter_init (&iter, ref_map);
-  while ((child = g_variant_iter_next_value (&iter)) != NULL)
+  exts = g_variant_get_child_value (state->summary, 1);
+
+  if (!g_variant_lookup (exts, "ostree.summary.collection-id", "&s", &collection_id))
+    collection_id = NULL;
+
+  populate_hash_table_from_refs_map (ret_all_refs, ref_map, collection_id);
+
+  /* refs that match other collection-ids */
+  collection_map = g_variant_lookup_value (exts, "ostree.summary.collection-map",
+                                           G_VARIANT_TYPE ("a{sa(s(taya{sv}))}"));
+  if (collection_map != NULL)
     {
-      const char *ref_name = NULL;
-      g_autoptr(GVariant) csum_v = NULL;
-      char tmp_checksum[65];
-
-      g_variant_get_child (child, 0, "&s", &ref_name);
-
-      if (ref_name != NULL)
-        {
-          const guchar *csum_bytes;
-
-          g_variant_get_child (child, 1, "(t@aya{sv})", NULL, &csum_v, NULL);
-          csum_bytes = ostree_checksum_bytes_peek_validate (csum_v, error);
-          if (csum_bytes == NULL)
-            return FALSE;
-
-          ostree_checksum_inplace_from_bytes (csum_bytes, tmp_checksum);
-
-          g_hash_table_insert (ret_all_refs,
-                               g_strdup (ref_name),
-                               g_strdup (tmp_checksum));
-        }
-
-      g_variant_unref (child);
+      g_variant_iter_init (&iter, collection_map);
+      while (g_variant_iter_loop (&iter, "{&s@a(s(taya{sv}))}", &collection_id, &ref_map))
+          populate_hash_table_from_refs_map (ret_all_refs, ref_map, collection_id);
     }
 
 
@@ -8395,6 +8424,7 @@ find_matching_refs (GHashTable *refs,
                     const char   *opt_name,
                     const char   *opt_branch,
                     const char   *opt_arch,
+                    const char   *opt_collection_id,
                     FlatpakKinds  kinds,
                     FindMatchingRefsFlags flags,
                     GError      **error)
@@ -8429,9 +8459,10 @@ find_matching_refs (GHashTable *refs,
       g_autofree char *ref = NULL;
       g_auto(GStrv) parts = NULL;
       gboolean is_app, is_runtime;
+      FlatpakCollectionRef *coll_ref = key;
 
       /* Unprefix any remote name if needed */
-      ostree_parse_refspec (key, NULL, &ref, NULL);
+      ostree_parse_refspec (coll_ref->ref_name, NULL, &ref, NULL);
       if (ref == NULL)
         continue;
 
@@ -8456,8 +8487,11 @@ find_matching_refs (GHashTable *refs,
       if (opt_branch != NULL && strcmp (opt_branch, parts[3]) != 0)
         continue;
 
+      if (opt_collection_id != NULL && strcmp (opt_collection_id, coll_ref->collection_id))
+        continue;
+
       if (flags & FIND_MATCHING_REFS_FLAGS_KEEP_REMOTE)
-        g_ptr_array_add (matched_refs, g_strdup (key));
+        g_ptr_array_add (matched_refs, g_strdup (coll_ref->ref_name));
       else
         g_ptr_array_add (matched_refs, g_steal_pointer (&ref));
     }
@@ -8472,6 +8506,7 @@ find_matching_ref (GHashTable *refs,
                    const char   *opt_branch,
                    const char   *opt_default_branch,
                    const char   *opt_arch,
+                   const char   *opt_collection_id,
                    FlatpakKinds  kinds,
                    GError      **error)
 {
@@ -8492,6 +8527,7 @@ find_matching_ref (GHashTable *refs,
                                          name,
                                          opt_branch,
                                          arches[i],
+                                         opt_collection_id,
                                          kinds,
                                          FIND_MATCHING_REFS_FLAGS_NONE,
                                          error);
@@ -8545,6 +8581,15 @@ find_matching_ref (GHashTable *refs,
   return NULL;
 }
 
+char *
+flatpak_dir_get_remote_collection_id (FlatpakDir *self,
+                                      const char *remote_name)
+{
+  char *collection_id = NULL;
+  repo_get_remote_collection_id (self->repo, remote_name, &collection_id, NULL);
+  return collection_id;
+}
+
 /* FIXME: For command line completion support for collection–refs over P2P,
  * we need a version which works with collections. */
 char **
@@ -8557,6 +8602,7 @@ flatpak_dir_find_remote_refs (FlatpakDir   *self,
                              GCancellable *cancellable,
                              GError      **error)
 {
+  g_autofree char *collection_id = NULL;
   g_autoptr(GHashTable) remote_refs = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
   GPtrArray *matched_refs;
@@ -8569,10 +8615,12 @@ flatpak_dir_find_remote_refs (FlatpakDir   *self,
                                      &remote_refs, cancellable, error))
     return NULL;
 
+  collection_id = flatpak_dir_get_remote_collection_id (self, remote);
   matched_refs = find_matching_refs (remote_refs,
                                      name,
                                      opt_branch,
                                      opt_arch,
+                                     collection_id,
                                      kinds,
                                      FIND_MATCHING_REFS_FLAGS_NONE,
                                      error);
@@ -8589,6 +8637,7 @@ find_ref_for_refs_set (GHashTable *refs,
                        const char   *opt_branch,
                        const char   *opt_default_branch,
                        const char   *opt_arch,
+                       const char   *collection_id,
                        FlatpakKinds  kinds,
                        FlatpakKinds *out_kind,
                        GError      **error)
@@ -8599,6 +8648,7 @@ find_ref_for_refs_set (GHashTable *refs,
                                              opt_branch,
                                              opt_default_branch,
                                              opt_arch,
+                                             collection_id,
                                              kinds,
                                              &my_error);
   if (ref == NULL)
@@ -8648,6 +8698,7 @@ flatpak_dir_find_remote_ref (FlatpakDir   *self,
                              GCancellable *cancellable,
                              GError      **error)
 {
+  g_autofree char *collection_id = NULL;
   g_autofree char *remote_ref = NULL;
   g_autoptr(GHashTable) remote_refs = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
@@ -8666,9 +8717,10 @@ flatpak_dir_find_remote_ref (FlatpakDir   *self,
                                      &remote_refs, cancellable, error))
     return NULL;
 
+  collection_id = flatpak_dir_get_remote_collection_id (self, remote);
   remote_ref = find_ref_for_refs_set (remote_refs, name, opt_branch,
-                                      opt_default_branch, opt_arch, kinds,
-                                      out_kind, &my_error);
+                                      opt_default_branch, opt_arch, collection_id,
+                                      kinds, out_kind, &my_error);
   if (!remote_ref)
     {
       if (g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -8689,6 +8741,40 @@ flatpak_dir_find_remote_ref (FlatpakDir   *self,
   return g_steal_pointer (&remote_ref);
 }
 
+static gboolean
+list_collection_refs_from_ostree_repo (OstreeRepo    *repo,
+                                       const char    *refspec_prefix,
+                                       const char    *opt_collection_id,
+                                       GHashTable   **out_all_refs,
+                                       GCancellable  *cancellable,
+                                       GError       **error)
+{
+  GHashTableIter iter;
+  gpointer key;
+  GHashTable *coll_refs = NULL;
+  g_autoptr(GHashTable) refs = NULL;
+
+  /* FIXME: Use ostree_repo_list_collection_refs when it's public */
+  if (!ostree_repo_list_refs (repo, refspec_prefix, &refs, cancellable, error))
+    return FALSE;
+
+  coll_refs = g_hash_table_new_full (flatpak_collection_ref_hash,
+                                     flatpak_collection_ref_equal,
+                                     (GDestroyNotify) flatpak_collection_ref_free,
+                                     NULL);
+
+  g_hash_table_iter_init (&iter, refs);
+  while (g_hash_table_iter_next (&iter, &key, NULL))
+    {
+      FlatpakCollectionRef *ref = flatpak_collection_ref_new (opt_collection_id, key);
+      g_hash_table_add (coll_refs, ref);
+    }
+
+  *out_all_refs = coll_refs;
+
+  return TRUE;
+}
+
 char *
 flatpak_dir_find_local_ref (FlatpakDir   *self,
                             const char   *remote,
@@ -8702,18 +8788,22 @@ flatpak_dir_find_local_ref (FlatpakDir   *self,
                             GError      **error)
 {
   g_autofree char *local_ref = NULL;
+  g_autofree char *collection_id = NULL;
   g_autoptr(GHashTable) local_refs = NULL;
   g_autoptr(GError) my_error = NULL;
+  g_autofree char *refspec_prefix = g_strconcat (remote, ":.", NULL);
 
   if (!flatpak_dir_ensure_repo (self, NULL, error))
     return NULL;
 
-  if (!ostree_repo_list_refs (self->repo, NULL, &local_refs, cancellable, error))
+  collection_id = flatpak_dir_get_remote_collection_id (self, remote);
+  if (!list_collection_refs_from_ostree_repo (self->repo, refspec_prefix, collection_id,
+                                              &local_refs, cancellable, error))
     return NULL;
 
   local_ref = find_ref_for_refs_set (local_refs, name, opt_branch,
-                                     opt_default_branch, opt_arch, kinds,
-                                     out_kind, &my_error);
+                                     opt_default_branch, opt_arch,
+                                     collection_id, kinds, out_kind, &my_error);
   if (!local_ref)
     {
       if (g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -8745,7 +8835,10 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
   if (!flatpak_dir_ensure_repo (self, NULL, error))
     return NULL;
 
-  local_refs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  local_refs = g_hash_table_new_full (flatpak_collection_ref_hash,
+                                      flatpak_collection_ref_equal,
+                                      (GDestroyNotify) flatpak_collection_ref_free,
+                                      NULL);
   if (kinds & FLATPAK_KINDS_APP)
     {
       g_auto(GStrv) app_refs = NULL;
@@ -8754,8 +8847,15 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
         return NULL;
 
       for (i = 0; app_refs[i] != NULL; i++)
-        g_hash_table_insert (local_refs, g_strdup (app_refs[i]),
-                             GINT_TO_POINTER (1));
+        {
+          g_autofree char *remote = NULL;
+          g_autofree char *collection_id = NULL;
+          remote = flatpak_dir_get_origin (self, app_refs[i], NULL, NULL);
+          if (remote != NULL)
+            collection_id = flatpak_dir_get_remote_collection_id (self, remote);
+          FlatpakCollectionRef *ref = flatpak_collection_ref_new (collection_id, app_refs[i]);
+          g_hash_table_add (local_refs, ref);
+        }
     }
   if (kinds & FLATPAK_KINDS_RUNTIME)
     {
@@ -8765,8 +8865,15 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
         return NULL;
 
       for (i = 0; runtime_refs[i] != NULL; i++)
-        g_hash_table_insert (local_refs, g_strdup (runtime_refs[i]),
-                             GINT_TO_POINTER (1));
+        {
+          g_autofree char *remote = NULL;
+          g_autofree char *collection_id = NULL;
+          remote = flatpak_dir_get_origin (self, runtime_refs[i], NULL, NULL);
+          if (remote != NULL)
+            collection_id = flatpak_dir_get_remote_collection_id (self, remote);
+          FlatpakCollectionRef *ref = flatpak_collection_ref_new (collection_id, runtime_refs[i]);
+          g_hash_table_add (local_refs, ref);
+        }
     }
 
   return g_steal_pointer (&local_refs);
@@ -8791,6 +8898,7 @@ flatpak_dir_find_installed_refs (FlatpakDir *self,
                                      opt_name,
                                      opt_branch,
                                      opt_arch,
+                                     NULL,
                                      kinds,
                                      FIND_MATCHING_REFS_FLAGS_NONE,
                                      error);
@@ -8820,7 +8928,7 @@ flatpak_dir_find_installed_ref (FlatpakDir   *self,
     return NULL;
 
   local_ref = find_matching_ref (local_refs, opt_name, opt_branch, NULL,
-                                  opt_arch, kinds, &my_error);
+                                 opt_arch, NULL, kinds, &my_error);
   if (local_ref == NULL)
     {
       if (g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
@@ -8912,11 +9020,12 @@ flatpak_dir_cleanup_undeployed_refs (FlatpakDir   *self,
   g_autoptr(GPtrArray) undeployed_refs = NULL;
   gsize i = 0;
 
-  if (!ostree_repo_list_refs (self->repo, NULL, &local_refspecs, cancellable, error))
+  if (!list_collection_refs_from_ostree_repo (self->repo, NULL, NULL, &local_refspecs,
+                                              cancellable, error))
     return FALSE;
 
   local_flatpak_refspecs = find_matching_refs (local_refspecs,
-                                               NULL, NULL, NULL,
+                                               NULL, NULL, NULL, NULL,
                                                FLATPAK_KINDS_APP |
                                                FLATPAK_KINDS_RUNTIME,
                                                FIND_MATCHING_REFS_FLAGS_KEEP_REMOTE,
@@ -9065,18 +9174,6 @@ get_group (const char *remote_name)
 }
 
 char *
-flatpak_dir_get_remote_collection_id (FlatpakDir *self,
-                                      const char *remote_name)
-{
-  g_autofree char *collection_id = NULL;
-
-  if (!repo_get_remote_collection_id (self->repo, remote_name, &collection_id, NULL))
-    return NULL;
-
-  return g_steal_pointer (&collection_id);
-}
-
-char *
 flatpak_dir_get_remote_title (FlatpakDir *self,
                               const char *remote_name)
 {
@@ -9200,7 +9297,8 @@ flatpak_dir_remote_has_deploys (FlatpakDir   *self,
   g_hash_table_iter_init (&hash_iter, refs);
   while (g_hash_table_iter_next (&hash_iter, &key, NULL))
     {
-      const char *ref = (const char *)key;
+      FlatpakCollectionRef *coll_ref = key;
+      const char *ref = coll_ref->ref_name;
       g_autofree char *origin = flatpak_dir_get_origin (self, ref, NULL, NULL);
 
       if (strcmp (remote, origin) == 0)
@@ -9588,6 +9686,7 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir *self,
                                         GBytes     *data,
                                         const char *default_arch,
                                         char      **remote_name_out,
+                                        char      **collection_id_out,
                                         char      **ref_out,
                                         GError    **error)
 {
@@ -9629,6 +9728,9 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir *self,
       if (remote == NULL)
         return FALSE;
     }
+
+  if (collection_id_out != NULL)
+    *collection_id_out = g_steal_pointer (&collection_id);
 
   *remote_name_out = g_steal_pointer (&remote);
   *ref_out = (char *)g_steal_pointer (&ref);
@@ -9993,8 +10095,9 @@ remove_unless_in_hash (gpointer key,
                        gpointer user_data)
 {
   GHashTable *table = user_data;
+  FlatpakCollectionRef *ref = key;
 
-  return !g_hash_table_contains (table, key);
+  return !g_hash_table_contains (table, ref->ref_name);
 }
 
 gboolean
@@ -11063,4 +11166,50 @@ flatpak_dir_get_locale_subpaths (FlatpakDir *self)
         }
     }
   return subpaths;
+}
+
+/* The flatpak_collection_ref_* methods were copied from the
+ * ostree_collection_ref_* ones */
+FlatpakCollectionRef *
+flatpak_collection_ref_new (const gchar *collection_id,
+                            const gchar *ref_name)
+{
+  g_autoptr(FlatpakCollectionRef) collection_ref = NULL;
+
+  collection_ref = g_new0 (FlatpakCollectionRef, 1);
+  collection_ref->collection_id = g_strdup (collection_id);
+  collection_ref->ref_name = g_strdup (ref_name);
+
+  return g_steal_pointer (&collection_ref);
+}
+
+void
+flatpak_collection_ref_free (FlatpakCollectionRef *ref)
+{
+  g_return_if_fail (ref != NULL);
+
+  g_free (ref->collection_id);
+  g_free (ref->ref_name);
+  g_free (ref);
+}
+
+guint
+flatpak_collection_ref_hash (gconstpointer ref)
+{
+  const FlatpakCollectionRef *_ref = ref;
+
+  if (_ref->collection_id != NULL)
+    return g_str_hash (_ref->collection_id) ^ g_str_hash (_ref->ref_name);
+  else
+    return g_str_hash (_ref->ref_name);
+}
+
+gboolean
+flatpak_collection_ref_equal (gconstpointer ref1,
+                             gconstpointer ref2)
+{
+  const FlatpakCollectionRef *_ref1 = ref1, *_ref2 = ref2;
+
+  return (g_strcmp0 (_ref1->collection_id, _ref2->collection_id) == 0 &&
+          g_strcmp0 (_ref1->ref_name, _ref2->ref_name) == 0);
 }

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -126,6 +126,21 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDeploy, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRelated, flatpak_related_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRemoteState, flatpak_remote_state_free)
 
+typedef struct
+{
+  char           *collection_id;
+  char           *ref_name;
+} FlatpakCollectionRef;
+
+FlatpakCollectionRef *    flatpak_collection_ref_new  (const char *collection_id,
+                                                       const char *ref_name);
+void                      flatpak_collection_ref_free  (FlatpakCollectionRef *ref);
+guint                     flatpak_collection_ref_hash  (gconstpointer ref);
+gboolean                  flatpak_collection_ref_equal (gconstpointer ref1,
+                                                        gconstpointer ref2);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakCollectionRef, flatpak_collection_ref_free)
+
 typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_NONE = 0,
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE = 1 << 0,
@@ -601,6 +616,7 @@ gboolean   flatpak_dir_create_remote_for_ref_file (FlatpakDir   *self,
                                                    GBytes  *data,
                                                    const char *default_arch,
                                                    char   **remote_name_out,
+                                                   char   **collection_id_out,
                                                    char   **ref_out,
                                                    GError **error);
 gboolean   flatpak_dir_create_suggested_remote_for_ref_file (FlatpakDir   *self,

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -46,6 +46,10 @@
             remote repositories with <citerefentry><refentrytitle>flatpak-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
         </para>
         <para>
+            <arg choice="plain">REMOTE</arg> can be a file:// URI pointing to a
+            local repository instead of a remote name.
+        </para>
+        <para>
             Unless overridden with the --system, --user, or --installation options,
             this command uses either the default system-wide installation or the
             per-user one, depending on which has the specified
@@ -182,8 +186,17 @@
             <command>$ flatpak --user remote-ls --app testrepo</command>
         </para>
 <programlisting>
+Ref
 org.gnome.Builder
 org.freedesktop.glxgears
+</programlisting>
+
+        <para>
+            <command>$ flatpak remote-ls file:///run/media/mwleeds/d4d37026-cde2-4e5e-8bcc-d23ebbf231f9/.ostree/repo</command>
+        </para>
+<programlisting>
+Ref
+org.kde.Khangman
 </programlisting>
 
     </refsect1>

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1198,6 +1198,7 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
 
   for (i = 0; remote_names[i] != NULL; ++i)
     {
+      g_autoptr(GError) local_error = NULL;
       if (types_filter[FLATPAK_REMOTE_TYPE_STATIC])
         g_ptr_array_add (remotes, flatpak_remote_new_with_dir (remote_names[i],
                                                                dir_clone));
@@ -1205,8 +1206,9 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
       /* Add the dynamic mirrors of this remote. */
       if (!list_remotes_for_configured_remote (self, remote_names[i], dir_clone,
                                                types_filter, remotes,
-                                               cancellable, error))
-        return NULL;
+                                               cancellable, &local_error))
+        g_debug ("Couldn't find remotes for configured remote %s: %s",
+                 remote_names[i], local_error->message);
     }
 
   return g_steal_pointer (&remotes);

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1218,8 +1218,8 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
- * Lists the remotes, in priority (highest first) order. For same priority,
- * an earlier added remote comes before a later added one.
+ * Lists the static remotes, in priority (highest first) order. For same
+ * priority, an earlier added remote comes before a later added one.
  *
  * Returns: (transfer container) (element-type FlatpakRemote): an GPtrArray of
  *   #FlatpakRemote instances
@@ -1229,7 +1229,8 @@ flatpak_installation_list_remotes (FlatpakInstallation *self,
                                    GCancellable        *cancellable,
                                    GError             **error)
 {
-  return flatpak_installation_list_remotes_by_type (self, NULL, 0, cancellable, error);
+  const FlatpakRemoteType types[] = { FLATPAK_REMOTE_TYPE_STATIC };
+  return flatpak_installation_list_remotes_by_type (self, types, 1, cancellable, error);
 }
 
 /**

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2176,6 +2176,7 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
                                      cancellable, error))
     return NULL;
 
+  /* FIXME: Rework to accept the collection ID as an input argument instead */
 #ifdef FLATPAK_ENABLE_P2P
   if (!ostree_repo_get_remote_option (flatpak_dir_get_repo (dir),
                                       remote_name, "collection-id",
@@ -2194,6 +2195,28 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
 
   coll_ref = flatpak_collection_ref_new (collection_id, ref);
   checksum = g_hash_table_lookup (ht, coll_ref);
+
+#ifdef FLATPAK_ENABLE_P2P
+  /* If there was not a match, it may be because the collection ID is
+   * not set in the local configuration, or it is wrong, so we resort to
+   * trying to match just the ref name */
+  if (checksum == NULL)
+    {
+      GHashTableIter iter;
+      gpointer key, value;
+
+      g_hash_table_iter_init (&iter, ht);
+      while (g_hash_table_iter_next (&iter, &key, &value))
+        {
+          FlatpakCollectionRef *current =  (FlatpakCollectionRef *) key;
+          if (g_strcmp0 (current->ref_name, ref) == 0)
+            {
+              checksum = (const gchar *) value;
+              break;
+            }
+        }
+    }
+#endif /* FLATPAK_ENABLE_P2P */
 
   if (checksum != NULL)
     return flatpak_remote_ref_new (coll_ref, checksum, remote_name, state);

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2020,7 +2020,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
 /**
  * flatpak_installation_list_remote_refs_sync:
  * @self: a #FlatpakInstallation
- * @remote_name: the name of the remote
+ * @remote_or_uri: the name or URI of the remote
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -2031,7 +2031,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
  */
 GPtrArray *
 flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
-                                            const char          *remote_name,
+                                            const char          *remote_or_uri,
                                             GCancellable        *cancellable,
                                             GError             **error)
 {
@@ -2047,7 +2047,7 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state (dir, remote_name, cancellable, error);
+  state = flatpak_dir_get_remote_state (dir, remote_or_uri, cancellable, error);
   if (state == NULL)
     return NULL;
 
@@ -2062,7 +2062,7 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
       FlatpakCollectionRef *coll_ref = key;
       const gchar *ref_commit = value;
 
-      ref = flatpak_remote_ref_new (coll_ref, ref_commit, remote_name, state);
+      ref = flatpak_remote_ref_new (coll_ref, ref_commit, remote_or_uri, state);
 
       if (ref)
         g_ptr_array_add (refs, ref);

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -176,9 +176,15 @@ FLATPAK_EXTERN FlatpakInstalledRef * flatpak_installation_get_current_installed_
                                                                                      const char          *name,
                                                                                      GCancellable        *cancellable,
                                                                                      GError             **error);
+
 FLATPAK_EXTERN GPtrArray           *flatpak_installation_list_remotes (FlatpakInstallation *self,
                                                                        GCancellable        *cancellable,
                                                                        GError             **error);
+FLATPAK_EXTERN GPtrArray           *flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
+                                                                               const FlatpakRemoteType  types[],
+                                                                               gsize                    num_types,
+                                                                               GCancellable            *cancellable,
+                                                                               GError                 **error);
 FLATPAK_EXTERN FlatpakRemote        *flatpak_installation_get_remote_by_name (FlatpakInstallation *self,
                                                                               const gchar         *name,
                                                                               GCancellable        *cancellable,

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -284,7 +284,7 @@ FLATPAK_EXTERN GBytes        *   flatpak_installation_fetch_remote_metadata_sync
                                                                                   GCancellable        *cancellable,
                                                                                   GError             **error);
 FLATPAK_EXTERN GPtrArray    *    flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
-                                                                             const char          *remote_name,
+                                                                             const char          *remote_or_uri,
                                                                              GCancellable        *cancellable,
                                                                              GError             **error);
 FLATPAK_EXTERN FlatpakRemoteRef  *flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,

--- a/lib/flatpak-remote-ref-private.h
+++ b/lib/flatpak-remote-ref-private.h
@@ -28,7 +28,7 @@
 #include <flatpak-remote-ref.h>
 #include <flatpak-dir.h>
 
-FlatpakRemoteRef *flatpak_remote_ref_new (const char *full_ref,
+FlatpakRemoteRef *flatpak_remote_ref_new (FlatpakCollectionRef *coll_ref,
                                           const char *commit,
                                           const char *remote_name,
                                           FlatpakRemoteState *remote_state);

--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -315,7 +315,7 @@ flatpak_remote_ref_get_eol_rebase (FlatpakRemoteRef *self)
 }
 
 FlatpakRemoteRef *
-flatpak_remote_ref_new (const char *full_ref,
+flatpak_remote_ref_new (FlatpakCollectionRef *coll_ref,
                         const char *commit,
                         const char *remote_name,
                         FlatpakRemoteState *state)
@@ -327,6 +327,7 @@ flatpak_remote_ref_new (const char *full_ref,
   g_auto(GStrv) parts = NULL;
   FlatpakRemoteRef *ref;
   g_autoptr(GVariant) sparse = NULL;
+  const char *full_ref = coll_ref->ref_name;
   const char *eol = NULL;
   const char *eol_rebase = NULL;
 
@@ -361,6 +362,7 @@ flatpak_remote_ref_new (const char *full_ref,
                       "name", parts[1],
                       "arch", parts[2],
                       "branch", parts[3],
+                      "collection-id", coll_ref->collection_id,
                       "commit", commit,
                       "remote-name", remote_name,
                       "installed-size", installed_size,

--- a/lib/flatpak-remote.c
+++ b/lib/flatpak-remote.c
@@ -751,6 +751,7 @@ flatpak_remote_new_from_ostree (OstreeRemote     *remote,
                                 OstreeRepoFinder *repo_finder,
                                 FlatpakDir       *dir)
 {
+  g_autofree gchar *url = NULL;
   FlatpakRemotePrivate *priv;
   FlatpakRemote *self = g_object_new (FLATPAK_TYPE_REMOTE,
                                       "name", ostree_remote_get_name (remote),
@@ -760,6 +761,10 @@ flatpak_remote_new_from_ostree (OstreeRemote     *remote,
   priv = flatpak_remote_get_instance_private (self);
   if (dir)
     priv->dir = g_object_ref (dir);
+
+  url = ostree_remote_get_url (remote);
+  if (url != NULL)
+    flatpak_remote_set_url (self, url);
 
   return self;
 }

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -46,6 +46,7 @@ tests/test-basic.sh: tests/package_version.txt
 
 dist_installed_test_extra_scripts += \
 	buildutil/tap-driver.sh \
+	tests/make-multi-collection-id-repo.sh \
 	tests/make-test-app.sh \
 	tests/make-test-runtime.sh \
 	tests/make-test-bundles.sh \

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -205,7 +205,7 @@ setup_repo_no_add () {
     fi
 
     GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.Platform "${COLLECTION_ID}" bash ls cat echo readlink > /dev/null
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "${COLLECTION_ID}" > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "" "${COLLECTION_ID}" > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
     if [ $REPONAME == "test" ]; then
         $(dirname $0)/test-webserver.sh repos
@@ -256,7 +256,7 @@ make_updated_app () {
         COLLECTION_ID=""
     fi
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "${COLLECTION_ID}" ${3:-UPDATED} > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "" "${COLLECTION_ID}" ${3:-UPDATED} > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 

--- a/tests/make-multi-collection-id-repo.sh
+++ b/tests/make-multi-collection-id-repo.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# make-multi-collection-id-repo.sh: Creates an  ostree repository
+# that will hold a different collection ID per ref.
+#
+# Copyright (C) 2017 Endless, Inc.
+#
+# Authors:
+#     Joaquim Rocha <jrocha@endlessm.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. $(dirname $0)/libtest.sh
+
+REPO_DIR=$1
+REPO_NAME=$(basename $REPO_DIR)
+
+COLLECTION_ID_PREFIX=org.test.Collection
+
+ostree --repo=${REPO_DIR} init --mode=archive --collection-id=${COLLECTION_ID_PREFIX}1
+
+for i in {1..3}; do
+    APP_REPO=test${i}
+    APP_REPO_DIR=`pwd`/repos/${APP_REPO}
+    APP_ID=org.test.Hello${i}
+    COLLECTION_ID=${COLLECTION_ID_PREFIX}${i}
+
+    $(dirname $0)/make-test-app.sh ${APP_REPO} ${APP_ID} ${COLLECTION_ID}
+    ref=$(ostree --repo=${APP_REPO_DIR} refs | grep ${APP_ID})
+
+    ostree --repo=${REPO_DIR} remote add --no-gpg-verify --collection-id=${COLLECTION_ID} ${APP_REPO} file://${APP_REPO_DIR}
+    ostree --repo=${REPO_DIR} pull ${APP_REPO} ${ref}
+done
+
+ostree --repo=${REPO_DIR} summary --update

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -6,8 +6,14 @@ DIR=`mktemp -d`
 
 REPONAME=$1
 shift
+APP_ID=$1
+shift
 COLLECTION_ID=$1
 shift
+
+if [ x$APP_ID = x ]; then
+    APP_ID=org.test.Hello
+fi
 
 EXTRA="${1-}"
 
@@ -16,7 +22,7 @@ ARCH=`flatpak --default-arch`
 # Init dir
 cat > ${DIR}/metadata <<EOF
 [Application]
-name=org.test.Hello
+name=$APP_ID
 runtime=org.test.Platform/$ARCH/master
 sdk=org.test.Platform/$ARCH/master
 EOF
@@ -35,25 +41,25 @@ Version=1.0
 Type=Application
 Name=Hello
 Exec=hello.sh
-Icon=org.test.Hello
+Icon=$APP_ID
 MimeType=x-test/Hello;
 EOF
 
 mkdir -p ${DIR}/files/share/icons/hicolor/64x64/apps
-cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/
+cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/${APP_ID}.png
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/dont-export.png
 mkdir -p ${DIR}/files/share/icons/HighContrast/64x64/apps
-cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/HighContrast/64x64/apps/
+cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/HighContrast/64x64/apps/${APP_ID}.png
 
 
 mkdir -p ${DIR}/files/share/app-info/xmls
 mkdir -p ${DIR}/files/share/app-info/icons/flatpak/64x64
-gzip -c > ${DIR}/files/share/app-info/xmls/org.test.Hello.xml.gz <<EOF
+gzip -c > ${DIR}/files/share/app-info/xmls/${APP_ID}.xml.gz <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <components version="0.8">
   <component type="desktop">
-    <id>org.test.Hello.desktop</id>
-    <name>Hello world test app</name>
+    <id>$APP_ID.desktop</id>
+    <name>Hello world test app: $APP_ID</name>
     <summary>Print a greeting</summary>
     <description><p>This is a test app.</p></description>
     <categories>
@@ -63,7 +69,7 @@ gzip -c > ${DIR}/files/share/app-info/xmls/org.test.Hello.xml.gz <<EOF
   </component>
 </components>
 EOF
-cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/app-info/icons/flatpak/64x64/
+cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/app-info/icons/flatpak/64x64/${APP_ID}.png
 
 if [ x$COLLECTION_ID != x ]; then
     collection_args=--collection-id=${COLLECTION_ID}

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -91,7 +91,7 @@ EOF
 mkdir -p repos
 ostree init --repo=repos/test --mode=archive-z2
 . $(dirname $0)/make-test-runtime.sh test org.test.Platform "" bash ls cat echo readlink > /dev/null
-. $(dirname $0)/make-test-app.sh test "" > /dev/null
+. $(dirname $0)/make-test-app.sh test "" "" > /dev/null
 
 # Modify platform metadata
 ostree checkout -U --repo=repos/test runtime/org.test.Platform/${ARCH}/master platform

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -28,7 +28,7 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-
     skip_without_p2p
 fi
 
-echo "1..15"
+echo "1..16"
 
 #Regular repo
 setup_repo
@@ -245,6 +245,13 @@ else
 fi
 
 echo "ok remote-ls"
+
+# Test that remote-ls can take a file:// URI
+ostree --repo=repos/test summary -u
+${FLATPAK} remote-ls file://`pwd`/repos/test > repo-list
+assert_file_has_content repo-list "org.test.Hello"
+
+echo "ok remote-ls URI"
 
 # Test that remote-modify works in all of the following cases:
 # * system remote, and --system is used

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -805,12 +805,12 @@ static void
 make_test_app (void)
 {
   g_autofree char *arg0 = NULL;
-  char *argv[] = { NULL, "test", "", NULL };
+  char *argv[] = { NULL, "test", "", "", NULL };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
   argv[0] = arg0;
 #ifdef FLATPAK_ENABLE_P2P
-  argv[2] = repo_collection_id;
+  argv[3] = repo_collection_id;
 #endif /* FLATPAK_ENABLE_P2P */
 
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
@@ -820,12 +820,12 @@ static void
 update_test_app (void)
 {
   g_autofree char *arg0 = NULL;
-  char *argv[] = { NULL, "test", "", "UPDATED", NULL };
+  char *argv[] = { NULL, "test", "", "", "UPDATED", NULL };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
   argv[0] = arg0;
 #ifdef FLATPAK_ENABLE_P2P
-  argv[2] = repo_collection_id;
+  argv[3] = repo_collection_id;
 #endif /* FLATPAK_ENABLE_P2P */
 
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -226,7 +226,10 @@ test_list_remotes (void)
   g_autoptr(FlatpakInstallation) inst = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GPtrArray) remotes = NULL;
+  g_autoptr(GPtrArray) remotes2 = NULL;
   FlatpakRemote *remote;
+  const FlatpakRemoteType types[] = { FLATPAK_REMOTE_TYPE_STATIC };
+  const FlatpakRemoteType types2[] = { FLATPAK_REMOTE_TYPE_LAN };
 
   inst = flatpak_installation_new_user (NULL, &error);
   g_assert_no_error (error);
@@ -238,6 +241,30 @@ test_list_remotes (void)
 
   remote = g_ptr_array_index (remotes, 0);
   g_assert (FLATPAK_IS_REMOTE (remote));
+
+  remotes2 = flatpak_installation_list_remotes_by_type (inst, types,
+                                                        G_N_ELEMENTS (types),
+                                                        NULL, &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (remotes2->len, ==, remotes->len);
+
+  for (guint i = 0; i < remotes->len; ++i)
+    {
+      FlatpakRemote *remote1 = g_ptr_array_index (remotes, i);
+      FlatpakRemote *remote2 = g_ptr_array_index (remotes2, i);
+      g_assert_cmpstr (flatpak_remote_get_name (remote1), ==,
+                       flatpak_remote_get_name (remote2));
+      g_assert_cmpstr (flatpak_remote_get_url (remote1), ==,
+                       flatpak_remote_get_url (remote2));
+    }
+
+  g_ptr_array_unref (remotes2);
+  remotes2 = flatpak_installation_list_remotes_by_type (inst,
+                                                        types2,
+                                                        G_N_ELEMENTS (types2),
+                                                        NULL, &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (remotes2->len, ==, 0);
 }
 
 static void


### PR DESCRIPTION
I have rebased this collection of patches that we had downstream in Endless that's related to the dynamic remotes (remotes in removable drives).
I could have divided this in more PRs but they're kind of related so I think it's fine to have them in a single one.

The most important concepts in the commits are:
  * Adding the URL of a repo in dynamic remotes (repos in removable drives);
  * Using collection IDs when listing/fetching refs;
  * API method to get remotes by type;
  * List only static remotes in `flatpak_installation_list_remotes` (this fixes a problem as described in the commit message)
  * More robustness when fetching dynamic remotes