### PR TITLE
Fix build with glib < 2.50

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -576,7 +576,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
 
   g_ptr_array_add (bwrap->argv, NULL);
 
-  g_snprintf (pid_str, sizeof (pid_str), "%" G_PID_FORMAT, getpid ());
+  g_snprintf (pid_str, sizeof (pid_str), "%d", getpid ());
   pid_path = g_build_filename (instance_id_host_dir, "pid", NULL);
   g_file_set_contents (pid_path, pid_str, -1, NULL);
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3114,7 +3114,7 @@ flatpak_run_app (const char     *app_ref,
                           error))
         return FALSE;
 
-      g_snprintf (pid_str, sizeof (pid_str), "%" G_PID_FORMAT, child_pid);
+      g_snprintf (pid_str, sizeof (pid_str), "%d", child_pid);
       pid_path = g_build_filename (instance_id_host_dir, "pid", NULL);
       g_file_set_contents (pid_path, pid_str, -1, NULL);
     }
@@ -3123,7 +3123,7 @@ flatpak_run_app (const char     *app_ref,
       char pid_str[64];
       g_autofree char *pid_path = NULL;
 
-      g_snprintf (pid_str, sizeof (pid_str), "%" G_PID_FORMAT, getpid ());
+      g_snprintf (pid_str, sizeof (pid_str), "%d", getpid ());
       pid_path = g_build_filename (instance_id_host_dir, "pid", NULL);
       g_file_set_contents (pid_path, pid_str, -1, NULL);
 


### PR DESCRIPTION
G_PID_FORMAT was added in glib 2.50, but pids are always %d on linux,
so we can avoid using it.