### PR TITLE
Include the icon in the tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -178,6 +178,8 @@ EXTRA_DIST += scripts/flatpak-bisect scripts/flatpak-coredumpctl
 
 EXTRA_DIST += README.md
 
+EXTRA_DIST += flatpak.png
+
 AM_DISTCHECK_CONFIGURE_FLAGS =		\
 	--enable-documentation		\
 	--disable-maintainer-mode	\


### PR DESCRIPTION
This makes it easier for third-party tools who want
to have an icon to use for flatpak.

Closes: #1344