### PR TITLE
Improve test diagnostics, wait longer for web server 

### DIFF
--- a/tests/test-webserver.sh
+++ b/tests/test-webserver.sh
@@ -12,6 +12,8 @@ child_pid=$!
 for x in $(seq 50); do
     # Snapshot the output
     cp ${test_tmpdir}/httpd-output{,.tmp}
+    sed -ne 's/^/# httpd-output.tmp: /' < ${test_tmpdir}/httpd-output.tmp >&2
+    echo >&2
     # If it's non-empty, see whether it matches our regexp
     if test -s ${test_tmpdir}/httpd-output.tmp; then
         sed -e 's,Serving HTTP on 0.0.0.0 port \([0-9]*\) \.\.\.,\1,' < ${test_tmpdir}/httpd-output.tmp > ${test_tmpdir}/httpd-port

--- a/tests/test-webserver.sh
+++ b/tests/test-webserver.sh
@@ -8,8 +8,10 @@ test_tmpdir=$(pwd)
 cd ${dir}
 env PYTHONUNBUFFERED=1 setsid python -m SimpleHTTPServer 0 >${test_tmpdir}/httpd-output &
 child_pid=$!
+echo "Web server pid: $child_pid" >&2
 
-for x in $(seq 50); do
+for x in $(seq 300); do
+    echo "Waiting for web server ($x/300)..." >&2
     # Snapshot the output
     cp ${test_tmpdir}/httpd-output{,.tmp}
     sed -ne 's/^/# httpd-output.tmp: /' < ${test_tmpdir}/httpd-output.tmp >&2

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -889,7 +889,7 @@ run_test_subprocess (char **argv,
   g_test_message ("Spawning %s", argv_str);
 
   if (flags & RUN_TEST_SUBPROCESS_NO_CAPTURE)
-    g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL, NULL, NULL, &status, &error);
+    g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL, NULL, NULL, NULL, NULL, &status, &error);
   else
     g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, &output, &errors, &status, &error);
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1152,7 +1152,7 @@ global_setup (void)
   g_mkdir_with_parents (homedir, S_IRWXU|S_IRWXG|S_IRWXO);
 
   g_setenv ("HOME", homedir, TRUE);
-  g_test_message ("setting HOME=%s", datadir);
+  g_test_message ("setting HOME=%s", homedir);
 
   cachedir = g_strconcat (testdir, "/home/cache", NULL);
   g_mkdir_with_parents (cachedir, S_IRWXU|S_IRWXG|S_IRWXO);


### PR DESCRIPTION
While updating Flatpak in Debian to 0.11.8 I ran into some build-time test failures, which seemed to be caused by the web server taking a few seconds to start, perhaps because other tests were being run in parallel.