### PR TITLE
Make various operation work without a system installation

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -398,7 +398,7 @@ flatpak_complete_info (FlatpakCompletion *completion)
 
   context = g_option_context_new ("");
   if (!flatpak_option_context_parse (context, options, &completion->argc, &completion->argv,
-                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS, &dirs, NULL, NULL))
+                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS|FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO, &dirs, NULL, NULL))
     return FALSE;
 
   kinds = FLATPAK_KINDS_APP | FLATPAK_KINDS_RUNTIME;

--- a/app/flatpak-builtins-list-remotes.c
+++ b/app/flatpak-builtins-list-remotes.c
@@ -54,7 +54,7 @@ flatpak_builtin_list_remotes (int argc, char **argv, GCancellable *cancellable, 
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,
-                                     FLATPAK_BUILTIN_FLAG_STANDARD_DIRS, &dirs, cancellable, error))
+                                     FLATPAK_BUILTIN_FLAG_STANDARD_DIRS|FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO, &dirs, cancellable, error))
     return FALSE;
 
   if (argc > 1)

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -313,7 +313,7 @@ flatpak_builtin_list (int argc, char **argv, GCancellable *cancellable, GError *
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,
-                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS,
+                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS|FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO,
                                      &dirs, cancellable, error))
     return FALSE;
 

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -243,7 +243,8 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,
-                                     FLATPAK_BUILTIN_FLAG_STANDARD_DIRS, &dirs, cancellable, error))
+                                     FLATPAK_BUILTIN_FLAG_STANDARD_DIRS | FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO,
+                                     &dirs, cancellable, error))
     return FALSE;
 
   if (argc < 2)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8997,7 +8997,7 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
   g_autoptr(GHashTable) local_refs = NULL;
   int i;
 
-  if (!flatpak_dir_ensure_repo (self, NULL, error))
+  if (!flatpak_dir_maybe_ensure_repo (self, NULL, error))
     return NULL;
 
   local_refs = g_hash_table_new_full (flatpak_collection_ref_hash,


### PR DESCRIPTION
This makes info, list, remotes, and search work if there is no
system flatpak repo. Before it failed with EPERM.