### PR TITLE
uninstall: Add a --remove-data option

### DIFF
--- a/app/flatpak-builtins-permission-reset.c
+++ b/app/flatpak-builtins-permission-reset.c
@@ -94,29 +94,13 @@ remove_for_app (XdpDbusPermissionStore *store,
 }
 
 gboolean
-flatpak_builtin_permission_reset (int argc, char **argv,
-                                  GCancellable *cancellable,
-                                  GError **error)
+reset_permissions_for_app (const char *app_id,
+                           GError **error)
 {
-  g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GDBusConnection) session_bus = NULL;
   XdpDbusPermissionStore *store = NULL;
-  const char *app_id;
   int i;
   g_auto(GStrv) tables = NULL;
-
-  context = g_option_context_new (_("APP_ID - Reset permissions for an app"));
-  g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
-
-  if (!flatpak_option_context_parse (context, options, &argc, &argv,
-                                     FLATPAK_BUILTIN_FLAG_NO_DIR,
-                                     NULL, cancellable, error))
-    return FALSE;
-
-  if (argc != 2)
-    return usage_error (context, _("Wrong number of arguments"), error);
-
-  app_id = argv[1];
 
   session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, error);
   if (session_bus == NULL)
@@ -137,6 +121,30 @@ flatpak_builtin_permission_reset (int argc, char **argv,
     }
 
   return TRUE;
+}
+
+gboolean
+flatpak_builtin_permission_reset (int argc, char **argv,
+                                  GCancellable *cancellable,
+                                  GError **error)
+{
+  g_autoptr(GOptionContext) context = NULL;
+  const char *app_id;
+
+  context = g_option_context_new (_("APP_ID - Reset permissions for an app"));
+  g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
+
+  if (!flatpak_option_context_parse (context, options, &argc, &argv,
+                                     FLATPAK_BUILTIN_FLAG_NO_DIR,
+                                     NULL, cancellable, error))
+    return FALSE;
+
+  if (argc != 2)
+    return usage_error (context, _("Wrong number of arguments"), error);
+
+  app_id = argv[1];
+
+  return reset_permissions_for_app (app_id, error);
 }
 
 gboolean

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -89,6 +89,9 @@ gboolean update_appstream (GPtrArray    *dirs,
                            GError      **error);
 
 char ** get_permission_tables (XdpDbusPermissionStore *store);
+gboolean reset_permissions_for_app (const char *app_id,
+                                    GError **error);
+
 
 /* --columns handling */
 

--- a/doc/flatpak-uninstall.xml
+++ b/doc/flatpak-uninstall.xml
@@ -64,6 +64,12 @@
             again. The <option>--keep-ref</option> option can be used to prevent this.
         </para>
         <para>
+            When <option>--delete-data</option> is specified while removing an app, its
+            data directory in <filename>~/.var/app</filename> and any permissions it might
+            have are removed. When <option>--delete-data</option> is used without a
+            <arg choice="plain">REF</arg>, all 'unowned' app data is removed.
+        </para>
+        <para>
             Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option>
             options, this command searches both the system-wide installation
             and the per-user one for <arg choice="plain">REF</arg> and errors
@@ -183,6 +189,14 @@
                 <term><option>--force-remove</option></term>
                 <listitem><para>
                     Remove files even if they're in use by a running application.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--delete-data</option></term>
+                <listitem><para>
+                    Remove app data in <filename>~/.var/app</filename> and in
+                    the permission store.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
When --cleanup is passed, remove all 'unowned' app data directories in ~/.var/app/.

I would be happier if this could be a library api, so it would be available to gnome-software as well.
But I haven't come up with a good place to fit it yet: flatpak_transaction_set_cleanup_app_dirs() ?
