### PR TITLE
Export XDG_DATA_DIRS for custom installation paths, take 2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -159,6 +159,9 @@ flatpak.env: env.d/flatpak.env.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
 		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
 
+envgendir = $(systemduserenvgendir)
+envgen_DATA = env.d/60-flatpak
+
 dbussnippetdir = $(systemduserunitdir)/dbus.service.d
 dbussnippet_DATA = flatpak.conf
 EXTRA_DIST += dbus.service.d/flatpak.conf.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -162,15 +162,6 @@ flatpak.env: env.d/flatpak.env.in
 envgendir = $(systemduserenvgendir)
 envgen_DATA = env.d/60-flatpak
 
-dbussnippetdir = $(systemduserunitdir)/dbus.service.d
-dbussnippet_DATA = flatpak.conf
-EXTRA_DIST += dbus.service.d/flatpak.conf.in
-DISTCLEANFILES += flatpak.conf
-
-flatpak.conf: dbus.service.d/flatpak.conf.in
-	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
-		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
-
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = flatpak.pc
 EXTRA_DIST += flatpak.pc.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -140,15 +140,7 @@ zshcompletion_DATA = completion/_flatpak
 EXTRA_DIST += $(zshcompletion_DATA)
 
 profiledir = $(PROFILE_DIR)
-profile_DATA = flatpak.sh
-EXTRA_DIST += \
-	profile/flatpak.sh.in \
-	$(NULL)
-DISTCLEANFILES += flatpak.sh
-
-flatpak.sh: profile/flatpak.sh.in
-	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
-		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
+profile_DATA = profile/flatpak.sh
 
 envdir = $(datadir)/gdm/env.d
 env_DATA = flatpak.env

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -49,6 +49,7 @@ static gboolean opt_version;
 static gboolean opt_default_arch;
 static gboolean opt_supported_arches;
 static gboolean opt_gl_drivers;
+static gboolean opt_list_installations;
 static gboolean opt_user;
 static gboolean opt_system;
 static char **opt_installations;
@@ -160,6 +161,7 @@ static GOptionEntry empty_entries[] = {
   { "default-arch", 0, 0, G_OPTION_ARG_NONE, &opt_default_arch, N_("Print default arch and exit"), NULL },
   { "supported-arches", 0, 0, G_OPTION_ARG_NONE, &opt_supported_arches, N_("Print supported arches and exit"), NULL },
   { "gl-drivers", 0, 0, G_OPTION_ARG_NONE, &opt_gl_drivers, N_("Print active gl drivers and exit"), NULL },
+  { "installations", 0, 0, G_OPTION_ARG_NONE, &opt_list_installations, N_("Print paths for system installations and exit"), NULL },
   { NULL }
 };
 
@@ -302,6 +304,27 @@ flatpak_option_context_parse (GOptionContext     *context,
       int i;
       for (i = 0; drivers[i] != NULL; i++)
         g_print ("%s\n", drivers[i]);
+      exit (EXIT_SUCCESS);
+    }
+
+  if (opt_list_installations)
+    {
+      GPtrArray *paths;
+      g_autoptr(GError) error = NULL;
+      guint i;
+
+      paths = flatpak_get_system_base_dir_locations (NULL, &error);
+      if (!paths)
+        return FALSE;
+
+      for (i = 0; i < paths->len; i++)
+        {
+          GFile *file = paths->pdata[i];
+          g_autofree char *path;
+
+          path = g_file_get_path (file);
+          g_print ("%s\n", path);
+        }
       exit (EXIT_SUCCESS);
     }
 

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,15 @@ AC_ARG_WITH([systemdsystemunitdir],
     [with_systemdsystemunitdir='${prefix}/lib/systemd/system'])
 AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 
+AC_ARG_WITH([systemduserenvgendir],
+            [AS_HELP_STRING([--with-systemduserenvgendir=DIR],
+                            [Directory for systemd user environment generators (default=PREFIX/lib/systemd/user-environment-generators)])],
+    [],
+    dnl This is deliberately not ${libdir}: systemd units always go in
+    dnl .../lib, never .../lib64 or .../lib/x86_64-linux-gnu
+    [with_systemduserenvgendir='${prefix}/lib/systemd/user-environment-generators'])
+AC_SUBST([systemduserenvgendir], [$with_systemduserenvgendir])
+
 AC_ARG_WITH(system_fonts_dir,
 		AS_HELP_STRING([--with-system-fonts-dir=PATH],[Directory where system fonts are, [default=/usr/share/fonts]]),
             with_system_fonts_dir="$withval", with_system_fonts_dir=/usr/share/fonts)

--- a/dbus.service.d/flatpak.conf.in
+++ b/dbus.service.d/flatpak.conf.in
@@ -1,2 +1,0 @@
-[Service]
-Environment=XDG_DATA_DIRS=%h/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -153,6 +153,14 @@
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--installations</option></term>
+
+                <listitem><para>
+                    Print paths of system installations and exit.
+                </para></listitem>
+            </varlistentry>
+
         </variablelist>
     </refsect1>
 

--- a/env.d/60-flatpak
+++ b/env.d/60-flatpak
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+new_dirs=
+while read -r install_path
+do
+    share_path=$install_path/exports/share
+    case ":$XDG_DATA_DIRS:" in
+        *":$share_path:"*) :;;
+        *":$share_path/:"*) :;;
+        *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
+    esac
+done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; flatpak  --installations)
+
+XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"

--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -1,4 +1,4 @@
-# @sysconfdir@/profile.d/flatpak.sh - set XDG_DATA_DIRS
+# set XDG_DATA_DIRS to include Flatpak installations
 
 new_dirs=
 while read -r install_path

--- a/profile/flatpak.sh.in
+++ b/profile/flatpak.sh.in
@@ -1,7 +1,15 @@
 # @sysconfdir@/profile.d/flatpak.sh - set XDG_DATA_DIRS
 
-if [ "${XDG_DATA_DIRS#*flatpak}" = "${XDG_DATA_DIRS}" ]; then
-    XDG_DATA_DIRS="${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak/exports/share:@localstatedir@/lib/flatpak/exports/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-fi
+new_dirs=
+while read -r install_path
+do
+    share_path=$install_path/exports/share
+    case ":$XDG_DATA_DIRS:" in
+        *":$share_path:"*) :;;
+        *":$share_path/:"*) :;;
+        *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
+    esac
+done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; flatpak --installations)
 
 export XDG_DATA_DIRS
+XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"


### PR DESCRIPTION
This is a slight rework of Bastiens earlier work in https://github.com/flatpak/flatpak/pull/2035, now using a systemd environment generator instead of per-service config and a gdm env.d file.