### PR TITLE
Include appstream and icons in OCI bundles as annotations

### DIFF
--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -44,6 +44,13 @@ for i in oci/registry/blobs/sha256/*; do
 done
 sha256sum -c sums
 
+digest=$(grep sha256: oci/registry/index.json | sed s'@.*sha256:\([a-fA-F0-9]\+\).*@\1@')
+manifest=oci/registry/blobs/sha256/$digest
+
+assert_has_file $manifest
+assert_file_has_content $manifest "org.freedesktop.appstream.appdata.*<summary>Print a greeting</summary>"
+assert_file_has_content $manifest "org.freedesktop.appstream.icon-64"
+
 echo "ok export oci"
 
 ostree --repo=repo2 init --mode=archive-z2


### PR DESCRIPTION
Include annotations:

 org.freedesktop.appstream.appdata
 org.freedesktop.appstream.icon-{64,128}

into OCI bundles. This not only makes the bundle self-describing, but also
if the bundle is imported into a registry, it becomes possible to browse
the registry and recreate an appstream by only retrieving the annotations
for relevant images, without having to download the actual images.

The icon annotations are formatted as data: URI's with base64 data. The idea
is that a server-side process to collect annotations could extract the icons
to separate storage and rewrite the URI's to remote URL's.