### PR TITLE
Fix error handling while deploying AppStream

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -589,7 +589,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
         {
           if (!flatpak_dir_pull (system, state, old_branch, NULL, NULL, NULL, NULL,
                                  FLATPAK_PULL_FLAGS_NONE, OSTREE_REPO_PULL_FLAGS_UNTRUSTED, ostree_progress,
-                                 NULL, NULL))
+                                 NULL, &second_error))
             {
               g_prefix_error (&first_error, "Error updating appstream2: ");
               g_prefix_error (&second_error, "%s; Error updating appstream: ", first_error->message);


### PR DESCRIPTION
Setting an error with second_error->message is going to work poorly
when second_error has never been set non-NULL.

Related to #1845, although not necessarily the full solution.

Signed-off-by: Simon McVittie <smcv@collabora.com>