### PR TITLE
Fix a thinko in the permission commands

### DIFF
--- a/app/flatpak-builtins-permission-list.c
+++ b/app/flatpak-builtins-permission-list.c
@@ -32,6 +32,7 @@
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"
+#include "flatpak-builtins-utils.h"
 #include "flatpak-table-printer.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-run-private.h"
@@ -39,33 +40,6 @@
 static GOptionEntry options[] = {
   { NULL }
 };
-
-static char **
-get_permission_tables (XdpDbusPermissionStore *store)
-{
-  g_autofree char *path = NULL;
-  GDir *dir;
-  const char *name;
-  GPtrArray *tables = NULL;
-
-  tables = g_ptr_array_new ();
-
-  path = g_build_filename (g_get_user_data_dir (), "flatpak/db", NULL);
-  dir = g_dir_open (path, 0, NULL);
-  if (dir != NULL)
-    {
-      while ((name = g_dir_read_name (dir)) != NULL)
-        {
-          g_ptr_array_add (tables, g_strdup (name));
-        }
-    }
-
-  g_dir_close (dir);
-
-  g_ptr_array_add (tables, NULL);
-
-  return (char **) g_ptr_array_free (tables, FALSE);
-}
 
 static char **
 get_ids_for_table (XdpDbusPermissionStore *store,

--- a/app/flatpak-builtins-permission-remove.c
+++ b/app/flatpak-builtins-permission-remove.c
@@ -32,6 +32,7 @@
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"
+#include "flatpak-builtins-utils.h"
 #include "flatpak-table-printer.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-run-private.h"
@@ -39,33 +40,6 @@
 static GOptionEntry options[] = {
   { NULL }
 };
-
-static char **
-get_permission_tables (XdpDbusPermissionStore *store)
-{
-  g_autofree char *path = NULL;
-  GDir *dir;
-  const char *name;
-  GPtrArray *tables = NULL;
-
-  tables = g_ptr_array_new ();
-
-  path = g_build_filename (g_get_user_data_dir (), "flatpak/db", NULL);
-  dir = g_dir_open (path, 0, NULL);
-  if (dir != NULL)
-    {
-      while ((name = g_dir_read_name (dir)) != NULL)
-        {
-          g_ptr_array_add (tables, g_strdup (name));
-        }
-    }
-
-  g_dir_close (dir);
-
-  g_ptr_array_add (tables, NULL);
-
-  return (char **) g_ptr_array_free (tables, FALSE);
-}
 
 static char **
 get_ids_for_table (XdpDbusPermissionStore *store,

--- a/app/flatpak-builtins-permission-reset.c
+++ b/app/flatpak-builtins-permission-reset.c
@@ -32,6 +32,7 @@
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"
+#include "flatpak-builtins-utils.h"
 #include "flatpak-table-printer.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-run-private.h"
@@ -39,33 +40,6 @@
 static GOptionEntry options[] = {
   { NULL }
 };
-
-static char **
-get_permission_tables (XdpDbusPermissionStore *store)
-{
-  g_autofree char *path = NULL;
-  GDir *dir;
-  const char *name;
-  GPtrArray *tables = NULL;
-
-  tables = g_ptr_array_new ();
-
-  path = g_build_filename (g_get_user_data_dir (), "flatpak/db", NULL);
-  dir = g_dir_open (path, 0, NULL);
-  if (dir != NULL)
-    {
-      while ((name = g_dir_read_name (dir)) != NULL)
-        {
-          g_ptr_array_add (tables, g_strdup (name));
-        }
-    }
-
-  g_dir_close (dir);
-
-  g_ptr_array_add (tables, NULL);
-
-  return (char **) g_ptr_array_free (tables, FALSE);
-}
 
 static gboolean
 remove_for_app (XdpDbusPermissionStore *store,

--- a/app/flatpak-builtins-permission-show.c
+++ b/app/flatpak-builtins-permission-show.c
@@ -32,6 +32,7 @@
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"
+#include "flatpak-builtins-utils.h"
 #include "flatpak-table-printer.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-run-private.h"
@@ -39,33 +40,6 @@
 static GOptionEntry options[] = {
   { NULL }
 };
-
-static char **
-get_permission_tables (XdpDbusPermissionStore *store)
-{
-  g_autofree char *path = NULL;
-  GDir *dir;
-  const char *name;
-  GPtrArray *tables = NULL;
-
-  tables = g_ptr_array_new ();
-
-  path = g_build_filename (g_get_user_data_dir (), "flatpak/db", NULL);
-  dir = g_dir_open (path, 0, NULL);
-  if (dir != NULL)
-    {
-      while ((name = g_dir_read_name (dir)) != NULL)
-        {
-          g_ptr_array_add (tables, g_strdup (name));
-        }
-    }
-
-  g_dir_close (dir);
-
-  g_ptr_array_add (tables, NULL);
-
-  return (char **) g_ptr_array_free (tables, FALSE);
-}
 
 static gboolean
 list_for_app (XdpDbusPermissionStore *store,

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -555,3 +555,29 @@ update_appstream (GPtrArray    *dirs,
 
   return TRUE;
 }
+
+char **
+get_permission_tables (XdpDbusPermissionStore *store)
+{
+  g_autofree char *path = NULL;
+  GDir *dir;
+  const char *name;
+  GPtrArray *tables = NULL;
+
+  tables = g_ptr_array_new ();
+
+  path = g_build_filename (g_get_user_data_dir (), "flatpak/db", NULL);
+  dir = g_dir_open (path, 0, NULL);
+  if (dir != NULL)
+    {
+      while ((name = g_dir_read_name (dir)) != NULL)
+        {
+          g_ptr_array_add (tables, g_strdup (name));
+        }
+      g_dir_close (dir);
+    }
+
+  g_ptr_array_add (tables, NULL);
+
+  return (char **) g_ptr_array_free (tables, FALSE);
+}

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -25,6 +25,7 @@
 #include "libglnx/libglnx.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-dir-private.h"
+#include "flatpak-permission-dbus-generated.h"
 
 /* Appstream data expires after a day */
 #define FLATPAK_APPSTREAM_TTL 86400
@@ -62,5 +63,8 @@ gboolean update_appstream (GPtrArray    *dirs,
                            gboolean      quiet,
                            GCancellable *cancellable,
                            GError      **error);
+
+char ** get_permission_tables (XdpDbusPermissionStore *store);
+
 
 #endif /* __FLATPAK_BUILTINS_UTILS_H__ */


### PR DESCRIPTION
Better to only call g_dir_close() if dir isn't NULL.

Take this opportunity to move the function to utils,
instead of carrying 4 identical copies.

Closes: https://github.com/flatpak/flatpak/issues/2130