### PR TITLE
dir: Fix detection of downgrades for P2P operations

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3545,6 +3545,10 @@ repo_pull (OstreeRepo                           *self,
   if (!ostree_repo_resolve_rev (self, remote_and_branch, TRUE, &current_checksum, error))
     return FALSE;
 
+  if (current_checksum != NULL &&
+      !ostree_repo_load_commit (self, current_checksum, &old_commit, NULL, error))
+    return FALSE;
+
   if (!repo_get_remote_collection_id (self, remote_name, &collection_id, NULL))
     g_clear_pointer (&collection_id, g_free);
 
@@ -3659,10 +3663,6 @@ repo_pull (OstreeRepo                           *self,
                              g_variant_new_variant (g_variant_new_strv ((const char * const *) revs_to_fetch, -1)));
 
       options = g_variant_ref_sink (g_variant_builder_end (&builder));
-
-      if (current_checksum != NULL &&
-          !ostree_repo_load_commit (self, current_checksum, &old_commit, NULL, error))
-        return FALSE;
 
       if (!ostree_repo_pull_with_options (self, remote_name, options,
                                           progress, cancellable, error))


### PR DESCRIPTION
In general Flatpak tries to prevent downgrades of anything: apps,
runtimes, repo metadata, etc. with some exceptions such as when the user
specifies a commit they want. However at the moment the detection of a
downgrade is broken if both of the following are true: (1) a collection
ID is enabled on the relevant remote, and (2) a per-user installation
is being used instead of the system-wide one (or the system-helper is
otherwise being circumvented, such as by running flatpak as root).

This bug is a security vulnerability, but it's one with limited impact
because very few people have collection IDs enabled yet, and the
downgrade attack would require either a MITM on the network connection
(which HTTPS should prevent) or a malicious USB drive or local network
peer.