### PR TITLE
test-webserver: Fix race condition

### DIFF
--- a/tests/test-webserver.sh
+++ b/tests/test-webserver.sh
@@ -8,6 +8,7 @@ test_tmpdir=$(pwd)
 
 [ "$dir" != "" ] && cd ${dir}
 echo "Running web server: PYTHONUNBUFFERED=1 setsid $cmd" >&2
+touch ${test_tmpdir}/httpd-output
 env PYTHONUNBUFFERED=1 setsid $cmd >${test_tmpdir}/httpd-output &
 child_pid=$!
 echo "Web server pid: $child_pid" >&2


### PR DESCRIPTION
If we rely on the background subshell to create the httpd-output file,
and we are unlucky, then the "cp" invocation in the loop might execute
before the file has been created, and fail. This appears to have
happened on Debian's arm64 autobuilder, which failed with:

    Running web server: PYTHONUNBUFFERED=1 setsid python3 /<<PKGBUILDDIR>>/tests/http-utils-test-server.py 0
    Web server pid: 13319
    Waiting for web server (1/300)...
    cp: cannot stat '/var/tmp/tap-test.p1cxRN/httpd-output': No such file or directory

Signed-off-by: Simon McVittie <smcv@debian.org>