### PR TITLE
Don't allow uninstalling runtime that apps use

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -247,6 +247,7 @@ guint64             flatpak_deploy_data_get_installed_size (GVariant *deploy_dat
 const char *        flatpak_deploy_data_get_alt_id (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_eol (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_eol_rebase (GVariant *deploy_data);
+const char *        flatpak_deploy_data_get_runtime (GVariant *deploy_data);
 
 GFile *        flatpak_deploy_get_dir (FlatpakDeploy *deploy);
 GVariant *     flatpak_load_deploy_data (GFile *deploy_dir,

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -85,7 +85,7 @@ assert_has_file $FL_DIR/repo/org.test.Hello-origin.trustedkeys.gpg
 
 echo "ok install app bundle"
 
-${FLATPAK} uninstall ${U} org.test.Platform
+${FLATPAK} uninstall --force-remove ${U} org.test.Platform
 
 assert_not_has_file $FL_DIR/repo/refs/remotes/org.test.Platform-origin/runtime/org.test.Platform/$ARCH/master
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -28,7 +28,7 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-
     skip_without_p2p
 fi
 
-echo "1..21"
+echo "1..22"
 
 #Regular repo
 setup_repo
@@ -259,6 +259,25 @@ assert_not_file_has_content list-log "^org.test.Hello"
 assert_not_file_has_content list-log "^org.test.Platform"
 
 echo "ok uninstall vs installations"
+
+${FLATPAK} ${U} install -y test-repo org.test.Hello
+
+${FLATPAK} ${U} list -d > list-log
+assert_file_has_content list-log "^org.test.Hello"
+assert_file_has_content list-log "^org.test.Platform"
+
+if ${FLATPAK} ${U} uninstall org.test.Platform; then
+    assert_not_reached "Should not be able to uninstall ${U} when there is a dependency installed"
+fi
+
+${FLATPAK} ${U} uninstall org.test.Hello
+${FLATPAK} ${U} uninstall org.test.Platform
+
+${FLATPAK} ${U} list -d > list-log
+assert_not_file_has_content list-log "^org.test.Hello"
+assert_not_file_has_content list-log "^org.test.Platform"
+
+echo "ok uninstall dependencies"
 
 ${FLATPAK} ${U} install -y --no-deploy test-repo org.test.Hello
 


### PR DESCRIPTION
If an application in the same installation uses the runtime we don't allow you to uninstall it.
Also, we need to take this into consideration when ordering uninstalls if both the app and its runtime are being uninstalled at the same time.