### PR TITLE
Avoid a crash in the absence of system bus

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1304,7 +1304,8 @@ flatpak_dir_finalize (GObject *object)
   g_clear_object (&self->basedir);
   g_clear_pointer (&self->extra_data, dir_extra_data_free);
 
-  g_clear_object (&self->system_helper_bus);
+  if (self->system_helper_bus != (gpointer)1)
+    g_clear_object (&self->system_helper_bus);
 
   g_clear_object (&self->soup_session);
   g_clear_pointer (&self->summary_cache, g_hash_table_unref);


### PR DESCRIPTION
When the system bus is not available, we set
system_helper_bus to (gpointer)1. And then we
segfault in finalize, trying to unref it.

Thats not nice, so avoid it.