### PR TITLE
Fix P2P build against ostree 2018.6 (backport to 0.10.x)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,26 +275,27 @@ AC_ARG_ENABLE(sudo,
               [SUDO_BIN="sudo"], [SUDO_BIN=""])
 AC_SUBST([SUDO_BIN])
 
-# Do we enable building peer to peer support using libostree’s experimental (non-stable) API?
-# If so, OSTREE_ENABLE_EXPERIMENTAL_API needs to be #defined before ostree.h is
-# included.
-AC_ARG_ENABLE([p2p],
-  [AS_HELP_STRING([--enable-p2p],
-                  [Enable unstable peer to peer support [default=no]])],,
-  [enable_p2p=no])
-AS_IF([test x$enable_p2p = xyes],[
-  PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
+# Decide whether to build with peer to peer support. This requires API in
+# libostree which before 2018.6 was experimental.
+enable_p2p=no
+PKG_CHECK_MODULES(OSTREE_P2P_REQ, [ostree-1 >= $OSTREE_REQS ostree-1 < 2018.6],[
 
   ostree_features=$($PKG_CONFIG --variable=features ostree-1)
   AS_CASE(["$ostree_features"],
           [*experimental*],[have_ostree_experimental=yes])
 
-  AS_IF([test "x$have_ostree_experimental" != "xyes"],
-        [AC_MSG_ERROR([Experimental API not found in ostree-1, which is needed for --enable-p2p. OSTree must be compiled with --enable-experimental-api.])])
-
-  AC_DEFINE([OSTREE_ENABLE_EXPERIMENTAL_API],[1],[Define if libostree experimental API should be enabled])
+  AS_IF([test "x$have_ostree_experimental" != "xyes"],[
+      AC_MSG_WARN([Experimental API not found in ostree-1, so flatpak will be compiled without P2P support. OSTree < 2018.6 must be compiled with --enable-experimental-api.])
+    ],[
+      enable_p2p=yes
+      AC_DEFINE([OSTREE_ENABLE_EXPERIMENTAL_API],[1],[Define if libostree experimental API should be enabled])
+      AC_DEFINE([FLATPAK_ENABLE_P2P],[1],[Define if peer to peer support should be enabled])
+    ])
+], :)
+PKG_CHECK_MODULES(OSTREE_2018_6, [ostree-1 >= 2018.6],[
+  enable_p2p=yes
   AC_DEFINE([FLATPAK_ENABLE_P2P],[1],[Define if peer to peer support should be enabled])
-])
+], :)
 AM_CONDITIONAL([ENABLE_P2P],[test x$enable_p2p = xyes])
 
 AC_ARG_WITH(system-install-dir,


### PR DESCRIPTION
ostree 2018.6 made the P2P API public that was previously experimental,
and added a "p2p" feature flag to replace "experimental". So this commit
updates the logic in flatpak's configure.ac so that we always enable P2P
support if ostree 2018.6 is available, and don't bother checking for a
feature flag or defining OSTREE_ENABLE_EXPERIMENTAL_API. This commit
also changes the behavior when flatpak is built against ostree <
2018.6. Specifically, P2P support is enabled if and only if we're
building against an ostree that has the relevant API, rather than
depending on the user to use `--enable-p2p` or `--disable-p2p`. This
way we can enable P2P by default (which will make it easier for Flathub
to enable P2P support) without breaking builds of flatpak
against versions of ostree without the experimental API.

In the near future we should remove all the ifdefs so that the P2P
functionality becomes unconditional, but if we wait for flatpak to take
a dependency on ostree 2018.6 we can avoid breaking any builds.