### PR TITLE
tests: Hacks to handle coreutils-single

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -65,6 +65,7 @@ $FLATPAK info ${U} org.test.Hello | grep $ID > /dev/null
 
 echo "ok install"
 
+test -n "${DEBUG_SHELL:-}" && env PS1='debugshell$ ' bash
 run org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 


### PR DESCRIPTION
In the Fedora 28 base container, `coreutils-single` is used and so
`/usr/bin/ls` is actually a "script":

```
$ file /usr/bin/ls
/usr/bin/ls: a /usr/bin/coreutils --coreutils-prog-shebang=ls script, ASCII text executable
```

This breaks the code to generate a runtime.  I got partway on this but
I have to context switch.  I also dislike programming nontrivial things in bash.
It's tempting to just use the rpm filelists, or undo the coreutils-single change
in the test container.