### PR TITLE
run: Make repos optional (again)

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -112,7 +112,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
   g_option_context_add_group (context, flatpak_context_get_options (arg_context));
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,
-                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS,
+                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS | FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO,
                                      &dirs, cancellable, error))
     return FALSE;
 


### PR DESCRIPTION
If some installation is empty (or otherwise broken) we fail the
entire run command, even though the app might exist in e.g. the
user installation. This is a regression from
651c86d3c60cdf41e9dea2ce23cc7eb2aacb9b4f which also ended up in 1.0.4.