### PR TITLE
transaction: Return G_IO_ERROR_CANCELLED when cancelled

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2840,6 +2840,12 @@ flatpak_transaction_run (FlatpakTransaction *self,
 
           if (!do_cont)
             {
+              if (g_cancellable_set_error_if_cancelled (cancellable, error))
+                {
+                  succeeded = FALSE;
+                  break;
+                }
+
               flatpak_fail_error (error, FLATPAK_ERROR_ABORTED, _("Aborted due to failure"));
               succeeded = FALSE;
               break;


### PR DESCRIPTION
Instead of FLATPAK_ERROR_ABORTED, return G_IO_ERROR_CANCELLED when the
passed in GCancellable gets cancelled. This makes it possible to cancel
updates in gnome-software without getting a generic "Aborted due to
failure" error popup.