### PR TITLE
app: Drop some dead code

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -483,16 +483,7 @@ update_appstream (GPtrArray    *dirs,
 
               if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
                   flatpak_dir_get_remote_noenumerate (dir, remotes[i]))
-                {
-                  if (local_error)
-                    {
-                      if (quiet)
-                        g_debug ("%s: %s", _("Error updating"), local_error->message);
-                      else
-                        g_printerr ("%s: %s\n", _("Error updating"), local_error->message);
-                    }
-                  continue;
-                }
+                continue;
 
               if (flatpak_dir_is_user (dir))
                 {


### PR DESCRIPTION
Since commit 096f7d4fb dropped flatpak_dir_check_for_appstream_update(),
this code can never be reached. Drop it to fix coverity issue 1471677.