### PR TITLE
lib: Strip gdbus error info from all passed on errors

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1121,6 +1121,8 @@ flatpak_dir_system_helper_call (FlatpakDir   *self,
                                 GCancellable *cancellable,
                                 GError      **error)
 {
+  GVariant *res;
+
   if (g_once_init_enter (&self->system_helper_bus))
     {
       const char *on_session = g_getenv ("FLATPAK_SYSTEM_HELPER_ON_SESSION");
@@ -1141,15 +1143,19 @@ flatpak_dir_system_helper_call (FlatpakDir   *self,
     }
 
   g_debug ("Calling system helper: %s", method_name);
-  return g_dbus_connection_call_sync (self->system_helper_bus,
-                                      "org.freedesktop.Flatpak.SystemHelper",
-                                      "/org/freedesktop/Flatpak/SystemHelper",
-                                      "org.freedesktop.Flatpak.SystemHelper",
-                                      method_name,
-                                      parameters,
-                                      NULL, G_DBUS_CALL_FLAGS_NONE, G_MAXINT,
-                                      cancellable,
-                                      error);
+  res = g_dbus_connection_call_sync (self->system_helper_bus,
+                                     "org.freedesktop.Flatpak.SystemHelper",
+                                     "/org/freedesktop/Flatpak/SystemHelper",
+                                     "org.freedesktop.Flatpak.SystemHelper",
+                                     method_name,
+                                     parameters,
+                                     NULL, G_DBUS_CALL_FLAGS_NONE, G_MAXINT,
+                                     cancellable,
+                                     error);
+  if (res == NULL && error)
+    g_dbus_error_strip_remote_error (*error);
+
+  return res;
 }
 
 static gboolean

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2511,7 +2511,11 @@ forward_file (XdpDbusDocuments *documents,
                                          NULL,
                                          NULL,
                                          error))
-    return FALSE;
+    {
+      if (error)
+        g_dbus_error_strip_remote_error (*error);
+      return FALSE;
+    }
 
   if (!xdp_dbus_documents_call_grant_permissions_sync (documents,
                                                        doc_id,
@@ -2519,7 +2523,11 @@ forward_file (XdpDbusDocuments *documents,
                                                        perms,
                                                        NULL,
                                                        error))
-    return FALSE;
+    {
+      if (error)
+        g_dbus_error_strip_remote_error (*error);
+      return FALSE;
+    }
 
   *out_doc_id = g_steal_pointer (&doc_id);
 


### PR DESCRIPTION
Whenever we forward some error from a lower level dbus call to the
caller of the library we strip the extra gdbus error info via a call
to g_dbus_error_strip_remote_error(). We do this, because callers of
libflatpak has no idea that there were remote calls involved, so they
will not do this themselves.

This is really an addition to https://github.com/flatpak/flatpak/pull/2066 which does this for all errors printed by the CLI. I.e. that change only would be enough for the CLI, but would not help for e.g. gnome-software.