### PR TITLE
Minor FlatpakRemoteState internal api fixes

### DIFF
--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -318,7 +318,7 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
 
               if (!flatpak_remote_state_lookup_cache (state, ref,
                                                       &download_size, &installed_size, NULL,
-                                                      NULL, error))
+                                                      error))
                 return FALSE;
 
               /* The sparse cache is optional */

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -564,7 +564,7 @@ flatpak_transaction_add_ref (FlatpakTransaction *self,
 
   if (metadata == NULL && remote != NULL)
     {
-      if (!flatpak_remote_state_lookup_cache (state, ref, NULL, NULL, &metadata, NULL, &local_error))
+      if (!flatpak_remote_state_lookup_cache (state, ref, NULL, NULL, &metadata, &local_error))
         {
           g_print (_("Warning: Can't find dependencies: %s\n"), local_error->message);
           g_clear_error (&local_error);

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -494,7 +494,6 @@ flatpak_transaction_add_ref (FlatpakTransaction *self,
 {
   g_autofree char *origin = NULL;
   const char *pref;
-  g_autofree char *remote_metadata = NULL;
   g_autoptr(GKeyFile) metakey = NULL;
   g_autoptr(GError) local_error = NULL;
   g_autofree char *origin_remote = NULL;
@@ -565,9 +564,7 @@ flatpak_transaction_add_ref (FlatpakTransaction *self,
 
   if (metadata == NULL && remote != NULL)
     {
-      if (flatpak_remote_state_lookup_cache (state, ref, NULL, NULL, &remote_metadata, NULL, &local_error))
-        metadata = remote_metadata;
-      else
+      if (!flatpak_remote_state_lookup_cache (state, ref, NULL, NULL, &metadata, NULL, &local_error))
         {
           g_print (_("Warning: Can't find dependencies: %s\n"), local_error->message);
           g_clear_error (&local_error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -303,7 +303,6 @@ flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
                                    guint64            *download_size,
                                    guint64            *installed_size,
                                    const char        **metadata,
-                                   GCancellable       *cancellable,
                                    GError            **error)
 {
   g_autoptr(GVariant) cache_v = NULL;
@@ -10640,7 +10639,7 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
 
   if (flatpak_remote_state_lookup_cache (state, ref,
                                          NULL, NULL, &metadata,
-                                         NULL, NULL) &&
+                                         NULL) &&
       g_key_file_load_from_data (metakey, metadata, -1, 0, NULL))
     {
       g_auto(GStrv) groups = NULL;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -302,9 +302,9 @@ flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
                                    const char         *ref,
                                    guint64            *download_size,
                                    guint64            *installed_size,
-                                   char               **metadata,
-                                   GCancellable        *cancellable,
-                                   GError             **error)
+                                   const char        **metadata,
+                                   GCancellable       *cancellable,
+                                   GError            **error)
 {
   g_autoptr(GVariant) cache_v = NULL;
   g_autoptr(GVariant) cache = NULL;
@@ -350,7 +350,7 @@ flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
     }
 
   if (metadata)
-    g_variant_get_child (res, 2, "s", metadata);
+    g_variant_get_child (res, 2, "&s", metadata);
 
   return TRUE;
 }
@@ -10618,7 +10618,7 @@ flatpak_dir_find_remote_related (FlatpakDir *self,
                                  GCancellable *cancellable,
                                  GError **error)
 {
-  g_autofree char *metadata = NULL;
+  const char *metadata = NULL;
   g_autoptr(GKeyFile) metakey = g_key_file_new ();
   int i;
   g_auto(GStrv) parts = NULL;

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -115,7 +115,6 @@ gboolean flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
                                             guint64            *download_size,
                                             guint64            *installed_size,
                                             const char        **metadata,
-                                            GCancellable       *cancellable,
                                             GError            **error);
 GVariant *flatpak_remote_state_lookup_sparse_cache (FlatpakRemoteState *self,
                                                     const char         *ref,

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -114,9 +114,9 @@ gboolean flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
                                             const char         *ref,
                                             guint64            *download_size,
                                             guint64            *installed_size,
-                                            char               **metadata,
-                                            GCancellable        *cancellable,
-                                            GError             **error);
+                                            const char        **metadata,
+                                            GCancellable       *cancellable,
+                                            GError            **error);
 GVariant *flatpak_remote_state_lookup_sparse_cache (FlatpakRemoteState *self,
                                                     const char         *ref,
                                                     GError             **error);

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1967,7 +1967,7 @@ flatpak_installation_fetch_remote_size_sync (FlatpakInstallation *self,
 
   return flatpak_remote_state_lookup_cache (state, full_ref,
                                             download_size, installed_size, NULL,
-                                            cancellable, error);
+                                            error);
 }
 
 /**
@@ -2008,7 +2008,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
 
   if (!flatpak_remote_state_lookup_cache (state, full_ref,
                                           NULL, NULL, &res,
-                                          cancellable, error))
+                                          error))
     return NULL;
 
   return g_bytes_new (res, strlen (res));

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -1996,7 +1996,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
   g_autoptr(FlatpakDir) dir = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
   g_autofree char *full_ref = flatpak_ref_format_ref (ref);
-  char *res = NULL;
+  const char *res = NULL;
 
   dir = flatpak_installation_get_dir (self, error);
   if (dir == NULL)
@@ -2011,7 +2011,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
                                           cancellable, error))
     return NULL;
 
-  return g_bytes_new_take (res, strlen (res));
+  return g_bytes_new (res, strlen (res));
 }
 
 /**

--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -322,7 +322,7 @@ flatpak_remote_ref_new (const char *full_ref,
 {
   FlatpakRefKind kind = FLATPAK_REF_KIND_APP;
   guint64 download_size = 0, installed_size = 0;
-  g_autofree char *metadata = NULL;
+  const char *metadata;
   g_autoptr(GBytes) metadata_bytes = NULL;
   g_auto(GStrv) parts = NULL;
   FlatpakRemoteRef *ref;
@@ -344,7 +344,7 @@ flatpak_remote_ref_new (const char *full_ref,
     }
 
   if (metadata)
-    metadata_bytes = g_bytes_new_take (g_steal_pointer (&metadata), strlen (metadata));
+    metadata_bytes = g_bytes_new (metadata, strlen (metadata));
 
   sparse = flatpak_remote_state_lookup_sparse_cache (state, full_ref, NULL);
   if (sparse)

--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -337,7 +337,7 @@ flatpak_remote_ref_new (const char *full_ref,
   if (state &&
       !flatpak_remote_state_lookup_cache (state, full_ref,
                                           &download_size, &installed_size, &metadata,
-                                          NULL, NULL))
+                                          NULL))
     {
       g_warning ("Ignoring ref %s due to lack of metadata", full_ref);
       return NULL;


### PR DESCRIPTION
Drops unnecessary strdups and function arguments.