### PR TITLE
Add a DeployCollectionID key to replace CollectionID

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -50,6 +50,7 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_REF_NAME_KEY "Name"
 #define FLATPAK_REF_BRANCH_KEY "Branch"
 #define FLATPAK_REF_COLLECTION_ID_KEY "CollectionID"
+#define FLATPAK_REF_DEPLOY_COLLECTION_ID_KEY "DeployCollectionID"
 
 #define FLATPAK_REPO_GROUP "Flatpak Repo"
 #define FLATPAK_REPO_VERSION_KEY "Version"
@@ -60,6 +61,7 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_REPO_NODEPS_KEY "NoDeps"
 
 #define FLATPAK_REPO_COLLECTION_ID_KEY "CollectionID"
+#define FLATPAK_REPO_DEPLOY_COLLECTION_ID_KEY "DeployCollectionID"
 
 #define FLATPAK_DEFAULT_UPDATE_FREQUENCY 100
 #define FLATPAK_CLI_UPDATE_FREQUENCY 300

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10859,7 +10859,10 @@ flatpak_dir_parse_repofile (FlatpakDir   *self,
     }
 
   collection_id = g_key_file_get_string (keyfile, source_group,
-                                         FLATPAK_REPO_COLLECTION_ID_KEY, NULL);
+                                         FLATPAK_REPO_DEPLOY_COLLECTION_ID_KEY, NULL);
+  if (collection_id == NULL || *collection_id == '\0')
+    collection_id = g_key_file_get_string (keyfile, source_group,
+                                           FLATPAK_REPO_COLLECTION_ID_KEY, NULL);
   if (collection_id != NULL)
     {
       if (gpg_key == NULL)
@@ -10955,7 +10958,14 @@ parse_ref_file (GKeyFile *keyfile,
     }
 
   collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
-                                         FLATPAK_REF_COLLECTION_ID_KEY, NULL);
+                                         FLATPAK_REF_DEPLOY_COLLECTION_ID_KEY, NULL);
+
+  if (collection_id == NULL || *collection_id == '\0')
+    {
+      collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
+                                             FLATPAK_REF_COLLECTION_ID_KEY, NULL);
+    }
+
   if (collection_id != NULL && *collection_id == '\0')
     collection_id = NULL;
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2298,7 +2298,9 @@ handle_suggested_remote_name (FlatpakTransaction *self, GKeyFile *keyfile, GErro
   if (url == NULL)
     return TRUE;
 
-  collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP, FLATPAK_REF_COLLECTION_ID_KEY, NULL);
+  collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP, FLATPAK_REF_DEPLOY_COLLECTION_ID_KEY, NULL);
+  if (collection_id == NULL || *collection_id == '\0')
+    collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP, FLATPAK_REF_COLLECTION_ID_KEY, NULL);
 
   if (remote_is_already_configured (self, url, collection_id))
     return TRUE;

--- a/doc/flatpak-flatpakref.xml
+++ b/doc/flatpak-flatpakref.xml
@@ -108,8 +108,18 @@
                     <listitem><para>The url of a webpage describing the application or runtime.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>DeployCollectionID</option> (string)</term>
+                    <listitem><para>
+                        The collection ID of the remote, if it has one. This uniquely
+                        identifies the collection of apps in the remote, to allow peer to peer
+                        redistribution. It is recommended to use this key over CollectionID because
+                        only newer clients pay attention to it (and older clients don't handle
+                        collection IDs properly).
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>CollectionID</option> (string)</term>
-                    <listitem><para>The collection ID of the remote, if it has one. This uniquely identifies the collection of apps in the remote, to allow peer to peer redistribution.</para></listitem>
+                    <listitem><para>This is deprecated but still supported for backwards compatibility. Use DeployCollectionID instead.</para></listitem>
                 </varlistentry>
 
                 <varlistentry>
@@ -142,6 +152,7 @@ Branch=stable
 Url=http://sdk.gnome.org/repo-apps/
 IsRuntime=False
 GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
+DeployCollectionID=org.gnome.Apps
 </programlisting>
     </refsect1>
 

--- a/doc/flatpak-flatpakrepo.xml
+++ b/doc/flatpak-flatpakrepo.xml
@@ -104,8 +104,18 @@
                     <listitem><para>The url of a webpage describing the remote.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>DeployCollectionID</option> (string)</term>
+                    <listitem><para>
+                        The collection ID of the remote, if it has one. This uniquely
+                        identifies the collection of apps in the remote, to allow peer to peer
+                        redistribution. It is recommended to use this key over CollectionID because
+                        only newer clients pay attention to it (and older clients don't handle
+                        collection IDs properly).
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>CollectionID</option> (string)</term>
-                    <listitem><para>The collection ID of the remote, if it has one. This uniquely identifies the collection of apps in the remote, to allow peer to peer redistribution.</para></listitem>
+                    <listitem><para>This is deprecated but still supported for backwards compatibility. Use DeployCollectionID instead.</para></listitem>
                 </varlistentry>
             </variablelist>
         </refsect2>
@@ -118,7 +128,7 @@
 Title=GEdit
 Url=http://sdk.gnome.org/repo-apps/
 GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
-CollectionID=org.gnome.Apps
+DeployCollectionID=org.gnome.Apps
 </programlisting>
     </refsect1>
 

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -104,7 +104,7 @@ Url=http://127.0.0.1:$(cat httpd-port-main)/test
 IsRuntime=False
 GPGKey=${FL_GPG_BASE64}
 #RuntimeRepo=http://127.0.0.1:$(cat httpd-port-main)/test
-CollectionID=org.test.Collection
+DeployCollectionID=org.test.Collection
 EOF
 
 ${FLATPAK} ${U} install -y --from ./org.test.App.flatpakref


### PR DESCRIPTION
This commit adds a key called DeployCollectionID to the flatpakref and
flatpakrepo file formats, which is intended to replace the CollectionID
key (which is still supported but deprecated). The reason for the change
is the same as for the metadata key change from xa.collection-id to
ostree.deploy-collection-id, which is that old versions of Flatpak
(roughly 0.9.8 through 1.0.1 depending on compile time options) hit
various bugs when collection IDs are in use. Flathub will soon enable
the metadata key to deploy collection IDs, and this change means Flathub
can also deploy the collection ID in flatpakref and flatpakrepo files
without affecting old clients.

Adding DeployCollectionID to the flatpakref and flatpakrepo files will
mean the flathub remote can be automatically configured with a
collection ID without depending on the metadata key to do that.