### PR TITLE
Add missing options to flatpak-info docs

### DIFF
--- a/doc/flatpak-info.xml
+++ b/doc/flatpak-info.xml
@@ -45,8 +45,18 @@
         </para>
         <para>
             By default, the output is formatted in a friendly format.
-            If you specify one of the options --show-ref, --show-commit,
-            --show-origin, --show-metadata or --show-size, the output is instead formatted
+            If you specify one of the options
+            --show-ref,
+            --show-origin,
+            --show-commit,
+            --show-size,
+            --show-metadata,
+            --show-permissions,
+            --file-access,
+            --show-location,
+            --show-runtime or
+            --show-sdk,
+            the output is instead formatted
             in a machine-readable format.
         </para>
         <para>

--- a/doc/flatpak-info.xml
+++ b/doc/flatpak-info.xml
@@ -153,6 +153,39 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--show-runtime</option></term>
+
+                <listitem><para>
+                    Show the runtime.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--show-sdk</option></term>
+
+                <listitem><para>
+                    Show the SDK.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-M</option></term>
+                <term><option>--show-permissions</option></term>
+
+                <listitem><para>
+                    Show the permissions.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--file-access=PATH</option></term>
+
+                <listitem><para>
+                    Show the level of access to the given path.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-e</option></term>
                 <term><option>--show-extensions</option></term>
 
@@ -171,10 +204,10 @@
             </varlistentry>
 
             <varlistentry>
-                <term><option>--version</option></term>
+                <term><option>--ostree-verbose</option></term>
 
                 <listitem><para>
-                    Print version information and exit.
+                    Print OSTree debug information during command processing.
                 </para></listitem>
             </varlistentry>
         </variablelist>


### PR DESCRIPTION
Compared to `flatpak info --help` (which is what actually counts), 4
options were not documented, and one (--version) was documented but
doesn't exist.