### PR TITLE
common: Reload FlatpakRemoteState after changes

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1809,6 +1809,9 @@ flatpak_transaction_update_metadata (FlatpakTransaction *self,
 
   flatpak_installation_drop_caches (priv->installation, NULL, NULL);
 
+  /* These are potentially out of date now */
+  g_hash_table_remove_all (priv->remote_states);
+
   return TRUE;
 }
 


### PR DESCRIPTION
Some remote metadata can cause changes to the local configuration for a
remote, but Flatpak is not properly reloading the new config after
making changes. Specifically in flatpak_transaction_update_metadata() we
call flatpak_dir_update_remote_configuration() for each remote and then
try to reload the configuration by calling flatpak_dir_recreate_repo().
The problem is that while this reloads the config instance stored by the
repo member of the FlatpakDir, the FlatpakTransaction object still has
FlatpakRemoteState objects stored which were initialized from the old
config.

A consequence of this is that if a remote repository has the
"ostree.deploy-collection-id" key set in its metadata, the next
install/update operation from that remote will fail with the error
message "Can't pull from untrusted non-gpg verified remote", and then
subsequent operations will succeed. This is because during the first
operation Flatpak will add the collection ID to the local configuration
in flatpak_transaction_update_metadata() but then in
flatpak_dir_install() the outdated FlatpakRemoteState object will be
used which still has no collection ID.

So this commit frees all the stored FlatpakRemoteState objects on the
transaction, so they will be recreated when they're needed (based on the
new config).