### PR TITLE
dir: Propagate errors from copying summary{.sig}

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -415,7 +415,7 @@ flatpak_remote_state_save_summary (FlatpakRemoteState *self,
   if (!g_file_replace_contents (summary_file,
                                 g_bytes_get_data (summary_bytes, NULL),
                                 g_bytes_get_size (summary_bytes),
-                                NULL, FALSE, 0, NULL, cancellable, NULL))
+                                NULL, FALSE, 0, NULL, cancellable, error))
     return FALSE;
 
   if (self->summary_sig_bytes != NULL)
@@ -424,7 +424,7 @@ flatpak_remote_state_save_summary (FlatpakRemoteState *self,
       if (!g_file_replace_contents (summary_sig_file,
                                     g_bytes_get_data (self->summary_sig_bytes, NULL),
                                     g_bytes_get_size (self->summary_sig_bytes),
-                                    NULL, FALSE, 0, NULL, cancellable, NULL))
+                                    NULL, FALSE, 0, NULL, cancellable, error))
         return FALSE;
     }
 


### PR DESCRIPTION
This commit ensures that flatpak_remote_state_save_summary()
initializes the passed GError pointer when returning FALSE. I found this
when looking into https://github.com/flatpak/flatpak/issues/1255 because
at the time of that bug report flatpak_dir_update_appstream() had this
g_file_replace_contents() code in it, which would have caused a seg
fault in update_appstream() after an unsuccessful call to
flatpak_dir_update_appstream().

Fixes https://github.com/flatpak/flatpak/issues/1255