### PR TITLE
dbus xml: Delete -- from docs

### DIFF
--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -67,13 +67,13 @@
            <varlistentry>
              <term>4</term>
              <listitem><para>
-               Spawn in a sandbox (equivalent of the -‍-sandbox option of flatpak run).
+               Spawn in a sandbox (equivalent of the sandbox option of flatpak run).
              </para></listitem>
            </varlistentry>
            <varlistentry>
              <term>8</term>
              <listitem><para>
-               Spawn without network (equivalent of the -‍-unshare=network option of flatpak run).
+               Spawn without network (equivalent of the unshare=network option of flatpak run).
              </para></listitem>
            </varlistentry>
          </variablelist>


### PR DESCRIPTION
Apparently -- is not valid XML, so a nonbreakable space was added, but
that breaks gdbus-codegen, so lets just drop the dashes totally.