### PR TITLE
Remove --show-columns leftovers

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -689,7 +689,6 @@ column_help (Column *columns)
 }
 
 /* Returns a filtered list of columns, free with g_free.
- * opt_show_help should correspond to --show-columns
  * opt_show_all should correspond to --show-details or be FALSE
  * opt_cols should correspond to --columns
  */

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -171,14 +171,6 @@
             </varlistentry>
 
             <varlistentry>
-                <term><option>--show-columns</option></term>
-
-                <listitem><para>
-                    Show the available values for the <option>--columns</option> option.
-                </para></listitem>
-            </varlistentry>
-
-            <varlistentry>
                 <term><option>--app-runtime=RUNTIME</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remotes.xml
+++ b/doc/flatpak-remotes.xml
@@ -127,14 +127,6 @@
             </varlistentry>
 
             <varlistentry>
-                <term><option>--show-columns</option></term>
-
-                <listitem><para>
-                    Show the available values for the <option>--columns</option> option.
-                </para></listitem>
-            </varlistentry>
-
-            <varlistentry>
                 <term><option>--columns=FIELD,…</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
When I decided to add --columns without --show-columns,
I remove the option everywhere. Almost. These are the
leftovers I forgot.