### PR TITLE
dir: Fix a subpath checkout error message

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6715,7 +6715,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                         checksum,
                                         cancellable, error))
             {
-              g_prefix_error (error, _("While trying to checkout metadata subpath: "));
+              g_prefix_error (error, _("While trying to checkout subpath ‘%s’: "), subpath);
               return FALSE;
             }
         }


### PR DESCRIPTION
In this loop we're checking out a subpath under /files, not /metadata,
so fix the error message.