### PR TITLE
uninstall --unused: Consider SDKs used

### DIFF
--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -221,6 +221,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
               g_autoptr(FlatpakDeploy) deploy = NULL;
               g_autofree char *origin = NULL;
               g_autofree char *runtime = NULL;
+              g_autofree char *sdk = NULL;
               g_autoptr(GKeyFile) metakey = NULL;
               g_auto(GStrv) parts = g_strsplit (ref, "/", -1);
 
@@ -241,6 +242,10 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
               runtime = g_key_file_get_string (metakey, "Application", "runtime", NULL);
               if (runtime)
                 g_hash_table_add (used_runtimes, g_steal_pointer (&runtime));
+
+              sdk = g_key_file_get_string (metakey, "Application", "sdk", NULL);
+              if (sdk)
+                g_hash_table_add (used_runtimes, g_steal_pointer (&sdk));
             }
 
           GLNX_HASH_TABLE_FOREACH (used_runtimes, const char *, runtime)


### PR DESCRIPTION
If some app uses a particular runtime as an sdk, consider it used.
This means if you once downloaded the sdk for some app you're debugging
it will not be removed until that app is uninstalled.

Its unclear exactly whether this is "used", but lets error on
the side of not deleting stuff.