### PR TITLE
tests: Forcefully kill the dbus daemon on exit

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -357,7 +357,7 @@ if ! /bin/kill -0 "$DBUS_SESSION_BUS_PID"; then
 fi
 
 cleanup () {
-    /bin/kill $DBUS_SESSION_BUS_PID ${FLATPAK_HTTP_PID:-}
+    /bin/kill -9 $DBUS_SESSION_BUS_PID ${FLATPAK_HTTP_PID:-}
     gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye || true
     fusermount -u $XDG_RUNTIME_DIR/doc || :
     if test -n "${TEST_SKIP_CLEANUP:-}"; then


### PR DESCRIPTION
In the cleanup() function used after each unit test exits, we kill the
dbus daemon process and remove the temporary test directory. However, on
an Endless Mini the daemon doesn't always exit properly before we try to
remove the test directory, leading to an error like:

rm: cannot remove '/var/tmp/test-flatpak-AlmZul/runtime/.dbus-proxy': Device or resource busy

which causes some of the tests to fail with e.g.:

ERROR: tests/test-bundle.sh - exited with status 1

I don't think this is specific to the Mini or to ARM computers; it could
probably happen on any slow computer. So this commit uses "kill -9"
instead of just "kill" to make sure the daemon exits.