### PR TITLE
deploy: Do required-version check on deploy too

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6025,13 +6025,18 @@ flatpak_dir_deploy (FlatpakDir          *self,
                             &metadata_contents, NULL, NULL, NULL))
     {
       g_autoptr(GKeyFile) keyfile = g_key_file_new ();
-      if (g_key_file_load_from_data (keyfile,
+      if (!g_key_file_load_from_data (keyfile,
                                       metadata_contents,
                                       -1,
                                       0, error))
-        application_runtime = g_key_file_get_string (keyfile,
-                                                     FLATPAK_METADATA_GROUP_APPLICATION,
-                                                     FLATPAK_METADATA_KEY_RUNTIME, NULL);
+        return FALSE;
+
+      application_runtime = g_key_file_get_string (keyfile,
+                                                   FLATPAK_METADATA_GROUP_APPLICATION,
+                                                   FLATPAK_METADATA_KEY_RUNTIME, NULL);
+
+      if (!flatpak_check_required_version (ref, keyfile, error))
+        return FALSE;
     }
 
   /* Check the metadata in the commit to make sure it matches the actual

--- a/common/flatpak-error.h
+++ b/common/flatpak-error.h
@@ -39,6 +39,7 @@ G_BEGIN_DECLS
  * @FLATPAK_ERROR_DIFFERENT_REMOTE: The App/Runtime is already installed, but from a different remote.
  * @FLATPAK_ERROR_ABORTED: The transaction was aborted (returned TRUE in operation-error signal).
  * @FLATPAK_ERROR_SKIPPED: The App/Runtime install was skipped due to earlier errors.
+ * @FLATPAK_ERROR_NEED_NEW_FLATPAK: The App/Runtime needs a more recent version of flatpak.
  *
  * Error codes for library functions.
  */
@@ -49,6 +50,7 @@ typedef enum {
   FLATPAK_ERROR_DIFFERENT_REMOTE,
   FLATPAK_ERROR_ABORTED,
   FLATPAK_ERROR_SKIPPED,
+  FLATPAK_ERROR_NEED_NEW_FLATPAK,
 } FlatpakError;
 
 #define FLATPAK_ERROR flatpak_error_quark ()

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -625,7 +625,6 @@ FlatpakXml *flatpak_xml_find (FlatpakXml  *node,
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakXml, flatpak_xml_free);
 
-
 FlatpakXml *flatpak_appstream_xml_new (void);
 gboolean   flatpak_appstream_xml_migrate (FlatpakXml *source,
                                           FlatpakXml *dest,
@@ -691,5 +690,9 @@ OstreeAsyncProgress *flatpak_progress_new (FlatpakProgressCallback progress,
                                            gpointer                progress_data);
 
 void flatpak_log_dir_access (FlatpakDir *dir);
+
+gboolean flatpak_check_required_version (const char *ref,
+                                         GKeyFile *metakey,
+                                         GError **error);
 
 #endif /* __FLATPAK_UTILS_H__ */


### PR DESCRIPTION
We only checked this in transaction. This is now the recommended way to installation
via libflatpak too, but if you use the old API this check also ensures that
installation fails if the required version is too old.

Also, we add a specific error code for this so callers can check for it.

Fixes https://github.com/flatpak/flatpak/issues/881