### PR TITLE
lib/installation: Adding missing documentation for the newly added API

### DIFF
--- a/doc/reference/flatpak-sections.txt
+++ b/doc/reference/flatpak-sections.txt
@@ -14,6 +14,7 @@ flatpak_installation_install_full
 flatpak_installation_update
 flatpak_installation_update_full
 flatpak_installation_uninstall
+flatpak_installation_uninstall_full
 flatpak_installation_launch
 flatpak_installation_get_current_installed_app
 flatpak_installation_get_display_name
@@ -52,6 +53,7 @@ flatpak_get_system_installations
 FlatpakProgressCallback
 FlatpakUpdateFlags
 FlatpakInstallFlags
+FlatpakUninstallFlags
 FlatpakStorageType
 <SUBSECTION Standard>
 FLATPAK_INSTALLATION

--- a/lib/flatpak-installation.h
+++ b/lib/flatpak-installation.h
@@ -52,7 +52,7 @@ typedef struct
  * @FLATPAK_UPDATE_FLAGS_NONE: Fetch remote builds and install the latest one (default)
  * @FLATPAK_UPDATE_FLAGS_NO_DEPLOY: Don't install any new builds that might be fetched
  * @FLATPAK_UPDATE_FLAGS_NO_PULL: Don't try to fetch new builds from the remote repo
- * @FLATPAK_UPDATE_FLAGS_NO_PRUNE: Don't prune the local OSTreee repository after updating
+ * @FLATPAK_UPDATE_FLAGS_NO_PRUNE: Don't prune the local OSTree repository after updating (Since: 0.11.8)
  *
  * Flags to alter the behavior of flatpak_installation_update().
  */
@@ -80,7 +80,7 @@ typedef enum {
 /**
  * FlatpakUninstallFlags:
  * @FLATPAK_UNINSTALL_FLAGS_NONE: Default
- * @FLATPAK_UNINSTALL_FLAGS_NO_PRUNE: Don't prune the local OSTreee repository after uninstalling
+ * @FLATPAK_UNINSTALL_FLAGS_NO_PRUNE: Don't prune the local OSTree repository after uninstalling
  *
  * Flags to alter the behavior of flatpak_installation_uninstall_full().
  *


### PR DESCRIPTION
Add FLATPAK_UPDATE_FLAGS_NO_PRUNE and flatpak_installation_uninstall_full()
to the documentation, along with a couple of small fixes.

https://github.com/flatpak/flatpak/issues/1703