### PR TITLE
create-usb: Don't leave a GError set

### DIFF
--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -146,7 +146,7 @@ add_related (GHashTable   *all_refs,
 
       g_assert (ext->ref);
 
-      ext_deploy_data = flatpak_dir_get_deploy_data (dir, ext->ref, cancellable, error);
+      ext_deploy_data = flatpak_dir_get_deploy_data (dir, ext->ref, cancellable, NULL);
       if (ext_deploy_data == NULL)
         {
           g_printerr (_("Warning: Omitting related ref ‘%s’ because it is not installed.\n"),


### PR DESCRIPTION
This commit clears the GError pointer when finding the deploy data for a
related ref fails. Otherwise the already-set error pointer can get
passed to flatpak_dir_update_summary() causing libostree to hit an
assertion failure when it checks (error == NULL || *error == NULL) in
_ostree_repo_lock_push().