### PR TITLE
Print nicer errors

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -627,6 +627,7 @@ main (int    argc,
           prefix = FLATPAK_ANSI_RED FLATPAK_ANSI_BOLD_ON;
           suffix = FLATPAK_ANSI_BOLD_OFF FLATPAK_ANSI_COLOR_RESET;
         }
+      g_dbus_error_strip_remote_error (error);
       g_printerr ("%s%s %s%s\n", prefix, _("error:"), suffix, error->message);
       g_error_free (error);
     }


### PR DESCRIPTION
Without this call, we show monsters like:

error: GDBus.Error:org.gtk.GDBus.UnmappedGError.Quark._g_2dio_2derror_2dquark.Code1: No such file or directory

With this call, it will be just:

error: No such file or directory