### PR TITLE
wip: Dconf

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -9,6 +9,7 @@ dn=$(dirname $0)
 pkg_install sudo which attr fuse bison \
     libubsan libasan libtsan clang python2 \
     elfutils git gettext-devel libappstream-glib-devel hicolor-icon-theme \
+    dconf-devel \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree
 pkg_install_builddeps flatpak

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -140,9 +140,10 @@ libflatpak_common_la_CFLAGS = \
 	$(LIBSECCOMP_CFLAGS) \
 	$(INTERNAL_GPGME_CFLAGS) \
 	$(SYSTEMD_CFLAGS) \
+	$(DCONF_CFLAGS) \
 	-I$(srcdir)/dbus-proxy \
 	$(NULL)
-libflatpak_common_la_LIBADD = $(AM_LIBADD) libglnx.la $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(XAUTH_LIBS) $(LIBSECCOMP_LIBS) $(INTERNAL_GPGME_LIBS) $(SYSTEMD_LIBS)
+libflatpak_common_la_LIBADD = $(AM_LIBADD) libglnx.la $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(XAUTH_LIBS) $(LIBSECCOMP_LIBS) $(INTERNAL_GPGME_LIBS) $(SYSTEMD_LIBS) $(DCONF_LIBS)
 
 
 libflatpak_la_SOURCES = \

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -104,6 +104,9 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_REF "ref"
 #define FLATPAK_METADATA_KEY_TAG "tag"
 
+#define FLATPAK_METADATA_GROUP_DCONF "X-DConf"
+#define FLATPAK_METADATA_KEY_DCONF_PATHS "paths"
+
 gboolean  flatpak_run_add_extension_args (FlatpakBwrap *bwrap,
                                           GKeyFile     *metakey,
                                           const char   *full_ref,

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,7 @@ POLKIT_GOBJECT_REQUIRED=0.98
 
 PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0 libarchive >= 2.8.0 libxml-2.0 >= 2.4 ])
 PKG_CHECK_MODULES(SOUP, [libsoup-2.4])
+PKG_CHECK_MODULES(DCONF, [dconf])
 PKG_CHECK_MODULES(SYSTEMD, [libsystemd], [have_libsystemd=yes], [have_libsystemd=no])
 if test $have_libsystemd = yes; then
   AC_DEFINE(HAVE_LIBSYSTEMD, 1, [Define if libsystemd is available])


### PR DESCRIPTION
This is a proof-of-concept patch to make defaults and locks from dconf available in a form that the keyfile settings backend will be able to read when the corresponding glib branch is merged.

The session-helper changes here are preliminary. I think we should watch dconf for changes, and then use dconf library to generate the files, instead of spawning dconf dump and dconf list-locks.