### PR TITLE
dir: Support finding related refs and dependencies offline

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8453,7 +8453,7 @@ flatpak_dir_remote_has_ref (FlatpakDir   *self,
   g_autoptr(GError) local_error = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
 
-  state = flatpak_dir_get_remote_state (self, remote, NULL, &local_error);
+  state = flatpak_dir_get_remote_state_optional (self, remote, NULL, &local_error);
   if (state == NULL)
     {
       g_debug ("Can't get state for remote %s: %s", remote, local_error->message);

--- a/common/flatpak-dir.h
+++ b/common/flatpak-dir.h
@@ -102,10 +102,11 @@ gboolean flatpak_remote_state_ensure_summary (FlatpakRemoteState *self,
                                               GError      **error);
 gboolean flatpak_remote_state_ensure_metadata (FlatpakRemoteState *self,
                                                GError      **error);
-char *flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,
-                                       const   char *ref,
-                                       GVariant    **out_variant,
-                                       GError      **error);
+gboolean flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,
+                                          const char         *ref,
+                                          char              **out_checksum,
+                                          GVariant          **out_variant,
+                                          GError            **error);
 char **flatpak_remote_state_match_subrefs (FlatpakRemoteState *self,
                                            const   char *ref);
 gboolean flatpak_remote_state_lookup_repo_metadata (FlatpakRemoteState *self,

--- a/lib/flatpak-installation.c
+++ b/lib/flatpak-installation.c
@@ -2389,6 +2389,9 @@ flatpak_installation_create_monitor (FlatpakInstallation *self,
  * flatpak_related_ref_should_delete () returns TRUE if it
  * should be uninstalled with the main ref.
  *
+ * The commit property of each FlatpakRelatedRef is not guaranteed to be
+ * non-%NULL.
+ *
  * Returns: (transfer container) (element-type FlatpakRelatedRef): a GPtrArray of
  *   #FlatpakRelatedRef instances
  *


### PR DESCRIPTION
Here are two commits to fix finding related refs and dependencies in the P2P case.