### PR TITLE
common: Document that get_latest_commit() can return NULL

### DIFF
--- a/common/flatpak-installed-ref.c
+++ b/common/flatpak-installed-ref.c
@@ -280,7 +280,7 @@ flatpak_installed_ref_get_origin (FlatpakInstalledRef *self)
  *
  * Gets the latest commit of the ref.
  *
- * Returns: (transfer none): the latest commit
+ * Returns: (transfer none) (nullable): the latest commit
  */
 const char *
 flatpak_installed_ref_get_latest_commit (FlatpakInstalledRef *self)


### PR DESCRIPTION
It's possible for the "latest_commit" field of a FlatpakInstalledRef to
be NULL, which I think happens if the ref is no longer in the
remote.[1][2][3] So this commit documents the possibility of
flatpak_installed_ref_get_latest_commit() returning NULL.

[1] https://github.com/flatpak/flatpak/issues/309
[2] https://github.com/flatpak/flatpak/commit/6b4402b60
[3] https://github.com/flatpak/flatpak/commit/230e18db7