### PR TITLE
Run the tests in /tmp

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -311,14 +311,6 @@ run_sh () {
     ${CMD_PREFIX} flatpak run --command=bash ${ARGS-} org.test.Hello -c "$*"
 }
 
-skip_without_user_xattrs () {
-    touch ${TEST_DATA_DIR}/test-xattrs
-    if ! setfattr -n user.testvalue -v somevalue ${TEST_DATA_DIR}/test-xattrs; then
-        echo "1..0 # SKIP this test requires xattr support"
-        exit 0
-    fi
-}
-
 skip_without_bwrap () {
     if [ -z "${FLATPAK_BWRAP:-}" ]; then
         # running installed-tests: assume we know what we're doing

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -72,8 +72,7 @@ fi
 export MALLOC_CHECK_=3
 export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))
 
-# We need this to be in /var/tmp because /tmp has no xattr support
-TEST_DATA_DIR=`mktemp -d /var/tmp/test-flatpak-XXXXXX`
+TEST_DATA_DIR=`mktemp -d /tmp/test-flatpak-XXXXXX`
 mkdir -p ${TEST_DATA_DIR}/home
 mkdir -p ${TEST_DATA_DIR}/runtime
 mkdir -p ${TEST_DATA_DIR}/system

--- a/tests/test-build-update-repo.sh
+++ b/tests/test-build-update-repo.sh
@@ -25,7 +25,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..2"
 

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..7"
 

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..2"
 

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -24,7 +24,6 @@ set -euo pipefail
 export FLATPAK_ENABLE_EXPERIMENTAL_OCI=1
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..2"
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..22"
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..12"
 

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -25,7 +25,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..7"
 

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -25,7 +25,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
-[ x${USE_SYSTEMDIR-} != xyes ] || skip_without_user_xattrs
 
 echo "1..3"
 


### PR DESCRIPTION
Since we don't actually need xattrs anymore this should be faster.