### PR TITLE
tests: Fix up ioctl suppressions for tests

### DIFF
--- a/tests/flatpak.supp
+++ b/tests/flatpak.supp
@@ -27,7 +27,6 @@
    ioctl(generic)
    fun:ioctl
    fun:glnx_regfile_copy_bytes
-   fun:glnx_file_copy_at
 }
 
 # There seem to be some leaks in "ostree pull", lets just ignore them for now


### PR DESCRIPTION
The FICLONE ioctl suppression was hit via a different
codepath too, so tweak the callstack for the
suppression.