### PR TITLE
Improve test diagnostics

### DIFF
--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -982,7 +982,6 @@ add_remote (void)
   g_autofree char *port = NULL;
   g_autofree char *pid = NULL;
   g_autofree char *collection_id_arg = NULL;
-  g_autofree char *argv_str = NULL;
 
   launch_httpd ();
 


### PR DESCRIPTION
While debugging some test issues in the Debian stretch backport (which turned out to be an outdated ostree command-line utility) I noticed that new test coverage added since commit 86fd56dce didn't take advantage of the `run_test_subprocess()` helper.