### PR TITLE
Add --allow=bluetooth support

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -421,6 +421,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   if (custom_usr)
     run_flags |= FLATPAK_RUN_FLAG_WRITABLE_ETC;
 
+  run_flags |= flatpak_context_get_run_flags (app_context);
+
   /* Unless manually specified, we disable dbus proxy */
   if (!flatpak_context_get_needs_session_bus_proxy (arg_context))
     run_flags |= FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY;

--- a/common/flatpak-common-types-private.h
+++ b/common/flatpak-common-types-private.h
@@ -26,6 +26,26 @@ typedef enum {
   FLATPAK_KINDS_RUNTIME = 1 << 1,
 } FlatpakKinds;
 
+typedef enum {
+  FLATPAK_RUN_FLAG_DEVEL              = (1 << 0),
+  FLATPAK_RUN_FLAG_BACKGROUND         = (1 << 1),
+  FLATPAK_RUN_FLAG_LOG_SESSION_BUS    = (1 << 2),
+  FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS     = (1 << 3),
+  FLATPAK_RUN_FLAG_NO_SESSION_HELPER  = (1 << 4),
+  FLATPAK_RUN_FLAG_MULTIARCH          = (1 << 5),
+  FLATPAK_RUN_FLAG_WRITABLE_ETC       = (1 << 6),
+  FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY = (1 << 7),
+  FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY = (1 << 8),
+  FLATPAK_RUN_FLAG_SET_PERSONALITY    = (1 << 9),
+  FLATPAK_RUN_FLAG_FILE_FORWARDING    = (1 << 10),
+  FLATPAK_RUN_FLAG_DIE_WITH_PARENT    = (1 << 11),
+  FLATPAK_RUN_FLAG_LOG_A11Y_BUS       = (1 << 12),
+  FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY  = (1 << 13),
+  FLATPAK_RUN_FLAG_SANDBOX            = (1 << 14),
+  FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL = (1 << 15),
+  FLATPAK_RUN_FLAG_BLUETOOTH          = (1 << 16),
+} FlatpakRunFlags;
+
 typedef struct FlatpakDir     FlatpakDir;
 typedef struct FlatpakDeploy  FlatpakDeploy;
 typedef struct FlatpakOciRegistry FlatpakOciRegistry;

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -51,6 +51,7 @@ typedef enum {
 typedef enum {
   FLATPAK_CONTEXT_FEATURE_DEVEL        = 1 << 0,
   FLATPAK_CONTEXT_FEATURE_MULTIARCH    = 1 << 1,
+  FLATPAK_CONTEXT_FEATURE_BLUETOOTH    = 1 << 2,
 } FlatpakContextFeatures;
 
 struct FlatpakContext

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -98,6 +98,7 @@ void           flatpak_context_set_system_bus_policy (FlatpakContext *context,
                                                       FlatpakPolicy   policy);
 void           flatpak_context_to_args (FlatpakContext *context,
                                         GPtrArray *args);
+FlatpakRunFlags flatpak_context_get_run_flags (FlatpakContext *context);
 void           flatpak_context_add_bus_filters (FlatpakContext *context,
                                                 const char     *app_id,
                                                 gboolean        session_bus,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -72,6 +72,7 @@ const char *flatpak_context_devices[] = {
 const char *flatpak_context_features[] = {
   "devel",
   "multiarch",
+  "bluetooth",
   NULL
 };
 
@@ -1982,6 +1983,9 @@ flatpak_context_get_run_flags (FlatpakContext *context)
 
   if (flatpak_context_allows_features (context, FLATPAK_CONTEXT_FEATURE_MULTIARCH))
     flags |= FLATPAK_RUN_FLAG_MULTIARCH;
+
+  if (flatpak_context_allows_features (context, FLATPAK_CONTEXT_FEATURE_BLUETOOTH))
+    flags |= FLATPAK_RUN_FLAG_BLUETOOTH;
 
   return flags;
 }

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1972,6 +1972,20 @@ flatpak_context_get_exports (FlatpakContext *context,
   return g_steal_pointer (&exports);
 }
 
+FlatpakRunFlags
+flatpak_context_get_run_flags (FlatpakContext *context)
+{
+  FlatpakRunFlags flags = 0;
+
+  if (flatpak_context_allows_features (context, FLATPAK_CONTEXT_FEATURE_DEVEL))
+    flags |= FLATPAK_RUN_FLAG_DEVEL;
+
+  if (flatpak_context_allows_features (context, FLATPAK_CONTEXT_FEATURE_MULTIARCH))
+    flags |= FLATPAK_RUN_FLAG_MULTIARCH;
+
+  return flags;
+}
+
 void
 flatpak_context_append_bwrap_filesystem (FlatpakContext *context,
                                          FlatpakBwrap *bwrap,

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -103,26 +103,6 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_REF "ref"
 #define FLATPAK_METADATA_KEY_TAG "tag"
 
-
-typedef enum {
-  FLATPAK_RUN_FLAG_DEVEL              = (1 << 0),
-  FLATPAK_RUN_FLAG_BACKGROUND         = (1 << 1),
-  FLATPAK_RUN_FLAG_LOG_SESSION_BUS    = (1 << 2),
-  FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS     = (1 << 3),
-  FLATPAK_RUN_FLAG_NO_SESSION_HELPER  = (1 << 4),
-  FLATPAK_RUN_FLAG_MULTIARCH          = (1 << 5),
-  FLATPAK_RUN_FLAG_WRITABLE_ETC       = (1 << 6),
-  FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY = (1 << 7),
-  FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY = (1 << 8),
-  FLATPAK_RUN_FLAG_SET_PERSONALITY    = (1 << 9),
-  FLATPAK_RUN_FLAG_FILE_FORWARDING    = (1 << 10),
-  FLATPAK_RUN_FLAG_DIE_WITH_PARENT    = (1 << 11),
-  FLATPAK_RUN_FLAG_LOG_A11Y_BUS       = (1 << 12),
-  FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY  = (1 << 13),
-  FLATPAK_RUN_FLAG_SANDBOX            = (1 << 14),
-  FLATPAK_RUN_FLAG_NO_DOCUMENTS_PORTAL = (1 << 15),
-} FlatpakRunFlags;
-
 gboolean  flatpak_run_add_extension_args (FlatpakBwrap   *bwrap,
                                           GKeyFile     *metakey,
                                           const char   *full_ref,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2824,11 +2824,7 @@ flatpak_run_app (const char     *app_ref,
       flatpak_bwrap_add_fd (bwrap, ld_so_fd);
     }
 
-  if (flatpak_context_allows_features (app_context, FLATPAK_CONTEXT_FEATURE_DEVEL))
-    flags |= FLATPAK_RUN_FLAG_DEVEL;
-
-  if (flatpak_context_allows_features (app_context, FLATPAK_CONTEXT_FEATURE_MULTIARCH))
-    flags |= FLATPAK_RUN_FLAG_MULTIARCH;
+  flags |= flatpak_context_get_run_flags (app_context);
 
   if (!flatpak_run_setup_base_argv (bwrap, runtime_files, app_id_dir, app_ref_parts[2], flags, error))
     return FALSE;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1867,10 +1867,11 @@ static gboolean
 setup_seccomp (FlatpakBwrap *bwrap,
                const char *arch,
                gulong      allowed_personality,
-               gboolean    multiarch,
-               gboolean    devel,
+               FlatpakRunFlags run_flags,
                GError    **error)
 {
+  gboolean multiarch = (run_flags & FLATPAK_RUN_FLAG_MULTIARCH) != 0;
+  gboolean devel = (run_flags & FLATPAK_RUN_FLAG_DEVEL) != 0;
   __attribute__((cleanup (cleanup_seccomp))) scmp_filter_ctx seccomp = NULL;
 
   /**** BEGIN NOTE ON CODE SHARING
@@ -2262,12 +2263,7 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
   personality (pers);
 
 #ifdef ENABLE_SECCOMP
-  if (!setup_seccomp (bwrap,
-                      arch,
-                      pers,
-                      (flags & FLATPAK_RUN_FLAG_MULTIARCH) != 0,
-                      (flags & FLATPAK_RUN_FLAG_DEVEL) != 0,
-                      error))
+  if (!setup_seccomp (bwrap, arch, pers, flags, error))
     return FALSE;
 #endif
 

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -166,7 +166,7 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                  </para><para>
                     The <code>devel</code> feature allows the application to
@@ -178,6 +178,10 @@
                     natively by the system. For example, for the <code>x86_64</code>
                     architecture, 32-bit <code>x86</code> binaries will be allowed as
                     well.
+                </para><para>
+                    The <code>bluetooth</code> feature allows the application to
+                    use bluetooth (AF_BLUETOOTH) sockets. Note, for bluetooth to
+                    fully work you must also have network access.
                 </para></listitem>
             </varlistentry>
 
@@ -187,7 +191,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -184,18 +184,11 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
-                 </para><para>
-                    The <code>devel</code> feature allows the application to
-                    access certain syscalls such as <code>ptrace()</code>, and
-                <code>perf_event_open()</code>.
-                </para><para>
-                    The <code>multiarch</code> feature allows the application to
-                    execute programs compiled for an ABI other than the one supported
-                    natively by the system. For example, for the <code>x86_64</code>
-                    architecture, 32-bit <code>x86</code> binaries will be allowed as
-                    well.
+                    </para><para>
+                    See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+                    for the meaning of the various features.
                 </para></listitem>
             </varlistentry>
 
@@ -205,7 +198,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -371,6 +371,13 @@
                                 Available since 0.6.12.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>bluetooth</option></term>
+                            <listitem><para>
+                              Allow the application to use bluetooth (AF_BLUETOOTH) sockets.
+                              Note, for bluetooth to fully work you must also have network access.
+                              Available since 0.11.8.
+                            </para></listitem></varlistentry>
+
                         </variablelist>
                         A feature can be prefixed with <option>!</option> to
                         indicate the absence of that feature, for example

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -174,18 +174,11 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                  </para><para>
-                    The <code>devel</code> feature allows the application to
-                    access certain syscalls such as <code>ptrace()</code>, and
-                <code>perf_event_open()</code>.
-                </para><para>
-                    The <code>multiarch</code> feature allows the application to
-                    execute programs compiled for an ABI other than the one supported
-                    natively by the system. For example, for the <code>x86_64</code>
-                    architecture, 32-bit <code>x86</code> binaries will be allowed as
-                    well.
+                    See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+                    for the meaning of the various features.
                 </para></listitem>
             </varlistentry>
 
@@ -195,7 +188,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -225,8 +225,11 @@
                 <listitem><para>
                     Allow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
+                    </para><para>
+                    See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+                    for the meaning of the various features.
                 </para></listitem>
             </varlistentry>
 
@@ -236,7 +239,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel, multiarch.
+                    FEATURE must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This gives access to AF_BLUETOOTH sockets in the seccomp rules. You additionally
need to give network access for the sockets to really work, because the
kernel doesn't (yet) namespace bluetooth sockets.

Fixes https://github.com/flatpak/flatpak/issues/1719