### PR TITLE
tests: Run P2P tests unconditionally

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -338,14 +338,6 @@ skip_without_python2 () {
     fi
 }
 
-skip_without_p2p () {
-    if ! ${FLATPAK} remote-add --help | grep -q -e '--collection-id'; then
-        echo "1..0 # SKIP this test requires peer to peer support (--enable-p2p)"
-        exit 0
-    fi
-}
-
-
 sed s#@testdir@#${test_builddir}# ${test_srcdir}/session.conf.in > session.conf
 dbus-daemon --fork --config-file=session.conf --print-address=3 --print-pid=4 \
     3> dbus-session-bus-address 4> dbus-session-bus-pid

--- a/tests/test-build-update-repo.sh
+++ b/tests/test-build-update-repo.sh
@@ -26,7 +26,6 @@ set -euo pipefail
 
 skip_without_bwrap
 [ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
-skip_without_p2p
 
 echo "1..2"
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,10 +24,6 @@ set -euo pipefail
 skip_without_bwrap
 [ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
-if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] || [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
-    skip_without_p2p
-fi
-
 echo "1..22"
 
 #Regular repo

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -26,7 +26,6 @@ set -euo pipefail
 
 skip_without_bwrap
 [ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
-skip_without_p2p
 
 echo "1..7"
 

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -26,7 +26,6 @@ set -euo pipefail
 
 skip_without_bwrap
 [ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
-skip_without_p2p
 
 echo "1..3"
 


### PR DESCRIPTION
Now that Flatpak always has P2P support enabled, the tests that are
dependent on it can always run.