### PR TITLE
installation: Don't return freed memory

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1512,7 +1512,7 @@ flatpak_installation_load_app_overrides (FlatpakInstallation *self,
                                          GError             **error)
 {
   g_autoptr(FlatpakDir) dir = NULL;
-  g_autofree char *metadata_contents = NULL;
+  char *metadata_contents;
   gsize metadata_size;
 
   dir = flatpak_installation_get_dir (self, error);


### PR DESCRIPTION
flatpak_installation_load_app_overrides was returning freed memory. Oops.