### PR TITLE
manpage: Refer to flatpak-metadata documentation

### DIFF
--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -341,6 +341,13 @@ key=v1;v2;
 
                 <listitem><para>
                   Add extension point info.
+                  See the documentation for
+                  <citerefentry>
+                    <refentrytitle>flatpak-metadata</refentrytitle>
+                    <manvolnum>5</manvolnum>
+                  </citerefentry>
+                  for the possible values of
+                  <replaceable>VARIABLE</replaceable> and <replaceable>VALUE</replaceable>.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
The documentation for extension info can be found there.

See #1341.