### PR TITLE
Fix tests with bare-user-only

### DIFF
--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -96,7 +96,7 @@ ostree init --repo=repos/test --mode=archive-z2
 # Modify platform metadata
 ostree checkout -U --repo=repos/test runtime/org.test.Platform/${ARCH}/master platform
 add_extensions platform
-ostree commit --repo=repos/test --owner-uid=0 --owner-gid=0 --no-xattrs --branch=runtime/org.test.Platform/${ARCH}/master -s "modified metadata" platform
+ostree commit --repo=repos/test --owner-uid=0 --owner-gid=0 --no-xattrs --canonical-permissions  --branch=runtime/org.test.Platform/${ARCH}/master -s "modified metadata" platform
 ostree summary -u --repo=repos/test
 
 ${FLATPAK} remote-add --user --no-gpg-verify test-repo repos/test
@@ -145,7 +145,7 @@ echo "ok runtime extensions"
 # Modify app metadata
 ostree checkout -U --repo=repos/test app/org.test.Hello/${ARCH}/master hello
 add_extensions hello
-ostree commit --repo=repos/test --owner-uid=0 --owner-gid=0 --no-xattrs --branch=app/org.test.Hello/${ARCH}/master -s "modified metadata" hello
+ostree commit --repo=repos/test --owner-uid=0 --owner-gid=0 --no-xattrs --canonical-permissions --branch=app/org.test.Hello/${ARCH}/master -s "modified metadata" hello
 ostree summary -u --repo=repos/test
 
 ${FLATPAK} --user update org.test.Hello master

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -344,7 +344,8 @@ flatpak build-init app org.test.Writable org.test.Platform org.test.Platform
 mkdir -p app/files/a-dir
 chmod a+rwx app/files/a-dir
 flatpak build-finish --command=hello.sh app
-ostree --repo=repos/test commit  ${FL_GPGARGS} --branch=app/org.test.Writable/$ARCH/master app
+# Note: not --canonical-permissions
+ostree --repo=repos/test commit --owner-uid=0 --owner-gid=0  --no-xattrs  ${FL_GPGARGS} --branch=app/org.test.Writable/$ARCH/master app
 update_repo
 
 ${FLATPAK} ${U} install test-repo org.test.Writable
@@ -359,7 +360,8 @@ mkdir -p app/files/
 touch app/files/exe
 chmod u+s app/files/exe
 flatpak build-finish --command=hello.sh app
-ostree --repo=repos/test commit  ${FL_GPGARGS} --branch=app/org.test.Setuid/$ARCH/master app
+# Note: not --canonical-permissions
+ostree --repo=repos/test commit --owner-uid=0 --owner-gid=0 --no-xattrs  ${FL_GPGARGS} --branch=app/org.test.Setuid/$ARCH/master app
 update_repo
 
 if ${FLATPAK} ${U} install test-repo org.test.Setuid &> err2.txt; then


### PR DESCRIPTION
This fixes the tests that were using the system-helper to test non-canonical permissions
in installs.

These days these will fail during the install, rather than fail and re-canonicalize the files,
so check that instead.