### PR TITLE
common: Update flatpakinclude_HEADERS

### DIFF
--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -15,6 +15,8 @@ flatpakinclude_HEADERS = \
 	common/flatpak-installation.h \
 	common/flatpak-remote.h \
 	common/flatpak-version-macros.h \
+	common/flatpak-portal-error.h \
+	common/flatpak-transaction.h \
 	$(NULL)
 
 nodist_flatpakinclude_HEADERS = \


### PR DESCRIPTION
These headers were recently added to flatpak.h, so they need to be in
flatpakinclude_HEADERS so they are installed.