### PR TITLE
common: Better handle NULL collection IDs

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10798,6 +10798,9 @@ parse_ref_file (GKeyFile *keyfile,
 
   collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
                                          FLATPAK_REF_COLLECTION_ID_KEY, NULL);
+  if (collection_id != NULL && *collection_id == '\0')
+    collection_id = NULL;
+
   if (collection_id != NULL && gpg_data == NULL)
     return flatpak_fail (error, "Collection ID requires GPG key to be provided");
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4657,7 +4657,8 @@ flatpak_bundle_load (GFile   *file,
 
   if (collection_id != NULL)
     {
-      if (!g_variant_lookup (metadata, "collection-id", "s", collection_id))
+      if (!g_variant_lookup (metadata, "collection-id", "s", collection_id) ||
+          **collection_id == '\0')
         *collection_id = NULL;
     }
 


### PR DESCRIPTION
Currently if you instal from a flatpak bundle that doesn't have a
collection ID set or from a flatpakref file that has the CollectionID
key set to the empty sting, you end up with an invalid configuration on
the origin remote created. This is because the collection_id parameter
of flatpak_dir_create_origin_remote() is set to the empty string, not
NULL, and create_origin_remote_config() then only checks for NULL when
deciding whether to set gpg-verify-summary to true or false. Then
because there's no collection ID configured but gpg-verify-summary is
set to false, you get the error "Can't pull from untrusted non-gpg
verified remote" when trying to pull related refs or update the app.

This commit fixes the bug by checking for the empty string when the
collection ID is read from a bundle or ref file, and collapsing that
into NULL.