### PR TITLE
Fix a typo that broke installed-tests

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -209,7 +209,7 @@ make_runtime () {
             if [ ! -d ${RUNTIME_REPO} ]; then
                 $(dirname $0)/make-test-runtime.sh ${RUNTIME_REPO} org.test.Platform "" > /dev/null
             fi
-        ) 200>${TEST_DATADIR}/runtime-repo-lock
+        ) 200>${TEST_DATA_DIR}/runtime-repo-lock
     fi
 
     if [ ! -d repos/${REPONAME} ]; then


### PR DESCRIPTION
The variable is `TEST_DATA_DIR`, not `TEST_DATADIR`.

(Flatpak doesn't seem to have CI for installed-tests. I can try to contribute that if you would be interested, although I don't have access to Papr so I'd have to add it blindly without testing. Are the Papr tests run as root? Are they allowed to write to /usr, or failing that, /usr/local?)