### PR TITLE
CI: Don't build ostree

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -7,19 +7,10 @@ dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
 pkg_install sudo which attr fuse bison \
-    libubsan libasan libtsan \
-    elfutils git gettext-devel libappstream-glib-devel \
+    libubsan libasan libtsan clang python2 \
+    elfutils git gettext-devel libappstream-glib-devel hicolor-icon-theme \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree
-pkg_install_if_os fedora gjs parallel clang python2
 pkg_install_builddeps flatpak
-
-pkg_install_builddeps ostree
-(git clone --depth=1 https://github.com/ostreedev/ostree.git
- cd ostree
- unset CFLAGS # the sanitizers require calling apps be linked too
- build --disable-introspection
- make install
-)
 
 build --enable-gtk-doc ${CONFIGOPTS:-}


### PR DESCRIPTION
ostree 2018.6 is in updates-testing now, use that.