### PR TITLE
Double disk de-duplication on --system pull

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -413,6 +413,11 @@ char *    flatpak_dir_load_override (FlatpakDir *dir,
                                      gsize      *length,
                                      GError    **error);
 OstreeRepo *flatpak_dir_get_repo (FlatpakDir *self);
+OstreeRepo *flatpak_dir_create_child_repo (FlatpakDir   *self,
+                                           GFile        *cache_dir,
+                                           GLnxLockFile *file_lock,
+                                           const char   *optional_commit,
+                                           GError      **error);
 gboolean    flatpak_dir_ensure_path (FlatpakDir   *self,
                                      GCancellable *cancellable,
                                      GError      **error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -71,11 +71,6 @@ static FlatpakOciRegistry *flatpak_dir_create_system_child_oci_registry (Flatpak
                                                                          GLnxLockFile *file_lock,
                                                                          GError      **error);
 
-static OstreeRepo * flatpak_dir_create_child_repo (FlatpakDir   *self,
-                                                   GFile        *cache_dir,
-                                                   GLnxLockFile *file_lock,
-                                                   const char   *optional_commit,
-                                                   GError      **error);
 static OstreeRepo * flatpak_dir_create_system_child_repo (FlatpakDir   *self,
                                                           GLnxLockFile *file_lock,
                                                           const char   *optional_commit,
@@ -7389,7 +7384,7 @@ flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
   return g_steal_pointer (&new_registry);
 }
 
-static OstreeRepo *
+OstreeRepo *
 flatpak_dir_create_child_repo (FlatpakDir   *self,
                                GFile        *cache_dir,
                                GLnxLockFile *file_lock,

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -156,6 +156,29 @@
       <arg type='s' name='installation' direction='in'/>
     </method>
 
+    <!-- This methods provides a child repo to the client which can be pulled in
+         the system's repo. The child repo resides inside a cache directory,
+         which gets mounted with bindfs so that the client(unprivileged)
+         can write to it as long as the mount exists. We do this because
+         it  enables the client to do a child pull at a location (currently repo/tmp)
+         which can be hardlinked during Deploy and avoid the temporary requirement
+         of double disk-space usage.
+
+         The expected call sequence is either of the following:
+         * GetChildRepoForPull -> Deploy
+         * GetChildRepoForPull -> CancelPull (in case an ongoing pull has to be cancelled)
+
+         This method can recover old partial pulls which might be failed due to various reasons.
+         In that case, the call sequence probably is:
+         * GetChildRepoForPull -> <failure occured> -> GetChildRepoForPull (partial pull recovered)
+    -->
+    <method name="GetChildRepoForPull">
+      <arg type='s' name='ref' direction='in'/>
+      <arg type='s' name='commit' direction='in'/>
+      <arg type='s' name='installation' direction='in'/>
+      <arg type='s' name='repo_path' direction='out'/>
+    </method>
+
   </interface>
 
 </node>

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -179,6 +179,13 @@
       <arg type='s' name='repo_path' direction='out'/>
     </method>
 
+    <!-- This method cancels an ongoing pull at repo_path. The cancellation triggered
+         by the client helps to cleanup the bindfs mount setup -->
+    <method name="CancelPull">
+      <arg type='s' name='installation' direction='in'/>
+      <arg type='s' name='repo_path' direction='in'/>
+    </method>
+
   </interface>
 
 </node>

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -25,21 +25,29 @@
 #include <string.h>
 #include <gio/gio.h>
 #include <polkit/polkit.h>
+#include <sys/mount.h>
+#include <gio/gunixmounts.h>
 
 #include "flatpak-dbus-generated.h"
 #include "flatpak-dir-private.h"
 #include "flatpak-oci-registry-private.h"
 #include "flatpak-error.h"
+#include "flatpak-utils-private.h"
 
 static PolkitAuthority *authority = NULL;
 static FlatpakSystemHelper *helper = NULL;
 static GMainLoop *main_loop = NULL;
 static guint name_owner_id = 0;
 
+G_LOCK_DEFINE (ongoing_pulls);
+static GPtrArray *ongoing_pulls = NULL;
+
 static gboolean on_session_bus = FALSE;
 static gboolean no_idle_exit = FALSE;
 
 #define IDLE_TIMEOUT_SECS 10 * 60
+#define MAX_PULLS_PER_USER 16
+#define MOUNT_TIMEOUT_SECS 15
 
 /* This uses a weird Auto prefix to avoid conflicts with later added polkit types.
  */
@@ -50,6 +58,254 @@ typedef PolkitSubject             AutoPolkitSubject;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitAuthorizationResult, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitDetails, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitSubject, g_object_unref)
+
+typedef struct
+{
+  FlatpakSystemHelper *object;
+  GDBusMethodInvocation *invocation;
+  GCancellable *cancellable;
+
+  guint watch_id;
+  uid_t uid;
+
+  gint ref_count;
+
+  gchar *ref;
+  gchar *commit;
+
+  /* root_dir_name points to root owned cache directory for the child repo.
+   * Actual file creation of the ongoing pull happens in this directory.
+   * Syntax: $repo/tmp/flatpak-cache-$ref-XXXXXX
+   *
+   * user_dir_name points to cache directory which is bind mount to root_dir_name
+   * using bindfs. This is given back to the client to initiate the pull.
+   * Syntax: $root_dir_name-bindfs
+   */
+  gchar *root_dir_name;
+  gchar *user_dir_name;
+  gchar *child_repo_path;
+  gboolean preserve; /* Don't rm -rf the child pull. It can be used to resume a partial pull */
+
+  GUnixMountMonitor *mount_monitor;
+  gulong mount_monitor_id;
+  guint unsuccessful_mount_timeout_id;
+  GSubprocess *bindfs;
+} OngoingPull;
+
+static void
+ongoing_pull_free (OngoingPull *pull)
+{
+  g_autoptr(GFile) root_dir = NULL;
+  g_autoptr(GFile) user_dir = NULL;
+  g_autoptr(GError) local_error = NULL;
+
+  root_dir = g_file_new_for_path (pull->root_dir_name);
+  user_dir = g_file_new_for_path (pull->user_dir_name);
+
+  g_cancellable_cancel (pull->cancellable);
+
+  g_clear_object (&pull->bindfs);
+
+  if (!pull->preserve)
+    {
+      if (!flatpak_rm_rf (root_dir, NULL, &local_error))
+        {
+          g_warning ("Unable to remove ongoing pull's root dir at: %s", local_error->message);
+          g_clear_error (&local_error);
+        }
+
+      if (!flatpak_rm_rf (user_dir, NULL, &local_error))
+        {
+          g_warning ("Unable to remove ongoing pull's user dir at: %s", local_error->message);
+          g_clear_error (&local_error);
+        }
+    }
+
+  g_clear_object (&pull->mount_monitor);
+
+  g_clear_pointer (&pull->root_dir_name, g_free);
+  g_clear_pointer (&pull->user_dir_name, g_free);
+  g_clear_pointer (&pull->child_repo_path, g_free);
+  g_clear_pointer (&pull->ref, g_free);
+  g_clear_pointer (&pull->commit, g_free);
+
+  g_slice_free (OngoingPull, pull);
+}
+
+/* This makes sure that we terminate the bindfs mount which in turn
+   releases the ref taken by the call to g_subprocess_wait_check_async. */
+static void
+ongoing_pull_teardown (OngoingPull *pull)
+{
+  if (pull->watch_id)
+    g_clear_handle_id (&pull->watch_id, g_bus_unwatch_name);
+
+  if (pull->bindfs != NULL)
+    {
+      /* We are probably here because bindfs was not terminated during deploy or we are on error
+         code path and trying to cleanup the mount. Hence, we try force unmount our bindfs directory,
+         to make sure no open FDs can write to it anymore. If this fails, we kill the subprocess and
+         try to cleanup /etc/mtab mount entry. */
+      if (umount2 (pull->user_dir_name, MNT_FORCE) == -1)
+        {
+          g_autoptr(GError) local_error = NULL;
+          glnx_throw_errno_prefix (&local_error, "Failed to unmount bindfs dir %s", pull->user_dir_name);
+          g_warning ("%s; killing subprocess", local_error->message);
+          g_clear_error (&local_error);
+
+          g_subprocess_force_exit (pull->bindfs);
+          /* Perform a lazy unmount operation to cleanup the dangling mount entry in /etc/mtab due to SIGKILL. */
+          if (umount2 (pull->user_dir_name, MNT_DETACH) == -1)
+            {
+              glnx_throw_errno_prefix (&local_error, "Failed to umount2 bindfs dir %s", pull->user_dir_name);
+              g_warning ("%s; mount maybe dangling in /etc/mtab", local_error->message);
+            }
+        }
+      g_clear_object (&pull->bindfs);
+    }
+
+  if (pull->unsuccessful_mount_timeout_id)
+    g_clear_handle_id (&pull->unsuccessful_mount_timeout_id, g_source_remove);
+
+  if (pull->mount_monitor_id)
+    {
+      g_signal_handler_disconnect (pull->mount_monitor, pull->mount_monitor_id);
+      pull->mount_monitor_id = 0;
+    }
+}
+
+static void
+ongoing_pull_unref (OngoingPull *pull)
+{
+  g_return_if_fail (pull != NULL);
+  g_return_if_fail (pull->ref_count > 0);
+
+  if (g_atomic_int_dec_and_test (&pull->ref_count))
+    {
+      ongoing_pull_teardown (pull);
+      ongoing_pull_free (pull);
+    }
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OngoingPull, ongoing_pull_unref);
+
+static OngoingPull *
+ongoing_pull_ref (OngoingPull *pull)
+{
+  g_return_val_if_fail (pull != NULL, NULL);
+  g_return_val_if_fail (pull->ref_count > 0, NULL);
+
+  g_atomic_int_inc (&pull->ref_count);
+  return pull;
+}
+
+static void
+name_vanished_cb (GDBusConnection *connection, const gchar *name, gpointer user_data)
+{
+  OngoingPull *pull = ((OngoingPull *) user_data);
+
+  pull->preserve = TRUE;
+  ongoing_pull_teardown (pull);
+  ongoing_pull_unref (pull);
+}
+
+static void
+mounts_changed_cb (GUnixMountMonitor *monitor, gpointer user_data)
+{
+  OngoingPull *pull = user_data;
+  GList *mounts = NULL;
+  GUnixMountEntry *mount_entry = NULL;
+  GList *l;
+  gboolean mount_successful = FALSE;
+
+  mounts = g_unix_mounts_get (NULL);
+  for (l = mounts; l != NULL; l = l->next)
+    {
+      mount_entry = (GUnixMountEntry *) l->data;
+      if (g_strcmp0 (pull->user_dir_name, g_unix_mount_get_mount_path (mount_entry)) == 0)
+        mount_successful = TRUE;
+    }
+  g_list_free_full (mounts, (GDestroyNotify) g_unix_mount_free);
+
+  if (mount_successful)
+    {
+      g_autofree gchar *basename = NULL;
+      g_autofree gchar *child_repo_path = NULL;
+
+      g_signal_handler_disconnect (monitor, pull->mount_monitor_id);
+      pull->mount_monitor_id = 0;
+
+      basename = g_path_get_basename (pull->child_repo_path);
+      child_repo_path = g_build_filename (pull->user_dir_name, basename, NULL);
+
+      flatpak_system_helper_complete_get_child_repo_for_pull (pull->object,
+                                                              pull->invocation,
+                                                              child_repo_path);
+
+      g_source_remove (pull->unsuccessful_mount_timeout_id);
+      pull->unsuccessful_mount_timeout_id = 0;
+    }
+}
+
+static gboolean
+unsuccessful_mount_timeout (gpointer user_data)
+{
+  OngoingPull *pull = user_data;
+
+  ongoing_pull_teardown (pull);
+  ongoing_pull_unref (pull);
+  g_dbus_method_invocation_return_error (pull->invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
+                                         "Failed to mount %s on %s with bindfs",
+                                         pull->user_dir_name, pull->root_dir_name);
+
+  return FALSE;
+}
+
+static OngoingPull *
+ongoing_pull_new (FlatpakSystemHelper   *object,
+                  GDBusMethodInvocation *invocation,
+                  const gchar           *ref,
+                  const gchar           *commit,
+                  uid_t                  uid,
+                  gchar                 *user_dir_name,
+                  gchar                 *root_dir_name,
+                  gchar                 *child_repo_path)
+{
+  GDBusConnection *connection = g_dbus_method_invocation_get_connection (invocation);
+  OngoingPull *pull;
+
+  pull = g_slice_new0 (OngoingPull);
+  pull->object = object;
+  pull->invocation = invocation;
+  pull->ref = g_strdup (ref);
+  pull->commit = g_strdup (commit);
+  pull->cancellable = g_cancellable_new ();
+  pull->uid = uid;
+  pull->ref_count = 1;
+  pull->preserve = FALSE;
+
+  pull->watch_id = g_bus_watch_name_on_connection (connection,
+                                                   g_dbus_connection_get_unique_name (connection),
+                                                   G_BUS_NAME_WATCHER_FLAGS_NONE, NULL,
+                                                   name_vanished_cb,
+                                                   pull, NULL);
+
+  pull->mount_monitor = g_unix_mount_monitor_get ();
+  pull->mount_monitor_id = g_signal_connect (pull->mount_monitor,
+                                             "mounts-changed",
+                                             G_CALLBACK (mounts_changed_cb),
+                                             pull);
+
+  pull->unsuccessful_mount_timeout_id = g_timeout_add_seconds (MOUNT_TIMEOUT_SECS,
+                                                               unsuccessful_mount_timeout,
+                                                               pull);
+
+  pull->user_dir_name = g_strdup (user_dir_name);
+  pull->root_dir_name = g_strdup (root_dir_name);
+  pull->child_repo_path = g_strdup (child_repo_path);
+
+  return pull;
+}
 
 static void
 skeleton_died_cb (gpointer data)
@@ -91,6 +347,12 @@ unref_skeleton_in_timeout (void)
 static gboolean
 idle_timeout_cb (gpointer user_data)
 {
+  G_LOCK (ongoing_pulls);
+  guint ongoing_pulls_len = ongoing_pulls->len;
+  G_UNLOCK (ongoing_pulls);
+  if (ongoing_pulls_len != 0)
+    return G_SOURCE_CONTINUE;
+
   if (name_owner_id)
     {
       g_debug ("Idle - unowning name");
@@ -191,6 +453,346 @@ get_sender_pid (GDBusMethodInvocation *invocation)
 }
 
 static gboolean
+get_connection_uid (GDBusMethodInvocation *invocation, uid_t *uid_out, GError **error)
+{
+  GDBusConnection *connection = g_dbus_method_invocation_get_connection (invocation);
+  const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
+  g_autoptr(GVariant) dict = NULL;
+  g_autoptr(GVariant) unixUserId = NULL;
+  g_autoptr(GVariant) credentials = NULL;
+  uid_t uid;
+
+  credentials = g_dbus_connection_call_sync (connection,
+                                             "org.freedesktop.DBus",
+                                             "/org/freedesktop/DBus",
+                                             "org.freedesktop.DBus",
+                                             "GetConnectionCredentials",
+                                             g_variant_new ("(s)", sender),
+                                             G_VARIANT_TYPE ("(a{sv})"), G_DBUS_CALL_FLAGS_NONE, G_MAXINT, NULL, error);
+  if (credentials == NULL)
+    return FALSE;
+
+  dict = g_variant_get_child_value (credentials, 0);
+  unixUserId = g_variant_lookup_value (dict, "UnixUserID", G_VARIANT_TYPE_UINT32);
+
+  if (unixUserId == NULL)
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
+                   "Failed to query UnixUserId for the bus name: %s", sender);
+      return FALSE;
+    }
+
+  *uid_out = g_variant_get_uint32 (unixUserId);
+  return TRUE;
+}
+
+static guint
+get_uid_pull_count (uid_t uid)
+{
+  OngoingPull *pull;
+  guint uid_pull_count = 0;
+
+  G_LOCK (ongoing_pulls);
+  for (guint i = 0; i < ongoing_pulls->len; i++)
+    {
+      pull = g_ptr_array_index (ongoing_pulls, i);
+      if (pull->uid == uid)
+        uid_pull_count++;
+    }
+  G_UNLOCK (ongoing_pulls);
+
+  return uid_pull_count;
+}
+
+static void
+subprocess_wait_check_cb (GObject      *source_object,
+                          GAsyncResult *result,
+                          gpointer      user_data)
+{
+  GSubprocess *subprocess = (GSubprocess *) source_object;
+  g_autoptr(OngoingPull) pull = user_data;
+  g_autoptr(GError) error = NULL;
+
+  if (!g_subprocess_wait_check_finish (subprocess, result, &error))
+    {
+      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        {
+          g_dbus_method_invocation_return_gerror (pull->invocation, error);
+          ongoing_pull_teardown (pull);
+        }
+    }
+}
+
+static gboolean
+check_for_repo_containing_partial_pull (GFile *cache_dir, const gchar *commit, gchar **out_repo_location)
+{
+  g_autoptr(GFileEnumerator) enumerator = NULL;
+  GFileInfo *file_info = NULL;
+  g_autoptr(GError) error = NULL;
+  const gchar *name;
+
+  enumerator = g_file_enumerate_children (cache_dir,
+                                          G_FILE_ATTRIBUTE_STANDARD_NAME,
+                                          G_FILE_QUERY_INFO_NONE, NULL, &error);
+  if (enumerator == NULL)
+    {
+      g_warning ("Failed to get file enumerator: %s", error->message);
+      return FALSE;
+    }
+
+  while (TRUE)
+    {
+      if (!g_file_enumerator_iterate (enumerator, &file_info, NULL, NULL, &error))
+        {
+          g_warning ("Error while file enumerator iterating: %s", error->message);
+          break;
+        }
+
+      if (file_info == NULL)
+        break;
+
+      name = g_file_info_get_name (file_info);
+      if (g_file_info_get_file_type (file_info) == G_FILE_TYPE_DIRECTORY &&
+          g_str_has_prefix (name, "repo-"))
+        {
+          g_autofree gchar *commit_partial_basename = g_strdup_printf ("%s.commitpartial", commit);
+          g_autoptr(GFile) repo_file = g_file_get_child (cache_dir, name);
+          g_autoptr(GFile) state = g_file_get_child (repo_file, "state");
+          g_autoptr(GFile) commit_partial = g_file_get_child (state, commit_partial_basename);
+
+          if (g_file_query_exists (commit_partial, NULL))
+            {
+              g_autoptr(OstreeRepo) repo = ostree_repo_new (repo_file);
+              g_autofree gchar *repo_path = g_file_get_path (repo_file);
+              /* Validate repo before returning */
+              if (!ostree_repo_open (repo, NULL, &error))
+                {
+                  g_warning ("Partial pull available at %s, but invalid repo: %s", repo_path, error->message);
+                  return FALSE;
+                }
+              else
+                {
+                  *out_repo_location = g_strdup (repo_path);
+                  return TRUE;
+                }
+            }
+        }
+    }
+
+  return FALSE;
+}
+
+static gboolean
+check_partial_pull_availability (const gchar *repo_tmp,
+                                 const gchar *ref_basename,
+                                 const gchar *commit,
+                                 gchar      **out_location)
+{
+  g_autoptr(GFileEnumerator) enumerator = NULL;
+  g_autoptr(GFile) repo_tmpfile = NULL;
+  GFileInfo *file_info = NULL;
+  g_autofree gchar *prefix = NULL;
+  g_autoptr(GError) error = NULL;
+  const gchar *name;
+
+  g_debug ("Checking partial pull availability for ref %s (commit: %s)", ref_basename, commit);
+
+  repo_tmpfile = g_file_new_for_path (repo_tmp);
+  enumerator = g_file_enumerate_children (repo_tmpfile,
+                                          G_FILE_ATTRIBUTE_STANDARD_NAME,
+                                          G_FILE_QUERY_INFO_NONE, NULL, NULL);
+  if (enumerator == NULL)
+    {
+      g_warning ("Failed to get file enumerator: %s", error->message);
+      return FALSE;
+    }
+
+  prefix = g_strdup_printf ("flatpak-cache-%s", ref_basename);
+
+  /* We are looking for flatpak-cache-$ref-XXXXXX directory in repo/tmp.
+     If we find one, we try to look for an OSTree repo which possibly has
+     the $commit.commitpartial file denoting the partial pull for that $commit. */
+  while (TRUE)
+    {
+      if (!g_file_enumerator_iterate (enumerator, &file_info, NULL, NULL, &error))
+        {
+          g_warning ("Error while file enumerator iterating: %s", error->message);
+          break;
+        }
+
+      if (file_info == NULL)
+        break;
+
+      name = g_file_info_get_name (file_info);
+      if (g_file_info_get_file_type (file_info) == G_FILE_TYPE_DIRECTORY &&
+          g_str_has_prefix (name, prefix))
+        {
+          g_autoptr(GFile) cache_dir = g_file_get_child (repo_tmpfile, name);
+
+          if (check_for_repo_containing_partial_pull (cache_dir, commit, out_location))
+            return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
+static gboolean
+handle_get_child_repo_for_pull (FlatpakSystemHelper   *object,
+                                GDBusMethodInvocation *invocation,
+                                const gchar           *ref,
+                                const gchar           *commit,
+                                const gchar           *arg_installation)
+{
+  GDBusConnection *connection = g_dbus_method_invocation_get_connection (invocation);
+  g_autoptr(FlatpakDir) system = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *bindfs_path = NULL;
+
+  g_debug ("GetChildRepoForPull %s", arg_installation);
+
+  system = dir_get_system (arg_installation, &error);
+  if (system == NULL)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
+      return TRUE;
+    }
+
+  bindfs_path = g_find_program_in_path ("bindfs");
+  if (bindfs_path == NULL)
+    {
+      g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED,
+                                             "Can't find bindfs in the system.");
+      return TRUE;
+    }
+  else
+    {
+      OngoingPull *new_pull;
+      g_autofree gchar *child_repo_path = NULL;
+      g_autofree gchar *user_dir = NULL;
+      g_autofree gchar *root_dir = NULL;
+      g_autofree gchar *flatpak_dir = NULL;
+      g_autofree gchar *arg_user = NULL;
+      g_autofree gchar *out_location = NULL;
+      g_autofree gchar *repo_tmp = NULL;
+      g_auto(GStrv) parts = NULL;
+      guint uid_pull_count = 0;
+      uid_t uid;
+
+      if (!get_connection_uid (invocation, &uid, &error))
+        {
+          g_dbus_method_invocation_return_gerror (invocation, error);
+          return TRUE;
+        }
+
+      uid_pull_count = get_uid_pull_count (uid);
+      if (uid_pull_count > MAX_PULLS_PER_USER)
+        {
+          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_LIMITS_EXCEEDED,
+                                                 "Maximum number of pulls per user exceeded for UID: %u", uid);
+          return TRUE;
+        }
+
+      flatpak_dir = g_file_get_path (flatpak_dir_get_path (system));
+      repo_tmp = g_build_filename (flatpak_dir, "repo", "tmp", NULL);
+
+      parts = flatpak_decompose_ref (ref, NULL);
+      if (check_partial_pull_availability (repo_tmp, parts[1], commit, &out_location))
+        {
+          g_autoptr(GFile) user_dir_file = NULL;
+
+          g_debug ("Found a partial pull for ref %s at: %s", parts[1], out_location);
+          root_dir = g_path_get_dirname (out_location);
+          user_dir = g_strdup_printf ("%s-bindfs", root_dir);
+          user_dir_file = g_file_new_for_path (user_dir);
+          if (!g_file_query_exists (user_dir_file, NULL))
+            g_mkdir_with_parents (user_dir, 0755);
+          child_repo_path = g_steal_pointer (&out_location);
+        }
+      else
+        {
+          g_autoptr(OstreeRepo) child_repo = NULL;
+          g_auto(GLnxLockFile) child_repo_lock = { 0, };
+          g_autoptr(GFile) root_dir_file = NULL;
+          g_autofree gchar *cache_dir_basename = NULL;
+
+          cache_dir_basename = g_strdup_printf ("flatpak-cache-%s-XXXXXX", parts[1]);
+          root_dir = g_mkdtemp_full (g_build_filename (repo_tmp, cache_dir_basename, NULL), 0755);
+          user_dir = g_strdup_printf ("%s-bindfs", root_dir);
+          if (g_mkdir_with_parents (user_dir, 0755) == -1)
+            {
+              glnx_throw_errno_prefix (&error, "Can't create directory for bindfs mount at %s", user_dir);
+              g_dbus_method_invocation_return_gerror (invocation, error);
+              return TRUE;
+            }
+
+          root_dir_file = g_file_new_for_path (root_dir);
+          child_repo = flatpak_dir_create_child_repo (system, root_dir_file, &child_repo_lock, NULL, &error);
+          if (child_repo == NULL)
+            {
+              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
+                                                     "Failed to create OSTree child repo at %s", root_dir);
+              return TRUE;
+            }
+          child_repo_path = g_file_get_path (ostree_repo_get_path (child_repo));
+        }
+
+      g_assert (child_repo_path != NULL);
+
+      new_pull = ongoing_pull_new (object, invocation, ref, commit,
+                                   uid, user_dir, root_dir, child_repo_path);
+
+      /* In bindfs, --force-user forces file-ownership to be seen in the mounted mirrored directory(i.e. user_dir),
+         while --create-for-user enforces the actual owner of the file during file creation on disk.  */
+      arg_user = g_strdup_printf ("--force-user=%"G_GUINT32_FORMAT, uid);
+      new_pull->bindfs = g_subprocess_new (G_SUBPROCESS_FLAGS_NONE,
+                                           &error,
+                                           bindfs_path,
+                                           arg_user,"-f",
+                                           "-o", "nonempty",
+                                           "--create-for-user=root",
+                                           "--create-for-group=root",
+                                           root_dir, user_dir, NULL);
+      if (new_pull->bindfs == NULL)
+        {
+          ongoing_pull_unref (new_pull);
+          g_dbus_method_invocation_return_gerror (invocation, error);
+          return TRUE;
+        }
+
+      G_LOCK (ongoing_pulls);
+      g_ptr_array_add (ongoing_pulls, new_pull);
+      G_UNLOCK (ongoing_pulls);
+
+      g_subprocess_wait_check_async (new_pull->bindfs,
+                                     new_pull->cancellable,
+                                     subprocess_wait_check_cb,
+                                     ongoing_pull_ref (new_pull));
+    }
+
+  return TRUE;
+}
+
+static OngoingPull *
+take_ongoing_pull_by_dir (const gchar *arg_repo_path)
+{
+  OngoingPull *pull = NULL;
+  g_autofree gchar *user_dir = g_path_get_dirname (arg_repo_path);
+
+  G_LOCK (ongoing_pulls);
+  for (guint i = 0; i < ongoing_pulls->len; i++)
+    {
+      pull = g_ptr_array_index (ongoing_pulls, i);
+      if (g_strcmp0 (pull->user_dir_name, user_dir) == 0)
+        break;
+    }
+  g_ptr_array_remove (ongoing_pulls, pull);
+  G_UNLOCK (ongoing_pulls);
+
+  return g_steal_pointer (&pull);
+}
+
+static gboolean
 handle_deploy (FlatpakSystemHelper   *object,
                GDBusMethodInvocation *invocation,
                const gchar           *arg_repo_path,
@@ -201,7 +803,7 @@ handle_deploy (FlatpakSystemHelper   *object,
                const gchar           *arg_installation)
 {
   g_autoptr(FlatpakDir) system = NULL;
-  g_autoptr(GFile) repo_file = g_file_new_for_path (arg_repo_path);
+  g_autoptr(GFile) repo_file = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GFile) deploy_dir = NULL;
   g_autoptr(OstreeAsyncProgress) ostree_progress = NULL;
@@ -211,6 +813,8 @@ handle_deploy (FlatpakSystemHelper   *object,
   gboolean local_pull;
   gboolean reinstall;
   g_autofree char *url = NULL;
+  g_autofree gchar *repo_path = NULL;
+  g_autoptr(OngoingPull) ongoing_pull = NULL;
 
   g_debug ("Deploy %s %u %s %s %s", arg_repo_path, arg_flags, arg_ref, arg_origin, arg_installation);
 
@@ -220,6 +824,40 @@ handle_deploy (FlatpakSystemHelper   *object,
       g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
+
+  ongoing_pull = take_ongoing_pull_by_dir (arg_repo_path);
+  if (ongoing_pull != NULL)
+    {
+      g_autofree gchar *bindfs_repo_path = NULL;
+      g_autofree gchar *real_repo_path = NULL;
+
+      if (umount (ongoing_pull->user_dir_name) == -1)
+        {
+          ongoing_pull_teardown (ongoing_pull);
+          glnx_throw_errno_prefix (&error, "Unmounting %s failed", ongoing_pull->user_dir_name);
+          g_dbus_method_invocation_return_gerror (invocation, error);
+          return TRUE;
+        }
+
+      if (ongoing_pull->bindfs)
+        {
+          g_subprocess_wait (ongoing_pull->bindfs, NULL, NULL);
+          g_clear_object (&ongoing_pull->bindfs);
+        }
+
+        bindfs_repo_path = g_path_get_basename (arg_repo_path);
+        real_repo_path = g_build_filename (ongoing_pull->root_dir_name, bindfs_repo_path, NULL);
+        repo_file = g_file_new_for_path (real_repo_path);
+        repo_path = g_steal_pointer (&real_repo_path);
+    }
+
+  if (repo_file == NULL)
+    {
+      repo_file = g_file_new_for_path (arg_repo_path);
+      repo_path = g_strdup (arg_repo_path);
+    }
+
+  g_assert (repo_path != NULL);
 
   flatpak_dir_set_source_pid (system, get_sender_pid (invocation));
 
@@ -284,9 +922,9 @@ handle_deploy (FlatpakSystemHelper   *object,
 
   is_oci = flatpak_dir_get_remote_oci (system, arg_origin);
 
-  if (strlen (arg_repo_path) > 0 && is_oci)
+  if (strlen (repo_path) > 0 && is_oci)
     {
-      g_autoptr(GFile) registry_file = g_file_new_for_path (arg_repo_path);
+      g_autoptr(GFile) registry_file = g_file_new_for_path (repo_path);
       g_autofree char *registry_uri = g_file_get_uri (registry_file);
       g_autoptr(FlatpakOciRegistry) registry = NULL;
       g_autoptr(FlatpakOciIndex) index = NULL;
@@ -390,7 +1028,7 @@ handle_deploy (FlatpakSystemHelper   *object,
           return TRUE;
         }
     }
-  else if (strlen (arg_repo_path) > 0)
+  else if (strlen (repo_path) > 0)
     {
       g_autoptr(GMainContextPopDefault) main_context = NULL;
 
@@ -399,7 +1037,7 @@ handle_deploy (FlatpakSystemHelper   *object,
 
       ostree_progress = ostree_async_progress_new_and_connect (no_progress_cb, NULL);
 
-      if (!flatpak_dir_pull_untrusted_local (system, arg_repo_path,
+      if (!flatpak_dir_pull_untrusted_local (system, repo_path,
                                              arg_origin,
                                              arg_ref,
                                              (const char **) arg_subpaths,
@@ -1421,7 +2059,8 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
   else if (g_strcmp0 (method_name, "RemoveLocalRef") == 0 ||
            g_strcmp0 (method_name, "PruneLocalRepo") == 0 ||
            g_strcmp0 (method_name, "EnsureRepo") == 0 ||
-           g_strcmp0 (method_name, "RunTriggers") == 0)
+           g_strcmp0 (method_name, "RunTriggers") == 0 ||
+           g_strcmp0 (method_name, "GetChildRepoForPull") == 0)
     {
       action = "org.freedesktop.Flatpak.modify-repo";
     }
@@ -1492,6 +2131,7 @@ on_bus_acquired (GDBusConnection *connection,
   g_signal_connect (helper, "handle-run-triggers", G_CALLBACK (handle_run_triggers), NULL);
   g_signal_connect (helper, "handle-update-summary", G_CALLBACK (handle_update_summary), NULL);
   g_signal_connect (helper, "handle-generate-oci-summary", G_CALLBACK (handle_generate_oci_summary), NULL);
+  g_signal_connect (helper, "handle-get-child-repo-for-pull", G_CALLBACK (handle_get_child_repo_for_pull), NULL);
 
   g_signal_connect (helper, "g-authorize-method",
                     G_CALLBACK (flatpak_authorize_method_handler),
@@ -1657,11 +2297,15 @@ main (int    argc,
                                   NULL,
                                   NULL);
 
+  ongoing_pulls = g_ptr_array_new ();
+
   /* Ensure we don't idle exit */
   schedule_idle_callback ();
 
   main_loop = g_main_loop_new (NULL, FALSE);
   g_main_loop_run (main_loop);
+
+  g_clear_pointer (&ongoing_pulls, g_ptr_array_unref);
 
   return 0;
 }


### PR DESCRIPTION
This PR tries to address the issue : https://github.com/ostreedev/ostree/issues/1723
(ideally we wanted to move this issue inside Flatpak's umbrella but it's seems that it's not possible). So please refer to the discussion there. Most of moderate to high-level details inside commit messages too.

Summary of changes:
* Let system-helper create a child repo in `$SYSTEM_REPO/tmp`. For convenience  put this child repo in a cache dir (that has the convention `flatpak-cache-$ref-XXXXXX`)
* `FlatpakSystemHelperOngoingPull`'s struct member `root_dir` points to this `flatpak-cache-$ref-XXXXXX` (because it's the root owned directory)
* `FlatpakSystemHelperOngoingPull`'s struct member `user_dir` points to this another directory that gets created `flatpak-cache-$ref-XXXXXX-bindfs`. We will `bindfs` mount this directory and give it back to the client to do the pull in the child repo. `bindfs` lets client (non-sudo) write to this child repo. While the actual file creation is being done in the `root_dir` folder. As long as the bindfs mount  is up, the client is able to write(or pull) to the child repo.
* When the child pull is finished, we unmount `bindfs` mount. In case of failure, we force unmount things or kill the `bindfs` subprocess. The idea to use a FUSE filesystem is basically that it is in user space and can be spawned into a separate child process(which can be killed).
* Make the local "trusted" pull. That should use hardlinks and thus double disk situation is avoided.
* In case of error in mounting directories or pull failures, we the system-helper's `CancelPull` method, to cleanup.
* If `bindfs` is not found on the system, we fallback on the current `--system` pull  behaviour (that would use double-disk space). 

I have been testing this since couple of weeks now. It has worked well in my testing locally. Though I am having troubles on how to write rigours tests for this feature (any help is welcome here). 