### PR TITLE
common: Reload FlatpakRemoteState after changes

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -100,6 +100,14 @@ gboolean flatpak_remote_state_ensure_summary (FlatpakRemoteState *self,
                                               GError            **error);
 gboolean flatpak_remote_state_ensure_metadata (FlatpakRemoteState *self,
                                                GError            **error);
+gboolean flatpak_remote_state_refresh (FlatpakRemoteState *self,
+                                       FlatpakDir         *dir,
+                                       gboolean            optional,
+                                       gboolean            local_only,
+                                       GBytes             *opt_summary,
+                                       GBytes             *opt_summary_sig,
+                                       GCancellable       *cancellable,
+                                       GError            **error);
 gboolean flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,
                                           const char         *ref,
                                           char              **out_checksum,

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1809,6 +1809,12 @@ flatpak_transaction_update_metadata (FlatpakTransaction *self,
 
   flatpak_installation_drop_caches (priv->installation, NULL, NULL);
 
+  GLNX_HASH_TABLE_FOREACH_KV (priv->remote_states, const char *, remote, FlatpakRemoteState *, state)
+    {
+      if (!flatpak_remote_state_refresh (state, priv->dir, TRUE, FALSE, NULL, NULL, cancellable, error))
+        return FALSE;
+    }
+
   return TRUE;
 }
 


### PR DESCRIPTION
Some remote metadata can cause changes to the local configuration for a
remote, but Flatpak is not properly reloading the new config after
making changes. Specifically in flatpak_transaction_update_metadata() we
call flatpak_dir_update_remote_configuration() for each remote and then
try to reload the configuration by calling flatpak_dir_recreate_repo().
The problem is that while this reloads the config instance stored by the
repo member of the FlatpakDir, the FlatpakTransaction object still has
FlatpakRemoteState objects stored which were initialized from the old
config.

So this commit adds a function called flatpak_remote_state_refresh()
which re-reads the config and re-initializes the summary and metadata,
because if for example a collection ID was added that will cause the
metadata to be fetched in a different way. This refresh function is then
called for each FlatpakRemoteState object held by the
FlatpakTransaction. It would be easier just to free them all, but I
don't think we can assume there are no references held on them.

The concrete bug this fixes is that if a remote repository has the
"ostree.deploy-collection-id" key set in its metadata, the next
install/update operation from that remote will fail with the error
message "Can't pull from untrusted non-gpg verified remote", and then
subsequent operations will succeed. This is because during the first
operation Flatpak will add the collection ID to the local configuration
in flatpak_transaction_update_metadata() but then in
flatpak_dir_install() the outdated FlatpakRemoteState object will be
used which still has no collection ID.