### PR TITLE
appstream: Allow multiple components per app

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3602,8 +3602,8 @@ extract_appstream (OstreeRepo   *repo,
               g_clear_error (&my_error);
             }
 
-          /* We updated icons for our component, so we're done */
-          break;
+          /* We might match other prefixes, so keep on going */
+          component = component->next_sibling;
         }
     }
 


### PR DESCRIPTION
Some apps (like libreoffice) has multiple sup-apps, so we allow them to have multiple
appstream components (as well as e.g. multiple desktop files).

Fixes #1749