### PR TITLE
system-helper: Add EnsureRepo operation

### DIFF
--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -136,6 +136,10 @@
       <arg type='s' name='installation' direction='in'/>
     </method>
 
+    <method name="EnsureRepo">
+      <arg type='s' name='installation' direction='in'/>
+    </method>
+
   </interface>
 
 </node>


### PR DESCRIPTION
This is used to create the /var/lib/flatpak repo if
needed so that other later operations work. We have
some partial support for it not working in various
operations (using the allow_empty argument) but
this is in no way complete. For example, this
can easily happen if you have a per-user installation
but no system one and then you run flatpak install
with no --user, then it will try to figure out
which one to use and die.