### PR TITLE
NULL initialize g_auto variables

### DIFF
--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -74,7 +74,7 @@ get_remote_stores (GPtrArray *dirs, const char *arch, GCancellable *cancellable)
           as_store_set_add_flags (store, as_store_get_add_flags (store) | AS_STORE_ADD_FLAG_USE_UNIQUE_ID);
 #endif
 
-          g_autofree char *appstream_path;
+          g_autofree char *appstream_path = NULL;
 
           if (flatpak_dir_get_remote_oci (dir, remotes[j]))
             appstream_path = g_build_filename (install_path, "appstream", remotes[j],

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3152,9 +3152,9 @@ replace_contents_compressed (GFile        *dest,
                              GCancellable *cancellable,
                              GError      **error)
 {
-  g_autoptr(GZlibCompressor) compressor;
-  g_autoptr(GFileOutputStream) out;
-  g_autoptr(GOutputStream) out2;
+  g_autoptr(GZlibCompressor) compressor = NULL;
+  g_autoptr(GFileOutputStream) out = NULL;
+  g_autoptr(GOutputStream) out2 = NULL;
 
   compressor = g_zlib_compressor_new (G_ZLIB_COMPRESSOR_FORMAT_GZIP, -1);
   out = g_file_replace (dest, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3878,7 +3878,7 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
         /* No need to commit if nothing changed */
         if (parent)
           {
-            g_autoptr(GFile) parent_root;
+            g_autoptr(GFile) parent_root = NULL;
 
             if (!ostree_repo_read_commit (repo, parent, &parent_root, NULL, cancellable, error))
               return FALSE;


### PR DESCRIPTION
It's a good idea to NULL initialize g_autoptr/g_autofree variables, so
we can be sure uninitialized memory isn't passed to g_free or similar.