### PR TITLE
repair: Refer to ostree fsck

### DIFF
--- a/doc/flatpak-repair.xml
+++ b/doc/flatpak-repair.xml
@@ -58,6 +58,9 @@
                 Enumerate all deployed refs and re-install any that are not in the repo (or are partial for a non-subdir deploy).
             </para></listitem>
         </itemizedlist>
+        <para>
+          An alternative command for repairing OSTree repositories is ostree fsck.
+        </para>
 
     </refsect1>
 
@@ -141,6 +144,7 @@
 
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>ostree-fsck</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>


### PR DESCRIPTION
Add a mention of ostree fsck to the flatpak repair man page,
so people know there are more alternatives.