### PR TITLE
Clarify object paths and bus names for portals

### DIFF
--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -46,6 +46,10 @@
       (see org.freedesktop.portal.Documents.GrantPermissions()) are reflected
       in the POSIX mode bits in the fuse filesystem.
 
+      The D-Bus interface for the document portal is available under the
+      bus name org.freedesktop.portal.Documents and the object path
+      /org/freedesktop/portal/documents.
+ 
       This documentation describes version 3 of this interface.
   -->
   <interface name='org.freedesktop.portal.Documents'>

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -32,6 +32,10 @@
       host to the sandbox. For example, it allows you to restart the
       applications or start a more sandboxed instance.
 
+      The D-Bus interface for the document portal is available under the
+      bus name org.freedesktop.portal.Flatpak and the object path
+      /org/freedesktop/portal/flatpak.
+
       This documentation describes version 1 of this interface.
   -->
   <interface name='org.freedesktop.portal.Flatpak'>


### PR DESCRIPTION
These portals are under their own bus name and
object path, clarify this in the docs. For the
document portal, this is just a sync-up with
the master copy in the xdg-desktop-portal repo.