### PR TITLE
make-test-runtime: Look in /{usr/,}sbin for ldconfig

### DIFF
--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -20,6 +20,10 @@ EOF
 
 cat ${DIR}/metadata
 
+# On Debian derivatives, /usr/sbin and /sbin aren't in ordinary users'
+# PATHs, but ldconfig is kept in /sbin
+PATH="$PATH:/usr/sbin:/sbin"
+
 # Add bash and dependencies
 mkdir -p ${DIR}/usr/bin
 mkdir -p ${DIR}/usr/lib


### PR DESCRIPTION
Under normal circumstances ldconfig isn't required to be in ordinary
users' PATHs, but running this script is not a normal circumstance.

Signed-off-by: Simon McVittie <smcv@collabora.com>