### PR TITLE
remote-ls: Show runtimes

### DIFF
--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -179,6 +179,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--app-runtime=RUNTIME</option></term>
+
+                <listitem><para>
+                    List applications that use the given runtime
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--columns=FIELD,…</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
Add a runtime column that shows the runtime an application
is using, and add an --app-runtime option to allow filtering
by the used runtime.