### PR TITLE
lib: Make metadata optional in FlatpakRemoteRef

### DIFF
--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -98,7 +98,7 @@ flatpak_remote_ref_set_property (GObject      *object,
 
     case PROP_METADATA:
       g_clear_pointer (&priv->metadata, g_bytes_unref);
-      priv->metadata = g_bytes_ref (g_value_get_boxed (value));
+      priv->metadata = g_value_get_boxed (value) ? g_bytes_ref (g_value_get_boxed (value)) : NULL;
       break;
 
     case PROP_EOL:
@@ -270,7 +270,8 @@ flatpak_remote_ref_get_download_size (FlatpakRemoteRef *self)
  *
  * Returns the app metadata from the metadata cach of the ref.
  *
- * Returns: (transfer none): a #GBytes with the metadata file contents
+ * Returns: (transfer none) (nullable): a #GBytes with the metadata file
+ * contents or %NULL
  */
 GBytes *
 flatpak_remote_ref_get_metadata (FlatpakRemoteRef *self)
@@ -340,8 +341,7 @@ flatpak_remote_ref_new (FlatpakCollectionRef *coll_ref,
                                           &download_size, &installed_size, &metadata,
                                           NULL))
     {
-      g_warning ("Ignoring ref %s due to lack of metadata", full_ref);
-      return NULL;
+      g_debug ("Can't find metadata for ref %s", full_ref);
     }
 
   if (metadata)


### PR DESCRIPTION
Sometimes we're not able to access the `xa.cache` data that's usually in
the summary and ostree-metadata, such as when the remote is a USB drive
that had `ostree summary -u` run on it. In that case, we don't want
flatpak_remote_ref_new() to fail, because the FlatpakRemoteRef instance
might still be useful enough without the metadata, such as in
flatpak_installation_list_remote_refs_sync. So this commit makes the
metadata property of FlatpakRemoteRef nullable which has the effect of
making the test_list_refs_in_remote() test pass with P2P enabled.

The metadata property wasn't added to FlatpakRemoteRef until commit
c33f842b7 so presumably no one is depending on it.