### PR TITLE
Warn when skipping installations

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -704,11 +704,18 @@ append_locations_from_config_file (GPtrArray    *locations,
       size_t len;
 
       if (!g_str_has_prefix (groups[i], "Installation \""))
-        continue;
+        {
+          if (g_str_has_prefix (groups[i], "Installation "))
+            g_warning ("Installation without quotes (%s). Ignoring", groups[i]);
+          continue;
+        }
 
       id = g_strdup (&groups[i][14]);
       if (!g_str_has_suffix (id, "\""))
-        continue;
+        {
+          g_warning ("Installation without closing quote (%s). Ignoring", groups[i]);
+          continue;
+        }
 
       len = strlen (id);
       if (len > 0)


### PR DESCRIPTION
When we fail to parse an installation, emit some
warnings that give the user a chance to figure out
what is going wrong. I ran into the missing quotes
issue myself when I first tried to create a custom
installation.