### PR TITLE
build-finish: Inherit permissions from runtime by default

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -42,6 +42,7 @@ static char **opt_extensions;
 static char **opt_remove_extensions;
 static char **opt_metadata;
 static gboolean opt_no_exports;
+static gboolean opt_no_inherit_permissions;
 static int opt_extension_prio = G_MININT;
 static char *opt_sdk;
 static char *opt_runtime;
@@ -57,7 +58,8 @@ static GOptionEntry options[] = {
   { "sdk", 0, 0, G_OPTION_ARG_STRING, &opt_sdk, N_("Change the sdk used for the app"),  N_("SDK") },
   { "runtime", 0, 0, G_OPTION_ARG_STRING, &opt_runtime, N_("Change the runtime used for the app"),  N_("RUNTIME") },
   { "metadata", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_metadata, N_("Set generic metadata option"),  N_("GROUP=KEY[=VALUE]") },
-  { NULL }
+  { "no-inherit-permissions", 0, 0, G_OPTION_ARG_NONE, &opt_no_inherit_permissions, N_("Don't inherit permissions from runtime"), NULL },
+ { NULL }
 };
 
 static gboolean
@@ -296,6 +298,7 @@ update_metadata (GFile *base, FlatpakContext *arg_context, gboolean is_runtime, 
   g_autofree char *path = NULL;
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autoptr(FlatpakContext) app_context = NULL;
+  g_autoptr(FlatpakContext) inherited_context = NULL;
   GError *temp_error = NULL;
   const char *group;
   int i;
@@ -445,12 +448,54 @@ update_metadata (GFile *base, FlatpakContext *arg_context, gboolean is_runtime, 
               g_print (_("No executable found\n"));
             }
         }
+
+      /* Inherit permissions from runtime by default */
+      if (!opt_no_inherit_permissions)
+        {
+          g_autofree char *runtime_ref = NULL;
+          g_autofree char *runtime_pref = NULL;
+          g_autoptr(GFile) runtime_deploy_dir = NULL;
+          g_autoptr(GFile) runtime_metadata_file = NULL;
+          g_autofree char *runtime_metadata_contents = NULL;
+          gsize runtime_metadata_size;
+          g_autoptr(GKeyFile) runtime_metakey = NULL;
+
+          runtime_pref = g_key_file_get_string (keyfile, group, FLATPAK_METADATA_KEY_RUNTIME, NULL);
+          if (runtime_pref == NULL)
+            {
+              flatpak_fail (error, _("No runtime defined for app"));
+              goto out;
+            }
+          runtime_ref = g_strconcat ("runtime/", runtime_pref, NULL);
+
+          runtime_deploy_dir = flatpak_find_deploy_dir_for_ref (runtime_ref, NULL, cancellable, error);
+          if (runtime_deploy_dir == NULL)
+            goto out;
+
+          runtime_metadata_file = g_file_get_child (runtime_deploy_dir, "metadata");
+          if (!g_file_load_contents (runtime_metadata_file, cancellable,
+                                     &runtime_metadata_contents, &runtime_metadata_size, NULL, error))
+            goto out;
+
+          runtime_metakey = g_key_file_new ();
+          if (!g_key_file_load_from_data (runtime_metakey, runtime_metadata_contents, runtime_metadata_size, 0, error))
+            goto out;
+
+          inherited_context = flatpak_context_new ();
+          if (!flatpak_context_load_metadata (inherited_context, runtime_metakey, error))
+            goto out;
+
+          /* non-permissions are inherited at runtime, so no need to inherit them */
+          flatpak_context_reset_non_permissions (inherited_context);
+        }
     }
 
   if (opt_require_version)
     g_key_file_set_string (keyfile, group, "required-flatpak", opt_require_version);
 
   app_context = flatpak_context_new ();
+  if (inherited_context)
+    flatpak_context_merge (app_context, inherited_context);
   if (!flatpak_context_load_metadata (app_context, keyfile, error))
     goto out;
   flatpak_context_merge (app_context, arg_context);

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -111,6 +111,7 @@ gboolean       flatpak_context_get_needs_session_bus_proxy (FlatpakContext *cont
 gboolean       flatpak_context_get_needs_system_bus_proxy (FlatpakContext *context);
 
 void           flatpak_context_reset_permissions (FlatpakContext *context);
+void           flatpak_context_reset_non_permissions (FlatpakContext *context);
 void           flatpak_context_make_sandboxed (FlatpakContext *context);
 
 gboolean       flatpak_context_allows_features (FlatpakContext        *context,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1824,6 +1824,12 @@ flatpak_context_add_bus_filters (FlatpakContext *context,
 }
 
 void
+flatpak_context_reset_non_permissions (FlatpakContext *context)
+{
+  g_hash_table_remove_all (context->env_vars);
+}
+
+void
 flatpak_context_reset_permissions (FlatpakContext *context)
 {
   context->shares_valid = 0;

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -399,6 +399,14 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
+                <term><option>--no-inherit-permissions</option></term>
+
+                <listitem><para>
+                    Don't inherit runtime permissions in the app.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -52,6 +52,12 @@
             group are set according to the options.
         </para>
         <para>
+             As part of finalization you can also specify permissions that the
+             app needs, using the various options specified below. Additionally
+             during finalization the permissions from the runtime are inherited
+             into the app unless you specify <option>--no-inherit-permissions</option>
+        </para>
+        <para>
             You should review the exported files and the application metadata
             before creating and distributing an application bundle.
         </para>


### PR DESCRIPTION
In version 0.99.1 (065053775b18e8a0f53cc94c1fb2b6cfa46cc0bc) flatpak
stopped inheriting permissions from the runtime, because that made
the story about application permissions way to complicated. What
we want is to have a static set of permissions for the app that
is frozen at install time.

However, inheriting permissions from the runtime makes a lot of sense
as certain permissions are required from the runtime, in particular this
is used by the kde runtime to read the kdeglobals file, etc.

So, to combine the best of the two worlds, we now do inherit permissions,
but at build-time (and you can disable it if you want). This way
kde apps don't have to repeat themselves, but we still get static
application permissions.