### PR TITLE
system-helper: set IO class to idle

### DIFF
--- a/system-helper/flatpak-system-helper.service.in
+++ b/system-helper/flatpak-system-helper.service.in
@@ -6,3 +6,4 @@ BusName=org.freedesktop.Flatpak.SystemHelper
 Environment=XDG_DATA_DIRS=@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/
 ExecStart=@libexecdir@/flatpak-system-helper
 Type=dbus
+IOSchedulingClass=idle


### PR DESCRIPTION
Our benchmarks show this significantly reduces the interactivity impact of
ongoing Flatpak operations while the user is continuing other tasks on the
system. The effect is very pronounced with the default CFQ scheduler, and in
combination with BFQ, using the idle class improves the worst case to nearly
the same as an unloaded system.

Thanks to @wjt for the benchmarking. Copy/pasting his results:
> I ran some benchmarks to time all combinations of:
> 
> - Mission (HDD root device), Yoga (SSD root device)
> - BFQ, CFQ (both with default settings, ie BFQ is in low-latency mode)
> - the following five background jobs:
>   - nothing
>   - `sudo -i sh -c 'while true; do flatpak install org.gnome.Lollipop.flatpak; flatpak uninstall app/org.gnome.Lollipop//stable; done'`
>   - `sudo -i iogenic org.gnome.Lollipop.flatpak (an implementation of that same loop, using the Flatpak API rather than repeatedly spawning the flatpak cli tool`
>   - `sudo -i ionice -c3 sh -c ...`
>   - `sudo -i ionice -c3 iogenic ...`
> 
> The benchmark is to launch LibreOffice 15 (on Yoga)/30 (on Mission, because the outliers were … much more outlying!) times. I ran the trials & collected data with:
> 
> `multitime -r 'echo 3 | sudo tee /proc/sys/vm/drop_caches' -n 15 flatpak run  org.libreoffice.LibreOffice --terminate_after_init`
> 
> https://github.com/wjt/ionogenic/blob/master/results/Plot.ipynb has the mean/min/max/median/std-dev for each combination of the above (there's 1 missing, sorry) and plots of it sliced in various ways. I think this plot below is the clearest. The coloured bars show the median launch time for Libreoffice, and the error bars show the min and max launch time for the trials:
> 
> ![download](https://user-images.githubusercontent.com/254468/44993109-4bb3e680-af91-11e8-960b-6a50ed3370ac.png)
> 
> I had a theory that `while true; do flatpak install; flatpak uninstall; done` is mis-detected by BFQ as a bunch of "soft real-time" processes being started, then dying off, which is why I wrote the long-lived process impl. I don't think this data supports my theory.
> 
> Rob has a theory that because fsyncs are global barriers on the filesystem, the scheduler can't do much about this, and my guess is that the big outliers pushing up the max in the loaded cases may be caused by that. I guess we could test this by sticking eatmydata around the install/uninstall loop.
> 
> Anyway, my conclusion is:
> 
> - On slow spinning disk, changing the scheduler and setting idle IO priority on Flatpak jobs will both independently help
> - On SSD, BFQ makes the worst case worse if we don't set idle IO priority (I guess it is still assigning too high a weight to the flatpak job) but if we do, it's a wash, and we saw above that under sustained IO workloads BFQ seems to perform better