### PR TITLE
common: Fix setting a collection ID on a repository

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2576,10 +2576,10 @@ flatpak_repo_set_collection_id (OstreeRepo  *repo,
 #ifdef FLATPAK_ENABLE_P2P
   g_autoptr(GKeyFile) config = NULL;
 
-  config = ostree_repo_copy_config (repo);
   if (!ostree_repo_set_collection_id (repo, collection_id, error))
     return FALSE;
 
+  config = ostree_repo_copy_config (repo);
   if (!ostree_repo_write_config (repo, config, error))
     return FALSE;
 #endif  /* FLATPAK_ENABLE_P2P */

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -78,6 +78,7 @@ endif
 
 dist_test_scripts = \
 	tests/test-basic.sh \
+	tests/test-build-update-repo.sh \
 	tests/test-run.sh \
 	tests/test-run-system.sh \
 	tests/test-run-deltas.sh \

--- a/tests/test-build-update-repo.sh
+++ b/tests/test-build-update-repo.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright © 2018 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Authors:
+#  - Philip Withnall <withnall@endlessm.com>
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
+skip_without_p2p
+
+echo "1..2"
+
+# Configure a repository, then set a collection ID on it and check that the ID
+# is saved in the config file.
+setup_repo
+install_repo
+
+${FLATPAK} build-update-repo --collection-id=org.test.Collection repos/test
+
+assert_file_has_content repos/test/config '^collection-id=org.test.Collection$'
+
+echo "ok 1 update repo to add collection ID"
+
+# Test that you’re not allowed to change the collection ID once it’s already set.
+if ${FLATPAK} build-update-repo --collection-id=org.test.Collection2 repos/test 2> build-update-repo-error-log; then
+    assert_not_reached "flatpak build-update-repo should not set a collection ID when one is already set"
+fi
+
+assert_file_has_content repos/test/config '^collection-id=org.test.Collection$'
+assert_not_file_has_content repos/test/config '^collection-id=org.test.Collection2$'
+
+echo "ok 2 collection ID cannot be changed"


### PR DESCRIPTION
It was taking a copy of the repository configuration, modifying the
original repository configuration (not the copy), then saving the copy
to disk.

Add a test.

Signed-off-by: Philip Withnall <withnall@endlessm.com>