### PR TITLE
uninstall: Refine definition of what is used

### DIFF
--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -130,11 +130,12 @@ find_used_refs (FlatpakDir *dir, GHashTable *used_refs, const char *ref, const c
       if (!rel->auto_prune && !g_hash_table_contains (used_refs, rel->ref))
         {
           g_autofree char *related_origin = NULL;
+
+          g_hash_table_add (used_refs, g_strdup (rel->ref));
+
           related_origin = flatpak_dir_get_origin (dir, rel->ref, NULL, NULL);
           if (related_origin != NULL)
             find_used_refs (dir, used_refs, rel->ref, related_origin);
-
-          g_hash_table_add (used_refs, g_strdup (rel->ref));
         }
     }
 }

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -127,8 +127,15 @@ find_used_refs (FlatpakDir *dir, GHashTable *used_refs, const char *ref, const c
     {
       FlatpakRelated *rel = g_ptr_array_index (related, i);
 
-      if (!rel->auto_prune)
-        g_hash_table_add (used_refs, g_strdup (rel->ref));
+      if (!rel->auto_prune && !g_hash_table_contains (used_refs, rel->ref))
+        {
+          g_autofree char *related_origin = NULL;
+          related_origin = flatpak_dir_get_origin (dir, rel->ref, NULL, NULL);
+          if (related_origin != NULL)
+            find_used_refs (dir, used_refs, rel->ref, related_origin);
+
+          g_hash_table_add (used_refs, g_strdup (rel->ref));
+        }
     }
 }
 


### PR DESCRIPTION
Currently it's possible for Flatpak to consider a runtime used but
consider its Locale extension unused when executing `flatpak uninstall
--unused`, which doesn't make much sense.  This only happens if the
runtime is indirectly used; in other words it's used as a related ref
rather than directly as the runtime of an installed app.

In the case of Endless, `com.endlessm.EknServicesMultiplexer` uses all
versions of `com.endlessm.apps.Platform`, and since v1 isn't used by any
app on this computer its Locale extension is considered unused:

$ flatpak list --runtime -a | grep com.endlessm.apps.Platform.*/x86_64/1
com.endlessm.apps.Platform.Locale/x86_64/1      system,partial
com.endlessm.apps.Platform/x86_64/1     system
$ flatpak uninstall --unused
Uninstalling from system:
com.endlessm.apps.Platform.Locale/x86_64/1
Is this ok [y/n]:

This commit changes the behavior of uninstall --unused so that when
something is considered used because it's a related ref, we recursively
check its own related refs so they are considered used too.