### PR TITLE
Don't expose host /dev/shm with --device=all (fixing debian problems)

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1045,7 +1045,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
           g_autofree char *link = flatpak_readlink ("/dev/shm", NULL);
           /* On debian (with sysv init) the host /dev/shm is a symlink to /run/shm, so we can't
              mount on top of it. */
-          if (strcmp (link, "/run/shm") == 0)
+          if (g_strcmp0 (link, "/run/shm") == 0)
             flatpak_bwrap_add_args (bwrap,
                                     "--dir", "/run/shm",
                                     NULL);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1035,6 +1035,23 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
       flatpak_bwrap_add_args (bwrap,
                               "--dev-bind", "/dev", "/dev",
                               NULL);
+      /* Don't expose the host /dev/shm, just the device nodes */
+      if (g_file_test ("/dev/shm", G_FILE_TEST_IS_DIR))
+        flatpak_bwrap_add_args (bwrap,
+                                "--tmpfs", "/dev/shm",
+                                NULL);
+      else if (g_file_test ("/dev/shm", G_FILE_TEST_IS_SYMLINK))
+        {
+          g_autofree char *link = flatpak_readlink ("/dev/shm", NULL);
+          /* On debian (with sysv init) the host /dev/shm is a symlink to /run/shm, so we can't
+             mount on top of it. */
+          if (strcmp (link, "/run/shm") == 0)
+            flatpak_bwrap_add_args (bwrap,
+                                    "--dir", "/run/shm",
+                                    NULL);
+          else
+            g_warning ("Unexpected /dev/shm symlink %s", link);
+        }
     }
   else
     {


### PR DESCRIPTION
--device=all really means the device nodes, we should not expose the host
shared memory objects.

This change incidentally fixes issues with --device=all on debian (#2136)
where /dev/shm is a symlink to /run/shm, which doesn't exist in the sandbox.