### PR TITLE
uninstall --unused

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -76,6 +76,7 @@ typedef struct
   char          **subpaths;
   gboolean        download;
   gboolean        delete;
+  gboolean        auto_prune;
 } FlatpakRelated;
 
 void         flatpak_related_free (FlatpakRelated *related);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11201,20 +11201,24 @@ local_match_prefix (FlatpakDir *self,
       g_hash_table_iter_init (&hash_iter, refs);
       while (g_hash_table_iter_next (&hash_iter, &key, NULL))
         {
-          char *ref = key;
-          g_auto(GStrv) cur_parts = g_strsplit (ref, "/", -1);
+          const char *partial_ref_and_origin = key;
+          g_autofree char *partial_ref = NULL;
+          g_auto(GStrv) cur_parts = NULL;
+
+          ostree_parse_refspec (partial_ref_and_origin, NULL, &partial_ref, NULL);
+
+          cur_parts = g_strsplit (partial_ref, "/", -1);
 
           /* Must match type, arch, branch */
-          if (strcmp (parts[0], cur_parts[0]) != 0 ||
-              strcmp (parts[2], cur_parts[2]) != 0 ||
-              strcmp (parts[3], cur_parts[3]) != 0)
+          if (strcmp (parts[2], cur_parts[1]) != 0 ||
+              strcmp (parts[3], cur_parts[2]) != 0)
             continue;
 
           /* But only prefix of id */
-          if (!g_str_has_prefix (cur_parts[1], parts_prefix))
+          if (!g_str_has_prefix (cur_parts[0], parts_prefix))
             continue;
 
-          g_ptr_array_add (matches, g_strdup (ref));
+          g_ptr_array_add (matches, g_strconcat (parts[0], "/", partial_ref, NULL));
         }
     }
 

--- a/common/flatpak-related-ref.c
+++ b/common/flatpak-related-ref.c
@@ -45,6 +45,7 @@ struct _FlatpakRelatedRefPrivate
   char   **subpaths;
   gboolean download;
   gboolean delete;
+  gboolean autoprune;
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (FlatpakRelatedRef, flatpak_related_ref, FLATPAK_TYPE_REF)
@@ -55,6 +56,7 @@ enum {
   PROP_SUBPATHS,
   PROP_SHOULD_DOWNLOAD,
   PROP_SHOULD_DELETE,
+  PROP_SHOULD_AUTOPRUNE,
 };
 
 static void
@@ -87,6 +89,10 @@ flatpak_related_ref_set_property (GObject      *object,
       priv->delete = g_value_get_boolean (value);
       break;
 
+    case PROP_SHOULD_AUTOPRUNE:
+      priv->autoprune = g_value_get_boolean (value);
+      break;
+
     case PROP_SUBPATHS:
       g_clear_pointer (&priv->subpaths, g_strfreev);
       priv->subpaths = g_strdupv (g_value_get_boxed (value));
@@ -115,6 +121,10 @@ flatpak_related_ref_get_property (GObject    *object,
 
     case PROP_SHOULD_DELETE:
       g_value_set_boolean (value, priv->delete);
+      break;
+
+    case PROP_SHOULD_AUTOPRUNE:
+      g_value_set_boolean (value, priv->autoprune);
       break;
 
     case PROP_SUBPATHS:
@@ -148,6 +158,13 @@ flatpak_related_ref_class_init (FlatpakRelatedRefClass *klass)
                                    g_param_spec_boolean ("should-delete",
                                                          "Should delete",
                                                          "Whether to auto-delete the ref with the main ref",
+                                                         FALSE,
+                                                         G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (object_class,
+                                   PROP_SHOULD_AUTOPRUNE,
+                                   g_param_spec_boolean ("should-autoprune",
+                                                         "Should autoprune",
+                                                         "Whether to delete when pruning unused refs",
                                                          FALSE,
                                                          G_PARAM_READWRITE|G_PARAM_CONSTRUCT_ONLY|G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (object_class,
@@ -198,6 +215,24 @@ flatpak_related_ref_should_delete (FlatpakRelatedRef *self)
   FlatpakRelatedRefPrivate *priv = flatpak_related_ref_get_instance_private (self);
 
   return priv->delete;
+}
+
+/**
+ * flatpak_related_ref_should_autoprune:
+ * @self: a #FlatpakRelatedRef
+ *
+ * Returns whether to delete when pruning unused refs.
+ *
+ * Returns: %TRUE if the ref should be considered unused when pruning.
+ *
+ * Since: 0.11.8
+ */
+gboolean
+flatpak_related_ref_should_autoprune (FlatpakRelatedRef *self)
+{
+  FlatpakRelatedRefPrivate *priv = flatpak_related_ref_get_instance_private (self);
+
+  return priv->autoprune;
 }
 
 /**

--- a/common/flatpak-related-ref.h
+++ b/common/flatpak-related-ref.h
@@ -53,5 +53,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRelatedRef, g_object_unref)
 FLATPAK_EXTERN const char * const *flatpak_related_ref_get_subpaths (FlatpakRelatedRef *self);
 FLATPAK_EXTERN gboolean     flatpak_related_ref_should_download (FlatpakRelatedRef *self);
 FLATPAK_EXTERN gboolean     flatpak_related_ref_should_delete (FlatpakRelatedRef *self);
+FLATPAK_EXTERN gboolean     flatpak_related_ref_should_autoprune (FlatpakRelatedRef *self);
 
 #endif /* __FLATPAK_RELATED_REF_H__ */

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -78,6 +78,7 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_DIRECTORY "directory"
 #define FLATPAK_METADATA_KEY_DOWNLOAD_IF "download-if"
 #define FLATPAK_METADATA_KEY_ENABLE_IF "enable-if"
+#define FLATPAK_METADATA_KEY_AUTOPRUNE_UNLESS "autoprune-unless"
 #define FLATPAK_METADATA_KEY_MERGE_DIRS "merge-dirs"
 #define FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD "no-autodownload"
 #define FLATPAK_METADATA_KEY_SUBDIRECTORIES "subdirectories"

--- a/doc/flatpak-uninstall.xml
+++ b/doc/flatpak-uninstall.xml
@@ -138,6 +138,28 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--all</option></term>
+                <listitem><para>
+                    Remove all refs on the system.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--unused</option></term>
+                <listitem><para>
+                    Remove unused refs on the system.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-y</option></term>
+                <term><option>--assumeyes</option></term>
+                <listitem><para>
+                    Automatically answer yes to all questions. This is useful for automation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--app</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
This removes all runtimes that are not used by some app, or any sdk used by a runtime that some app uses.
