### PR TITLE
Batch prunes of the local repo

### DIFF
--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -274,6 +274,9 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
                                       cancellable, error))
             return FALSE;
         }
+
+      if (!opt_keep_ref)
+        flatpak_dir_prune (udir->dir, cancellable, NULL);
     }
 
   return TRUE;

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -911,6 +911,8 @@ flatpak_transaction_run (FlatpakTransaction *self,
 
  out:
 
+  flatpak_dir_prune (self->dir, cancellable, NULL);
+
   for (i = 0; i < self->added_origin_remotes->len; i++)
     flatpak_dir_prune_origin_remote (self->dir, g_ptr_array_index (self->added_origin_remotes, i));
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6173,8 +6173,6 @@ flatpak_dir_deploy_update (FlatpakDir   *self,
   /* Release lock before doing possibly slow prune */
   glnx_release_lock_file (&lock);
 
-  flatpak_dir_prune (self, cancellable, NULL);
-
   if (!flatpak_dir_mark_changed (self, error))
     return FALSE;
 
@@ -7152,9 +7150,6 @@ flatpak_dir_uninstall (FlatpakDir          *self,
   glnx_release_lock_file (&lock);
 
   flatpak_dir_prune_origin_remote (self, repository);
-
-  if (!keep_ref)
-    flatpak_dir_prune (self, cancellable, NULL);
 
   flatpak_dir_cleanup_removed (self, cancellable, NULL);
 

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1815,6 +1815,9 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
   if (result == NULL)
     goto out;
 
+  if ((flags & FLATPAK_UPDATE_FLAGS_NO_DEPLOY) != 0)
+    flatpak_dir_prune (dir_clone, cancellable, NULL);
+
 out:
   if (main_context)
     g_main_context_pop_thread_default (main_context);
@@ -1912,6 +1915,8 @@ flatpak_installation_uninstall (FlatpakInstallation    *self,
   if (!flatpak_dir_uninstall (dir_clone, ref, FLATPAK_HELPER_UNINSTALL_FLAGS_NONE,
                               cancellable, error))
     return FALSE;
+
+  flatpak_dir_prune (dir_clone, cancellable, NULL);
 
   return TRUE;
 }


### PR DESCRIPTION
This moves the prune call out of flatpak_dir_update() and
flatpak_dir_uninstall() and instead does this manually at all call
sites. The advantage is that we now only call it *once* even if you
uninstall or update multiple apps.

This means update everything is much faster as we don't have to scan
over the entire local repo for each updated app.