### PR TITLE
Warn if RuntimeRepo is missing

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3568,7 +3568,10 @@ handle_runtime_repo_deps_from_keyfile (FlatpakTransaction *self,
   dep_url = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
                                    FLATPAK_REF_RUNTIME_REPO_KEY, NULL);
   if (dep_url == NULL)
-    return TRUE;
+    {
+      g_warning ("Flatpakref file does not contain a %s", FLATPAK_REF_RUNTIME_REPO_KEY);
+      return TRUE;
+    }
 
   name = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP, FLATPAK_REF_NAME_KEY, NULL);
   if (name == NULL)

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -206,7 +206,7 @@ ok "install via flatpakref"
 ${FLATPAK} ${U} -y uninstall org.test.Platform
 
 ${FLATPAK} remotes > remotes-list
-assert_not_file_has_content remotes '^platform-origin'
+assert_not_file_has_content remotes-list '^platform-origin'
 
 assert_not_has_file $base/oci/platform-origin.index.gz
 

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -170,7 +170,16 @@ assert_not_has_dir $base/appstream/oci-registry
 
 ok "delete remote"
 
-# Try installing the platform via a flatpakref file.
+# Try installing the platform via a flatpakref file. We use a different URL
+# for the runtime repo so we can test that the origin remote is pruned on
+# uninstall below.
+
+cat << EOF > runtime-repo.flatpakrepo
+[Flatpak Repo]
+Version=1
+Url=oci+http://localhost:${port}
+Title=The OCI Title
+EOF
 
 cat << EOF > org.test.Platform.flatpakref
 [Flatpak Ref]
@@ -179,6 +188,7 @@ Name=org.test.Platform
 Branch=master
 Url=oci+http://127.0.0.1:${port}
 IsRuntime=true
+RuntimeRepo=file://$(pwd)/runtime-repo.flatpakrepo
 EOF
 
 ${FLATPAK} ${U} install -y --from ./org.test.Platform.flatpakref


### PR DESCRIPTION
This is making the flatpakref file less portable,
so we should warn to give developers a hint that
this is a possible problem. 