### PR TITLE
Support accessing host trusted certificates

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1705,6 +1705,7 @@ add_monitor_path_args (gboolean use_session_helper,
 {
   g_autoptr(AutoFlatpakSessionHelper) session_helper = NULL;
   g_autofree char *monitor_path = NULL;
+  g_autoptr(GVariant) session_data = NULL;
 
   if (use_session_helper)
     {
@@ -1717,17 +1718,18 @@ add_monitor_path_args (gboolean use_session_helper,
     }
 
   if (session_helper &&
-      flatpak_session_helper_call_request_monitor_sync (session_helper,
-                                                        &monitor_path,
+      flatpak_session_helper_call_request_session_sync (session_helper,
+                                                        &session_data,
                                                         NULL, NULL))
     {
-      flatpak_bwrap_add_args (bwrap,
-                              "--ro-bind", monitor_path, "/run/host/monitor",
-                              "--symlink", "/run/host/monitor/localtime", "/etc/localtime",
-                              "--symlink", "/run/host/monitor/resolv.conf", "/etc/resolv.conf",
-                              "--symlink", "/run/host/monitor/host.conf", "/etc/host.conf",
-                              "--symlink", "/run/host/monitor/hosts", "/etc/hosts",
-                              NULL);
+      if (g_variant_lookup (session_data, "path", "s", &monitor_path))
+        flatpak_bwrap_add_args (bwrap,
+                                "--ro-bind", monitor_path, "/run/host/monitor",
+                                "--symlink", "/run/host/monitor/localtime", "/etc/localtime",
+                                "--symlink", "/run/host/monitor/resolv.conf", "/etc/resolv.conf",
+                                "--symlink", "/run/host/monitor/host.conf", "/etc/host.conf",
+                                "--symlink", "/run/host/monitor/hosts", "/etc/hosts",
+                                NULL);
     }
   else
     {

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -30,6 +30,10 @@
     <method name="RequestMonitor">
       <arg type='ay' name='path' direction='out'/>
     </method>
+
+    <method name="RequestSession">
+      <arg type='a{sv}' name='data' direction='out'/>
+    </method>
   </interface>
 
   <interface name='org.freedesktop.Flatpak.Development'>


### PR DESCRIPTION
If p11-kit server is installed on the host, we spawn a copy of this, forwarding the access to the p11-kit trust module in a read-only way.
    
We then (if the above worked) bind mount the socket as /run/user/$UID/p11-kit/pkcs11 in the sandbox,   which is the default socket path for the p11-kit-client module.
    
We also add a configuration file in /etc/pkcs11/modules/p11-kit-trust.module that makes the trust module actually load the client module instead. This means applications automatically switch to using the host certs for trust if possible, and use the runtime ca-certificates otherwise.
    
Additionally we add a config file that always disables pkcs user config merging, because pkcs11 modules on the host are unlikely to work in a random runtime.
