### PR TITLE
dir: Support looking up available remote refs and related refs from local repo

### DIFF
--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -231,8 +231,8 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
       if (origin == NULL)
         continue;
 
-      related = flatpak_dir_find_local_related (udir->dir, first_ref, origin,
-                                                NULL, &local_error);
+      related = flatpak_dir_find_local_related_for_deployed (udir->dir, first_ref, origin,
+                                                             NULL, &local_error);
       if (related == NULL)
         {
           g_printerr (_("Warning: Problem looking for related refs: %s\n"),

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -370,7 +370,11 @@ add_related (FlatpakTransaction *self,
     return TRUE;
 
   if (self->no_pull)
-    related = flatpak_dir_find_local_related (self->dir, ref, remote, NULL, &local_error);
+    related = flatpak_dir_find_local_related_for_deployed (self->dir,
+                                                           ref,
+                                                           remote,
+                                                           NULL,
+                                                           &local_error);
   else
     related = flatpak_dir_find_remote_related (self->dir, state, ref, NULL, &local_error);
   if (related == NULL)

--- a/app/flatpak-transaction.c
+++ b/app/flatpak-transaction.c
@@ -370,11 +370,11 @@ add_related (FlatpakTransaction *self,
     return TRUE;
 
   if (self->no_pull)
-    related = flatpak_dir_find_local_related_for_deployed (self->dir,
-                                                           ref,
-                                                           remote,
-                                                           NULL,
-                                                           &local_error);
+    related = flatpak_dir_find_local_related_for_ref_in_repo (self->dir,
+                                                              ref,
+                                                              remote,
+                                                              NULL,
+                                                              &local_error);
   else
     related = flatpak_dir_find_remote_related (self->dir, state, ref, NULL, &local_error);
   if (related == NULL)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10934,22 +10934,19 @@ local_match_prefix (FlatpakDir *self,
   return matches;
 }
 
-GPtrArray *
-flatpak_dir_find_local_related (FlatpakDir *self,
-                                const char *ref,
-                                const char *remote_name,
-                                GCancellable *cancellable,
-                                GError **error)
+static GPtrArray *
+flatpak_dir_find_local_related_for_metadata (FlatpakDir *self,
+                                             const char *ref,
+                                             const char *remote_name,
+                                             GKeyFile   *metakey,
+                                             GCancellable *cancellable,
+                                             GError **error)
 {
-  g_autoptr(GFile) deploy_dir = NULL;
-  g_autoptr(GFile) metadata = NULL;
-  g_autofree char *metadata_contents = NULL;
-  gsize metadata_size;
-  g_autoptr(GKeyFile) metakey = g_key_file_new ();
   int i;
   g_auto(GStrv) parts = NULL;
   g_autoptr(GPtrArray) related = g_ptr_array_new_with_free_func ((GDestroyNotify)flatpak_related_free);
   g_autofree char *collection_id = NULL;
+  g_auto(GStrv) groups = NULL;
 
   /* Derive the collection ID from the remote we are querying. This will act as
    * a sanity check on the summary ref lookup. */
@@ -10963,110 +10960,93 @@ flatpak_dir_find_local_related (FlatpakDir *self,
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return NULL;
 
-  deploy_dir = flatpak_dir_get_if_deployed (self, ref, NULL, cancellable);
-  if (deploy_dir == NULL)
+  groups = g_key_file_get_groups (metakey, NULL);
+  for (i = 0; groups[i] != NULL; i++)
     {
-      g_set_error (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED,
-                   _("%s not installed"), ref);
-      return NULL;
-    }
+      char *tagged_extension;
 
-  metadata = g_file_get_child (deploy_dir, "metadata");
-  if (!g_file_load_contents (metadata, cancellable, &metadata_contents, &metadata_size, NULL, NULL))
-    return g_steal_pointer (&related); /* No metadata => no related, but no error */
-
-  if (g_key_file_load_from_data (metakey, metadata_contents, metadata_size, 0, NULL))
-    {
-      g_auto(GStrv) groups = NULL;
-
-      groups = g_key_file_get_groups (metakey, NULL);
-      for (i = 0; groups[i] != NULL; i++)
+      if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
+          *(tagged_extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
         {
-          char *tagged_extension;
+          g_autofree char *extension = NULL;
+          g_autofree char *version = g_key_file_get_string (metakey, groups[i],
+                                                            FLATPAK_METADATA_KEY_VERSION, NULL);
+          gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
+                                                            FLATPAK_METADATA_KEY_SUBDIRECTORIES, NULL);
+          gboolean no_autodownload = g_key_file_get_boolean (metakey, groups[i],
+                                                             FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD, NULL);
+          g_autofree char *download_if = g_key_file_get_string (metakey, groups[i],
+                                                                FLATPAK_METADATA_KEY_DOWNLOAD_IF, NULL);
+          gboolean autodelete = g_key_file_get_boolean (metakey, groups[i],
+                                                        FLATPAK_METADATA_KEY_AUTODELETE, NULL);
+          gboolean locale_subset = g_key_file_get_boolean (metakey, groups[i],
+                                                           FLATPAK_METADATA_KEY_LOCALE_SUBSET, NULL);
+          const char *branch;
+          g_autofree char *extension_ref = NULL;
+          g_autofree char *prefixed_extension_ref = NULL;
+          g_autofree char *checksum = NULL;
+          g_autofree char *extension_collection_id = NULL;
 
-          if (g_str_has_prefix (groups[i], FLATPAK_METADATA_GROUP_PREFIX_EXTENSION) &&
-              *(tagged_extension = (groups[i] + strlen (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION))) != 0)
-            {
-              g_autofree char *extension = NULL;
-              g_autofree char *version = g_key_file_get_string (metakey, groups[i],
-                                                                FLATPAK_METADATA_KEY_VERSION, NULL);
-              gboolean subdirectories = g_key_file_get_boolean (metakey, groups[i],
-                                                                FLATPAK_METADATA_KEY_SUBDIRECTORIES, NULL);
-              gboolean no_autodownload = g_key_file_get_boolean (metakey, groups[i],
-                                                                 FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD, NULL);
-              g_autofree char *download_if = g_key_file_get_string (metakey, groups[i],
-                                                                    FLATPAK_METADATA_KEY_DOWNLOAD_IF, NULL);
-              gboolean autodelete = g_key_file_get_boolean (metakey, groups[i],
-                                                            FLATPAK_METADATA_KEY_AUTODELETE, NULL);
-              gboolean locale_subset = g_key_file_get_boolean (metakey, groups[i],
-                                                               FLATPAK_METADATA_KEY_LOCALE_SUBSET, NULL);
-              const char *branch;
-              g_autofree char *extension_ref = NULL;
-              g_autofree char *prefixed_extension_ref = NULL;
-              g_autofree char *checksum = NULL;
-              g_autofree char *extension_collection_id = NULL;
+          /* Parse actual extension name */
+          flatpak_parse_extension_with_tag (tagged_extension, &extension, NULL);
 
-              /* Parse actual extension name */
-              flatpak_parse_extension_with_tag (tagged_extension, &extension, NULL);
-
-              if (version)
-                branch = version;
-              else
-                branch = parts[3];
+          if (version)
+            branch = version;
+          else
+            branch = parts[3];
 
 #ifdef FLATPAK_ENABLE_P2P
-              extension_collection_id = g_key_file_get_string (metakey, groups[i],
-                                                               FLATPAK_METADATA_KEY_COLLECTION_ID, NULL);
+          extension_collection_id = g_key_file_get_string (metakey, groups[i],
+                                                           FLATPAK_METADATA_KEY_COLLECTION_ID, NULL);
 #endif  /* FLATPAK_ENABLE_P2P */
 
-              /* As we’re looking locally, we can’t support extension
-               * collection IDs which don’t match the current remote (since the
-               * associated refs could be anywhere). */
-              if (extension_collection_id != NULL && *extension_collection_id != '\0' &&
-                  g_strcmp0 (extension_collection_id, collection_id) != 0)
-                {
-                  g_debug ("Skipping related extension ‘%s’ because it’s in collection "
-                           "‘%s’ which does not match the current remote ‘%s’.",
-                           extension, extension_collection_id, collection_id);
-                  continue;
-                }
+          /* As we’re looking locally, we can’t support extension
+           * collection IDs which don’t match the current remote (since the
+           * associated refs could be anywhere). */
+          if (extension_collection_id != NULL && *extension_collection_id != '\0' &&
+              g_strcmp0 (extension_collection_id, collection_id) != 0)
+            {
+              g_debug ("Skipping related extension ‘%s’ because it’s in collection "
+                       "‘%s’ which does not match the current remote ‘%s’.",
+                       extension, extension_collection_id, collection_id);
+              continue;
+            }
 
-              g_clear_pointer (&extension_collection_id, g_free);
-              extension_collection_id = g_strdup (collection_id);
+          g_clear_pointer (&extension_collection_id, g_free);
+          extension_collection_id = g_strdup (collection_id);
 
-              extension_ref = g_build_filename ("runtime", extension, parts[2], branch, NULL);
-              prefixed_extension_ref = g_strdup_printf ("%s:%s", remote_name, extension_ref);
-              if (ostree_repo_resolve_rev (self->repo,
-                                           prefixed_extension_ref,
-                                           FALSE,
-                                           &checksum,
-                                           NULL))
+          extension_ref = g_build_filename ("runtime", extension, parts[2], branch, NULL);
+          prefixed_extension_ref = g_strdup_printf ("%s:%s", remote_name, extension_ref);
+          if (ostree_repo_resolve_rev (self->repo,
+                                       prefixed_extension_ref,
+                                       FALSE,
+                                       &checksum,
+                                       NULL))
+            {
+              add_related (self, related, extension, extension_collection_id, extension_ref,
+                           checksum, no_autodownload, download_if, autodelete, locale_subset);
+            }
+          else if (subdirectories)
+            {
+              g_autoptr(GPtrArray) matches = local_match_prefix (self, extension_ref, remote_name);
+              int j;
+              for (j = 0; j < matches->len; j++)
                 {
-                  add_related (self, related, extension, extension_collection_id, extension_ref,
-                               checksum, no_autodownload, download_if, autodelete, locale_subset);
-                }
-              else if (subdirectories)
-                {
-                  g_autoptr(GPtrArray) matches = local_match_prefix (self, extension_ref, remote_name);
-                  int j;
-                  for (j = 0; j < matches->len; j++)
+                  const char *match = g_ptr_array_index (matches, j);
+                  g_autofree char *prefixed_match = NULL;
+                  g_autofree char *match_checksum = NULL;
+
+                  prefixed_match = g_strdup_printf ("%s:%s", remote_name, match);
+
+                  if (ostree_repo_resolve_rev (self->repo,
+                                               prefixed_match,
+                                               FALSE,
+                                               &match_checksum,
+                                               NULL))
                     {
-                      const char *match = g_ptr_array_index (matches, j);
-                      g_autofree char *prefixed_match = NULL;
-                      g_autofree char *match_checksum = NULL;
-
-                      prefixed_match = g_strdup_printf ("%s:%s", remote_name, match);
-
-                      if (ostree_repo_resolve_rev (self->repo,
-                                                   prefixed_match,
-                                                   FALSE,
-                                                   &match_checksum,
-                                                   NULL))
-                        {
-                          add_related (self, related, extension,
-                                       extension_collection_id, match, match_checksum,
-                                       no_autodownload, download_if, autodelete, locale_subset);
-                        }
+                      add_related (self, related, extension,
+                                   extension_collection_id, match, match_checksum,
+                                   no_autodownload, download_if, autodelete, locale_subset);
                     }
                 }
             }
@@ -11113,6 +11093,36 @@ flatpak_dir_get_deployed_metadata (FlatpakDir    *self,
 
   *out_metadata = g_steal_pointer (&metakey);
   return TRUE;
+}
+
+/* Use flatpak_dir_find_local_related_for_deployed to find the
+ * related refs for an already deployed ref (which might be
+ * different to the one in the repo) */
+GPtrArray *
+flatpak_dir_find_local_related_for_deployed (FlatpakDir *self,
+                                             const char *ref,
+                                             const char *remote_name,
+                                             GCancellable *cancellable,
+                                             GError **error)
+{
+  g_autoptr(GKeyFile) metakey = NULL;
+
+  if (!flatpak_dir_get_deployed_metadata (self,
+                                          ref,
+                                          cancellable,
+                                          &metakey,
+                                          error))
+    return FALSE;
+
+  if (metakey == NULL)
+    return NULL;
+
+  return flatpak_dir_find_local_related_for_metadata (self,
+                                                      ref,
+                                                      remote_name,
+                                                      metakey,
+                                                      cancellable,
+                                                      error);
 }
 
 /* Get the metadata the most recent commit of ref in the

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11172,6 +11172,38 @@ flatpak_dir_get_metadata_for_ref_in_repo (FlatpakDir    *self,
   return g_steal_pointer (&metakey);
 }
 
+/* Use flatpak_dir_find_local_related_for_ref_in_repo to find the related
+ * refs for a ref in the repo (that might not be deployed yet, or different
+ * from the one that is deployed). */
+GPtrArray *
+flatpak_dir_find_local_related_for_ref_in_repo (FlatpakDir *self,
+                                                const char *ref,
+                                                const char *remote_name,
+                                                GCancellable *cancellable,
+                                                GError **error)
+{
+  g_autoptr(GKeyFile) metakey = NULL;
+
+  if (!flatpak_dir_ensure_repo (self, cancellable, error))
+    return NULL;
+
+  metakey = flatpak_dir_get_metadata_for_ref_in_repo (self,
+                                                      ref,
+                                                      remote_name,
+                                                      cancellable,
+                                                      error);
+
+  if (metakey == NULL)
+    return NULL;
+
+  return flatpak_dir_find_local_related_for_metadata (self,
+                                                      ref,
+                                                      remote_name,
+                                                      metakey,
+                                                      cancellable,
+                                                      error);
+}
+
 static GDBusProxy *
 get_accounts_dbus_proxy (void)
 {

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -711,6 +711,11 @@ GPtrArray * flatpak_dir_find_local_related_for_deployed (FlatpakDir *self,
                                                          const char *ref,
                                                          GCancellable *cancellable,
                                                          GError **error);
+GPtrArray * flatpak_dir_find_local_related_for_ref_in_repo (FlatpakDir *self,
+                                                            const char *remote_name,
+                                                            const char *ref,
+                                                            GCancellable *cancellable,
+                                                            GError **error);
 
 char ** flatpak_dir_get_default_locale_languages (FlatpakDir *self);
 char ** flatpak_dir_get_locale_languages (FlatpakDir *self);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -706,11 +706,11 @@ GPtrArray * flatpak_dir_find_remote_related (FlatpakDir *dir,
                                              const char *ref,
                                              GCancellable *cancellable,
                                              GError **error);
-GPtrArray * flatpak_dir_find_local_related (FlatpakDir *self,
-                                            const char *remote_name,
-                                            const char *ref,
-                                            GCancellable *cancellable,
-                                            GError **error);
+GPtrArray * flatpak_dir_find_local_related_for_deployed (FlatpakDir *self,
+                                                         const char *remote_name,
+                                                         const char *ref,
+                                                         GCancellable *cancellable,
+                                                         GError **error);
 
 char ** flatpak_dir_get_default_locale_languages (FlatpakDir *self);
 char ** flatpak_dir_get_locale_languages (FlatpakDir *self);

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2476,8 +2476,8 @@ flatpak_installation_list_installed_related_refs_sync (FlatpakInstallation *self
   if (dir == NULL)
     return NULL;
 
-  related = flatpak_dir_find_local_related (dir, ref, remote_name,
-                                            cancellable, error);
+  related = flatpak_dir_find_local_related_for_deployed (dir, ref, remote_name,
+                                                         cancellable, error);
   if (related == NULL)
     return NULL;
 

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2450,9 +2450,10 @@ flatpak_installation_list_remote_related_refs_sync (FlatpakInstallation *self,
  *
  * This function is similar to flatpak_installation_list_remote_related_refs_sync,
  * but instead of looking at what is available on the remote, it only looks
- * at the locally installed refs. This is useful for instance when you're
- * looking for related refs to uninstall, or when you're planning to use
- * FLATPAK_UPDATE_FLAGS_NO_PULL to install previously pulled refs.
+ * for related refs in the repo for the ref that is currently installed.
+ * This is useful for instance when you're looking for related refs to uninstall,
+ * or when you're planning to use FLATPAK_UPDATE_FLAGS_NO_PULL to install
+ * previously pulled refs.
  *
  * Returns: (transfer container) (element-type FlatpakRelatedRef): a GPtrArray of
  *   #FlatpakRelatedRef instances


### PR DESCRIPTION
This branch adds support for looking up the available remote refs and related refs from the local repo instead of using the network to work out what refs are available. This can be used by callers who need have downloaded refs into the local repository and might need to read the information about the downloaded refs to do dependency resolution in a later process.

It adds `flatpak_installation_list_local_refs_for_remote_sync` which looks at all the refs pulled into the current repository and lists the ones which correspond with the given remote.

It also adds `flatpak_installation_list_local_related_refs_sync` which looks at the the most recently pulled commit metadata for a given ref and lists all the related refs for that ref based on that commit metadata. This might be different from the related refs according to the currently deployed metadata if the local ref is more up to date.