### PR TITLE
lib: Don't try to read uninitialized memory

### DIFF
--- a/lib/flatpak-remote-ref.c
+++ b/lib/flatpak-remote-ref.c
@@ -326,7 +326,7 @@ flatpak_remote_ref_new (FlatpakCollectionRef *coll_ref,
 {
   FlatpakRefKind kind = FLATPAK_REF_KIND_APP;
   guint64 download_size = 0, installed_size = 0;
-  const char *metadata;
+  const char *metadata = NULL;
   g_autoptr(GBytes) metadata_bytes = NULL;
   g_auto(GStrv) parts = NULL;
   FlatpakRemoteRef *ref;


### PR DESCRIPTION
Oddly this uninitialized memory read leads to a seg fault on ARM but
not on x86_64.