### PR TITLE
Add ssh-auth socket support

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -40,6 +40,7 @@ typedef enum {
   FLATPAK_CONTEXT_SOCKET_SESSION_BUS = 1 << 3,
   FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS  = 1 << 4,
   FLATPAK_CONTEXT_SOCKET_FALLBACK_X11 = 1 << 5, /* For backwards compat, also set SOCKET_X11 */
+  FLATPAK_CONTEXT_SOCKET_SSH_AUTH    = 1 << 6,
 } FlatpakContextSockets;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -59,6 +59,7 @@ const char *flatpak_context_sockets[] = {
   "session-bus",
   "system-bus",
   "fallback-x11",
+  "ssh-auth",
   NULL
 };
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -252,6 +252,32 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
   return res;
 }
 
+static void
+flatpak_run_add_ssh_args(FlatpakBwrap *bwrap)
+{
+  const char * auth_socket;
+  g_autofree char * sandbox_auth_socket = NULL;
+
+  auth_socket = g_getenv ("SSH_AUTH_SOCK");
+
+  if (!auth_socket)
+    return; /* ssh agent not present */
+
+  if (!g_file_test (auth_socket, G_FILE_TEST_EXISTS))
+    {
+      /* Let's clean it up, so that the application will not try to connect */
+      flatpak_bwrap_unset_env(bwrap, "SSH_AUTH_SOCK");
+      return;
+    }
+
+  sandbox_auth_socket = g_strdup_printf ("/run/user/%d/ssh-auth", getuid());
+
+  flatpak_bwrap_add_args (bwrap,
+                          "--bind", auth_socket, sandbox_auth_socket,
+                          NULL);
+  flatpak_bwrap_set_env (bwrap, "SSH_AUTH_SOCK", sandbox_auth_socket, TRUE);
+}
+
 /* Try to find a default server from a pulseaudio confguration file */
 static char *
 flatpak_run_get_pulseaudio_server_user_config (const char *path)
@@ -1050,6 +1076,10 @@ flatpak_run_add_environment_args (FlatpakBwrap   *bwrap,
     allow_x11 = (context->sockets & FLATPAK_CONTEXT_SOCKET_X11) != 0;
 
   flatpak_run_add_x11_args (bwrap, allow_x11);
+
+  if (context->sockets & FLATPAK_CONTEXT_SOCKET_SSH_AUTH) {
+    flatpak_run_add_ssh_args (bwrap);
+  }
 
   if (context->sockets & FLATPAK_CONTEXT_SOCKET_PULSEAUDIO)
     {

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -122,7 +122,7 @@
                 <listitem><para>
                     Expose a well known socket to the application. This updates
                     the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -133,7 +133,7 @@
                 <listitem><para>
                     Don't expose a well known socket to the application. This updates
                     the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -140,7 +140,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -151,7 +151,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -142,7 +142,7 @@
                     <term><option>sockets</option> (list)</term>
                     <listitem><para>
                         List of well-known sockets to make available in the sandbox.
-                        Possible sockets: x11, wayland, fallback-x11, pulseaudio, session-bus, system-bus.
+                        Possible sockets: x11, wayland, fallback-x11, pulseaudio, session-bus, system-bus, ssh-auth.
                         When making a socket available, flatpak also sets
                         well-known environment variables like DISPLAY or
                         DBUS_SYSTEM_BUS_ADDRESS to let the application

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -130,7 +130,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -141,7 +141,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -181,7 +181,7 @@
                 <listitem><para>
                     Expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -192,7 +192,7 @@
                 <listitem><para>
                     Don't expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus.
+                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
SSH authentication sockets can be placed in a number of places, so it
is difficult for applications to just mount a fixed directory or
directories, hoping that SSH_AUTH_SOCK points somewhere inside the
mounted content.