### PR TITLE
all: Use GMainContextPopDefault when handling thread defaults

### DIFF
--- a/app/flatpak-builtins-repo-update.c
+++ b/app/flatpak-builtins-repo-update.c
@@ -291,6 +291,7 @@ generate_all_deltas (OstreeRepo *repo,
   g_autoptr(GVariantBuilder) parambuilder = NULL;
   g_autoptr(GVariant) params = NULL;
   int n_spawned_delta_generate = 0;
+  g_autoptr(GMainContextPopDefault) context = NULL;
 
   g_print ("Generating static deltas\n");
 
@@ -316,7 +317,7 @@ generate_all_deltas (OstreeRepo *repo,
                               cancellable, error))
     return FALSE;
 
-  g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
+  context = flatpak_main_context_new_default ();
 
   g_hash_table_iter_init (&iter, all_refs);
   while (g_hash_table_iter_next (&iter, &key, &value))

--- a/app/flatpak-builtins-repo-update.c
+++ b/app/flatpak-builtins-repo-update.c
@@ -281,7 +281,6 @@ generate_all_deltas (OstreeRepo *repo,
                      GCancellable *cancellable,
                      GError **error)
 {
-  g_autoptr(GMainContext) context = g_main_context_new ();
   g_autoptr(GHashTable) all_refs = NULL;
   g_autoptr(GHashTable) all_deltas_hash = NULL;
   g_autoptr(GHashTable) wanted_deltas_hash = NULL;
@@ -317,7 +316,7 @@ generate_all_deltas (OstreeRepo *repo,
                               cancellable, error))
     return FALSE;
 
-  g_main_context_push_thread_default (context);
+  g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
 
   g_hash_table_iter_init (&iter, all_refs);
   while (g_hash_table_iter_next (&iter, &key, &value))
@@ -342,7 +341,7 @@ generate_all_deltas (OstreeRepo *repo,
           if (!spawn_delete_generation (context, &n_spawned_delta_generate, repo, params,
                                         ref, NULL, commit,
                                         error))
-            goto error;
+            return FALSE;
         }
 
       /* Mark this one as wanted */
@@ -368,7 +367,7 @@ generate_all_deltas (OstreeRepo *repo,
               if (!spawn_delete_generation (context, &n_spawned_delta_generate, repo, params,
                                             ref, parent_commit, commit,
                                             error))
-                goto error;
+                return FALSE;
             }
 
           /* Mark parent-to-current as wanted */
@@ -392,8 +391,6 @@ generate_all_deltas (OstreeRepo *repo,
   while (n_spawned_delta_generate > 0)
     g_main_context_iteration (context, TRUE);
 
-  g_main_context_pop_thread_default (context);
-
   *unwanted_deltas = g_ptr_array_new_with_free_func (g_free);
   for (i = 0; i < all_deltas->len; i++)
     {
@@ -403,10 +400,6 @@ generate_all_deltas (OstreeRepo *repo,
     }
 
   return TRUE;
-
- error:
-  g_main_context_pop_thread_default (context);
-  return FALSE;
 }
 
 gboolean

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2313,7 +2313,6 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
       /* Find the latest rev from the remote and its available mirrors, including
        * LAN and USB sources. */
       g_auto(GVariantBuilder) find_builder = FLATPAK_VARIANT_BUILDER_INITIALIZER;
-      g_autoptr(GMainContext) context = NULL;
       g_autoptr(GVariant) find_options = NULL;
       g_autoptr(GAsyncResult) find_result = NULL;
       g_auto(OstreeRepoFinderResultv) results = NULL;
@@ -2332,8 +2331,7 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
 
       find_options = g_variant_ref_sink (g_variant_builder_end (&find_builder));
 
-      context = g_main_context_new ();
-      g_main_context_push_thread_default (context);
+      g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
 
       ostree_repo_find_remotes_async (self->repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                       find_options,
@@ -2345,8 +2343,6 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
         g_main_context_iteration (context, TRUE);
 
       results = ostree_repo_find_remotes_finish (self->repo, find_result, error);
-
-      g_main_context_pop_thread_default (context);
 
       if (results == NULL)
         return FALSE;
@@ -2760,7 +2756,6 @@ repo_pull (OstreeRepo          *self,
     {
       GVariantBuilder find_builder, pull_builder;
       g_autoptr(GVariant) find_options = NULL, pull_options = NULL;
-      g_autoptr(GMainContext) context = NULL;
       g_autoptr(GAsyncResult) find_result = NULL, pull_result = NULL;
       g_auto(OstreeRepoFinderResultv) results = NULL;
       OstreeCollectionRef collection_ref;
@@ -2804,8 +2799,7 @@ repo_pull (OstreeRepo          *self,
                                force_disable_deltas, flags, progress);
       pull_options = g_variant_ref_sink (g_variant_builder_end (&pull_builder));
 
-      context = g_main_context_new ();
-      g_main_context_push_thread_default (context);
+      g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
 
       if (results_to_fetch == NULL)
         {
@@ -2835,8 +2829,6 @@ repo_pull (OstreeRepo          *self,
         }
       else
         res = FALSE;
-
-      g_main_context_pop_thread_default (context);
     }
   else
     res = FALSE;
@@ -3550,7 +3542,6 @@ flatpak_dir_pull (FlatpakDir          *self,
         {
           GVariantBuilder find_builder;
           g_autoptr(GVariant) find_options = NULL;
-          g_autoptr(GMainContext) context = NULL;
           g_autoptr(GAsyncResult) find_result = NULL;
           OstreeCollectionRef collection_ref;
           OstreeCollectionRef *collection_refs_to_fetch[2];
@@ -3582,8 +3573,7 @@ flatpak_dir_pull (FlatpakDir          *self,
 
           find_options = g_variant_ref_sink (g_variant_builder_end (&find_builder));
 
-          context = g_main_context_new ();
-          g_main_context_push_thread_default (context);
+          g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
 
           ostree_repo_find_remotes_async (self->repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                           find_options,
@@ -3594,8 +3584,6 @@ flatpak_dir_pull (FlatpakDir          *self,
             g_main_context_iteration (context, TRUE);
 
           allocated_results = ostree_repo_find_remotes_finish (self->repo, find_result, error);
-
-          g_main_context_pop_thread_default (context);
 
           results = (const OstreeRepoFinderResult * const *) allocated_results;
           if (results == NULL)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2319,6 +2319,7 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
       OstreeCollectionRef collection_ref = { state->collection_id, (char *) ref };
       OstreeCollectionRef *collection_refs_to_fetch[2] = { &collection_ref, NULL };
       gsize i;
+      g_autoptr(GMainContextPopDefault) context = NULL;
 
       /* Find options */
       g_variant_builder_init (&find_builder, G_VARIANT_TYPE ("a{sv}"));
@@ -2331,7 +2332,7 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
 
       find_options = g_variant_ref_sink (g_variant_builder_end (&find_builder));
 
-      g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
+      context = flatpak_main_context_new_default ();
 
       ostree_repo_find_remotes_async (self->repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                       find_options,
@@ -2761,6 +2762,7 @@ repo_pull (OstreeRepo          *self,
       OstreeCollectionRef collection_ref;
       OstreeCollectionRef *collection_refs_to_fetch[2];
       guint32 update_freq = 0;
+      g_autoptr(GMainContextPopDefault) context = NULL;
 
       /* Find options */
       g_variant_builder_init (&find_builder, G_VARIANT_TYPE ("a{sv}"));
@@ -2799,7 +2801,7 @@ repo_pull (OstreeRepo          *self,
                                force_disable_deltas, flags, progress);
       pull_options = g_variant_ref_sink (g_variant_builder_end (&pull_builder));
 
-      g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
+      context = flatpak_main_context_new_default ();
 
       if (results_to_fetch == NULL)
         {
@@ -3548,6 +3550,7 @@ flatpak_dir_pull (FlatpakDir          *self,
           gboolean force_disable_deltas = (flatpak_flags & FLATPAK_PULL_FLAGS_NO_STATIC_DELTAS) != 0;
           guint update_freq = 0;
           gsize i;
+          g_autoptr(GMainContextPopDefault) context = NULL;
 
           g_variant_builder_init (&find_builder, G_VARIANT_TYPE ("a{sv}"));
 
@@ -3573,7 +3576,7 @@ flatpak_dir_pull (FlatpakDir          *self,
 
           find_options = g_variant_ref_sink (g_variant_builder_end (&find_builder));
 
-          g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
+          context = flatpak_main_context_new_default ();
 
           ostree_repo_find_remotes_async (self->repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                           find_options,

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1006,9 +1006,11 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
    * because the refs array cannot be empty in ostree_repo_find_remotes_async
    * (otherwise it early returns and we never get our callback called) */
   if (collection_refs->len > 0) {
+    g_autoptr(GMainContextPopDefault) context = NULL;
+
     g_ptr_array_add (collection_refs, NULL);
 
-    g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
+    context = flatpak_main_context_new_default ();
 
     ostree_repo_find_remotes_async (flatpak_dir_get_repo (dir),
                                     (const OstreeCollectionRef * const *) collection_refs->pdata,
@@ -1117,6 +1119,7 @@ list_remotes_for_configured_remote (FlatpakInstallation  *self,
   OstreeRepoFinder *finders[3] = { NULL, };
   gsize i;
   guint finder_index = 0;
+  g_autoptr(GMainContextPopDefault) context = NULL;
 
   if (!types_filter[FLATPAK_REMOTE_TYPE_USB] &&
       !types_filter[FLATPAK_REMOTE_TYPE_LAN])
@@ -1130,7 +1133,7 @@ list_remotes_for_configured_remote (FlatpakInstallation  *self,
   if (collection_id == NULL || *collection_id == '\0')
     return TRUE;
 
-  g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
+  context = flatpak_main_context_new_default ();
 
   appstream_ref = g_strdup_printf ("appstream/%s", flatpak_get_arch ());
   ref.collection_id = collection_id;
@@ -1695,6 +1698,7 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
   FlatpakInstalledRef *result = NULL;
   g_autoptr(GFile) deploy_dir = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
+  g_autoptr(GMainContextPopDefault) main_context = NULL;
 
   dir = flatpak_installation_get_dir (self, error);
   if (dir == NULL)
@@ -1723,7 +1727,7 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
     return NULL;
 
   /* Work around ostree-pull spinning the default main context for the sync calls */
-  g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+  main_context = flatpak_main_context_new_default ();
 
   if (progress)
     ostree_progress = flatpak_progress_new (progress, progress_data);
@@ -1852,6 +1856,7 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
   g_autofree char *target_commit = NULL;
   g_auto(OstreeRepoFinderResultv) check_results = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
+  g_autoptr(GMainContextPopDefault) main_context = NULL;
 
   dir = flatpak_installation_get_dir (self, error);
   if (dir == NULL)
@@ -1892,7 +1897,7 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
     return NULL;
 
   /* Work around ostree-pull spinning the default main context for the sync calls */
-  g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+  main_context = flatpak_main_context_new_default ();
 
   if (progress)
     ostree_progress = flatpak_progress_new (progress, progress_data);
@@ -2358,6 +2363,7 @@ flatpak_installation_update_appstream_full_sync (FlatpakInstallation *self,
   g_autoptr(FlatpakDir) dir_clone = NULL;
   g_autoptr(OstreeAsyncProgress) ostree_progress = NULL;
   gboolean res;
+  g_autoptr(GMainContextPopDefault) main_context = NULL;
 
   dir = flatpak_installation_get_dir (self, error);
   if (dir == NULL)
@@ -2369,7 +2375,7 @@ flatpak_installation_update_appstream_full_sync (FlatpakInstallation *self,
     return FALSE;
 
   /* Work around ostree-pull spinning the default main context for the sync calls */
-  g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+  main_context = flatpak_main_context_new_default ();
 
   if (progress)
     ostree_progress = flatpak_progress_new (progress, progress_data);

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1005,30 +1005,31 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
    * dynamic remotes for them, to avoid extra unnecessary processing, and also
    * because the refs array cannot be empty in ostree_repo_find_remotes_async
    * (otherwise it early returns and we never get our callback called) */
-  if (collection_refs->len > 0) {
-    g_autoptr(GMainContextPopDefault) context = NULL;
+  if (collection_refs->len > 0)
+    {
+      g_autoptr(GMainContextPopDefault) context = NULL;
 
-    g_ptr_array_add (collection_refs, NULL);
+      g_ptr_array_add (collection_refs, NULL);
 
-    context = flatpak_main_context_new_default ();
+      context = flatpak_main_context_new_default ();
 
-    ostree_repo_find_remotes_async (flatpak_dir_get_repo (dir),
-                                    (const OstreeCollectionRef * const *) collection_refs->pdata,
-                                    NULL,  /* no options */
-                                    NULL, /* default finders */
-                                    NULL,  /* no progress */
-                                    cancellable,
-                                    async_result_cb,
-                                    &result);
+      ostree_repo_find_remotes_async (flatpak_dir_get_repo (dir),
+                                      (const OstreeCollectionRef * const *) collection_refs->pdata,
+                                      NULL,  /* no options */
+                                      NULL, /* default finders */
+                                      NULL,  /* no progress */
+                                      cancellable,
+                                      async_result_cb,
+                                      &result);
 
-    while (result == NULL)
-      g_main_context_iteration (context, TRUE);
+      while (result == NULL)
+        g_main_context_iteration (context, TRUE);
 
-    results = ostree_repo_find_remotes_finish (flatpak_dir_get_repo (dir), result, error);
+      results = ostree_repo_find_remotes_finish (flatpak_dir_get_repo (dir), result, error);
 
-    if (results == NULL)
-      return NULL;
-  }
+      if (results == NULL)
+        return NULL;
+    }
 
   for (i = 0; i < installed->len; i++)
     {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1347,6 +1347,7 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
   GMainLoop *main_loop = NULL;
   struct JobData data;
   gboolean res = FALSE;
+  g_autoptr(GMainContextPopDefault) main_context = NULL;
 
   path = g_strdup_printf ("/run/user/%d/systemd/private", getuid ());
 
@@ -1354,7 +1355,7 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
     return flatpak_fail (error,
                          "No systemd user session available, cgroups not available");
 
-  g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+  main_context = flatpak_main_context_new_default ();
   main_loop = g_main_loop_new (main_context, FALSE);
 
   address = g_strconcat ("unix:path=", path, NULL);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1344,7 +1344,6 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
   GVariant *properties = NULL;
   GVariant *aux = NULL;
   guint32 pid;
-  GMainContext *main_context = NULL;
   GMainLoop *main_loop = NULL;
   struct JobData data;
   gboolean res = FALSE;
@@ -1355,10 +1354,8 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
     return flatpak_fail (error,
                          "No systemd user session available, cgroups not available");
 
-  main_context = g_main_context_new ();
+  g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
   main_loop = g_main_loop_new (main_context, FALSE);
-
-  g_main_context_push_thread_default (main_context);
 
   address = g_strconcat ("unix:path=", path, NULL);
 
@@ -1411,11 +1408,6 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
   res = TRUE;
 
 out:
-  if (main_context)
-    {
-      g_main_context_pop_thread_default (main_context);
-      g_main_context_unref (main_context);
-    }
   if (main_loop)
     g_main_loop_unref (main_loop);
   if (manager)

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -311,8 +311,10 @@ handle_deploy (FlatpakSystemHelper   *object,
     }
   else if (strlen (arg_repo_path) > 0)
     {
+      g_autoptr(GMainContextPopDefault) main_context = NULL;
+
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+      main_context = flatpak_main_context_new_default ();
 
       ostree_progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
 
@@ -333,6 +335,8 @@ handle_deploy (FlatpakSystemHelper   *object,
     }
   else if (local_pull)
     {
+      g_autoptr(GMainContextPopDefault) main_context = NULL;
+
       g_autoptr(FlatpakRemoteState) state = NULL;
       if (!ostree_repo_remote_get_url (flatpak_dir_get_repo (system),
                                        arg_origin,
@@ -360,7 +364,7 @@ handle_deploy (FlatpakSystemHelper   *object,
         }
 
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+      main_context = flatpak_main_context_new_default ();
 
       ostree_progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
 
@@ -513,9 +517,10 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
     {
       g_autoptr(GError) first_error = NULL;
       g_autoptr(GError) second_error = NULL;
+      g_autoptr(GMainContextPopDefault) main_context = NULL;
 
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+      main_context = flatpak_main_context_new_default ();
 
       if (!flatpak_dir_pull_untrusted_local (system, arg_repo_path,
                                              arg_origin,
@@ -546,6 +551,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
       g_autoptr(GError) first_error = NULL;
       g_autoptr(GError) second_error = NULL;
       g_autofree char *url = NULL;
+      g_autoptr(GMainContextPopDefault) main_context = NULL;
 
       if (!ostree_repo_remote_get_url (flatpak_dir_get_repo (system),
                                        arg_origin,
@@ -573,7 +579,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
         }
 
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
+      main_context = flatpak_main_context_new_default ();
 
       ostree_progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
 

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -160,7 +160,6 @@ handle_deploy (FlatpakSystemHelper   *object,
   gboolean no_deploy;
   gboolean local_pull;
   gboolean reinstall;
-  g_autoptr(GMainContext) main_context = NULL;
   g_autofree char *url = NULL;
 
   g_debug ("Deploy %s %u %s %s %s", arg_repo_path, arg_flags, arg_ref, arg_origin, arg_installation);
@@ -313,8 +312,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   else if (strlen (arg_repo_path) > 0)
     {
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      main_context = g_main_context_new ();
-      g_main_context_push_thread_default (main_context);
+      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
 
       ostree_progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
 
@@ -325,12 +323,10 @@ handle_deploy (FlatpakSystemHelper   *object,
                                              ostree_progress,
                                              NULL, &error))
         {
-          g_main_context_pop_thread_default (main_context);
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                                                  "Error pulling from repo: %s", error->message);
           return TRUE;
         }
-      g_main_context_pop_thread_default (main_context);
 
       if (ostree_progress)
         ostree_async_progress_finish (ostree_progress);
@@ -364,8 +360,7 @@ handle_deploy (FlatpakSystemHelper   *object,
         }
 
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      main_context = g_main_context_new ();
-      g_main_context_push_thread_default (main_context);
+      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
 
       ostree_progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
 
@@ -373,13 +368,10 @@ handle_deploy (FlatpakSystemHelper   *object,
                              FLATPAK_PULL_FLAGS_NONE, OSTREE_REPO_PULL_FLAGS_UNTRUSTED, ostree_progress,
                              NULL, &error))
         {
-          g_main_context_pop_thread_default (main_context);
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                                                  "Error pulling from repo: %s", error->message);
           return TRUE;
         }
-
-      g_main_context_pop_thread_default (main_context);
 
       if (ostree_progress)
         ostree_async_progress_finish (ostree_progress);
@@ -430,7 +422,6 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
 {
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
-  g_autoptr(GMainContext) main_context = NULL;
   g_autofree char *new_branch = NULL;
   g_autofree char *old_branch = NULL;
   gboolean is_oci;
@@ -524,8 +515,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
       g_autoptr(GError) second_error = NULL;
 
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      main_context = g_main_context_new ();
-      g_main_context_push_thread_default (main_context);
+      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
 
       if (!flatpak_dir_pull_untrusted_local (system, arg_repo_path,
                                              arg_origin,
@@ -541,7 +531,6 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
                                                  NULL,
                                                  NULL, &second_error))
             {
-              g_main_context_pop_thread_default (main_context);
               g_prefix_error (&first_error, "Error updating appstream2: ");
               g_prefix_error (&second_error, "%s; Error updating appstream: ", first_error->message);
               g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
@@ -549,8 +538,6 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
               return TRUE;
             }
         }
-
-      g_main_context_pop_thread_default (main_context);
     }
   else /* empty path == local pull */
     {
@@ -586,8 +573,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
         }
 
       /* Work around ostree-pull spinning the default main context for the sync calls */
-      main_context = g_main_context_new ();
-      g_main_context_push_thread_default (main_context);
+      g_autoptr(GMainContextPopDefault) main_context = flatpak_main_context_new_default ();
 
       ostree_progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
 
@@ -599,7 +585,6 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
                                  FLATPAK_PULL_FLAGS_NONE, OSTREE_REPO_PULL_FLAGS_UNTRUSTED, ostree_progress,
                                  NULL, NULL))
             {
-              g_main_context_pop_thread_default (main_context);
               g_prefix_error (&first_error, "Error updating appstream2: ");
               g_prefix_error (&second_error, "%s; Error updating appstream: ", first_error->message);
               g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
@@ -607,8 +592,6 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
               return TRUE;
             }
         }
-
-      g_main_context_pop_thread_default (main_context);
 
       if (ostree_progress)
         ostree_async_progress_finish (ostree_progress);


### PR DESCRIPTION
Simplify some of the return logic when handling pushing/popping the
thread default main context by using g_autoptr(GMainContextPopDefault).

Signed-off-by: Philip Withnall <withnall@endlessm.com>