### PR TITLE
Replace FlatpakCollectionRef with OstreeCollectionRef

### DIFF
--- a/app/flatpak-builtins-ls-remote.c
+++ b/app/flatpak-builtins-ls-remote.c
@@ -215,7 +215,7 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
       g_hash_table_iter_init (&iter, refs);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          FlatpakCollectionRef *coll_ref = key;
+          OstreeCollectionRef *coll_ref = key;
           char *ref = coll_ref->ref_name;
           char *partial_ref;
           const char *slash = strchr (ref, '/');
@@ -233,7 +233,7 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
       g_hash_table_iter_init (&iter, refs);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          FlatpakCollectionRef *coll_ref = key;
+          OstreeCollectionRef *coll_ref = key;
           const char *ref = coll_ref->ref_name;
           const char *checksum = value;
           const char *name = NULL;
@@ -294,7 +294,7 @@ flatpak_builtin_ls_remote (int argc, char **argv, GCancellable *cancellable, GEr
               strcmp (arches[0], parts[2]) != 0)
             {
               g_autofree char *alt_arch_ref = g_strconcat (parts[0], "/", parts[1], "/", arches[0], "/", parts[3], NULL);
-              g_autoptr(FlatpakCollectionRef) alt_arch_coll_ref = flatpak_collection_ref_new (coll_ref->collection_id, alt_arch_ref);
+              g_autoptr(OstreeCollectionRef) alt_arch_coll_ref = ostree_collection_ref_new (coll_ref->collection_id, alt_arch_ref);
               if (g_hash_table_lookup (refs, alt_arch_coll_ref))
                 continue;
             }

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -126,21 +126,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDeploy, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRelated, flatpak_related_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRemoteState, flatpak_remote_state_unref)
 
-typedef struct
-{
-  char *collection_id;
-  char *ref_name;
-} FlatpakCollectionRef;
-
-FlatpakCollectionRef *    flatpak_collection_ref_new (const char *collection_id,
-                                                      const char *ref_name);
-void                      flatpak_collection_ref_free (FlatpakCollectionRef *ref);
-guint                     flatpak_collection_ref_hash (gconstpointer ref);
-gboolean                  flatpak_collection_ref_equal (gconstpointer ref1,
-                                                        gconstpointer ref2);
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakCollectionRef, flatpak_collection_ref_free)
-
 typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_NONE = 0,
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE = 1 << 0,

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1630,7 +1630,7 @@ flatpak_installation_install_ref_file (FlatpakInstallation *self,
   g_autofree char *remote = NULL;
   g_autofree char *ref = NULL;
   g_autofree char *collection_id = NULL;
-  g_autoptr(FlatpakCollectionRef) coll_ref = NULL;
+  g_autoptr(OstreeCollectionRef) coll_ref = NULL;
   g_autoptr(GKeyFile) keyfile = g_key_file_new ();
 
   dir = flatpak_installation_get_dir (self, error);
@@ -1649,7 +1649,7 @@ flatpak_installation_install_ref_file (FlatpakInstallation *self,
   if (!flatpak_installation_drop_caches (self, cancellable, error))
     return NULL;
 
-  coll_ref = flatpak_collection_ref_new (collection_id, ref);
+  coll_ref = ostree_collection_ref_new (collection_id, ref);
   return flatpak_remote_ref_new (coll_ref, NULL, remote, NULL);
 }
 
@@ -2208,7 +2208,7 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
       FlatpakRemoteRef *ref;
-      FlatpakCollectionRef *coll_ref = key;
+      OstreeCollectionRef *coll_ref = key;
       const gchar *ref_commit = value;
 
       ref = flatpak_remote_ref_new (coll_ref, ref_commit, remote_or_uri, state);
@@ -2249,7 +2249,7 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
   g_autoptr(GHashTable) ht = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
   g_autofree char *ref = NULL;
-  g_autoptr(FlatpakCollectionRef) coll_ref = NULL;
+  g_autoptr(OstreeCollectionRef) coll_ref = NULL;
   g_autofree gchar *collection_id = NULL;
   const char *checksum;
 
@@ -2283,7 +2283,7 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
                                      branch,
                                      arch);
 
-  coll_ref = flatpak_collection_ref_new (collection_id, ref);
+  coll_ref = ostree_collection_ref_new (collection_id, ref);
   checksum = g_hash_table_lookup (ht, coll_ref);
 
   /* If there was not a match, it may be because the collection ID is
@@ -2297,7 +2297,7 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
       g_hash_table_iter_init (&iter, ht);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          FlatpakCollectionRef *current =  (FlatpakCollectionRef *) key;
+          OstreeCollectionRef *current =  (OstreeCollectionRef *) key;
           if (g_strcmp0 (current->ref_name, ref) == 0)
             {
               checksum = (const gchar *) value;

--- a/common/flatpak-remote-ref-private.h
+++ b/common/flatpak-remote-ref-private.h
@@ -28,7 +28,7 @@
 #include <flatpak-remote-ref.h>
 #include <flatpak-dir-private.h>
 
-FlatpakRemoteRef *flatpak_remote_ref_new (FlatpakCollectionRef *coll_ref,
+FlatpakRemoteRef *flatpak_remote_ref_new (OstreeCollectionRef *coll_ref,
                                           const char           *commit,
                                           const char           *remote_name,
                                           FlatpakRemoteState   *remote_state);

--- a/common/flatpak-remote-ref.c
+++ b/common/flatpak-remote-ref.c
@@ -319,7 +319,7 @@ flatpak_remote_ref_get_eol_rebase (FlatpakRemoteRef *self)
 }
 
 FlatpakRemoteRef *
-flatpak_remote_ref_new (FlatpakCollectionRef *coll_ref,
+flatpak_remote_ref_new (OstreeCollectionRef *coll_ref,
                         const char           *commit,
                         const char           *remote_name,
                         FlatpakRemoteState   *state)

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -242,7 +242,7 @@ handle_deploy (FlatpakSystemHelper   *object,
       const FlatpakOciManifestDescriptor *desc;
       g_autoptr(FlatpakOciVersioned) versioned = NULL;
       g_autoptr(FlatpakRemoteState) state = NULL;
-      FlatpakCollectionRef collection_ref;
+      OstreeCollectionRef collection_ref;
       g_autoptr(GHashTable) remote_refs = NULL;
       g_autofree char *checksum = NULL;
       const char *verified_digest;


### PR DESCRIPTION
Now that Ostree 2018.6 made OstreeCollectionRef public, we can use that
instead of FlatpakCollectionRef.