### PR TITLE
install: Auto-pick installation based on remote

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -325,11 +325,13 @@ flatpak_option_context_parse (GOptionContext     *context,
            * FLATPAK_BUILTIN_FLAG_STANDARD_DIRS or FLATPAK_BUILTIN_FLAG_ALL_DIRS
            * must be set.
            */
-          if (opt_user || (!opt_system && opt_installations == NULL))
-            g_ptr_array_add (dirs, flatpak_dir_get_user ());
 
+          /* If nothing is set, then we put the system dir first, which can be used as the default */
           if (opt_system || (!opt_user && opt_installations == NULL))
             g_ptr_array_add (dirs, flatpak_dir_get_system_default ());
+
+          if (opt_user || (!opt_system && opt_installations == NULL))
+            g_ptr_array_add (dirs, flatpak_dir_get_user ());
 
           if (opt_installations != NULL)
             {


### PR DESCRIPTION
This changes install to use FLATPAK_BUILTIN_FLAG_STANDARD_DIRS, which
returns the default dirs. This is tweaked such that it returns the
system installaton first if no options were set, which is the default
in the old ONE_DIR case.

In the bundle and flatpakref install case we use the first element
of the dirs[], which now is the same as the old default, and
otherwise is the one the options picked.

However, if a remote is specified, we use
flatpak_resolve_duplicate_remotes() to pick the actual installation.