### PR TITLE
Don't allow writes to runtime files in /etc

### DIFF
--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -245,7 +245,7 @@ flatpak_bwrap_add_args_data (FlatpakBwrap *bwrap,
   if (!flatpak_buffer_to_sealed_memfd_or_tmpfile (&args_tmpf, name, content, content_size, error))
     return FALSE;
 
-  flatpak_bwrap_add_args_data_fd (bwrap, "--bind-data", glnx_steal_fd (&args_tmpf.fd), path);
+  flatpak_bwrap_add_args_data_fd (bwrap, "--ro-bind-data", glnx_steal_fd (&args_tmpf.fd), path);
   return TRUE;
 }
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -207,7 +207,7 @@ flatpak_run_add_x11_args (FlatpakBwrap *bwrap,
                   g_autofree char *dest = g_strdup_printf ("/run/user/%d/Xauthority", getuid ());
 
                   write_xauth (d, output);
-                  flatpak_bwrap_add_args_data_fd (bwrap, "--bind-data", tmp_fd, dest);
+                  flatpak_bwrap_add_args_data_fd (bwrap, "--ro-bind-data", tmp_fd, dest);
 
                   flatpak_bwrap_set_env (bwrap, "XAUTHORITY", dest, TRUE);
                 }

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2466,7 +2466,7 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
             }
           else
             {
-              flatpak_bwrap_add_args (bwrap, "--bind", src, dest, NULL);
+              flatpak_bwrap_add_args (bwrap, "--ro-bind", src, dest, NULL);
             }
         }
     }


### PR DESCRIPTION
We mistakenly bind-mounted the runtime /usr/etc files read-write in /etc, which means that application could modify some parts of the runtimes (at least when using a per-user installed runtime). Fix this by using a --ro-bind.

We also disallow writes to various configuration files generated specifically for the sandbox. The app modifying these will not cause any problems, but it is still unnecessary to even make this possible.