### PR TITLE
Remove old OSTree version checks

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8126,17 +8126,6 @@ flatpak_dir_update (FlatpakDir                           *self,
         return flatpak_fail_error (error, FLATPAK_ERROR_DOWNGRADE,
                                    _("Can't update to a specific commit without root permissions"));
 
-      if (!OSTREE_CHECK_VERSION (2017, 13))
-        {
-          /* If the existing pull is partial, disable static deltas. They can
-           * break on ostree < 2017.13 which doesn't look at the parent repo for
-           * commitpartial state. This was fixed in
-           * https://github.com/ostreedev/ostree/commit/90ebd48f6aaf45c47b48c44354359f973dcf22a8
-           */
-          if (old_subpaths && old_subpaths[0] != NULL)
-            flatpak_flags |= FLATPAK_PULL_FLAGS_NO_STATIC_DELTAS;
-        }
-
       if (!flatpak_dir_ensure_repo (self, cancellable, error))
         return FALSE;
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -567,23 +567,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRepoTransaction, flatpak_repo_transaction_
 
 #define AUTOLOCK(name) G_GNUC_UNUSED __attribute__((cleanup (flatpak_auto_unlock_helper))) GMutex * G_PASTE (auto_unlock, __LINE__) = flatpak_auto_lock_helper (&G_LOCK_NAME (name))
 
-/* OSTREE_CHECK_VERSION was added immediately after the 2017.3 release */
-#ifndef OSTREE_CHECK_VERSION
-#define OSTREE_CHECK_VERSION(year, minor) (0)
-#endif
-/* Cleanups are always exported in 2017.4, and some git releases between 2017.3 and 2017.4.
-   We actually check against 2017.3 so that we work on the git releases *after* 2017.3
-   which is safe, because the real OSTREE_CHECK_VERSION macro was added after 2017.3
-   too. */
-#if !OSTREE_CHECK_VERSION (2017, 3)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepo, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeMutableTree, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeAsyncProgress, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeGpgVerifyResult, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoCommitModifier, ostree_repo_commit_modifier_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeRepoDevInoCache, ostree_repo_devino_cache_unref)
-#endif
-
 #if !defined(SOUP_AUTOCLEANUPS_H) && !defined(__SOUP_AUTOCLEANUPS_H__)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupSession, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupMessage, g_object_unref)


### PR DESCRIPTION
Flatpak depends on OSTree 2018.7 now, so we don't need these.