### PR TITLE
flatpak-coredumpctl: launch flatpak with --filesystem=home

### DIFF
--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -31,7 +31,7 @@ class CoreDumper():
             sys.exit(1)
 
         # We need access to the host from the sandbox to run.
-        flatpak_command = ["flatpak", "build" if self.build_directory else "run",
+        flatpak_command = ["flatpak", "build" if self.build_directory else "run", "--filesystem=home",
                            "--filesystem=%s" % tempfile.gettempdir()] + shlex.split(self.extra_flatpak_args)
         if not self.build_directory:
             flatpak_command.extend(["--command=gdb",


### PR DESCRIPTION
This is a debugging tool so there's no need for a strict sandbox. I
want to be able to extract backtraces from gdb using 'set logging on'
and it's not currently possible without using
--extra-flatpak-args="--filesystem=home".