### PR TITLE
Override refinements

### DIFF
--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -35,7 +35,10 @@
 #include "flatpak-utils-private.h"
 #include "flatpak-run-private.h"
 
+static gboolean opt_reset;
+
 static GOptionEntry options[] = {
+  { "reset", 0, 0, G_OPTION_ARG_NONE, &opt_reset, N_("Remove existing overrides"), NULL },
   { NULL }
 };
 
@@ -75,6 +78,9 @@ flatpak_builtin_override (int argc, char **argv, GCancellable *cancellable, GErr
     }
   else
     app = NULL;
+
+  if (opt_reset)
+    return flatpak_remove_override_keyfile (app, flatpak_dir_is_user (dir), &my_error);
 
   metakey = flatpak_load_override_keyfile (app, flatpak_dir_is_user (dir), &my_error);
   if (metakey == NULL)

--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -36,9 +36,11 @@
 #include "flatpak-run-private.h"
 
 static gboolean opt_reset;
+static gboolean opt_show;
 
 static GOptionEntry options[] = {
   { "reset", 0, 0, G_OPTION_ARG_NONE, &opt_reset, N_("Remove existing overrides"), NULL },
+  { "show", 0, 0, G_OPTION_ARG_NONE, &opt_show, N_("Show existing overrides"), NULL },
   { NULL }
 };
 
@@ -91,6 +93,18 @@ flatpak_builtin_override (int argc, char **argv, GCancellable *cancellable, GErr
           return FALSE;
         }
       metakey = g_key_file_new ();
+    }
+
+  if (opt_show)
+    {
+      g_autofree char *data = NULL;
+
+      data = g_key_file_to_data (metakey, NULL, error);
+      if (data == NULL)
+        return FALSE;
+
+      g_print ("%s", data);
+      return TRUE;
     }
 
   overrides = flatpak_context_new ();

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -224,6 +224,9 @@ gboolean       flatpak_save_override_keyfile (GKeyFile   *metakey,
                                               const char *app_id,
                                               gboolean    user,
                                               GError    **error);
+gboolean       flatpak_remove_override_keyfile (const char  *app_id,
+                                                gboolean     user,
+                                                GError     **error);
 
 const char *        flatpak_deploy_data_get_origin (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_commit (GVariant *deploy_data);

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -320,6 +320,14 @@ key=v1;v2;
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--show</option></term>
+
+                <listitem><para>
+                    Shows overrides. If an APP is given, shows the overrides for that
+                    application, otherwise shows the global overrides.
+                </para></listitem>
+            </varlistentry>
 
             <varlistentry>
                 <term><option>-v</option></term>

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -312,6 +312,16 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
+                <term><option>--reset</option></term>
+
+                <listitem><para>
+                    Remove overrides. If an APP is given, remove the overrides for that
+                    application, otherwise remove the global overrides.
+                </para></listitem>
+            </varlistentry>
+
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 


### PR DESCRIPTION
Add --reset and --show options to make override handling a little less rudimentary.