### PR TITLE
dir: Match pre-existing remotes better wrt collection-id

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11030,7 +11030,7 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir *self,
 }
 
 /* This tries to find a pre-configured remote for the specified uri
- * and (optionally) collection id. This ia a bit more complex than it
+ * and (optionally) collection id. This is a bit more complex than it
  * sounds, because a local remote could be configured in different
  * ways for a remote repo (i.e. it could be not using collection ids,
  * even though the remote specifies it, or the flatpakrepo might lack

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11029,6 +11029,21 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir *self,
   return TRUE;
 }
 
+/* This tries to find a pre-configured remote for the specified uri
+ * and (optionally) collection id. This ia a bit more complex than it
+ * sounds, because a local remote could be configured in different
+ * ways for a remote repo (i.e. it could be not using collection ids,
+ * even though the remote specifies it, or the flatpakrepo might lack
+ * the collection id details). So, we use these rules:
+ *
+ *  If the url is the same, it is a match even if one part lacks
+ *  collection ids. However, if both collection ids are specified and
+ *  differ there is no match.
+ *
+ *  If the collection id is the same (and specified), its going to be
+ *  the same remote, even if the url is different (because it could be
+ *  some other mirror of the same repo).
+ */
 char *
 flatpak_dir_find_remote_by_uri (FlatpakDir *self,
                                 const char *uri,
@@ -11058,8 +11073,18 @@ flatpak_dir_find_remote_by_uri (FlatpakDir *self,
           if (!repo_get_remote_collection_id (self->repo, remote, &remote_collection_id, NULL))
             continue;
 
+          /* Exact collection ids always match, independent of the uris used */
+          if (collection_id != NULL &&
+              remote_collection_id != NULL &&
+              strcmp (collection_id, remote_collection_id) == 0)
+            return g_strdup (remote);
+
+          /* Same repo if uris matches, unless both have collection-id
+             specified but different */
           if (strcmp (uri, remote_uri) == 0 &&
-              g_strcmp0 (collection_id, remote_collection_id) == 0)
+              !(collection_id != NULL &&
+                remote_collection_id != NULL &&
+                strcmp (collection_id, remote_collection_id) != 0))
             return g_strdup (remote);
         }
     }

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1493,6 +1493,9 @@ setup_repo (void)
   add_flatpakrepo ();
   configure_languages ();
 
+  /* another copy of the same repo, with different url */
+  symlink("test", "repos/copy-of-test");
+
   /* another repo, with only the app */
   make_test_app2 ();
   update_repo2 ();
@@ -2209,7 +2212,8 @@ test_transaction_install_flatpakref (void)
                    "Title=Test App\n"
                    "Name=org.test.Hello\n"
                    "Branch=master\n"
-                   "Url=http://127.0.0.1:", httpd_port, "/test\n"
+                   /* Uses a different url for the repo, so we can ensure it gets added */
+                   "Url=http://127.0.0.1:", httpd_port, "/copy-of-test\n"
                    "IsRuntime=False\n"
                    "SuggestRemoteName=my-little-repo\n"
                    "RuntimeRepo=http://127.0.0.1:", httpd_port, "/test/test.flatpakrepo\n",


### PR DESCRIPTION
If you have a pre-existing remote configured its exact definition
might differ from the one specified in a flatpakrepo file and yet
be the same.

For example, i have:

$ flatpak --user remotes -d
Name      Title      URL                            Collection ID          Priority Options
flathub   Flathub    https://dl.flathub.org/repo/   org.flathub.Stable     1

Yet when i install a flatpakref:

$ flatpak --user install http://flathub.org/repo/appstream/org.gnome.gedit.flatpakref
The application org.gnome.gedit depends on runtimes from:
  https://dl.flathub.org/repo/
Configure this as new remote 'flathub-1' [y/n]:

Because the flathub flatpakrepo does not yet have the collection id specified.

So, we need to be more lenient when matching the pre-configured remotes.