### PR TITLE
New dbus work

### DIFF
--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -52,6 +52,7 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 
 #define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
 #define FLATPAK_METADATA_KEY_INSTANCE_PATH "instance-path"
+#define FLATPAK_METADATA_KEY_INSTANCE_ID "instance-id"
 #define FLATPAK_METADATA_KEY_APP_PATH "app-path"
 #define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
 #define FLATPAK_METADATA_KEY_APP_EXTENSIONS "app-extensions"


### PR DESCRIPTION
This is a set of changes that targets supporting a portalized dconf daemon, as well as eventually using the [new dbus container filtering APIs](https://bugs.freedesktop.org/show_bug.cgi?id=101902) instead of the proxy.

Some changes in the proxy behaviour:
 * We now treat wildcarded name matches identical to arg0namespace in dbus
 * More options when filtering messages, including separating filtering of calls and receiving broadcasts.

Additionally flatpak now:
 * Allocates a unique random uint32 instance id for every flatpak instance
 * Puts the instance id in the `.flatpak-info` file
 * Creates a `$XDG_RUN_DIR/.flatpak/$INSTANCE_ID` directory on the host
 * Read-only mounts the above directory in the sandbox
 * Changes the default portal proxy rules so that only broadcasts with the `/flatpak/$INSTANCE_ID` object-path prefix reach the sandbox.

@smcv @allisonkarlitskaya @amigadave can you all take a look at this? Does it make sense.
