### PR TITLE
lib: Add metadata info in FlatpakRemoteRef

### DIFF
--- a/lib/flatpak-bundle-ref.c
+++ b/lib/flatpak-bundle-ref.c
@@ -123,7 +123,7 @@ flatpak_bundle_ref_class_init (FlatpakBundleRefClass *klass)
                                                         "",
                                                         "",
                                                         G_TYPE_FILE,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
 }
 
 static void

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1509,7 +1509,7 @@ flatpak_installation_install_bundle (FlatpakInstallation    *self,
  * in @ref_file_data and returns the #FlatpakRemoteRef that can be used
  * to install it.
  *
- * Note, the #FlatpakRemoteRef will not have the commit field set, to
+ * Note, the #FlatpakRemoteRef will not have the commit field set, or other details, to
  * avoid unnecessary roundtrips. If you need that you have to resolve it
  * explicitly with flatpak_installation_fetch_remote_ref_sync ().
  *
@@ -1538,7 +1538,7 @@ flatpak_installation_install_ref_file (FlatpakInstallation *self,
   if (!flatpak_installation_drop_caches (self, cancellable, error))
     return NULL;
 
-  return flatpak_remote_ref_new (ref, NULL, remote);
+  return flatpak_remote_ref_new (ref, NULL, remote, NULL);
 }
 
 /**
@@ -1934,6 +1934,9 @@ flatpak_installation_uninstall (FlatpakInstallation    *self,
  * for instance if you're doing an update then the real download size may be smaller
  * than what is returned here.
  *
+ * NOTE: Since 0.11.4 this information is accessible in FlatpakRemoteRef, so this
+ * function is not very useful anymore.
+ *
  * Returns: %TRUE, unless an error occurred
  */
 gboolean
@@ -1971,6 +1974,9 @@ flatpak_installation_fetch_remote_size_sync (FlatpakInstallation *self,
  * @error: return location for a #GError
  *
  * Obtains the metadata file from a commit.
+ *
+ * NOTE: Since 0.11.4 this information is accessible in FlatpakRemoteRef, so this
+ * function is not very useful anymore.
  *
  * Returns: (transfer full): a #GBytes containing the flatpak metadata file,
  *   or %NULL if an error occurred
@@ -2048,7 +2054,7 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
       const char *checksum = value;
       FlatpakRemoteRef *ref;
 
-      ref = flatpak_remote_ref_new (refspec, checksum, remote_name);
+      ref = flatpak_remote_ref_new (refspec, checksum, remote_name, state);
 
       if (ref)
         g_ptr_array_add (refs, ref);
@@ -2115,7 +2121,7 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
   checksum = g_hash_table_lookup (ht, ref);
 
   if (checksum != NULL)
-    return flatpak_remote_ref_new (ref, checksum, remote_name);
+    return flatpak_remote_ref_new (ref, checksum, remote_name, state);
 
   g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
                "Reference %s doesn't exist in remote", ref);

--- a/lib/flatpak-ref.c
+++ b/lib/flatpak-ref.c
@@ -186,28 +186,28 @@ flatpak_ref_class_init (FlatpakRefClass *klass)
                                                         "Name",
                                                         "The name of the application or runtime",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_ARCH,
                                    g_param_spec_string ("arch",
                                                         "Architecture",
                                                         "The architecture of the application or runtime",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_BRANCH,
                                    g_param_spec_string ("branch",
                                                         "Branch",
                                                         "The branch of the application or runtime",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_COMMIT,
                                    g_param_spec_string ("commit",
                                                         "Commit",
                                                         "The commit",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_KIND,
                                    g_param_spec_enum ("kind",
@@ -215,14 +215,14 @@ flatpak_ref_class_init (FlatpakRefClass *klass)
                                                       "The kind of artifact",
                                                       FLATPAK_TYPE_REF_KIND,
                                                       FLATPAK_REF_KIND_APP,
-                                                      G_PARAM_READWRITE));
+                                                      G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_COLLECTION_ID,
                                    g_param_spec_string ("collection-id",
                                                         "Collection ID",
                                                         "The collection ID",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
 }
 
 static void

--- a/lib/flatpak-related-ref.c
+++ b/lib/flatpak-related-ref.c
@@ -142,21 +142,21 @@ flatpak_related_ref_class_init (FlatpakRelatedRefClass *klass)
                                                          "Should download",
                                                          "Whether to auto-download the ref with the main ref",
                                                          FALSE,
-                                                         G_PARAM_READWRITE));
+                                                         G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_SHOULD_DELETE,
                                    g_param_spec_boolean ("should-delete",
                                                          "Should delete",
                                                          "Whether to auto-delete the ref with the main ref",
                                                          FALSE,
-                                                         G_PARAM_READWRITE));
+                                                         G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_SUBPATHS,
                                    g_param_spec_boxed ("subpaths",
                                                        "",
                                                        "",
                                                        G_TYPE_STRV,
-                                                       G_PARAM_READWRITE));
+                                                       G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
 }
 
 static void

--- a/lib/flatpak-remote-ref-private.h
+++ b/lib/flatpak-remote-ref-private.h
@@ -30,6 +30,7 @@
 
 FlatpakRemoteRef *flatpak_remote_ref_new (const char *full_ref,
                                           const char *commit,
-                                          const char *remote_name);
+                                          const char *remote_name,
+                                          FlatpakRemoteState *remote_state);
 
 #endif /* __FLATPAK_REMOTE_REF_PRIVATE_H__ */

--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -40,6 +40,12 @@ typedef struct _FlatpakRemoteRefPrivate FlatpakRemoteRefPrivate;
 struct _FlatpakRemoteRefPrivate
 {
   char *remote_name;
+  guint64 installed_size;
+  guint64 download_size;
+  GBytes *metadata;
+  char *eol;
+  char *eol_rebase;
+
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (FlatpakRemoteRef, flatpak_remote_ref, FLATPAK_TYPE_REF)
@@ -48,6 +54,11 @@ enum {
   PROP_0,
 
   PROP_REMOTE_NAME,
+  PROP_INSTALLED_SIZE,
+  PROP_DOWNLOAD_SIZE,
+  PROP_METADATA,
+  PROP_EOL,
+  PROP_EOL_REBASE,
 };
 
 static void
@@ -77,6 +88,29 @@ flatpak_remote_ref_set_property (GObject      *object,
       priv->remote_name = g_value_dup_string (value);
       break;
 
+    case PROP_INSTALLED_SIZE:
+      priv->installed_size = g_value_get_uint64 (value);
+      break;
+
+    case PROP_DOWNLOAD_SIZE:
+      priv->download_size = g_value_get_uint64 (value);
+      break;
+
+    case PROP_METADATA:
+      g_clear_pointer (&priv->metadata, g_bytes_unref);
+      priv->metadata = g_bytes_ref (g_value_get_boxed (value));
+      break;
+
+    case PROP_EOL:
+      g_clear_pointer (&priv->eol, g_free);
+      priv->eol = g_value_dup_string (value);
+      break;
+
+    case PROP_EOL_REBASE:
+      g_clear_pointer (&priv->eol_rebase, g_free);
+      priv->eol_rebase = g_value_dup_string (value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -96,6 +130,26 @@ flatpak_remote_ref_get_property (GObject    *object,
     {
     case PROP_REMOTE_NAME:
       g_value_set_string (value, priv->remote_name);
+      break;
+
+    case PROP_INSTALLED_SIZE:
+      g_value_set_uint64 (value, priv->installed_size);
+      break;
+
+    case PROP_DOWNLOAD_SIZE:
+      g_value_set_uint64 (value, priv->installed_size);
+      break;
+
+    case PROP_METADATA:
+      g_value_set_boxed (value, priv->metadata);
+      break;
+
+    case PROP_EOL:
+      g_value_set_string (value, priv->eol);
+      break;
+
+    case PROP_EOL_REBASE:
+      g_value_set_string (value, priv->eol_rebase);
       break;
 
     default:
@@ -118,6 +172,41 @@ flatpak_remote_ref_class_init (FlatpakRemoteRefClass *klass)
                                    g_param_spec_string ("remote-name",
                                                         "Remote Name",
                                                         "The name of the remote",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_INSTALLED_SIZE,
+                                   g_param_spec_uint64 ("installed-size",
+                                                        "Installed Size",
+                                                        "The installed size of the application",
+                                                        0, G_MAXUINT64, 0,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_DOWNLOAD_SIZE,
+                                   g_param_spec_uint64 ("download-size",
+                                                        "Download Size",
+                                                        "The download size of the application",
+                                                        0, G_MAXUINT64, 0,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_METADATA,
+                                   g_param_spec_boxed ("metadata",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_BYTES,
+                                                       G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_EOL,
+                                   g_param_spec_string ("end-of-life",
+                                                        "End of life",
+                                                        "The reason for the ref to be end of life",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_EOL_REBASE,
+                                   g_param_spec_string ("end-of-life-rebase",
+                                                        "End of life rebase",
+                                                        "The new ref for the end of lifeed ref",
                                                         NULL,
                                                         G_PARAM_READWRITE));
 }
@@ -143,20 +232,126 @@ flatpak_remote_ref_get_remote_name (FlatpakRemoteRef *self)
   return priv->remote_name;
 }
 
+/**
+ * flatpak_remote_ref_get_installed_size:
+ * @self: a #FlatpakRemoteRef
+ *
+ * Returns the installed size of the ref.
+ *
+ * Returns: the installed size
+ */
+guint64
+flatpak_remote_ref_get_installed_size (FlatpakRemoteRef *self)
+{
+  FlatpakRemoteRefPrivate *priv = flatpak_remote_ref_get_instance_private (self);
+
+  return priv->installed_size;
+}
+
+/**
+ * flatpak_remote_ref_get_download_size:
+ * @self: a #FlatpakRemoteRef
+ *
+ * Returns the download size of the ref.
+ *
+ * Returns: the download size
+ */
+guint64
+flatpak_remote_ref_get_download_size (FlatpakRemoteRef *self)
+{
+  FlatpakRemoteRefPrivate *priv = flatpak_remote_ref_get_instance_private (self);
+
+  return priv->download_size;
+}
+
+/**
+ * flatpak_remote_ref_get_metadata:
+ * @self: a #FlatpakRemoteRef
+ *
+ * Returns the app metadata from the metadata cach of the ref.
+ *
+ * Returns: (transfer none): a #GBytes with the metadata file contents
+ */
+GBytes *
+flatpak_remote_ref_get_metadata (FlatpakRemoteRef *self)
+{
+  FlatpakRemoteRefPrivate *priv = flatpak_remote_ref_get_instance_private (self);
+
+  return priv->metadata;
+}
+
+/**
+ * flatpak_remote_ref_get_eol:
+ * @self: a #FlatpakRemoteRef
+ *
+ * Returns the end-of-life reason string, or %NULL if the
+ * ref is not end-of-lifed.
+ *
+ * Returns: (transfer none): the end-of-life reason or %NULL
+ */
+const char *
+flatpak_remote_ref_get_eol (FlatpakRemoteRef *self)
+{
+  FlatpakRemoteRefPrivate *priv = flatpak_remote_ref_get_instance_private (self);
+
+  return priv->eol;
+}
+
+/**
+ * flatpak_remote_ref_get_eol_rebase:
+ * @self: a #FlatpakRemoteRef
+ *
+ * Returns the end-of-life rebased ref, or %NULL if the
+ * ref is not end-of-lifed.
+ *
+ * Returns: (transfer none): the end-of-life rebased ref or %NULL
+ */
+const char *
+flatpak_remote_ref_get_eol_rebase (FlatpakRemoteRef *self)
+{
+  FlatpakRemoteRefPrivate *priv = flatpak_remote_ref_get_instance_private (self);
+
+  return priv->eol_rebase;
+}
 
 FlatpakRemoteRef *
 flatpak_remote_ref_new (const char *full_ref,
                         const char *commit,
-                        const char *remote_name)
+                        const char *remote_name,
+                        FlatpakRemoteState *state)
 {
   FlatpakRefKind kind = FLATPAK_REF_KIND_APP;
-
+  guint64 download_size = 0,  installed_size = 0;
+  g_autofree char *metadata = NULL;
+  g_autoptr(GBytes) metadata_bytes = NULL;
   g_auto(GStrv) parts = NULL;
   FlatpakRemoteRef *ref;
+  g_autoptr(GVariant) sparse = NULL;
+  const char *eol = NULL;
+  const char *eol_rebase = NULL;
 
   parts = flatpak_decompose_ref (full_ref, NULL);
   if (parts == NULL)
     return NULL;
+
+  if (state &&
+      !flatpak_remote_state_lookup_cache (state, full_ref,
+                                          &download_size, &installed_size, &metadata,
+                                          NULL, NULL))
+    {
+      g_warning ("Ignoring ref %s due to lack of metadata", full_ref);
+      return NULL;
+    }
+
+  if (metadata)
+    metadata_bytes = g_bytes_new_take (g_steal_pointer (&metadata), strlen (metadata));
+
+  sparse = flatpak_remote_state_lookup_sparse_cache (state, full_ref, NULL);
+  if (sparse)
+    {
+      g_variant_lookup (sparse, "eol", "&s", &eol);
+      g_variant_lookup (sparse, "eolr", "&s", &eol_rebase);
+    }
 
   if (strcmp (parts[0], "app") != 0)
     kind = FLATPAK_REF_KIND_RUNTIME;
@@ -168,6 +363,11 @@ flatpak_remote_ref_new (const char *full_ref,
                       "branch", parts[3],
                       "commit", commit,
                       "remote-name", remote_name,
+                      "installed-size", installed_size,
+                      "download-size", download_size,
+                      "metadata", metadata_bytes,
+                      "end-of-life", eol,
+                      "end-of-life-rebase", eol_rebase,
                       NULL);
 
   return ref;

--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -173,42 +173,42 @@ flatpak_remote_ref_class_init (FlatpakRemoteRefClass *klass)
                                                         "Remote Name",
                                                         "The name of the remote",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_INSTALLED_SIZE,
                                    g_param_spec_uint64 ("installed-size",
                                                         "Installed Size",
                                                         "The installed size of the application",
                                                         0, G_MAXUINT64, 0,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_DOWNLOAD_SIZE,
                                    g_param_spec_uint64 ("download-size",
                                                         "Download Size",
                                                         "The download size of the application",
                                                         0, G_MAXUINT64, 0,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_METADATA,
                                    g_param_spec_boxed ("metadata",
                                                        "Metadata",
                                                        "The metadata info for the application",
                                                        G_TYPE_BYTES,
-                                                       G_PARAM_READWRITE));
+                                                       G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_EOL,
                                    g_param_spec_string ("end-of-life",
                                                         "End of life",
                                                         "The reason for the ref to be end of life",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
                                    PROP_EOL_REBASE,
                                    g_param_spec_string ("end-of-life-rebase",
                                                         "End of life rebase",
                                                         "The new ref for the end of lifeed ref",
                                                         NULL,
-                                                        G_PARAM_READWRITE));
+                                                        G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
 }
 
 static void

--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -191,8 +191,8 @@ flatpak_remote_ref_class_init (FlatpakRemoteRefClass *klass)
   g_object_class_install_property (object_class,
                                    PROP_METADATA,
                                    g_param_spec_boxed ("metadata",
-                                                       "",
-                                                       "",
+                                                       "Metadata",
+                                                       "The metadata info for the application",
                                                        G_TYPE_BYTES,
                                                        G_PARAM_READWRITE));
   g_object_class_install_property (object_class,
@@ -321,7 +321,7 @@ flatpak_remote_ref_new (const char *full_ref,
                         FlatpakRemoteState *state)
 {
   FlatpakRefKind kind = FLATPAK_REF_KIND_APP;
-  guint64 download_size = 0,  installed_size = 0;
+  guint64 download_size = 0, installed_size = 0;
   g_autofree char *metadata = NULL;
   g_autoptr(GBytes) metadata_bytes = NULL;
   g_auto(GStrv) parts = NULL;

--- a/lib/flatpak-remote-ref.h
+++ b/lib/flatpak-remote-ref.h
@@ -47,6 +47,11 @@ typedef struct
 } FlatpakRemoteRefClass;
 
 FLATPAK_EXTERN const char * flatpak_remote_ref_get_remote_name (FlatpakRemoteRef *self);
+FLATPAK_EXTERN guint64      flatpak_remote_ref_get_installed_size (FlatpakRemoteRef *self);
+FLATPAK_EXTERN guint64      flatpak_remote_ref_get_download_size (FlatpakRemoteRef *self);
+FLATPAK_EXTERN GBytes *     flatpak_remote_ref_get_metadata (FlatpakRemoteRef *self);
+FLATPAK_EXTERN const char * flatpak_remote_ref_get_eol (FlatpakRemoteRef *self);
+FLATPAK_EXTERN const char * flatpak_remote_ref_get_eol_rebase (FlatpakRemoteRef *self);
 
 #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRemoteRef, g_object_unref)


### PR DESCRIPTION
This adds things like the size and the metadata, as well as eol strings
to FlatpakRemoteRef. We typically have this accessible anyway, in the
FlatpakRemoteState.

This makes flatpak_installation_fetch_remote_size/metadata_sync deprecated.