### PR TITLE
Make tests compatible with either python2 or python3

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -271,19 +271,6 @@ setup_sdk_repo () {
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 
-setup_python2_repo () {
-    REPONAME=${1:-test}
-    if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
-        COLLECTION_ID=${2:-org.test.Collection.${REPONAME}}
-    else
-        COLLECTION_ID=""
-    fi
-
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.PythonPlatform "${COLLECTION_ID}" bash python2 ls cat echo rm readlink > /dev/null
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.PythonSdk "${COLLECTION_ID}" python2 bash ls cat echo rm readlink make mkdir cp touch > /dev/null
-    update_repo $REPONAME "${COLLECTION_ID}"
-}
-
 install_repo () {
     REPONAME=${1:-test}
     ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Platform master
@@ -293,12 +280,6 @@ install_repo () {
 install_sdk_repo () {
     REPONAME=${1:-test}
     ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Sdk master
-}
-
-install_python2_repo () {
-    REPONAME=${1:-test}
-    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.PythonPlatform master
-    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.PythonSdk master
 }
 
 run () {
@@ -318,13 +299,6 @@ skip_without_bwrap () {
             --ro-bind / / /bin/true > bwrap-result 2>&1; then
         sed -e 's/^/# /' < bwrap-result
         echo "1..0 # SKIP Cannot run bwrap"
-        exit 0
-    fi
-}
-
-skip_without_python2 () {
-    if ! test -f /usr/bin/python2 || ! /usr/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
-        echo "1..0 # SKIP this test requires /usr/bin/python2 (2.7) support"
         exit 0
     fi
 }

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -61,31 +61,6 @@ add_bin() {
 for i in $@; do
     I=`which $i`
     add_bin $I
-    if test $i == python2; then
-        mkdir -p ${DIR}/usr/lib/python2.7/lib-dynload
-        # This is a hardcoded minimal set of modules we need in the current tests.
-        # Pretty hacky stuff. Add modules as needed.
-        PYDIR=/usr/lib/python2.7
-        if test -d /usr/lib64/python2.7; then PYDIR=/usr/lib64/python2.7; fi
-        for py in site os stat posixpath genericpath warnings \
-                       linecache types UserDict abc _abcoll \
-                       _weakrefset copy_reg traceback sysconfig \
-                       re sre_compile sre_parse sre_constants \
-                       _sysconfigdata ; do
-            cp ${PYDIR}/$py.py ${DIR}/usr/lib/python2.7
-        done
-        # These might not exist, depending how Python was configured; and the
-        # part after ${so} might be "module" or ".x86_64-linux-gnu" or
-        # something else
-        for so in _locale strop ; do
-            cp ${PYDIR}/lib-dynload/${so}*.so ${DIR}/usr/lib/python2.7/lib-dynload || :
-        done
-        for plat in $( cd ${PYDIR} && echo plat-* ); do
-            test -e ${PYDIR}/${plat} || continue
-            mkdir -p ${DIR}/usr/lib/python2.7/${plat}
-            cp ${PYDIR}/${plat}/*.py ${DIR}/usr/lib/python2.7/${plat}/
-        done
-    fi
 done
 for i in `cat $BINS`; do
     echo Adding binary $i 1>&2

--- a/tests/oci-registry-client.py
+++ b/tests/oci-registry-client.py
@@ -1,8 +1,15 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 
-import httplib
-import urllib
+from __future__ import print_function
+
 import sys
+
+if sys.version_info[0] >= 3:
+    import http.client as http_client
+    import urllib.parse as urllib_parse
+else:
+    import httplib as http_client
+    import urllib as urllib_parse
 
 if sys.argv[2] == 'add':
     detach_icons = '--detach-icons' in sys.argv
@@ -11,28 +18,28 @@ if sys.argv[2] == 'add':
     params = {'d': sys.argv[5]}
     if detach_icons:
         params['detach-icons'] = 1
-    query = urllib.urlencode(params)
-    conn = httplib.HTTPConnection(sys.argv[1])
+    query = urllib_parse.urlencode(params)
+    conn = http_client.HTTPConnection(sys.argv[1])
     path = "/testing/{repo}/{tag}?{query}".format(repo=sys.argv[3],
                                                    tag=sys.argv[4],
                                                    query=query)
     conn.request("POST", path)
     response = conn.getresponse()
     if response.status != 200:
-        print >>sys.stderr, response.read()
-        print >>sys.stderr, "Failed: status={}".format(response.status)
+        print(response.read(), file=sys.stderr)
+        print("Failed: status={}".format(response.status), file=sys.stderr)
         sys.exit(1)
 elif sys.argv[2] == 'delete':
-    conn = httplib.HTTPConnection(sys.argv[1])
+    conn = http_client.HTTPConnection(sys.argv[1])
     path = "/testing/{repo}/{ref}".format(repo=sys.argv[3],
                                           ref=sys.argv[4])
     conn.request("DELETE", path)
     response = conn.getresponse()
     if response.status != 200:
-        print >>sys.stderr, response.read()
-        print >>sys.stderr, "Failed: status={}".format(response.status)
+        print(response.read(), file=sys.stderr)
+        print("Failed: status={}".format(response.status), file=sys.stderr)
         sys.exit(1)
 else:
-    print >>sys.stderr, "Usage: oci-registry-client.py [add|remove] ARGS"
+    print("Usage: oci-registry-client.py [add|remove] ARGS", file=sys.stderr)
     sys.exit(1)
 

--- a/tests/test-http-utils.sh
+++ b/tests/test-http-utils.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-$(dirname $0)/test-webserver.sh "" "python2 $test_srcdir/http-utils-test-server.py 0"
+$(dirname $0)/test-webserver.sh "" "python $test_srcdir/http-utils-test-server.py 0"
 FLATPAK_HTTP_PID=$(cat httpd-pid)
 mv httpd-port httpd-port-main
 port=$(cat httpd-port-main)

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -27,11 +27,11 @@ echo "1..13"
 
 # Start the fake registry server
 
-$(dirname $0)/test-webserver.sh "" "python2 $test_srcdir/oci-registry-server.py 0"
+$(dirname $0)/test-webserver.sh "" "python $test_srcdir/oci-registry-server.py 0"
 FLATPAK_HTTP_PID=$(cat httpd-pid)
 mv httpd-port httpd-port-main
 port=$(cat httpd-port-main)
-client="python2 $test_srcdir/oci-registry-client.py 127.0.0.1:$port"
+client="python $test_srcdir/oci-registry-client.py 127.0.0.1:$port"
 
 setup_repo_no_add oci
 

--- a/tests/test-webserver.sh
+++ b/tests/test-webserver.sh
@@ -7,6 +7,7 @@ cmd=${2:-python -m SimpleHTTPServer 0}
 test_tmpdir=$(pwd)
 
 [ "$dir" != "" ] && cd ${dir}
+echo "Running web server: PYTHONUNBUFFERED=1 setsid $cmd" >&2
 env PYTHONUNBUFFERED=1 setsid $cmd >${test_tmpdir}/httpd-output &
 child_pid=$!
 echo "Web server pid: $child_pid" >&2
@@ -30,3 +31,4 @@ done
 port=$(cat ${test_tmpdir}/httpd-port)
 echo "http://127.0.0.1:${port}" > ${test_tmpdir}/httpd-address
 echo "$child_pid" > ${test_tmpdir}/httpd-pid
+echo "Started web server '$cmd': process $child_pid on port $port" >&2


### PR DESCRIPTION
Distributions like Debian and Ubuntu are trying to reduce or remove dependencies on Python 2 for their next stable releases, so in Debian I'm applying a distro patch that runs test scripts under Python 3. This pull request doesn't do that; however, it does make the test helper scripts compatible with either Python 2.7 or Python 3, so that my extra patch becomes very small.

I have not tested this with Python 2.6 or older, so it might not work there.

I can also send a PR to use Python 3 for the tests by default (or even make it the only possible Python) if desired, but I don't know whether you're trying to retain support for an old version of RHEL or CentOS that only has Python 2.

The two commits are separable, so if you don't like one, please consider the other.