### PR TITLE
completion: Only show files with the correct prefix

### DIFF
--- a/completion/flatpak
+++ b/completion/flatpak
@@ -13,9 +13,9 @@ __flatpak() {
         if [[ "${RES[$i]}" = "__FLATPAK_FILE" ]]; then
             declare -a COMPGEN_OPTS=('-f')
         elif [[ "${RES[$i]}" = "__FLATPAK_BUNDLE_FILE" ]]; then
-            declare -a COMPGEN_OPTS=('-f' '-G' '*.flatpak')
+            declare -a COMPGEN_OPTS=('-f' '-X' '!*.flatpak')
         elif [[ "${RES[$i]}" = "__FLATPAK_BUNDLE_OR_REF_FILE" ]]; then
-            declare -a COMPGEN_OPTS=('-f' '-G' '*.flatpak@(|ref)')
+            declare -a COMPGEN_OPTS=('-f' '-X' '!*.flatpak@(|ref)')
         elif [[ "${RES[$i]}" = "__FLATPAK_DIR" ]]; then
             declare -a COMPGEN_OPTS=('-d')
         else


### PR DESCRIPTION
Currently flatpak's bash completion is a bit broken. It shows all files
with the appropriate extension (.flatpak or .flatpakref) rather than
just the ones starting with the characters you've already typed. So this
commit fixes that behavior by using the -X compgen option rather than
-G. For example, here's the old behavior:

$ flatpak install e<TAB>
bijiben.flatpak  eos              eos-runtimes
builder.flatpak  eos-apps         eos-sdk

and here's the new behavior:

$ flatpak install e<TAB>
eos            eos-apps       eos-runtimes   eos-sdk
$ flatpak install b<TAB>
bijiben.flatpak  builder.flatpak