### PR TITLE
common: Improve "No xa.metadata" error messages

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2929,7 +2929,7 @@ flatpak_dir_do_resolve_p2p_refs (FlatpakDir             *self,
           commit_metadata = g_variant_get_child_value (commit_data, 0);
           g_variant_lookup (commit_metadata, "xa.metadata", "&s", &xa_metadata);
           if (xa_metadata == NULL)
-            g_message ("Warning: No xa.metadata in commit");
+            g_message ("Warning: No xa.metadata in commit %s ref %s", resolve->resolved_commit, resolve->ref);
           else
             resolve->resolved_metadata = g_bytes_new (xa_metadata, strlen (xa_metadata) + 1);
 
@@ -2981,7 +2981,7 @@ flatpak_dir_do_resolve_p2p_refs (FlatpakDir             *self,
       commit_metadata = g_variant_get_child_value (commit_data, 0);
       g_variant_lookup (commit_metadata, "xa.metadata", "&s", &xa_metadata);
       if (xa_metadata == NULL)
-        g_message ("Warning: No xa.metadata in commit");
+        g_message ("Warning: No xa.metadata in commit %s ref %s", resolve->resolved_commit, resolve->ref);
       else
         resolve->resolved_metadata = g_bytes_new (xa_metadata, strlen (xa_metadata) + 1);
     }
@@ -12243,13 +12243,14 @@ flatpak_dir_find_local_related (FlatpakDir   *self,
     }
   else
     {
-      g_autoptr(GVariant) commit_data = flatpak_dir_read_latest_commit (self, remote_name, ref, NULL, NULL, NULL);
+      g_autofree char *checksum = NULL;
+      g_autoptr(GVariant) commit_data = flatpak_dir_read_latest_commit (self, remote_name, ref, &checksum, NULL, NULL);
       if (commit_data)
         {
           g_autoptr(GVariant) commit_metadata = g_variant_get_child_value (commit_data, 0);
           g_variant_lookup (commit_metadata, "xa.metadata", "s", &metadata_contents);
           if (metadata_contents == NULL)
-            g_debug ("No xa.metadata in local commit");
+            g_debug ("No xa.metadata in local commit %s ref %s", checksum, ref);
         }
     }
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1702,7 +1702,7 @@ resolve_ops (FlatpakTransaction *self,
           commit_metadata = g_variant_get_child_value (commit_data, 0);
           g_variant_lookup (commit_metadata, "xa.metadata", "&s", &xa_metadata);
           if (xa_metadata == NULL)
-            g_message ("Warning: No xa.metadata in local commit");
+            g_message ("Warning: No xa.metadata in local commit %s ref %s", checksum, op->ref);
           else
             metadata_bytes = g_bytes_new (xa_metadata, strlen (xa_metadata) + 1);
 


### PR DESCRIPTION
When I run `flatpak update` I get messages saying "Warning: No
xa.metadata in commit" which isn't very helpful without knowing what
commit is being referred to. So this commit adds the checksum and ref to
such error messages.