### PR TITLE
tests/Makefile.am.inc: Fix distcheck error

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -113,6 +113,9 @@ tests/runtime-repo: tests/make-test-runtime.sh flatpak
 
 check_DATA+=tests/runtime-repo
 
+distclean-local:
+	rm -rf tests/runtime-repo
+
 include tests/Makefile-test-matrix.am.inc
 
 test_scripts = ${TEST_MATRIX}

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -109,7 +109,7 @@ tests/test-%.wrap:
 
 tests/runtime-repo: tests/make-test-runtime.sh flatpak
 	rm -rf tests/runtime-repo
-	PATH=$$(cd $(top_builddir) && pwd):$${PATH} tests/make-test-runtime.sh tests/runtime-repo org.test.Platform ""
+	PATH=$(abs_top_builddir):$${PATH} $(top_srcdir)/tests/make-test-runtime.sh tests/runtime-repo org.test.Platform ""
 
 check_DATA+=tests/runtime-repo
 


### PR DESCRIPTION
Currently `make distcheck` fails with:

PATH=$(cd . && pwd):${PATH} tests/make-test-runtime.sh
tests/runtime-repo org.test.Platform ""
/bin/bash: tests/make-test-runtime.sh: No such file or directory

This was caused by commit b5d86fe90 and is fixed by this commit.