### PR TITLE
dbus-proxy: Fix handling of broadcasts

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -573,9 +573,11 @@ flatpak_run_add_session_dbus_args (FlatpakBwrap   *app_bwrap,
         {
           flatpak_context_add_bus_filters (context, app_id, TRUE, proxy_arg_bwrap);
 
-          /* Allow calling any interface+method on all portals, but don't receive broadcasts */
+          /* Allow calling any interface+method on all portals, but only receive broadcasts under /org/desktop/portal */
           flatpak_bwrap_add_arg (proxy_arg_bwrap,
                                  "--call=org.freedesktop.portal.*=*");
+          flatpak_bwrap_add_arg (proxy_arg_bwrap,
+                                 "--broadcast=org.freedesktop.portal.*=@/org/freedesktop/portal/*");
         }
 
       if ((flags & FLATPAK_RUN_FLAG_LOG_SESSION_BUS) != 0)

--- a/dbus-proxy/flatpak-proxy.c
+++ b/dbus-proxy/flatpak-proxy.c
@@ -574,7 +574,8 @@ filter_matches (Filter        *filter,
                 const char    *interface,
                 const char    *member)
 {
-  if ((filter->types & type) == 0)
+  if (filter->policy < FLATPAK_POLICY_TALK ||
+      (filter->types & type) == 0)
     return FALSE;
 
   if (filter->path)


### PR DESCRIPTION
In https://github.com/flatpak/flatpak/pull/1689 we were meant to
have limited the receiving of broadcasts on portals, but die to a
bug in the proxy we accidentally allowed all broadcasts anyway.

The change which ignores all applied filters < POLICY_TALK fixes that.

However, it also turns out that the desktop portal actually *does*
rely on signals. For example the network portal uses property change
notification.

So, to make sure this works we allow all signal from the portal
names, but only if they are on a object path starting under
/org/freedesktop/portal (which incidentally all portal object are).
This means there is no real change in anything that is currently
deployed, but it does allow portals to opt out of this global signal
visiblity if they want by using a different object path, which we
want to use in dconf.