### PR TITLE
doc/flatpak-build-bundle.xml: Add a usage example

### DIFF
--- a/doc/flatpak-build-bundle.xml
+++ b/doc/flatpak-build-bundle.xml
@@ -158,6 +158,15 @@
     </refsect1>
 
     <refsect1>
+        <title>Examples</title>
+
+        <para>
+            <command>$ flatpak build-bundle /var/lib/flatpak/repo gnome-calculator.flatpak org.gnome.Calculator stable</command>
+        </para>
+
+    </refsect1>
+
+    <refsect1>
         <title>See also</title>
 
         <para>


### PR DESCRIPTION
In the output of `flatpak build-bundle --help` it's not clear what
LOCATION is, so the least we can do is add an example of its usage to
the man page. At some point it would be nice to also have explanations
of positional arguments in help output.