### PR TITLE
Fix more build issues for generated files in app/

### DIFF
--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -83,4 +83,5 @@ flatpak_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS
 flatpak_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
         -I$(srcdir)/app \
+        -I$(builddir)/app \
         -DLOCALEDIR=\"$(localedir)\"


### PR DESCRIPTION
Now that app/ contains generated sources, we need to tell make how to generate the .h, and make sure it can be included from the $(builddir) for out-of-tree builds, as we already did for common/.