### PR TITLE
doc: Uncomment and tweak P2P docs

### DIFF
--- a/doc/flatpak-build-bundle.xml
+++ b/doc/flatpak-build-bundle.xml
@@ -48,11 +48,11 @@
             in the repository at <arg choice="plain">LOCATION</arg>. If
             a <arg choice="plain">BRANCH</arg> is specified, this branch of
             the application is used.
-            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+        </para>
+        <para>
             The collection ID set on the repository at
             <arg choice="plain">LOCATION</arg> (if set) will be used for the
             bundle.
-            -->
         </para>
         <para>
             The format of the bundle file is that of an ostree static delta

--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -46,11 +46,11 @@
             contents (and most of the metadata) taken from another
             branch, either from another repo, or from another branch in
             the same repository.
-            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
+        </para>
+        <para>
             The collection ID set on
             <arg choice="plain">DST-REPO</arg> (if set) will be used for the
             newly created commits.
-            -->
         </para>
         <para>
             This command is very useful when you want to maintain a branch

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -63,16 +63,14 @@
             subdirectories and the <filename>metadata</filename> file are included
             in the commit, anything else is ignored.
         </para>
-        <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
         <para>
             When exporting a flatpak to be published to the internet,
-            <option>-FIXME-collection-id=COLLECTION-ID</option> should be specified
+            <option>--collection-id=COLLECTION-ID</option> should be specified
             as a globally unique reverse DNS value to identify the collection of
             flatpaks this will be added to. Setting a globally unique collection
             ID allows the apps in the repository to be shared over peer to peer
             systems without needing further configuration.
         </para>
-        -->
         <para>
             The build-update-repo command should be used to update repository
             metadata whenever application builds are added to a repository.
@@ -112,9 +110,8 @@
                 </para></listitem>
             </varlistentry>
 
-            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
             <varlistentry>
-                <term><option>-FIXME-collection-id=COLLECTION-ID</option></term>
+                <term><option>--collection-id=COLLECTION-ID</option></term>
 
                 <listitem><para>
                     Set as the collection ID of the repository. Setting a globally
@@ -125,7 +122,6 @@
                     repository.
                 </para></listitem>
             </varlistentry>
-            -->
 
             <varlistentry>
                 <term><option>--arch=ARCH</option></term>

--- a/doc/flatpak-build-update-repo.xml
+++ b/doc/flatpak-build-update-repo.xml
@@ -102,9 +102,8 @@
                 </para></listitem>
             </varlistentry>
 
-            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
             <varlistentry>
-                <term><option>-FIXME-collection-id=COLLECTION-ID</option></term>
+                <term><option>--collection-id=COLLECTION-ID</option></term>
 
                 <listitem><para>
                     The globally unique identifier of the remote repository, to
@@ -117,10 +116,10 @@
             </varlistentry>
 
             <varlistentry>
-                <term><option>-FIXME-deploy-collection-id</option></term>
+                <term><option>--deploy-collection-id</option></term>
 
                 <listitem><para>
-                    Deploy the collection ID (set using <option>-FIXME-collection-id</option>
+                    Deploy the collection ID (set using <option>--collection-id</option>
                     in the static remote configuration for all clients. This is
                     irrevocable once published in a repository. Use it to decide
                     when to roll out a collection ID to users of an existing repository.
@@ -128,7 +127,6 @@
                     you should typically always pass this option.
                 </para></listitem>
             </varlistentry>
-            -->
 
             <varlistentry>
                 <term><option>--gpg-sign=KEYID</option></term>

--- a/doc/flatpak-flatpakref.xml
+++ b/doc/flatpak-flatpakref.xml
@@ -107,13 +107,10 @@
                     <term><option>Homepage</option> (string)</term>
                     <listitem><para>The url of a webpage describing the application or runtime.</para></listitem>
                 </varlistentry>
-                <!--
-                FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
                 <varlistentry>
                     <term><option>CollectionID</option> (string)</term>
                     <listitem><para>The collection ID of the remote, if it has one. This uniquely identifies the collection of apps in the remote, to allow peer to peer redistribution.</para></listitem>
                 </varlistentry>
-                -->
 
                 <varlistentry>
                     <term><option>IsRuntime</option> (boolean)</term>

--- a/doc/flatpak-flatpakrepo.xml
+++ b/doc/flatpak-flatpakrepo.xml
@@ -103,13 +103,10 @@
                     <term><option>Homepage</option> (string)</term>
                     <listitem><para>The url of a webpage describing the remote.</para></listitem>
                 </varlistentry>
-                <!--
-                FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
                 <varlistentry>
                     <term><option>CollectionID</option> (string)</term>
                     <listitem><para>The collection ID of the remote, if it has one. This uniquely identifies the collection of apps in the remote, to allow peer to peer redistribution.</para></listitem>
                 </varlistentry>
-                -->
             </variablelist>
         </refsect2>
     </refsect1>
@@ -121,10 +118,7 @@
 Title=GEdit
 Url=http://sdk.gnome.org/repo-apps/
 GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
-<!--
-FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
 CollectionID=org.gnome.Apps
--->
 </programlisting>
     </refsect1>
 

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -665,7 +665,6 @@
                         Available since 0.6.7.
                     </para></listitem>
                 </varlistentry>
-                <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
                 <varlistentry>
                     <term><option>collection-id</option> (string)</term>
                     <listitem><para>
@@ -674,10 +673,9 @@
                         or runtime that the extension point is for.
                         Currently, extension points must be in the same collection as the
                         application or runtime that they are for.
-                        Available since FIXME.
+                        Available since 0.99.1.
                     </para></listitem>
                 </varlistentry>
-                -->
             </variablelist>
         </refsect2>
         <refsect2>

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -189,18 +189,16 @@
                 </para></listitem>
             </varlistentry>
 
-            <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
             <varlistentry>
-                <term><option>-FIXME-collection-id=COLLECTION-ID</option></term>
+                <term><option>--collection-id=COLLECTION-ID</option></term>
 
                 <listitem><para>
                     The globally unique identifier of the remote repository, to
                     allow mirrors to be grouped. This must only be set to the
                     collection ID provided by the remote, and must not be set if the
-                    remote does not provide an collection ID.
+                    remote does not provide a collection ID.
                 </para></listitem>
             </varlistentry>
-            -->
 
             <varlistentry>
                 <term><option>--url=URL</option></term>

--- a/doc/flatpak-remote.xml
+++ b/doc/flatpak-remote.xml
@@ -80,18 +80,13 @@
                     <term><option>gpg-verify-summary</option> (boolean)</term>
                     <listitem>
                         <para>Whether to use GPG verification for the summary of this remote.</para>
-                        <!--
-                        FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
                         <para>This is ignored if <option>collection-id</option> is set, as refs are verified in commit metadata in that case. Enabling <option>gpg-verify-summary</option> would break peer to peer distribution of refs.</para>
-                        -->
                     </listitem>
                 </varlistentry>
-                <!-- FIXME: Uncomment this when enable-p2p is enabled unconditionally.
                 <varlistentry>
                     <term><option>collection-id</option> (string)</term>
                     <listitem><para>The globally unique identifier for the upstream collection repository, to allow mirrors to be grouped.</para></listitem>
                 </varlistentry>
-                -->
             </variablelist>
             <para>
                 All flatpak-specific keys have a xa. prefix:
@@ -148,13 +143,17 @@
 [remote "gnome-nightly-apps"]
 gpg-verify=true
 gpg-verify-summary=true
-<!--
-FIXME: Uncomment this when P2P support is made unconditional on enable-p2p.
-gpg-verify-summary=false
-collection-id=org.gnome.Apps.Nightly
--->
 url=https://sdk.gnome.org/nightly/repo-apps/
 xa.title=GNOME Applications
+</programlisting>
+
+<programlisting>
+[remote "flathub"]
+gpg-verify=true
+gpg-verify-summary=false
+collection-id=org.flathub.Stable
+url=https://dl.flathub.org/repo/
+xa.title=Flathub
 </programlisting>
 
     </refsect1>


### PR DESCRIPTION
Now that P2P support is enabled unconditionally, uncomment the
P2P-related parts of the man pages.