### PR TITLE
run: Don't block on blocking autofs mounts

### DIFF
--- a/common/flatpak-utils.h
+++ b/common/flatpak-utils.h
@@ -34,6 +34,8 @@
 #include <ostree.h>
 #include <json-glib/json-glib.h>
 
+#define AUTOFS_SUPER_MAGIC    0x0187
+
 typedef enum {
   FLATPAK_HOST_COMMAND_FLAGS_CLEAR_ENV = 1 << 0,
 } FlatpakHostCommandFlags;


### PR DESCRIPTION
When we start a sandbox and one of the directories we bind-mount into the sandbox, for example
one of the top dirs like /boot, is an autofs, then the bind mount will trigger an automount.
Often this is not really a problem, but in some cases (such as a missing device or a network
mount that is not available) this can block for potentially a very long time.

Ideally we would like to avoid this by not triggering the automount when bind-mounting, but
that doesn't seem possible with the current kernel APIs. So, instead we try to detect
any autofs paths and try to do a blocking operation on them, if this takes more than
200 milliseconds we assume the mountpoint is broken and ignore it.

There are various technical details here:

We can check for autofs using open(O_PATH) + fstatfs() and looking for
f_type == AUTOFS_SUPER_MAGIC (as described in the open manpage).

The blocking operation we do is open(O_DIRECTORY), but to allow this to timeout we
need to fork() and do this in the child, which we can kill after timing out, whick
we detect via select() using a self-pipe.

This fixes https://github.com/flatpak/flatpak/issues/1633