### PR TITLE
Add lcov support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -182,3 +182,18 @@ AM_DISTCHECK_CONFIGURE_FLAGS =		\
 	--enable-documentation		\
 	--disable-maintainer-mode	\
 	--enable-introspection
+
+.PHONY: coverage lcov-clean genlcov
+
+coverage:
+	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) lcov-clean
+	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) check
+	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) genlcov
+
+lcov-clean:
+	$(AM_V_GEN) $(LCOV) --directory $(top_builddir) --zerocounters
+
+genlcov:
+	$(AM_V_GEN) $(LCOV) --directory $(top_builddir) --capture --output-file coverage.info
+	$(AM_V_GEN) $(GENHTML) --prefix $(top_builddir) --output-directory coverage coverage.info
+	$(AM_V_GEN)

--- a/Makefile.am
+++ b/Makefile.am
@@ -187,7 +187,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS =		\
 
 coverage:
 	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) lcov-clean
-	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) check
+	$(AM_V_GEN) $(MAKE) -j $(getconf _NPROCESSORS_ONLN) check
 	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) genlcov
 
 lcov-clean:

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -278,10 +278,10 @@ new_operation (FlatpakTransaction          *transaction,
 static void
 operation_done (FlatpakTransaction          *transaction,
                 FlatpakTransactionOperation *operation,
+                const char                  *commit,
                 FlatpakTransactionResult     details)
 {
   FlatpakTransactionOperationType operation_type = flatpak_transaction_operation_get_operation_type (operation);
-  const char *commit = flatpak_transaction_operation_get_commit (operation);
   g_autofree char *short_commit = g_strndup (commit, 12);
 
   progress_done (transaction);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -836,6 +836,7 @@ flatpak_transaction_class_init (FlatpakTransactionClass *klass)
    * FlatpakTransaction::operation-done:
    * @object: A #FlatpakTransaction
    * @operation: The #FlatpakTransactionOperation which finished
+   * @commit: The commit
    * @result: A #FlatpakTransactionResult giving details about the result
    *
    * The ::operation-done signal gets emitted during the execution of
@@ -848,7 +849,7 @@ flatpak_transaction_class_init (FlatpakTransactionClass *klass)
                   G_STRUCT_OFFSET (FlatpakTransactionClass, operation_done),
                   NULL, NULL,
                   NULL,
-                  G_TYPE_NONE, 2, FLATPAK_TYPE_TRANSACTION_OPERATION, G_TYPE_INT);
+                  G_TYPE_NONE, 3, FLATPAK_TYPE_TRANSACTION_OPERATION, G_TYPE_STRING, G_TYPE_INT);
 
   /**
    * FlatpakTransaction::choose-remote-for-ref:

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2166,7 +2166,10 @@ flatpak_transaction_get_current_operation (FlatpakTransaction *self)
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
 
-  return g_object_ref (priv->current_op);
+  if (priv->current_op)
+    return g_object_ref (priv->current_op);
+
+  return NULL;
 }
 
 /**

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -100,6 +100,7 @@ struct _FlatpakTransactionClass
                                         FlatpakTransactionProgress  *progress);
   void (*operation_done)       (FlatpakTransaction          *transaction,
                                 FlatpakTransactionOperation *operation,
+                                const char                  *commit,
                                 FlatpakTransactionResult     details);
   gboolean (*operation_error)  (FlatpakTransaction            *transaction,
                                 FlatpakTransactionOperation   *operation,

--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,27 @@ case "$host" in
 esac
 AC_SUBST(HIDDEN_VISIBILITY_CFLAGS)
 
+##########################################
+# Coverage testing
+##########################################
+AC_ARG_ENABLE(coverage,
+  AS_HELP_STRING([--enable-coverage],
+                 [enable coverage testing with gcov]),
+  [use_lcov=$enableval], [use_lcov=no])
+
+if test x$use_lcov = xyes; then
+  AC_PATH_PROG(LCOV, lcov)
+  AC_PATH_PROG(GENHTML, genhtml)
+
+  # remove all optimization from CFLAGS
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9]*//g'`
+  changequote([,])
+
+  CFLAGS="$CFLAGS -O0 -fprofile-arcs -ftest-coverage"
+  LDFLAGS="$LDFLAGS -lgcov"
+fi
+
 GLIB_TESTS
 
 FLATPAK_MAJOR_VERSION=flatpak_major_version

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-echo "1..3"
+echo "1..41"
 
 ${FLATPAK} --version > version_out
 
@@ -46,3 +46,19 @@ ${FLATPAK} --supported-arches > arches
 assert_streq `head -1 arches` `cat arch`
 
 echo "ok default arch"
+
+for cmd in install update uninstall list info config repair create-usb \
+           search run override make-current enter ps document-export \
+           document-unexport document-info document-list permission-remove \
+           permission-list permission-show permission-reset remotes remote-add \
+           remote-modify remote-delete remote-ls remote-info build-init \
+           build build-finish build-export build-bundle build-import-bundle \
+           build-sign build-update-repo build-commit-from repo;
+do
+  ${FLATPAK} $cmd --help | head -2 > help_out
+
+  assert_file_has_content help_out "^Usage:$"
+  assert_file_has_content help_out "${FLATPAK} $cmd"
+
+  echo "ok $cmd help"
+done

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-echo "1..41"
+echo "1..4"
 
 ${FLATPAK} --version > version_out
 
@@ -59,6 +59,6 @@ do
 
   assert_file_has_content help_out "^Usage:$"
   assert_file_has_content help_out "${FLATPAK} $cmd"
-
-  echo "ok $cmd help"
 done
+
+echo "ok command help"


### PR DESCRIPTION
This adds a --enable-coverage configure option and a
coverage target to generate coverage testing for
the testsuite. The generated html ends up in the
coverage/ directory.