### PR TITLE
Fix hang in system-herlpe::DeplayAppstream for OCI

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -501,10 +501,12 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
 
   if (is_oci)
     {
+      g_autoptr(GMainContextPopDefault) context =  NULL;
+
       /* This does soup http requests spinning the current mainloop, so we need one
          for this thread. */
-      g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
-    /* In the OCI case, we just do the full update, including network i/o, in the
+      context = flatpak_main_context_new_default ();
+      /* In the OCI case, we just do the full update, including network i/o, in the
        * system helper, see comment in flatpak_dir_update_appstream()
        */
       if (!flatpak_dir_update_appstream (system,

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -501,7 +501,10 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
 
   if (is_oci)
     {
-      /* In the OCI case, we just do the full update, including network i/o, in the
+      /* This does soup http requests spinning the current mainloop, so we need one
+         for this thread. */
+      g_autoptr(GMainContextPopDefault) context = flatpak_main_context_new_default ();
+    /* In the OCI case, we just do the full update, including network i/o, in the
        * system helper, see comment in flatpak_dir_update_appstream()
        */
       if (!flatpak_dir_update_appstream (system,


### PR DESCRIPTION
When deploying the appstream for an OCI remote we actually pull the
http remote. This triggers some libsoup code that recurses the default
mainloop. As this happens of the main thread we can get the response
back on the wrong thread leading causing us to never send the reply
back, hanging the call.