### PR TITLE
Drop xdg-app migration support

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -591,8 +591,6 @@ main (int    argc,
   if (argc >= 4 && strcmp (argv[1], "complete") == 0)
     return complete (argc, argv);
 
-  flatpak_migrate_from_xdg_app ();
-
   ret = flatpak_run (argc, argv, &error);
 
   if (error != NULL)

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -302,8 +302,6 @@ FlatpakInstallation *
 flatpak_installation_new_user (GCancellable *cancellable,
                                GError      **error)
 {
-  flatpak_migrate_from_xdg_app ();
-
   return flatpak_installation_new_steal_dir (flatpak_dir_get_user (), cancellable, error);
 }
 
@@ -323,8 +321,6 @@ flatpak_installation_new_for_path (GFile *path, gboolean user,
                                    GCancellable *cancellable,
                                    GError **error)
 {
-  flatpak_migrate_from_xdg_app ();
-
   return flatpak_installation_new_steal_dir (flatpak_dir_new (path, user), cancellable, error);
 }
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2097,7 +2097,7 @@ setup_seccomp (FlatpakBwrap   *bwrap,
    *
    *  https://github.com/sandstorm-io/sandstorm
    *    in src/sandstorm/supervisor.c++
-   *  http://cgit.freedesktop.org/xdg-app/xdg-app/
+   *  https://github.com/flatpak/flatpak.git
    *    in common/flatpak-run.c
    *  https://git.gnome.org/browse/linux-user-chroot
    *    in src/setup-seccomp.c

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -97,8 +97,6 @@ char **flatpak_subpaths_merge (char **subpaths1,
 char *flatpak_get_lang_from_locale (const char *locale);
 char **flatpak_get_current_locale_langs (void);
 
-void flatpak_migrate_from_xdg_app (void);
-
 gboolean flatpak_write_update_checksum (GOutputStream *out,
                                         gconstpointer  data,
                                         gsize          len,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -605,29 +605,6 @@ flatpak_get_bwrap (void)
   return HELPER;
 }
 
-/* We only migrate the user dir, because thats what most people used with xdg-app,
- * and its where all per-user state/config are stored.
- */
-void
-flatpak_migrate_from_xdg_app (void)
-{
-  g_autofree char *source = g_build_filename (g_get_user_data_dir (), "xdg-app", NULL);
-  g_autofree char *dest = g_build_filename (g_get_user_data_dir (), "flatpak", NULL);
-
-  if (!g_file_test (dest, G_FILE_TEST_EXISTS) &&
-      g_file_test (source, G_FILE_TEST_EXISTS))
-    {
-      g_print (_("Migrating %s to %s\n"), source, dest);
-      if (rename (source, dest) != 0)
-        {
-          if (errno != ENOENT &&
-              errno != ENOTEMPTY &&
-              errno != EEXIST)
-            g_print (_("Error during migration: %s\n"), g_strerror (errno));
-        }
-    }
-}
-
 static gboolean
 is_valid_initial_name_character (gint c, gboolean allow_dash)
 {

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -752,8 +752,6 @@ main (int    argc,
   if (verbose)
     g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
 
-  flatpak_migrate_from_xdg_app ();
-
   client_pid_data_hash = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) pid_data_free);
 
   session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);


### PR DESCRIPTION
It has been long enough. It is unlikely that we can still
find any xdg-app installations in the wild.