### PR TITLE
tests: Only generate the test platform once

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -107,9 +107,9 @@ update-test-matrix:
 tests/test-%.wrap:
 	@true
 
-tests/runtime-repo: tests/make-test-runtime.sh
+tests/runtime-repo: tests/make-test-runtime.sh flatpak
 	rm -rf tests/runtime-repo
-	tests/make-test-runtime.sh tests/runtime-repo org.test.Platform ""
+	PATH=$$(cd $(top_builddir) && pwd):$${PATH} tests/make-test-runtime.sh tests/runtime-repo org.test.Platform ""
 
 check_DATA+=tests/runtime-repo
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -107,6 +107,12 @@ update-test-matrix:
 tests/test-%.wrap:
 	@true
 
+tests/runtime-repo: tests/make-test-runtime.sh
+	rm -rf tests/runtime-repo
+	tests/make-test-runtime.sh tests/runtime-repo org.test.Platform ""
+
+check_DATA+=tests/runtime-repo
+
 include tests/Makefile-test-matrix.am.inc
 
 test_scripts = ${TEST_MATRIX}

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -203,7 +203,7 @@ setup_repo_no_add () {
         COLLECTION_ID=
     fi
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Platform "${COLLECTION_ID}" bash ls cat echo readlink > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Platform "${COLLECTION_ID}" > /dev/null
     GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh repos/${REPONAME} "" "${COLLECTION_ID}" > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
     if [ $REPONAME == "test" ]; then
@@ -267,7 +267,7 @@ setup_sdk_repo () {
         COLLECTION_ID=""
     fi
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Sdk "${COLLECTION_ID}" bash ls cat echo readlink make mkdir cp touch > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Sdk "${COLLECTION_ID}" make mkdir cp touch > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -195,6 +195,36 @@ export FL_GPGARGS2="--gpg-homedir=${FL_GPG_HOMEDIR2} --gpg-sign=${FL_GPG_ID2}"
 export FL_GPG_BASE64="mQENBFbPBvoBCADWbz5O+XzuyN+dDExK81pci+gIzBNWB+7SsN0EgoJppKgwBCX+Bd6ERe9Yz0nJbJB/tjazRp7MnnoPnh6fXnhIbHA766/Eciy4sL5X8laqDmWmROCqCe79QZH/w6vYTKsDmoLQrw9eKRP1ilCvECNGcVdhIyfTDlNrU//uy5U4h2PVUz1/Al87lvaJnrj5423m5GnX+qpEG8mmpmcw52lvXNPuC95ykylPQJjI0WnOuaTcxzRhm5eHPkqKQ+nPIS+66iw1SFdobYuye/vg/rDiyp8uyQkh7FWXnzHxz4J8ovesnrCM7pKI4VEHCnZ4/sj2v9E3l0wJlqZxLTULaV3lABEBAAG0D1hkZy1hcHAgdGVzdGluZ4kBOAQTAQIAIgUCVs8G+gIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQE4sx4HsJYf2DiAf7BQ8anU3CgYpJjuO2rT8jQPO0jGRCNaPyaeAcBx8IjFkjf8daKMPCAt6gQioEpC8OhDig86Bl5piYOB7L7JSB53mgUrADJXhgC/dG4soCt7/U4wW30MseXdlXSOqHGApblF/bIs4B30OBGReBj3DcWIqyb48GraSKlPlaCpkZFySNEAcGUCeCqbbygxCQAM8MDq9FgVRk5oVrE/nAUm6oScEBhseoB7+CaHaRTmLoe/SBs0z2AJ7alIH1Sv4X3mQXpfsAIcWf3Zu2MZydF/Vuh8vTMROwPYtOVEtGxZvEBN3h5uc88dHSk928maqsop9T6oEwM43mBKCOu1gdAOw4OLkBDQRWzwb6AQgAx/XuEaQvdI3J2YYmOE6RY0jJZXLauXH46cJR4q70mlDev/OqYKTSLlo4q06D4ozCwzTYflppDak7kmjWMN224/u1koqFOtF76LsglAeLaQmweWmX0ecbPrzFYaX30kaQAqQ9Wk0PRe0+arRzWDWfUv3qX3y1decKUrBCuEC6WvVVwooWs+zX0cUBS8CROhazTjvXFAz36mhK0u+B3WCBlK+T2tIPOjLjlYgzYARw+X7/J6B3C798r2Hw/yXqCDcKLrq7WWUB33kv3buuG2G6LUamctdD8IsTBxi+nIjAvQITFqq4cPbbXAJGaAnWGuLOddQ9e/GhCOI4JjopRnnjOwARAQABiQEfBBgBAgAJBQJWzwb6AhsMAAoJEBOLMeB7CWH9TC8H/A6oreCxeiL8DPOWN29OaQ5sEw7Dg7bnLSZLu8aREgwfCiFSv0numOABjn/G89Y5M6NiEXFZZhUa+SXOALiBLUy98O84lyp9hlP9qGbWRgBXwe5vOAJERqtoUwR5bygpAw5Nc4y3wddPC4vH7upJ8ftU/eEFtPdI0cKrrAZDFdhXFp3RxdCC6fD62wbofE0mo1Ea1iD3xqVh2t7jfWN1RhMV308htHRGkkmWcEbbvHqugwL6dWZEvQmLYi6/7tQyA1KdG4AZksBP/MBi3t2hthRqQx1v52JwdCaZNuItuEe5rWXhfvoGxPoqYZt9ZPjna6yJfcfJwPbMfjNwX2LR4p4="
 export FL_GPG_BASE642="mQENBFkSyx4BCACq/8XFcF+NTpJKfoo8F6YyR8RQXww6kCV47zN78Dt7aCh43WSYLRUBRt1tW5MRT8R60pwCsGvKnFiNS2Vqe4T1IW4mDnFMZIZJXdNVwKUqVBPL/jzkIDnQ9NXtuPNH0qET6VhYnb9aykLo/MiBmx6q+4MvYd/qwiN8kstRifRIxjjZx6wsg+muY6yx9fZKxlgvhc3nsrl3oyDo7/+V+b3heYLtMCQFwlHRKz3Yf2X9H0aUSbDYcgTy6w3q94HVNCpJSqeiR+kBG175BQYKR2l7WYdaVPFf5LMEvAJh0SGnqu77X+8TYYRQiiBB5fYjGOeHfOh6uH5GAJRQymVIJwy/ABEBAAG0KkZsYXRwYWsgKFRlc3Qga2V5IDIpIDxmbGF0cGFrQGZsYXRwYWsub3JnPokBOAQTAQIAIgUCWRLLHgIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQdZ9f0LIxTvyeUQf/euAZpipXBkGWxeW4G10r1QRi2tZAWNeLpy8SB17eo9E6yB61SdH80jALborVs/plnZzKcFf+nLvjCn51FLMh6QPL3S+079WHsed//qtUWfbJ85hLevfCMTZMLktUmqwwUh238WW/gKtbUjYOqr1IZSMBoMiQtc0iOVBP7HUdhYigxTKvs/MBEGHANeQkY07ZnX9oFXElOo+EIPAHScwEOSwEVrXUVHpQODzIfjOoPUHWAZtM1yJT+iWmVHe4HtU8CyBnPyUcnTmTWKr92QmgfWkb1T7ugT5gXt/6ZlYAaZGnr9yNuSk3MMhDMOyldtJBM5Zl8eScE9KBf7pRJoxnMLkBDQRZEsseAQgAvA29IyiJpB+jUHj3MOyVyTBOmvLme+0Ndhpt/mTh+swchJUvzb0IzQS9Le5yVAvn+ppAtDCMb+bV4Xh5zrbiH0Hu0qwK4Qk+KcIKRE8ImDiUM8NFE2SZoomZSsgZ1NBWbAdEyVpkBfrt3Dd8FssMrwPF6kqo02TZr7Pxng+BEHUZT6jPCxueqyXyv2cLbQMe1H0U7klsxPmnnIYUqdwOmPxUspVEYP9oJb5y123mx0yj5JuYdZMjWbP3cRLox1RKIlFWgQqOn2yJiEoWzpqdbtb7sE3ggnbZKJED0ZxUZIakjnyMhX+GAEA8ZMZ6+HfDt1iHV8qHcYiLW5A3AQTxZwARAQABiQEfBBgBAgAJBQJZEsseAhsMAAoJEHWfX9CyMU78Ns4IAJRQ5UJ9KkeZClHm1EjYlgsAq1UJr9wgbyBFKTEkGZ/CAvVmgg+BUXcN/SPAkELbEAOJZTyv8C5cuJC49iFHOxUbRZXZ5eN2SvhZzl+5gep2uHwVLdqRIxFDTHbLWnmtHxPeU7IRA9u86q3wV1N0pD7kreNN7BWKY3/tI33hY2/XVVFy0MN5sutPn+lVK66MqAHqtode5xqqz9Z8LmS7LlqokQkAytcGd6Xqsx99NTk8kk3bnk9HWsAvDO8tRZroeseKeRNmbhGvCNUxPSB6bpYBJLvQtjA9ZVv6sNm0E+SuiXKizZkBGO5AH50pDoy0+MCGoOhwwXeY5+1kZAOzkMI="
 
+make_runtime () {
+    REPONAME="$1"
+    COLLECTION_ID="$2"
+    GPGARGS="$3"
+
+    if [ -d ${test_builddir}/runtime-repo ]; then
+        RUNTIME_REPO=${test_builddir}/runtime-repo
+    else
+        RUNTIME_REPO=${TEST_DATA_DIR}/runtime-repo
+        (
+            flock -s 200
+            if [ ! -d ${RUNTIME_REPO} ]; then
+                $(dirname $0)/make-test-runtime.sh ${RUNTIME_REPO} org.test.Platform "" > /dev/null
+            fi
+        ) 200>${TEST_DATADIR}/runtime-repo-lock
+    fi
+
+    if [ ! -d repos/${REPONAME} ]; then
+        if [ "x${COLLECTION_ID}" != "x" ]; then
+            collection_args=--collection-id=${COLLECTION_ID}
+        else
+            collection_args=
+        fi
+        mkdir -p repos
+        ostree --repo=repos/${REPONAME} init --mode=archive-z2 ${collection_args}
+    fi
+
+    flatpak build-commit-from --disable-fsync --src-repo=${RUNTIME_REPO} --force ${GPGARGS} repos/${REPONAME}  runtime/org.test.Platform/$(flatpak --default-arch)/master
+}
+
 setup_repo_no_add () {
     REPONAME=${1:-test}
     if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
@@ -203,7 +233,7 @@ setup_repo_no_add () {
         COLLECTION_ID=
     fi
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Platform "${COLLECTION_ID}" > /dev/null
+    make_runtime "${REPONAME}" "${COLLECTION_ID}" "${GPGARGS:-${FL_GPGARGS}}"
     GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh repos/${REPONAME} "" "${COLLECTION_ID}" > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
     if [ $REPONAME == "test" ]; then

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -203,8 +203,8 @@ setup_repo_no_add () {
         COLLECTION_ID=
     fi
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.Platform "${COLLECTION_ID}" bash ls cat echo readlink > /dev/null
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "" "${COLLECTION_ID}" > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Platform "${COLLECTION_ID}" bash ls cat echo readlink > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh repos/${REPONAME} "" "${COLLECTION_ID}" > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
     if [ $REPONAME == "test" ]; then
         $(dirname $0)/test-webserver.sh repos
@@ -255,7 +255,7 @@ make_updated_app () {
         COLLECTION_ID=""
     fi
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh ${REPONAME} "" "${COLLECTION_ID}" ${3:-UPDATED} > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-app.sh repos/${REPONAME} "" "${COLLECTION_ID}" ${3:-UPDATED} > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 
@@ -267,7 +267,7 @@ setup_sdk_repo () {
         COLLECTION_ID=""
     fi
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh ${REPONAME} org.test.Sdk "${COLLECTION_ID}" bash ls cat echo readlink make mkdir cp touch > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Sdk "${COLLECTION_ID}" bash ls cat echo readlink make mkdir cp touch > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 

--- a/tests/make-multi-collection-id-repo.sh
+++ b/tests/make-multi-collection-id-repo.sh
@@ -40,7 +40,7 @@ for i in {1..3}; do
     APP_ID=org.test.Hello${i}
     COLLECTION_ID=${COLLECTION_ID_PREFIX}${i}
 
-    $(dirname $0)/make-test-app.sh ${APP_REPO} ${APP_ID} ${COLLECTION_ID}
+    $(dirname $0)/make-test-app.sh repos/${APP_REPO} ${APP_ID} ${COLLECTION_ID}
     ref=$(ostree --repo=${APP_REPO_DIR} refs | grep ${APP_ID})
 
     ostree --repo=${REPO_DIR} remote add --no-gpg-verify --collection-id=${COLLECTION_ID} ${APP_REPO} file://${APP_REPO_DIR}

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -4,7 +4,7 @@ set -e
 
 DIR=`mktemp -d`
 
-REPONAME=$1
+REPO=$1
 shift
 APP_ID=$1
 shift
@@ -79,5 +79,5 @@ fi
 
 flatpak build-finish --command=hello.sh ${DIR}
 mkdir -p repos
-flatpak build-export ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} repos/${REPONAME} ${DIR}
+flatpak build-export ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR}
 rm -rf ${DIR}

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -7,7 +7,7 @@ set +x
 
 DIR=`mktemp -d`
 
-REPONAME=$1
+REPO=$1
 shift
 ID=$1
 shift
@@ -85,5 +85,5 @@ else
 fi
 
 mkdir -p repos
-flatpak build-export ${collection_args} --runtime ${GPGARGS-} repos/${REPONAME} ${DIR}
+flatpak build-export ${collection_args} --runtime ${GPGARGS-} ${REPO} ${DIR}
 rm -rf ${DIR}

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -58,7 +58,7 @@ add_bin() {
     fi
 }
 
-for i in $@; do
+for i in $@ bash ls cat echo readlink; do
     I=`which $i`
     add_bin $I
 done

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -95,8 +95,8 @@ EOF
 
 mkdir -p repos
 ostree init --repo=repos/test --mode=archive-z2
-. $(dirname $0)/make-test-runtime.sh test org.test.Platform "" bash ls cat echo readlink > /dev/null
-. $(dirname $0)/make-test-app.sh test "" "" > /dev/null
+. $(dirname $0)/make-test-runtime.sh repos/test org.test.Platform "" bash ls cat echo readlink > /dev/null
+. $(dirname $0)/make-test-app.sh repos/test "" "" > /dev/null
 
 # Modify platform metadata
 ostree checkout -U --repo=repos/test runtime/org.test.Platform/${ARCH}/master platform

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -941,7 +941,7 @@ make_test_runtime (void)
 {
   g_autofree char *arg0 = NULL;
   char *argv[] = {
-    NULL, "test", "org.test.Platform", "", "bash", "ls", "cat", "echo", "readlink", NULL
+    NULL, "repos/test", "org.test.Platform", "", "bash", "ls", "cat", "echo", "readlink", NULL
   };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-runtime.sh", NULL);
@@ -955,7 +955,7 @@ static void
 make_test_app (void)
 {
   g_autofree char *arg0 = NULL;
-  char *argv[] = { NULL, "test", "", "", NULL };
+  char *argv[] = { NULL, "repos/test", "", "", NULL };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
   argv[0] = arg0;
@@ -968,7 +968,7 @@ static void
 update_test_app (void)
 {
   g_autofree char *arg0 = NULL;
-  char *argv[] = { NULL, "test", "", "", "UPDATED", NULL };
+  char *argv[] = { NULL, "repos/test", "", "", "UPDATED", NULL };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-app.sh", NULL);
   argv[0] = arg0;

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -941,7 +941,7 @@ make_test_runtime (void)
 {
   g_autofree char *arg0 = NULL;
   char *argv[] = {
-    NULL, "repos/test", "org.test.Platform", "", "bash", "ls", "cat", "echo", "readlink", NULL
+    NULL, "repos/test", "org.test.Platform", "", NULL
   };
 
   arg0 = g_test_build_filename (G_TEST_DIST, "make-test-runtime.sh", NULL);


### PR DESCRIPTION
Rather than regenerating it over and over we generate the test
platform as check_DATA and refer to it from the individual tests.
This cuts down "time make check -j8" from 1:25 to 1:06 in user time on
my machine, which is nice in itself, but it is also a stepping stone
for splitting out our large test-scripts into smaller ones where it
will make even more difference.
    
For the installed-tests case we fall back to creating the platform  once per test.
