### PR TITLE
transaction: Fix NULL pointer dereference

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1414,7 +1414,7 @@ flatpak_transaction_add_install_flatpakref (FlatpakTransaction *self,
 
   if (!g_key_file_load_from_data (keyfile, g_bytes_get_data (flatpakref_data, NULL),
                                   g_bytes_get_size (flatpakref_data),
-                                  0, error))
+                                  0, &local_error))
     return flatpak_fail (error, "Invalid .flatpakref: %s", local_error->message);
 
   priv->flatpakrefs = g_list_append (priv->flatpakrefs, g_steal_pointer (&keyfile));


### PR DESCRIPTION
This fixes coverity issue 1471684, and ensures we can correctly generate
an error message in flatpak_transaction_add_install_flatpakref().