### PR TITLE
Re-fix export filename checks, this time also for build-finish

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -60,57 +60,15 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-typedef gboolean (*DirectoryExportFileFilterFunc) (char *path, gpointer user_data);
-
-typedef struct _BuiltinExportedDirectoryInfo {
-  char                          *path;
-  DirectoryExportFileFilterFunc  filter_func;
-  gpointer                       user_data;
-  GDestroyNotify                 user_data_destroy;
-} BuiltinExportedDirectoryInfo;
-
-static BuiltinExportedDirectoryInfo *
-builtin_exported_directory_info_new (const char                    *path,
-                                     DirectoryExportFileFilterFunc  filter_func,
-                                     gpointer                       user_data,
-                                     GDestroyNotify                 user_data_destroy)
-{
-  BuiltinExportedDirectoryInfo *info = g_new0 (BuiltinExportedDirectoryInfo, 1);
-
-  info->path = g_strdup (path);
-  info->filter_func = filter_func;
-  info->user_data = user_data;
-  info->user_data_destroy = user_data_destroy;
-
-  return info;
-}
-
-static BuiltinExportedDirectoryInfo *
-builtin_exported_directory_info_new_simple (const char *path,
-                                            const char *permissible_prefix)
-{
-  return builtin_exported_directory_info_new (path,
-                                              (DirectoryExportFileFilterFunc) flatpak_has_name_prefix,
-                                              g_strdup (permissible_prefix),
-                                              g_free);
-}
-
-static void
-builtin_exported_directory_info_free (BuiltinExportedDirectoryInfo *info)
-{
-  g_clear_pointer (&info->path, g_free);
-
-  if (info->user_data_destroy != NULL)
-    g_clear_pointer (&info->user_data, info->user_data_destroy);
-}
-
 static gboolean
 export_dir (int                            source_parent_fd,
             const char                    *source_name,
             const char                    *source_relpath,
             int                            destination_parent_fd,
             const char                    *destination_name,
-            BuiltinExportedDirectoryInfo  *exported_directory_info,
+            char                         **allowed_prefixes,
+            char                         **allowed_extensions,
+            gboolean                       require_exact_match,
             GCancellable                  *cancellable,
             GError                       **error)
 {
@@ -173,17 +131,34 @@ export_dir (int                            source_parent_fd,
           g_autofree gchar *child_relpath = g_build_filename (source_relpath, dent->d_name, NULL);
 
           if (!export_dir (source_iter.fd, dent->d_name, child_relpath, destination_dfd, dent->d_name,
-                           exported_directory_info, cancellable, error))
+                           allowed_prefixes, allowed_extensions, require_exact_match,
+                           cancellable, error))
             return FALSE;
         }
       else if (S_ISREG (stbuf.st_mode))
         {
+          g_autofree gchar *name_without_extension = NULL;
+          int i;
+
           source_printable = g_build_filename (source_relpath, dent->d_name, NULL);
 
-          if (!exported_directory_info->filter_func (dent->d_name,
-                                                     exported_directory_info->user_data))
+          for (i = 0; allowed_extensions[i] != NULL; i++)
             {
-              g_print (_("Not exporting %s, wrong prefix\n"), source_printable);
+              if (g_str_has_suffix (dent->d_name, allowed_extensions[i]))
+                break;
+            }
+
+          if (allowed_extensions[i] == NULL)
+            {
+              g_print (_("Not exporting %s, wrong extension\n"), source_printable);
+              continue;
+            }
+
+          name_without_extension = g_strndup (dent->d_name, strlen (dent->d_name) - strlen (allowed_extensions[i]));
+
+          if (!flatpak_name_matches_one_wildcard_prefix (name_without_extension, (const char * const *) allowed_prefixes, require_exact_match))
+            {
+              g_print (_("Not exporting %s, non-allowed export filename\n"), source_printable);
               continue;
             }
 
@@ -224,7 +199,9 @@ static gboolean
 copy_exports (GFile                         *source,
               GFile                         *destination,
               const char                    *source_prefix,
-              BuiltinExportedDirectoryInfo  *exported_directory_info,
+              char                         **allowed_prefixes,
+              char                         **allowed_extensions,
+              gboolean                       require_exact_match,
               GCancellable                  *cancellable,
               GError                       **error)
 {
@@ -234,28 +211,11 @@ copy_exports (GFile                         *source,
   /* The fds are closed by this call */
   if (!export_dir (AT_FDCWD, flatpak_file_get_path_cached (source), source_prefix,
                    AT_FDCWD, flatpak_file_get_path_cached (destination),
-                   exported_directory_info, cancellable, error))
+                   allowed_prefixes, allowed_extensions, require_exact_match,
+                   cancellable, error))
     return FALSE;
 
   return TRUE;
-}
-
-static GStrv
-lookup_permitted_dbus_service_file_prefixes (FlatpakContext  *arg_context,
-                                             const char      *app_id)
-{
-  g_auto(GStrv) dbus_own_name_prefixes =
-    flatpak_context_get_session_bus_policy_allowed_own_names (arg_context);
-  g_autoptr(GPtrArray) permitted_prefixes = g_ptr_array_new_with_free_func (g_free);
-  GStrv iter = dbus_own_name_prefixes;
-
-  g_ptr_array_add (permitted_prefixes, g_strdup (app_id));
-
-  for (; *iter != NULL; ++iter)
-    g_ptr_array_add (permitted_prefixes, g_strdup (*iter));
-
-  g_ptr_array_add (permitted_prefixes, NULL);
-  return (GStrv) g_ptr_array_free (g_steal_pointer (&permitted_prefixes), FALSE);
 }
 
 static gboolean
@@ -267,34 +227,16 @@ collect_exports (GFile          *base,
 {
   g_autoptr(GFile) files = NULL;
   g_autoptr(GFile) export = NULL;
-  g_autoptr(GPtrArray) exported_directory_infos =
-    g_ptr_array_new_with_free_func ((GDestroyNotify) builtin_exported_directory_info_free);
-  g_auto(GStrv) permitted_dbus_service_file_prefixes =
-    lookup_permitted_dbus_service_file_prefixes (arg_context, app_id);
   int i;
+  const char *paths[] = {
+    "share/applications",                 /* Copy desktop files */
+    "share/mime/packages",                /* Copy MIME Type files */
+    "share/icons",                        /* Icons */
+    "share/dbus-1/services",              /* D-Bus service files */
+    "share/gnome-shell/search-providers", /* Search providers */
+    NULL,
+  };
 
-  /* Copy desktop files */
-  g_ptr_array_add (exported_directory_infos,
-                   builtin_exported_directory_info_new_simple ("share/applications", app_id));
-
-  /* Copy MIME type files */
-  g_ptr_array_add (exported_directory_infos,
-                   builtin_exported_directory_info_new_simple ("share/mime/packages", app_id));
-
-  /* Copy icons */
-  g_ptr_array_add (exported_directory_infos,
-                   builtin_exported_directory_info_new_simple ("share/icons", app_id));
-
-  /* Copy D-Bus service files */
-  g_ptr_array_add (exported_directory_infos,
-                   builtin_exported_directory_info_new ("share/dbus-1/services",
-                                                        (DirectoryExportFileFilterFunc) flatpak_name_matches_one_wildcard_prefix,
-                                                        g_steal_pointer (&permitted_dbus_service_file_prefixes),
-                                                        (GDestroyNotify) g_strfreev));
-
-  /* Copy Search Providers */
-  g_ptr_array_add (exported_directory_infos,
-                   builtin_exported_directory_info_new_simple ("share/gnome-shell/search-providers", app_id));
 
   files = g_file_get_child (base, "files");
 
@@ -306,12 +248,18 @@ collect_exports (GFile          *base,
   if (opt_no_exports)
     return TRUE;
 
-  for (i = 0; i < exported_directory_infos->len; i++)
+  for (i = 0; paths[i]; i++)
     {
-      g_autoptr(GFile) src = NULL;
-      BuiltinExportedDirectoryInfo *info = g_ptr_array_index (exported_directory_infos, i);
-      const char * path = info->path;
-      src = g_file_resolve_relative_path (files, path);
+      const char * path = paths[i];
+      g_autoptr(GFile) src = g_file_resolve_relative_path (files, path);
+      g_auto(GStrv) allowed_prefixes = NULL;
+      g_auto(GStrv) allowed_extensions = NULL;
+      gboolean require_exact_match = FALSE;
+
+      if (!flatpak_get_allowed_exports (path, app_id, arg_context,
+                                        &allowed_extensions, &allowed_prefixes, &require_exact_match))
+        return flatpak_fail (error, "Unexpectedly not allowed to export %s", path);
+
       if (g_file_query_exists (src, cancellable))
         {
           g_debug ("Exporting from %s", path);
@@ -326,7 +274,9 @@ collect_exports (GFile          *base,
           if (!copy_exports (src,
                              dest,
                              path,
-                             info,
+                             allowed_prefixes,
+                             allowed_extensions,
+                             require_exact_match,
                              cancellable,
                              error))
             return FALSE;

--- a/common/flatpak-common-types.h
+++ b/common/flatpak-common-types.h
@@ -30,5 +30,6 @@ typedef struct FlatpakDir     FlatpakDir;
 typedef struct FlatpakDeploy  FlatpakDeploy;
 typedef struct FlatpakOciRegistry FlatpakOciRegistry;
 typedef struct _FlatpakOciManifest FlatpakOciManifest;
+typedef struct FlatpakCompletion FlatpakCompletion;
 
 #endif /* __FLATPAK_COMMON_TYPES_H__ */

--- a/common/flatpak-context.h
+++ b/common/flatpak-context.h
@@ -23,7 +23,7 @@
 
 #include "libglnx/libglnx.h"
 #include "dbus-proxy/flatpak-proxy.h"
-#include "flatpak-utils.h"
+#include <flatpak-common-types.h>
 #include "flatpak-exports.h"
 
 typedef struct FlatpakContext FlatpakContext;

--- a/common/flatpak-exports.h
+++ b/common/flatpak-exports.h
@@ -22,7 +22,6 @@
 #define __FLATPAK_EXPORTS_H__
 
 #include "libglnx/libglnx.h"
-#include "flatpak-utils.h"
 #include "flatpak-bwrap.h"
 
 /* In numerical order of more privs */

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -141,12 +141,17 @@ gboolean flatpak_summary_lookup_ref (GVariant    *summary,
                                      char       **out_checksum,
                                      GVariant   **out_variant);
 
-gboolean flatpak_has_name_prefix (const char *string,
-                                  const char *name);
-gboolean flatpak_name_matches_one_prefix (const char         *string,
-                                          const char * const *prefixes);
 gboolean flatpak_name_matches_one_wildcard_prefix (const char         *string,
-                                                   const char * const *maybe_wildcard_prefixes);
+                                                   const char * const *maybe_wildcard_prefixes,
+                                                   gboolean require_exact_match);
+
+gboolean flatpak_get_allowed_exports (const char *source_path,
+                                      const char *app_id,
+                                      FlatpakContext *context,
+                                      char ***allowed_extensions_out,
+                                      char ***allowed_prefixes_out,
+                                      gboolean *require_exact_match_out);
+
 gboolean flatpak_is_valid_name (const char *string,
                                 GError **error);
 gboolean flatpak_is_valid_branch (const char *string,

--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -30,6 +30,7 @@
 #include <libsoup/soup.h>
 #include "flatpak-dbus.h"
 #include "flatpak-document-dbus.h"
+#include "flatpak-context.h"
 #include <ostree.h>
 #include <json-glib/json-glib.h>
 
@@ -654,7 +655,7 @@ gboolean flatpak_download_http_uri (SoupSession *soup_session,
                                     GCancellable *cancellable,
                                     GError      **error);
 
-typedef struct {
+struct FlatpakCompletion {
   char *shell_cur;
   char *cur;
   char *prev;
@@ -664,7 +665,7 @@ typedef struct {
   char **original_argv;
   int argc;
   int original_argc;
-} FlatpakCompletion;
+};
 
 void flatpak_completion_debug (const gchar *format, ...);
 


### PR DESCRIPTION
The fix in 5122766284295c460320153c1213bccc7c8e3609 was not right.
First of all it didn't changethe regressing behaviour for build-finish, just install.

Secondly, it changed the prefix matches to always use flatpak_name_matches_one_wildcard_prefix() which had slight differences in behaviour that the previously used  flatpak_name_matches_one_prefix. For example, it always removed the extension, no matter what it was.

This has all been replaced with a shared (between install and build-finish) version that is more strict with extensions, and with what names can be exported as service files (these have to match exactly, with the wildcard and cannot have suffixes).

To test this i tried to install these apps from flathub that has some more complex exports:

     org.sparkleshare.SparkleShare:
      org.sparkleshare.SparkleShare.Invites.desktop
      org.sparkleshare.SparkleShare-symbolic.svg
    
     org.libreoffice.LibreOffice:
      org.libreoffice.LibreOffice.desktop
      org.libreoffice.LibreOffice-impress.desktop
      org.libreoffice.LibreOffice-writer.png
      org.libreoffice.LibreOffice-calc.png
    
     com.github.bajoja.indicator-kdeconnect:
       com.github.bajoja.indicator-kdeconnect.desktop
       com.github.bajoja.indicator-kdeconnect.settings.desktop
       com.github.bajoja.indicator-kdeconnect.tablettrusted.svg
    
     com.github.philip_scott.spice-up:
       com.github.philip_scott.spice-up.svg
       com.github.philip_scott.spice-up-mime.svg
       com.github.philip_scott.spice-up.mime.xml
    
     org.gnome.Recipes:
       org.gnome.Recipes.desktop
       org.gnome.Recipes.service
       org.gnome.Recipes-search-provider.ini
       org.gnome.Recipes.png
       org.gnome.Recipes-symbolic.symbolic.png
       org.gnome.Recipes-mime.xml
    
     org.gnome.Characters:
       org.gnome.Characters.desktop
       org.gnome.Characters.BackgroundService.service
       org.gnome.Characters.service
       org.gnome.Characters.search-provider.ini
       org.gnome.Characters.png
       org.gnome.Characters-symbolic.svg
    
     org.gnome.Weather
       org.gnome.Weather.Application.desktop
       org.gnome.Weather.Application.service
       org.gnome.Weather.BackgroundService.service
       org.gnome.Weather.Application.search-provider.ini
    
     org.gpodder.gpodder:
       org.gpodder.gpodder.desktop
       org.gpodder.gpodder.gpodder-url-handler.desktop

