### PR TITLE
installation: Respect configured set of repo finders

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1237,6 +1237,9 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
 #if OSTREE_CHECK_VERSION (2018, 9)
       else if (default_repo_finders == NULL)
         types_filter[i] = TRUE;
+#else
+      else
+        types_filter[i] = TRUE;
 #endif
     }
 
@@ -1246,15 +1249,21 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
       g_autofree char *default_repo_finders_str = g_strjoinv (" ", default_repo_finders);
       g_debug ("Using default repo finder list: %s", default_repo_finders_str);
 
-      if (g_strv_contains (default_repo_finders, "config"))
-        types_filter[FLATPAK_REMOTE_TYPE_STATIC] = TRUE;
-      else if (g_strv_contains (default_repo_finders, "lan"))
-        types_filter[FLATPAK_REMOTE_TYPE_LAN] = TRUE;
-      else if (g_strv_contains (default_repo_finders, "mount"))
-        types_filter[FLATPAK_REMOTE_TYPE_USB] = TRUE;
-      else
-        g_warning ("Unknown value in list returned by ostree_repo_get_default_repo_finders(): %s",
-                   default_repo_finders_str);
+      for (const char **iter = default_repo_finders; iter && *iter; iter++)
+        {
+          const char *default_repo_finder = *iter;
+
+          if (strcmp (default_repo_finder, "config") == 0)
+            types_filter[FLATPAK_REMOTE_TYPE_STATIC] = TRUE;
+          else if (strcmp (default_repo_finder, "lan") == 0)
+            types_filter[FLATPAK_REMOTE_TYPE_LAN] = TRUE;
+          else if (strcmp (default_repo_finder, "mount") == 0)
+            types_filter[FLATPAK_REMOTE_TYPE_USB] = TRUE;
+          else
+            g_debug ("Unknown value in list returned by "
+                     "ostree_repo_get_default_repo_finders(): %s",
+                     default_repo_finder);
+        }
     }
 #endif
 

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1234,12 +1234,18 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
     {
       if (num_types != 0)
         types_filter[i] = FALSE;
+#if OSTREE_CHECK_VERSION (2018, 9)
       else if (default_repo_finders == NULL)
         types_filter[i] = TRUE;
+#endif
     }
 
+#if OSTREE_CHECK_VERSION (2018, 9)
   if (default_repo_finders != NULL && num_types == 0)
     {
+      g_autofree char *default_repo_finders_str = g_strjoinv (" ", default_repo_finders);
+      g_debug ("Using default repo finder list: %s", default_repo_finders_str);
+
       if (g_strv_contains (default_repo_finders, "config"))
         types_filter[FLATPAK_REMOTE_TYPE_STATIC] = TRUE;
       else if (g_strv_contains (default_repo_finders, "lan"))
@@ -1247,8 +1253,10 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
       else if (g_strv_contains (default_repo_finders, "mount"))
         types_filter[FLATPAK_REMOTE_TYPE_USB] = TRUE;
       else
-        g_debug ("Invalid value was returned by ostree_repo_get_default_repo_finders()");
+        g_warning ("Unknown value in list returned by ostree_repo_get_default_repo_finders(): %s",
+                   default_repo_finders_str);
     }
+#endif
 
   for (i = 0; i < num_types; ++i)
     {

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1210,7 +1210,9 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
   const guint NUM_FLATPAK_REMOTE_TYPES = 3;
   gboolean types_filter[NUM_FLATPAK_REMOTE_TYPES];
   gsize i;
+#if OSTREE_CHECK_VERSION (2018, 9)
   const char * const *default_repo_finders = NULL;
+#endif
 
   remote_names = flatpak_dir_list_remotes (dir, cancellable, error);
   if (remote_names == NULL)

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1246,10 +1246,10 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
 #if OSTREE_CHECK_VERSION (2018, 9)
   if (default_repo_finders != NULL && num_types == 0)
     {
-      g_autofree char *default_repo_finders_str = g_strjoinv (" ", default_repo_finders);
+      g_autofree char *default_repo_finders_str = g_strjoinv (" ", (gchar **)default_repo_finders);
       g_debug ("Using default repo finder list: %s", default_repo_finders_str);
 
-      for (const char **iter = default_repo_finders; iter && *iter; iter++)
+      for (const char * const *iter = default_repo_finders; iter && *iter; iter++)
         {
           const char *default_repo_finder = *iter;
 


### PR DESCRIPTION
OSTree now has a repo config option to set which repo finders (that is,
sources for refs) will be used, and API which exposes the default set
(which was either configured by the user or decided by libostree). So
this commit changes flatpak_installation_list_remotes_by_type() to
respect that configuration, since that's the only place flatpak passes a
set of OstreeRepoFinder instances to libostree.

See also https://github.com/ostreedev/ostree/pull/1758/