### PR TITLE
Remove outdated ostree version check

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1060,14 +1060,10 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
             continue;
 
           /* The ref_to_checksum map only tells us if this remote is offering
-           * the latest commit of the available remotes, not what the timestamp
-           * is. So unless we're using a new enough version of ostree to
-           * provide ref_to_timestamp, we have no way of knowing if the commit
-           * is an update or a downgrade (we could check the summary but
-           * there's no signature, and we'd have to add the temporary remote to
-           * the local configuration).
+           * the latest commit of the available remotes; we have to check
+           * ref_to_timestamp to know if the commit is an update or a
+           * downgrade.
            */
-#ifdef OSTREE_VERSION_2018_5
             {
               guint64 local_timestamp = 0;
               guint64 *remote_timestamp;
@@ -1088,7 +1084,6 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
               if (*remote_timestamp != 0 && *remote_timestamp <= local_timestamp)
                 continue;
             }
-#endif /* OSTREE_VERSION_2018_5 */
 
           g_ptr_array_add (updates, g_object_ref (installed_ref));
 

--- a/configure.ac
+++ b/configure.ac
@@ -232,9 +232,6 @@ fi
 
 PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
 
-# FIXME: Remove this check and the use of it when the ostree requirement is at least 2018.5
-PKG_CHECK_MODULES(OSTREE_2018_5, [ostree-1 >= 2018.5], AC_DEFINE([OSTREE_VERSION_2018_5], [1], [Define if ostree is at least version 2018.5]), :)
-
 PKG_CHECK_MODULES(JSON, [json-glib-1.0])
 
 PKG_CHECK_MODULES(APPSTREAM_GLIB, [appstream-glib >= 0.5.10])


### PR DESCRIPTION
Now that flatpak depends on ostree 2018.6 we don't need to check if we
have 2018.5. Remove the check and update a comment.