### PR TITLE
repo: Don't use remote ostree-metadata

### DIFF
--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -206,8 +206,8 @@ flatpak_builtin_repo (int argc, char **argv,
   /* Try loading the metadata from the ostree-metadata branch first. If that
    * fails, fall back to the summary file. */
   ostree_metadata_ref = OSTREE_REPO_METADATA_REF;
-  if (!ostree_repo_resolve_rev (repo, ostree_metadata_ref,
-                                TRUE, &ostree_metadata_checksum, error))
+  if (!ostree_repo_resolve_rev_ext (repo, ostree_metadata_ref,
+                                    TRUE, 0, &ostree_metadata_checksum, error))
     return FALSE;
 
   if (ostree_metadata_checksum != NULL)


### PR DESCRIPTION
The code was looking for a ref with the name
ostree-metadata, but using an api that falls
back to remote refs with the same name, which
is not desirable here.

Use a different ostree api instead that only
resolves local refs.

Closes: #1805