### PR TITLE
Add --disable-fsync to build-export and build-commit-from

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -40,6 +40,7 @@ static char *opt_body;
 static gboolean opt_update_appstream;
 static gboolean opt_no_update_summary;
 static gboolean opt_untrusted;
+static gboolean opt_disable_fsync;
 static gboolean opt_force;
 static char **opt_gpg_key_ids;
 static char *opt_gpg_homedir;
@@ -59,6 +60,7 @@ static GOptionEntry options[] = {
   { "gpg-homedir", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_homedir, N_("GPG Homedir to use when looking for keyrings"), N_("HOMEDIR") },
   { "end-of-life", 0, 0, G_OPTION_ARG_STRING, &opt_endoflife, N_("Mark build as end-of-life"), N_("REASON") },
   { "timestamp", 0, 0, G_OPTION_ARG_STRING, &opt_timestamp, N_("Override the timestamp of the commit (NOW for current time)"), N_("TIMESTAMP") },
+  { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
   { NULL }
 };
 
@@ -270,6 +272,9 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
   dst_repo = ostree_repo_new (dst_repofile);
   if (!ostree_repo_open (dst_repo, cancellable, error))
     return FALSE;
+
+  if (opt_disable_fsync)
+    ostree_repo_set_disable_fsync (dst_repo, TRUE);
 
   if (opt_src_repo)
     {

--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -39,6 +39,7 @@ static char *opt_arch;
 static gboolean opt_runtime;
 static gboolean opt_update_appstream;
 static gboolean opt_no_update_summary;
+static gboolean opt_disable_fsync;
 static char **opt_gpg_key_ids;
 static char **opt_exclude;
 static char **opt_include;
@@ -65,6 +66,7 @@ static GOptionEntry options[] = {
   { "end-of-life", 0, 0, G_OPTION_ARG_STRING, &opt_endoflife, N_("Mark build as end-of-life"), N_("REASON") },
   { "timestamp", 0, 0, G_OPTION_ARG_STRING, &opt_timestamp, N_("Override the timestamp of the commit"), N_("TIMESTAMP") },
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id, N_("Collection ID"), "COLLECTION-ID" },
+  { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
 
   { NULL }
 };
@@ -807,6 +809,9 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
       if (!ostree_repo_create (repo, OSTREE_REPO_MODE_ARCHIVE_Z2, cancellable, error))
         goto out;
     }
+
+  if (opt_disable_fsync)
+    ostree_repo_set_disable_fsync (repo, TRUE);
 
   /* Get the canonical collection ID which we’ll use for the commit. This might
    * be %NULL if the existing repo doesn’t have one and none was specified on

--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -158,6 +158,15 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--disable-fsync</option></term>
+
+                <listitem><para>
+                  Don't fsync when writing to the repository. This can result in data loss in exceptional situations, but can improve performance when
+                  working with temporary or test repositories.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--gpg-sign=KEYID</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -178,6 +178,15 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--disable-fsync</option></term>
+
+                <listitem><para>
+                  Don't fsync when writing to the repository. This can result in data loss in exceptional situations, but can improve performance when
+                  working with temporary or test repositories.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--update-appstream</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
This mirrors ostree commit --disable-fsync and is useful in some cases.
For instance, we'd like to use it when building the temporary import
repositories in flathub.