### PR TITLE
Small fixes to many man pages

### DIFF
--- a/doc/flatpak-build-bundle.xml
+++ b/doc/flatpak-build-bundle.xml
@@ -107,7 +107,7 @@
                 <term><option>--runtime-repo=URL</option></term>
 
                 <listitem><para>
-                  The URL for a .flatpakrepo file that contains
+                  The URL for a <filename>.flatpakrepo</filename> file that contains
                   the information about the repository that supplies
                   the runtimes required by the app.
                 </para></listitem>
@@ -117,7 +117,7 @@
                 <term><option>--gpg-keys=FILE</option></term>
 
                 <listitem><para>
-                    Add the GPG key from FILE (use - for stdin).
+                    Add the GPG key from <arg choice="plain">FILE</arg> (use - for stdin).
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -135,7 +135,7 @@
                 <term><option>--exclude=PATTERN</option></term>
 
                 <listitem><para>
-                    Exclude files matching PATTERN from the commit.
+                    Exclude files matching <arg choice="plain">PATTERN</arg> from the commit.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -144,7 +144,7 @@
                 <term><option>--include=PATTERN</option></term>
 
                 <listitem><para>
-                    Don't exclude files matching PATTERN from the commit, even if they match the --export patterns.
+                    Don't exclude files matching <arg choice="plain">PATTERN</arg> from the commit, even if they match the <option>--export</option> patterns.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -156,7 +156,7 @@
                   Use the specified filename as metadata in the exported app instead of
                   the default file (called <filename>metadata</filename>). This is useful
                   if you want to commit multiple things from a single build tree, typically
-                  used in combination with --files and --exclude.
+                  used in combination with <option>--files</option> and <option>--exclude</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -280,8 +280,8 @@ key=v1;v2;
                 <term><option>--own-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to own the well known name NAME on the session bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
+                    Allow the application to own the well known name <arg choice="plain">NAME</arg> on the session bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to own all matching names.
 
                     This updates the [Session Bus Policy] group in the metadata.
                     This option can be used multiple times.
@@ -292,8 +292,8 @@ key=v1;v2;
                 <term><option>--talk-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to talk to the well known name NAME on the session bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    Allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the session bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
                     This updates the [Session Bus Policy] group in the metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -303,8 +303,8 @@ key=v1;v2;
                 <term><option>--system-own-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to own the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
+                    Allow the application to own the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to own all matching names.
                     This updates the [System Bus Policy] group in the metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -314,8 +314,8 @@ key=v1;v2;
                 <term><option>--system-talk-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to talk to the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    Allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
                     This updates the [System Bus Policy] group in the metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -326,7 +326,7 @@ key=v1;v2;
 
                 <listitem><para>
                     If the application doesn't have access to the real homedir, make the (homedir-relative) path
-                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    <arg choice="plain">FILENAME</arg> a bind mount to the corresponding path in the per-application directory,
                     allowing that location to be used for persistent data.
                     This updates the [Context] group in the metadata.
                     This option can be used multiple times.
@@ -391,7 +391,7 @@ key=v1;v2;
                 <listitem><para>
                     Adds information about extra data uris to the app. These will be downloaded
                     and verified by the client when the app is installed and placed in the
-                    /app/extra directory. You can also supply an /app/bin/apply_extra script
+                    <filename>/app/extra</filename> directory. You can also supply an <filename>/app/bin/apply_extra</filename> script
                     that will be run after the files are downloaded.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build-init.xml
+++ b/doc/flatpak-build-init.xml
@@ -121,7 +121,7 @@
                 <term><option>--sdk-extension=EXTENSION</option></term>
 
                 <listitem><para>
-                    When using --writable-sdk, in addition to the sdk, also install the specified extension.
+                    When using <option>--writable-sdk</option>, in addition to the sdk, also install the specified extension.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -138,7 +138,7 @@
                 <term><option>--sdk-dir</option></term>
 
                 <listitem><para>
-                    Specify a custom subdirectory to use instead of <filename>usr</filename> for --writable-sdk.
+                    Specify a custom subdirectory to use instead of <filename>usr</filename> for <option>--writable-sdk</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -162,7 +162,7 @@
                 <term><option>--base-version=VERSION</option></term>
 
                 <listitem><para>
-                    Specify the version to use for --base. If not specified, will default to
+                    Specify the version to use for <option>--base</option>. If not specified, will default to
                     "master".
                 </para></listitem>
             </varlistentry>
@@ -170,7 +170,7 @@
                 <term><option>--base-extension=EXTENSION</option></term>
 
                 <listitem><para>
-                    When using --base, also install the specified extension from the app.
+                    When using <option>--base</option>, also install the specified extension from the app.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -126,7 +126,7 @@
                 <listitem><para>
                     Share a subsystem with the host session. This overrides
                     the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
+                    <arg choice="plain">SUBSYSTEM</arg> must be one of: network, ipc.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -137,7 +137,7 @@
                 <listitem><para>
                     Don't share a subsystem with the host session. This overrides
                     the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
+                    <arg choice="plain">SUBSYSTEM</arg> must be one of: network, ipc.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -148,7 +148,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
+                    <arg choice="plain">SOCKET</arg> must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -159,7 +159,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
+                    <arg choice="plain">SOCKET</arg> must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -170,7 +170,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -181,7 +181,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -192,7 +192,7 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
                     This option can be used multiple times.
                     </para><para>
                     See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
@@ -206,7 +206,7 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -217,7 +217,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -234,7 +234,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
@@ -245,7 +245,7 @@
                 <term><option>--with-appdir</option></term>
 
                 <listitem><para>
-                  Expose and configure access to the per-app storage directory in $HOME/.var/app. This is
+                  Expose and configure access to the per-app storage directory in <filename>$HOME/.var/app</filename>. This is
                   not normally useful when building, but helps when testing built apps.
                 </para></listitem>
             </varlistentry>
@@ -328,7 +328,7 @@ key=v1;v2;
 
                 <listitem><para>
                     If the application doesn't have access to the real homedir, make the (homedir-relative) path
-                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    <arg choice="plain">FILENAME</arg> a bind mount to the corresponding path in the per-application directory,
                     allowing that location to be used for persistent data.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
@@ -340,9 +340,9 @@ key=v1;v2;
 
                 <listitem><para>
                   Normally if there is a <filename>usr</filename> directory in the build dir, this is used
-                  for the runtime files (this can be created by --writable-sdk or --type=runtime arguments
-                  to build-init). If you specify --sdk-dir this directoryname will be used instead.
-                  Use this if you passed --sdk-dir to build-init.
+                  for the runtime files (this can be created by <option>--writable-sdk</option> or <option>--type=runtime</option> arguments
+                  to build-init). If you specify <option>--sdk-dir</option>, this directory will be used instead.
+                  Use this if you passed <option>--sdk-dir</option> to build-init.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-config.xml
+++ b/doc/flatpak-config.xml
@@ -41,7 +41,17 @@
         <title>Description</title>
 
         <para>
-            Show and modify current configuration
+            Show and modify the configuration of a flatpak installation.
+        </para>
+
+        <para>
+            For configuration of individual remotes, see
+            <citerefentry><refentrytitle>flatpak-remote-modify</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+        </para>
+
+        <para>
+            For configuration of individual applications, see
+            <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
         </para>
 
     </refsect1>
@@ -65,7 +75,7 @@
                 <term><option>--list</option></term>
 
                 <listitem><para>
-                    Print all keys and their values
+                    Print all keys and their values.
                 </para></listitem>
             </varlistentry>
 
@@ -73,7 +83,7 @@
                 <term><option>--set</option></term>
 
                 <listitem><para>
-                    Set key KEY to VALUE
+                    Set key <arg choice="plain">KEY</arg> to <arg choice="plain">VALUE</arg>.
                 </para></listitem>
             </varlistentry>
 
@@ -81,7 +91,7 @@
                 <term><option>--unset</option></term>
 
                 <listitem><para>
-                    Unset key KEY
+                    Unset key <arg choice="plain">KEY</arg>.
                 </para></listitem>
             </varlistentry>
 
@@ -89,7 +99,7 @@
                 <term><option>--get</option></term>
 
                 <listitem><para>
-                  Print value of KEY.
+                  Print value of <arg choice="plain">KEY</arg>.
                 </para></listitem>
             </varlistentry>
 
@@ -116,8 +126,8 @@
                     Configure the system-wide installation
                     specified by <arg choice="plain">NAME</arg> among those defined in
                     <filename>/etc/flatpak/installations.d/</filename>. Using
-                    <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -154,6 +164,8 @@
 
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-remote-modify</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-create-usb.xml
+++ b/doc/flatpak-create-usb.xml
@@ -62,7 +62,7 @@
         <para>
             By default this looks for both installed apps and runtimes
             with the given <arg choice="plain">REF</arg>, but you can
-            limit this by using the --app or --runtime option.
+            limit this by using the <option>--app</option> or <option>--runtime</option> option.
         </para>
         <para>
             All <arg choice="plain">REF</arg>s must be in the same installation (user, system, or other).
@@ -77,7 +77,7 @@
             consumers of libostree) for install/update operations.
         </para>
         <para>
-            Unless overridden with the --system, --user, or --installation
+            Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option>
             options, this command searches both the system-wide installation
             and the per-user one for <arg choice="plain">REF</arg> and errors
             out if it exists in more than one.
@@ -123,8 +123,8 @@
                     Copy refs from a system-wide installation specified by
                     <arg choice="plain">NAME</arg> among those defined in
                     <filename>/etc/flatpak/installations.d/</filename>.  Using
-                    <arg choice="plain">--installation=default</arg> is
-                    equivalent to using <arg choice="plain">--system</arg>.
+                    <option>--installation=default</option> is
+                    equivalent to using <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -147,7 +147,7 @@
                 <term><option>--destination-repo</option>=DEST</term>
 
                 <listitem><para>
-                  Create the repository in DEST under MOUNT-PATH, rather than
+                  Create the repository in <arg choice="plain">DEST</arg> under <arg choice="plain">MOUNT-PATH</arg>, rather than
                   the default location.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-document-export.xml
+++ b/doc/flatpak-document-export.xml
@@ -43,7 +43,7 @@
             Creates a document id for a local file that can be exposed to
             sandboxed applications, allowing them access to files that they
             would not otherwise see. The exported files are exposed in a
-            fuse filesystem at /run/user/$UID/doc/.
+            fuse filesystem at <filename>/run/user/$UID/doc/</filename>.
         </para>
 
         <para>
@@ -104,8 +104,8 @@
 
                 <listitem><para>
                   Grant read access to the specified application. The
-                  --allow and --forbid options can be used to grant
-                  or remove additional privileges.
+                  <option>--allow</option> and <option>--forbid</option> options
+                  can be used to grant or remove additional privileges.
                   This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -115,7 +115,7 @@
                 <term><option>--allow-read</option></term>
 
                 <listitem><para>
-                  Grant read access to the applications specified with --app.
+                  Grant read access to the applications specified with <option>--app</option>.
                   This defaults to TRUE.
                 </para></listitem>
             </varlistentry>
@@ -124,7 +124,7 @@
                 <term><option>--forbid-read</option></term>
 
                 <listitem><para>
-                  Revoke read access for the applications specified with --app.
+                  Revoke read access for the applications specified with <option>--app</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -133,7 +133,7 @@
                 <term><option>--allow-write</option></term>
 
                 <listitem><para>
-                  Grant write access to the applications specified with --app.
+                  Grant write access to the applications specified with <option>--app</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -141,7 +141,7 @@
                 <term><option>--forbid-write</option></term>
 
                 <listitem><para>
-                  Revoke write access for the applications specified with --app.
+                  Revoke write access for the applications specified with <option>--app</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -150,7 +150,7 @@
                 <term><option>--allow-delete</option></term>
 
                 <listitem><para>
-                  Grant the ability to remove the document from the document portal to the applications specified with --app.
+                  Grant the ability to remove the document from the document portal to the applications specified with <option>--app</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -158,7 +158,7 @@
                 <term><option>--forbid-delete</option></term>
 
                 <listitem><para>
-                  Revoke the ability to remove the document from the document portal from the applications specified with --app.
+                  Revoke the ability to remove the document from the document portal from the applications specified with <option>--app</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -167,7 +167,7 @@
                 <term><option>--allow-grant-permission</option></term>
 
                 <listitem><para>
-                  Grant the ability to grant further permissions to the applications specified with --app.
+                  Grant the ability to grant further permissions to the applications specified with <option>--app</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -175,7 +175,7 @@
                 <term><option>--forbid-grant-permission</option></term>
 
                 <listitem><para>
-                  Revoke the ability to grant further permissions for the applications specified with --app.
+                  Revoke the ability to grant further permissions for the applications specified with <option>--app</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-document-info.xml
+++ b/doc/flatpak-document-info.xml
@@ -45,7 +45,7 @@
             filesystem, and the per-application permissions.
         </para>
         <para>
-            FILE can either be a file in the fuse filesystem at /run/user/$UID/doc/,
+            <arg choice="plain">FILE</arg> can either be a file in the fuse filesystem at <filename>/run/user/$UID/doc/</filename>,
             or a file anywhere else.
         </para>
 

--- a/doc/flatpak-document-list.xml
+++ b/doc/flatpak-document-list.xml
@@ -41,7 +41,7 @@
 
         <para>
             Lists exported files, with their document id and the
-            full path to their origin. If an APPID is specified,
+            full path to their origin. If an <arg choice="plain">APPID</arg> is specified,
             only the files exported to this app are listed.
         </para>
 

--- a/doc/flatpak-history.xml
+++ b/doc/flatpak-history.xml
@@ -44,7 +44,7 @@
         </para>
         <para>
             By default, both per-user and system-wide installations are shown. Use the
-            --user, --installation or --system options to change this.
+            <option>--user</option>, <option>--installation</option> or <option>--system</option> options to change this.
         </para>
         <para>
             The information for the history command is taken from the systemd journal,
@@ -90,8 +90,8 @@
                 <listitem><para>
                     Show changes to the installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -139,14 +139,6 @@
 
                 <listitem><para>
                     Print OSTree debug information during command processing.
-                </para></listitem>
-            </varlistentry>
-
-            <varlistentry>
-                <term><option>--show-columns</option></term>
-
-                <listitem><para>
-                    Show the available values for the <option>--columns</option> option.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-info.xml
+++ b/doc/flatpak-info.xml
@@ -45,24 +45,14 @@
         </para>
         <para>
             By default, the output is formatted in a friendly format.
-            If you specify one of the options
-            --show-ref,
-            --show-origin,
-            --show-commit,
-            --show-size,
-            --show-metadata,
-            --show-permissions,
-            --file-access,
-            --show-location,
-            --show-runtime or
-            --show-sdk,
-            the output is instead formatted
-            in a machine-readable format.
+            If you specify any of the <option>--show-…</option> or
+            <option>--file-access</option> options, the output is instead
+            formatted in a machine-readable format.
         </para>
         <para>
-            By default, both per-user and system-wide installations
-            are queried. Use the --user, --system or --installation
-            options to change this.
+            By default, both per-user and system-wide installations are queried.
+            Use the <option>--user</option>, <option>--system</option>
+            or <option>--installation</option> options to change this.
         </para>
 
     </refsect1>
@@ -104,8 +94,8 @@
                 <listitem><para>
                     Query a system-wide installation by <arg choice="plain">NAME</arg> among
                     those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -29,26 +29,17 @@
     </refnamediv>
 
     <refsynopsisdiv>
-            <para>Install from a configured remote:</para>
             <cmdsynopsis>
                 <command>flatpak install</command>
                 <arg choice="opt" rep="repeat">OPTION</arg>
                 <arg choice="opt">REMOTE</arg>
                 <arg choice="plain" rep="repeat">REF</arg>
             </cmdsynopsis>
-            <para>Install from a .flatpakref file:</para>
             <cmdsynopsis>
                 <command>flatpak install</command>
                 <arg choice="opt" rep="repeat">OPTION</arg>
-                <arg choice="opt">--from</arg>
+                <arg choice="opt">--from|--bundle</arg>
                 <arg choice="plain">LOCATION</arg>
-            </cmdsynopsis>
-            <para>Install from a .flatpak bundle:</para>
-            <cmdsynopsis>
-                <command>flatpak install</command>
-                <arg choice="opt" rep="repeat">OPTION</arg>
-                <arg choice="opt">--bundle</arg>
-                <arg choice="plain">FILENAME</arg>
             </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -57,57 +48,59 @@
 
         <para>
           Installs an application or runtime. The primary way to
-          install is to specify a <arg>REMOTE</arg>
-          name as the source and one ore more <arg>REF</arg>s to specify the
-          application or runtime to install. If <arg>REMOTE</arg> is omitted,
-          the configured remotes are searched for the first <arg>REF</arg>
+          install is to specify a <arg choice="plain">REMOTE</arg>
+          name as the source and one ore more <arg choice="plain">REF</arg>s to specify the
+          application or runtime to install. If <arg choice="plain">REMOTE</arg> is omitted,
+          the configured remotes are searched for the first <arg choice="plain">REF</arg>
           and the user is asked to confirm the resulting choice.
         </para>
         <para>
-            Each <arg choice="plain">REF</arg> argument is a full or partial indentifier in the
-            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
-            except ID are optional and can be left out, including the slashes,
-            so most of the time you need only specify ID. Any part left out will be matched
-            against what is in the remote, and if there are multiple matches you will be
-            prompted to choose one of them. You will also be prompted with choices if
-            <arg choice="plain">REF</arg> doesn't match anything in the remote exactly but is
-            similar to one or more refs in the remote (e.g. "devhelp" is similar to
-            "org.gnome.Devhelp").
+          Each <arg choice="plain">REF</arg> argument is a full or partial indentifier in the
+          flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH".
+          All elements except ID are optional and can be left out, including the slashes,
+          so most of the time you need only specify ID. Any part left out will be matched
+          against what is in the remote, and if there are multiple matches you will be
+          prompted to choose one of them. You will also be prompted with choices if
+          <arg choice="plain">REF</arg> doesn't match anything in the remote exactly but is
+          similar to one or more refs in the remote (e.g. "devhelp" is similar to
+          "org.gnome.Devhelp").
         </para>
         <para>
-            By default this looks for both apps and runtimes with the given <arg choice="plain">REF</arg> in
-            the specified <arg choice="plain">REMOTE</arg>, but you can limit this by using the --app or
-            --runtime option, or by supplying the initial element in the REF.
+          By default this looks for both apps and runtimes with the given
+          <arg choice="plain">REF</arg> in the specified <arg choice="plain">REMOTE</arg>,
+          but you can limit this by using the <option>--app</option> or <option>--runtime</option>
+          option, or by supplying the initial element in the <arg choice="plain">REF</arg>.
         </para>
         <para>
-            If <arg choice="plain">REMOTE</arg> is a uri or a path (absolute or relative starting with ./)
-            to a local repository, then that repository will be used as the source, and a temporary remote
-            will be created for the lifetime of the <arg choice="plain">REF</arg>.
+          If <arg choice="plain">REMOTE</arg> is a uri or a path (absolute or relative starting
+          with ./) to a local repository, then that repository will be used as the source, and
+          a temporary remote will be created for the lifetime of the <arg choice="plain">REF</arg>.
         </para>
         <para>
-            If the specified <arg choice="plain">REMOTE</arg> has a collection ID configured on it,
-            flatpak will search mounted filesystems such as USB drives as well as Avahi services
-            advertised on the local network for the needed refs, in order to support
-            offline updates. See <citerefentry><refentrytitle>ostree-find-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>
-            for more information.
+          If the specified <arg choice="plain">REMOTE</arg> has a collection ID configured on it,
+          flatpak will search mounted filesystems such as USB drives as well as Avahi services
+          advertised on the local network for the needed refs, in order to support
+          offline updates. See <citerefentry><refentrytitle>ostree-find-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+          for more information.
         </para>
         <para>
-            The alternative form of the command (<arg>--from</arg> or
-            <arg>--bundle</arg> allows you to
-            install directly from a source such as a .flatpak
-            single-file bundle, a .flatpakref app description. The options are optional if the first
-            argument has the right extension.
+          The alternative form of the command (with <option>--from</option> or
+          <option>--bundle</option>) allows to install directly from a source such as a
+          <filename>.flatpak</filename> single-file bundle or a <filename>.flatpakref</filename>
+          application description. The options are optional if the first argument has the expected
+          filename extension.
         </para>
         <para>
-            Note that flatpak allows one to have multiple branches of an application and runtimes
-            installed and used at the same time. However, only one version of an application can be current,
-            meaning its exported files (for instance desktop files and icons) are
-            visible to the host. The last installed version is made current by
-            default, but you can manually change with make-current.
+          Note that flatpak allows to have multiple branches of an application and runtimes
+          installed and used at the same time. However, only one version of an application
+          can be current, meaning its exported files (for instance desktop files and icons)
+          are visible to the host. The last installed version is made current by default, but
+          this can manually changed with flatpak make-current.
         </para>
         <para>
-            Unless overridden with the --user or the --installation option, this command installs
-            the application or runtime in the default system-wide installation.
+          Unless overridden with the <option>--user</option> or the <option>--installation</option>
+          option, this command installs the application or runtime in the default system-wide
+          installation.
         </para>
 
     </refsect1>
@@ -131,8 +124,8 @@
                 <term><option>--bundle</option></term>
 
                 <listitem><para>
-                  Assume LOCATION is a .flatpak single-bundle file.
-                  This is optional if the arguments ends with .flatpak.
+                  Treat <arg choice="plain">LOCATION</arg> as a single-bundle file.
+                  This is assumed if the argument ends with <filename>.flatpak</filename>.
                 </para></listitem>
             </varlistentry>
 
@@ -140,8 +133,8 @@
                 <term><option>--from</option></term>
 
                 <listitem><para>
-                  Assume LOCATION is a .flatpakref file containing the details of the app to be installed.
-                  This is optional if the arguments ends with .flatpakref.
+                  Treat <arg choice="plain">LOCATION</arg> as an application description file.
+                  This is assumed if the argument ends with <filename>.flatpakref</filename>.
                 </para></listitem>
             </varlistentry>
 
@@ -176,8 +169,8 @@
                     Install the application or runtime in a system-wide installation
                     specified by <arg choice="plain">NAME</arg> among those defined in
                     <filename>/etc/flatpak/installations.d/</filename>. Using
-                    <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -193,8 +186,9 @@
                 <term><option>--subpath=PATH</option></term>
 
                 <listitem><para>
-                  Install only a subpath of the ref. This is mainly used to install a subset of locales.
-                  This can be added multiple times to install multiple subpaths.,
+                  Install only a subpath of <arg choice="plain">REF</arg>. This is mainly used to
+                  install a subset of locales. This can be added multiple times to install multiple
+                  subpaths.
                 </para></listitem>
             </varlistentry>
 
@@ -202,7 +196,7 @@
                 <term><option>--gpg-file=FILE</option></term>
 
                 <listitem><para>
-                  Check bundle signatures with GPG key from FILE (- for stdin).
+                  Check bundle signatures with GPG key from <arg choice="plain">FILE</arg> (- for stdin).
                 </para></listitem>
             </varlistentry>
 
@@ -306,7 +300,9 @@
             <citerefentry><refentrytitle>flatpak-update</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-build-bundle</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-flatpakref</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-flatpakref</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-make-current</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>ostree-find-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-kill.xml
+++ b/doc/flatpak-kill.xml
@@ -39,7 +39,11 @@
         <title>Description</title>
 
         <para>
-            Kill a running sandbox. <replaceable>INSTANCE</replaceable> can be
+            Stop a running Flatpak instance.
+        </para>
+
+        <para>
+            <arg choice="plain">INSTANCE</arg> can be
             either the numeric instance ID or the application ID of a running
             Flatpak.
         </para>

--- a/doc/flatpak-list.xml
+++ b/doc/flatpak-list.xml
@@ -39,20 +39,21 @@
         <title>Description</title>
 
         <para>
-            Lists the names of the installed applications and/or runtimes.
+            Lists the names of the installed applications and runtimes.
         </para>
         <para>
-            By default, both per-user and system-wide installations
-            are shown. Use the --user, --installation or --system
-            options to change this.
+            By default, both apps and runtimes are shown, but you can
+            change this by using the <option>--app</option> or
+            <option>--runtime</option> options.
         </para>
         <para>
-            By default this lists both installed apps and runtimes, but you can
-            change this by using the --app or --runtime option.
+            By default, both per-user and system-wide installations are shown.
+            Use the <option>--user</option>, <option>--installation</option> or
+            <option>--system</option> options to change this.
         </para>
         <para>
             The list command can also be used to find installed apps that
-            use a certain runtime, with the --app-runtime option.
+            use a certain runtime, with the <option>--app-runtime</option> option.
         </para>
 
     </refsect1>
@@ -94,8 +95,8 @@
                 <listitem><para>
                     List a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-make-current.xml
+++ b/doc/flatpak-make-current.xml
@@ -50,7 +50,7 @@
             command is often not needed.
         </para>
         <para>
-            Unless overridden with the --user or --installation options, this command
+            Unless overridden with the <option>--user</option> or <option>--installation</option> options, this command
             changes the default system-wide installation.
         </para>
 
@@ -93,8 +93,8 @@
                 <listitem><para>
                     Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -54,7 +54,7 @@
             but the per-application overrides can override the global overrides.
         </para>
         <para>
-            Unless overridden with the --user or --installation options, this command
+            Unless overridden with the <option>--user</option> or <option>--installation</option> options, this command
             changes the default system-wide installation.
         </para>
 
@@ -97,8 +97,8 @@
                 <listitem><para>
                     Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -108,7 +108,7 @@
                 <listitem><para>
                     Share a subsystem with the host session. This overrides
                     the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
+                    <arg choice="plain">SUBSYSTEM</arg> must be one of: network, ipc.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -119,7 +119,7 @@
                 <listitem><para>
                     Don't share a subsystem with the host session. This overrides
                     the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
+                    <arg choice="plain">SUBSYSTEM</arg> must be one of: network, ipc.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -130,7 +130,7 @@
                 <listitem><para>
                     Expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
+                    <arg choice="plain">SOCKET</arg> must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -141,7 +141,7 @@
                 <listitem><para>
                     Don't expose a well-known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
+                    <arg choice="plain">SOCKET</arg> must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -152,7 +152,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -163,7 +163,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -174,7 +174,7 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
                     This option can be used multiple times.
                  </para><para>
                     See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
@@ -188,18 +188,18 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 
             <varlistentry>
-                <term><option>--filesystem=FS</option></term>
+                <term><option>--filesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths
@@ -217,7 +217,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
@@ -261,7 +261,7 @@ key=v1;v2;
                 <term><option>--own-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to own the well-known name NAME on the session bus.
+                    Allow the application to own the well-known name <arg choice="plain">NAME</arg> on the session bus.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -271,7 +271,7 @@ key=v1;v2;
                 <term><option>--talk-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to talk to the well-known name NAME on the session bus.
+                    Allow the application to talk to the well-known name <arg choice="plain">NAME</arg> on the session bus.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -281,8 +281,8 @@ key=v1;v2;
                 <term><option>--system-own-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to own the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
+                    Allow the application to own the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to own all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -292,8 +292,8 @@ key=v1;v2;
                 <term><option>--system-talk-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to talk to the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    Allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -304,7 +304,7 @@ key=v1;v2;
 
                 <listitem><para>
                     If the application doesn't have access to the real homedir, make the (homedir-relative) path
-                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    <arg choice="plain">FILENAME</arg> a bind mount to the corresponding path in the per-application directory,
                     allowing that location to be used for persistent data.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
@@ -315,7 +315,7 @@ key=v1;v2;
                 <term><option>--reset</option></term>
 
                 <listitem><para>
-                    Remove overrides. If an APP is given, remove the overrides for that
+                    Remove overrides. If an <arg choice="plain">APP</arg> is given, remove the overrides for that
                     application, otherwise remove the global overrides.
                 </para></listitem>
             </varlistentry>
@@ -324,7 +324,7 @@ key=v1;v2;
                 <term><option>--show</option></term>
 
                 <listitem><para>
-                    Shows overrides. If an APP is given, shows the overrides for that
+                    Shows overrides. If an <arg choice="plain">APP</arg> is given, shows the overrides for that
                     application, otherwise shows the global overrides.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-permission-list.xml
+++ b/doc/flatpak-permission-list.xml
@@ -50,7 +50,7 @@
           the entries in all permission store tables. When called
           with one argument, lists all the entries in the named
           table. When called with two arguments, lists the entry
-          in the named table for the given object ID.
+          in the named table for the given object <arg choice="plain">ID</arg>.
         </para>
 
         <para>
@@ -103,7 +103,7 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permission-remove.xml
+++ b/doc/flatpak-permission-remove.xml
@@ -41,8 +41,8 @@
         <title>Description</title>
 
         <para>
-          Removes an entry for the object with id ID to the permission
-          store table TABLE. The ID must be in a suitable format
+          Removes an entry for the object with id <arg choice="plain">ID</arg> to the permission
+          store table <arg choice="plain">TABLE</arg>. The <arg choice="plain">ID</arg> must be in a suitable format
           for the table.
         </para>
         <para>
@@ -95,7 +95,7 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permission-reset.xml
+++ b/doc/flatpak-permission-reset.xml
@@ -94,7 +94,7 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permission-show.xml
+++ b/doc/flatpak-permission-show.xml
@@ -102,7 +102,7 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-ps.xml
+++ b/doc/flatpak-ps.xml
@@ -43,7 +43,7 @@
         </para>
         <para>
           To see full details of a running instance, you can open the file
-          /run/user/$UID/.flatpak/$INSTANCE/info, where $INSTANCE is the instance
+          <filename>/run/user/$UID/.flatpak/$INSTANCE/info</filename>, where <replaceable>$INSTANCE</replaceable> is the instance
           ID reported by flatpak ps.
         </para>
 

--- a/doc/flatpak-remote-add.xml
+++ b/doc/flatpak-remote-add.xml
@@ -29,15 +29,6 @@
     </refnamediv>
 
     <refsynopsisdiv>
-            <para>Add from a .flatpakrepo file:</para>
-            <cmdsynopsis>
-                <command>flatpak remote-add</command>
-                <arg choice="opt" rep="repeat">OPTION</arg>
-                <arg choice="opt">--from</arg>
-                <arg choice="plain">NAME</arg>
-                <arg choice="plain">LOCATION</arg>
-            </cmdsynopsis>
-            <para>Manually specify repo uri and options:</para>
             <cmdsynopsis>
                 <command>flatpak remote-add</command>
                 <arg choice="opt" rep="repeat">OPTION</arg>
@@ -50,16 +41,16 @@
         <title>Description</title>
 
         <para>
-            Adds a remote repository to the flatpak repository
-            configuration.  <arg>NAME</arg> is the name for the new
-            remote, and <arg>LOCATION</arg> is a url or pathname.  The
-            <arg>LOCATION</arg> is either a flatpak repository, or a
-            .flatpakrepo file which describes a repository. In the
-            former case you may also have to specify extra options,
-            such as the gpg key for the repo.
+            Adds a remote repository to the flatpak repository configuration.
+            <arg choice="plain">NAME</arg> is the name for the new remote, and
+            <arg choice="plain">LOCATION</arg> is a url or pathname.
+            The <arg choice="plain">LOCATION</arg> is either a flatpak repository,
+            or a <filename>.flatpakrepo</filename> file which
+            describes a repository. In the former case you may also have to specify
+            extra options, such as the gpg key for the repo.
         </para>
         <para>
-            Unless overridden with the --user or --installation options, this command
+            Unless overridden with the <option>--user</option> or <option>--installation</option> options, this command
             changes the default system-wide installation.
         </para>
 
@@ -111,8 +102,8 @@
                 <listitem><para>
                     Modify a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -232,7 +223,7 @@
                 <citerefentry><refentrytitle>flatpak-remote-modify</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
                 <citerefentry><refentrytitle>flatpak-remote-delete</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
                 <citerefentry><refentrytitle>flatpak-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-                <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+                <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry>
             </para>
     </refsect1>
 

--- a/doc/flatpak-remote-delete.xml
+++ b/doc/flatpak-remote-delete.xml
@@ -44,7 +44,7 @@
             <arg choice="plain">NAME</arg> is the name of an existing remote.
         </para>
         <para>
-            Unless overridden with the --system, --user, or --installation options,
+            Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option> options,
             this command uses either the default system-wide installation or the
             per-user one, depending on which has the specified
             <arg choice="plain">REMOTE</arg>.
@@ -89,8 +89,8 @@
                 <listitem><para>
                     Modify a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-info.xml
+++ b/doc/flatpak-remote-info.xml
@@ -47,12 +47,11 @@
         </para>
         <para>
             By default, the output is formatted in a friendly format.
-            If you specify one of the options --show-ref, --show-commit,
-            --show-parent, or --show-metadata, the output is instead formatted
-            in a machine-readable format.
+            If you specify one of the <option>--show-…</option> options,
+            the output is instead formatted in a machine-readable format.
         </para>
         <para>
-            Unless overridden with the --system, --user, or --installation options,
+            Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option> options,
             this command uses either the default system-wide installation or the
             per-user one, depending on which has the specified
             <arg choice="plain">REMOTE</arg>.
@@ -97,8 +96,8 @@
                 <listitem><para>
                     Use a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -43,14 +43,14 @@
             Shows runtimes and applications that are available in the
             remote repository with the name <arg choice="plain">REMOTE</arg>,
             or all remotes if one isn't specified. You can find all configured
-            remote repositories with <citerefentry><refentrytitle>flatpak-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+            remote repositories with <command>flatpak remotes</command>.
         </para>
         <para>
             <arg choice="plain">REMOTE</arg> can be a file:// URI pointing to a
             local repository instead of a remote name.
         </para>
         <para>
-            Unless overridden with the --system, --user, or --installation options,
+            Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option> options,
             this command uses either the default system-wide installation or the
             per-user one, depending on which has the specified
             <arg choice="plain">REMOTE</arg>.
@@ -95,8 +95,8 @@
                 <listitem><para>
                     Use a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -149,7 +149,7 @@
 
                 <listitem><para>
                     Show only those matching the specied architecture. By default, only
-                    supported architectures are shown. Use --arch=* to show all archtectures.
+                    supported architectures are shown. Use <option>--arch=*</option> to show all architectures.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -44,7 +44,7 @@
             <arg choice="plain">NAME</arg> is the name for the remote.
         </para>
         <para>
-            Unless overridden with the --system, --user, or --installation options,
+            Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option> options,
             this command uses either the default system-wide installation or the
             per-user one, depending on which has the specified
             <arg choice="plain">REMOTE</arg>.
@@ -89,8 +89,8 @@
                 <listitem><para>
                     Modify a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-remote.xml
+++ b/doc/flatpak-remote.xml
@@ -41,7 +41,7 @@
 
        <para>
             Normally, it is not necessary to edit remote config files directly, the
-            flatpak remote-modify command should be used to change properties of remotes.
+            <command>flatpak remote-modify</command> command should be used to change properties of remotes.
        </para>
 
        <para>

--- a/doc/flatpak-remotes.xml
+++ b/doc/flatpak-remotes.xml
@@ -43,7 +43,7 @@
         </para>
         <para>
             By default, both per-user and system-wide installations
-            are shown. Use the --user, --system or --installation
+            are shown. Use the <option>--user</option>, <option>--system</option> or <option>--installation</option>
             options to change this.
         </para>
 
@@ -86,8 +86,8 @@
                 <listitem><para>
                     Show a system-wide installation by <arg choice="plain">NAME</arg> among
                     those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-repo.xml
+++ b/doc/flatpak-repo.xml
@@ -44,8 +44,8 @@
         </para>
         <para>
             If you need to modify a local repository, see the
-            flatpak build-update-repo command, or use the
-            ostree tool.
+            <command>flatpak build-update-repo</command> command, or use the
+            <command>ostree</command> tool.
         </para>
 
     </refsect1>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -130,8 +130,8 @@
                     Look for the application and runtime in the system-wide installation specified
                     by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -211,7 +211,7 @@
                 <listitem><para>
                     Share a subsystem with the host session. This overrides
                     the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
+                    <arg choice="plain">SUBSYSTEM</arg> must be one of: network, ipc.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -222,7 +222,7 @@
                 <listitem><para>
                     Don't share a subsystem with the host session. This overrides
                     the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
+                    <arg choice="plain">SUBSYSTEM</arg> must be one of: network, ipc.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -233,7 +233,7 @@
                 <listitem><para>
                     Expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
+                    <arg choice="plain">SOCKET</arg> must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -244,7 +244,7 @@
                 <listitem><para>
                     Don't expose a well known socket to the application. This overrides to
                     the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
+                    <arg choice="plain">SOCKET</arg> must be one of: x11, wayland, fallback-x11, pulseaudio, system-bus, session-bus, ssh-auth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -255,7 +255,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -266,7 +266,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -277,7 +277,7 @@
                 <listitem><para>
                     Allow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth.
+                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                     </para><para>
                     See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
@@ -291,18 +291,18 @@
                 <listitem><para>
                     Disallow access to a specific feature. This overrides to
                     the Context section from the application metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth.
+                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
 
             <varlistentry>
-                <term><option>--filesystem=FS</option></term>
+                <term><option>--filesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     xdg-run, xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths
@@ -320,7 +320,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
@@ -364,8 +364,8 @@ key=v1;v2;
                 <term><option>--own-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to own the well known name NAME on the session bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
+                    Allow the application to own the well known name <arg choice="plain">NAME</arg> on the session bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to own all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -375,8 +375,8 @@ key=v1;v2;
                 <term><option>--talk-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to talk to the well known name NAME on the session bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    Allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the session bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -386,8 +386,8 @@ key=v1;v2;
                 <term><option>--system-own-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to own the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
+                    Allow the application to own the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to own all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -397,8 +397,8 @@ key=v1;v2;
                 <term><option>--system-talk-name=NAME</option></term>
 
                 <listitem><para>
-                    Allow the application to talk to the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    Allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.
                 </para></listitem>
@@ -409,7 +409,7 @@ key=v1;v2;
 
                 <listitem><para>
                     If the application doesn't have access to the real homedir, make the (homedir-relative) path
-                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    <arg choice="plain">FILENAME</arg> a bind mount to the corresponding path in the per-application directory,
                     allowing that location to be used for persistent data.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.

--- a/doc/flatpak-search.xml
+++ b/doc/flatpak-search.xml
@@ -41,7 +41,7 @@
         <para>
             Searches for applications and runtimes matching
             <arg choice="plain">TEXT</arg>. Note that this uses appstream data
-            that can be updated with <citerefentry><refentrytitle>flatpak-update</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+            that can be updated with the <command>flatpak update</command> command.
             The appstream data is updated automatically only if it's at least a day old.
         </para>
     </refsect1>
@@ -74,8 +74,8 @@
                 <listitem><para>
                     Show a system-wide installation by <arg choice="plain">NAME</arg> among
                     those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-uninstall.xml
+++ b/doc/flatpak-uninstall.xml
@@ -53,22 +53,22 @@
         </para>
         <para>
             By default this looks for both installed apps and runtimes with the given
-            <arg choice="plain">REF</arg>, but you can limit this by using the --app
-            or --runtime option, or by supplying the initial element in the REF.
+            <arg choice="plain">REF</arg>, but you can limit this by using the <option>--app</option>
+            or <option>--runtime</option> option, or by supplying the initial element in the <arg choice="plain">REF</arg>.
         </para>
         <para>
             Normally, this command removes the ref for this application/runtime from the
             local OSTree repository and purges any objects that are no longer
             needed to free up disk space. If the same application is later
             reinstalled, the objects will be pulled from the remote repository
-            again. The --keep-ref option can be used to prevent this.
+            again. The <option>--keep-ref</option> option can be used to prevent this.
         </para>
         <para>
             If all branches of the application/runtime are removed, this command
             also purges the data directory for the application.
         </para>
         <para>
-            Unless overridden with the --system, --user, or --installation
+            Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option>
             options, this command searches both the system-wide installation
             and the per-user one for <arg choice="plain">REF</arg> and errors
             out if it exists in more than one.
@@ -123,8 +123,8 @@
                     Uninstalls from a system-wide installation specified by
                     <arg choice="plain">NAME</arg> among those defined in
                     <filename>/etc/flatpak/installations.d/</filename>.  Using
-                    <arg choice="plain">--installation=default</arg> is
-                    equivalent to using <arg choice="plain">--system</arg>.
+                    <option>--installation=default</option> is
+                    equivalent to using <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-update.xml
+++ b/doc/flatpak-update.xml
@@ -60,8 +60,8 @@
         </para>
         <para>
             By default this looks for both apps and runtimes with the given <arg choice="plain">REF</arg>,
-            but you can limit this by using the --app or --runtime option, or by supplying the initial
-            element in the REF.
+            but you can limit this by using the <option>--app</option> or <option>--runtime</option> option, or by supplying the initial
+            element in the <arg choice="plain">REF</arg>.
         </para>
         <para>
             Normally, this command updates the application to the tip
@@ -80,10 +80,10 @@
             a different branch, and runtime updates are expected to keep
             strict compatibility. If an application update does cause
             a problem, it is possible to go back to the previous
-            version, with the --commit option.
+            version, with the <option>--commit</option> option.
         </para>
         <para>
-            Unless overridden with the --user, --system or --installation option, this command updates
+            Unless overridden with the <option>--user</option>, <option>--system</option> or <option>--installation</option> option, this command updates
             any matching refs in the standard system-wide installation and the per-user one.
         </para>
 
@@ -126,8 +126,8 @@
                 <listitem><para>
                     Updates a system-wide installation specified by <arg choice="plain">NAME</arg>
                     among those defined in <filename>/etc/flatpak/installations.d/</filename>.
-                    Using <arg choice="plain">--installation=default</arg> is equivalent to using
-                    <arg choice="plain">--system</arg>.
+                    Using <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
                 </para></listitem>
             </varlistentry>
 
@@ -263,7 +263,8 @@
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-install</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>ostree-find-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>


### PR DESCRIPTION
Make synopses more concise in various place, improve
consistency of formatting, and fix some small mistakes
and oversights.