### PR TITLE
main: Don't spuriously print usage info

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -205,29 +205,6 @@ flatpak_option_context_new_with_commands (FlatpakCommand *commands)
   return context;
 }
 
-static int
-flatpak_usage (FlatpakCommand *commands,
-               gboolean        is_error)
-{
-  GOptionContext *context;
-  g_autofree char *help = NULL;
-
-  context = flatpak_option_context_new_with_commands (commands);
-
-  g_option_context_add_main_entries (context, global_entries, NULL);
-
-  help = g_option_context_get_help (context, FALSE, NULL);
-
-  if (is_error)
-    g_printerr ("%s", help);
-  else
-    g_print ("%s", help);
-
-  g_option_context_free (context);
-
-  return is_error ? 1 : 0;
-}
-
 gboolean
 flatpak_option_context_parse (GOptionContext     *context,
                               const GOptionEntry *main_entries,
@@ -617,8 +594,6 @@ main (int    argc,
   flatpak_migrate_from_xdg_app ();
 
   ret = flatpak_run (argc, argv, &error);
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED))
-    flatpak_usage (commands, TRUE);
 
   if (error != NULL)
     {


### PR DESCRIPTION
Currently if any command errors out with G_IO_ERROR_NOT_SUPPORTED,
flatpak prints the usage information (the output of --help), but this is
not correct. For example if the create-usb command hits that error when
trying to use extended attributes on a filesystem that doesn't support
them, the help output is printed as we saw here:
https://github.com/flatpak/flatpak/issues/2019#issuecomment-416798304

So this commit removes the check for G_IO_ERROR_NOT_SUPPORTED in
flatpak-main.c and the helper function it uses. The flatpak_run()
function handles printing usage info for the overall flatpak command,
and subcommands use the usage_error() function to print usage
information, so there's no need for it.