### PR TITLE
remote: Add a way to get/set xa.main-ref

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -684,6 +684,8 @@ char      *flatpak_dir_get_remote_title (FlatpakDir *self,
                                          const char *remote_name);
 char      *flatpak_dir_get_remote_collection_id (FlatpakDir *self,
                                                  const char *remote_name);
+char      *flatpak_dir_get_remote_main_ref (FlatpakDir *self,
+                                            const char *remote_name);
 gboolean   flatpak_dir_get_remote_oci (FlatpakDir *self,
                                        const char *remote_name);
 char      *flatpak_dir_get_remote_default_branch (FlatpakDir *self,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10535,6 +10535,19 @@ flatpak_dir_get_remote_oci (FlatpakDir *self,
 }
 
 char *
+flatpak_dir_get_remote_main_ref (FlatpakDir *self,
+                                 const char *remote_name)
+{
+  GKeyFile *config = ostree_repo_get_config (self->repo);
+  g_autofree char *group = get_group (remote_name);
+
+  if (config)
+    return g_key_file_get_string (config, group, "xa.main-ref", NULL);
+
+  return NULL;
+}
+
+char *
 flatpak_dir_get_remote_default_branch (FlatpakDir *self,
                                        const char *remote_name)
 {

--- a/common/flatpak-remote.h
+++ b/common/flatpak-remote.h
@@ -83,6 +83,9 @@ FLATPAK_EXTERN void          flatpak_remote_set_title (FlatpakRemote *self,
 FLATPAK_EXTERN char *        flatpak_remote_get_default_branch (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_default_branch (FlatpakRemote *self,
                                                                 const char    *default_branch);
+FLATPAK_EXTERN char *        flatpak_remote_get_main_ref (FlatpakRemote *self);
+FLATPAK_EXTERN void          flatpak_remote_set_main_ref (FlatpakRemote *self,
+                                                          const char    *main_ref);
 FLATPAK_EXTERN gboolean      flatpak_remote_get_gpg_verify (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_gpg_verify (FlatpakRemote *self,
                                                             gboolean       gpg_verify);


### PR DESCRIPTION
This is useful for gnome-software in order to figure out which app to
show from noenumerate remotes.