### PR TITLE
tests: Don't assume architecture is x86_64

### DIFF
--- a/tests/test-info.sh
+++ b/tests/test-info.sh
@@ -13,7 +13,7 @@ COMMIT=`${FLATPAK} ${U} info --show-commit org.test.Hello`
 
 ${FLATPAK} info -rcos  org.test.Hello > info
 
-assert_file_has_content info "^app/org.test.Hello/x86_64/master test-repo ${COMMIT}"
+assert_file_has_content info "^app/org.test.Hello/$(flatpak --default-arch)/master test-repo ${COMMIT}"
 
 echo "ok info -rcos"
 
@@ -25,25 +25,25 @@ echo "ok info --show-permissions"
 
 ${FLATPAK} info --show-location  org.test.Hello > info
 
-assert_file_has_content info "app/org.test.Hello/x86_64/master/${COMMIT}"
+assert_file_has_content info "app/org.test.Hello/$(flatpak --default-arch)/master/${COMMIT}"
 
 echo "ok info --show-location"
 
 ${FLATPAK} info --show-runtime  org.test.Hello > info
 
-assert_file_has_content info "^org.test.Platform/x86_64/master$"
+assert_file_has_content info "^org.test.Platform/$(flatpak --default-arch)/master$"
 
 echo "ok info --show-runtime"
 
 ${FLATPAK} info --show-sdk  org.test.Hello > info
 
-assert_file_has_content info "^org.test.Platform/x86_64/master$"
+assert_file_has_content info "^org.test.Platform/$(flatpak --default-arch)/master$"
 
 echo "ok info --show-sdk"
 
 ${FLATPAK} info --show-extensions org.test.Hello > info
 
-assert_file_has_content info "^Extension: runtime/org.test.Hello.Locale/x86_64/master$"
+assert_file_has_content info "^Extension: runtime/org.test.Hello.Locale/$(flatpak --default-arch)/master$"
 
 echo "ok info --show-extensions"
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -404,6 +404,6 @@ update_repo
 ${FLATPAK} ${U} install -y test-repo org.test.App
 ${FLATPAK} ${U} info -m org.test.App > out
 
-assert_file_has_content out ^sdk=org.test.Sdk/x86_64/master$
+assert_file_has_content out "^sdk=org.test.Sdk/$(flatpak --default-arch)/master$"
 
 echo "ok --sdk option"

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -83,7 +83,7 @@ echo "ok 2 update repo config to deploy collection ID"
 # We have to manually add refs under the old collection ID so the client can pull
 # using its old collection ID.
 #UPDATE_REPO_ARGS="--collection-id=net.malicious.NewCollection --deploy-collection-id" update_repo
-#for ref in app/org.test.App/x86_64/master app/org.test.Hello/x86_64/master appstream/x86_64 ostree-metadata runtime/org.test.Platform/x86_64/master; do
+#for ref in app/org.test.App/$(flatpak --default-arch)/master app/org.test.Hello/$(flatpak --default-arch)/master appstream/$(flatpak --default-arch) ostree-metadata runtime/org.test.Platform/$(flatpak --default-arch)/master; do
 #  ostree --repo=repos/test refs --collections --create=org.test.Collection:$ref $ref
 #done
 ostree --repo=repos/test summary --update --add-metadata="ostree.deploy-collection-id='net.malicious.NewCollection'"

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -293,17 +293,17 @@ test_ref (void)
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_REF);
   g_clear_error (&error);
 
-  ref = flatpak_ref_parse ("app//x86_64/master", &error);
+  ref = flatpak_ref_parse ("app//m68k/master", &error);
   g_assert_null (ref);
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_REF);
   g_clear_error (&error);
 
-  ref = flatpak_ref_parse ("app/org.test.Hello/x86_64/", &error);
+  ref = flatpak_ref_parse ("app/org.test.Hello/m68k/", &error);
   g_assert_null (ref);
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_REF);
   g_clear_error (&error);
 
-  ref = flatpak_ref_parse ("app/org.test.Hello/x86_64/a[b]c", &error);
+  ref = flatpak_ref_parse ("app/org.test.Hello/m68k/a[b]c", &error);
   g_assert_null (ref);
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_REF);
   g_clear_error (&error);
@@ -318,28 +318,28 @@ test_ref (void)
 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-"/x86_64/master", &error);
+"/m68k/master", &error);
   g_assert_null (ref);
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_REF);
   g_clear_error (&error);
 
-  ref = flatpak_ref_parse ("app/.abc/x86_64/master", &error);
+  ref = flatpak_ref_parse ("app/.abc/m68k/master", &error);
   g_assert_null (ref);
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_REF);
   g_clear_error (&error);
 
-  ref = flatpak_ref_parse ("app/0abc/x86_64/master", &error);
+  ref = flatpak_ref_parse ("app/0abc/m68k/master", &error);
   g_assert_null (ref);
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_REF);
   g_clear_error (&error);
 
-  valid = "app/org.flatpak.Hello/x86_64/master";
+  valid = "app/org.flatpak.Hello/m68k/master";
   ref = flatpak_ref_parse (valid, &error);
   g_assert_no_error (error);
   g_assert (FLATPAK_IS_REF (ref));
   g_assert_cmpint (flatpak_ref_get_kind (ref), ==, FLATPAK_REF_KIND_APP);
   g_assert_cmpstr (flatpak_ref_get_name (ref), ==, "org.flatpak.Hello");
-  g_assert_cmpstr (flatpak_ref_get_arch (ref), ==, "x86_64");
+  g_assert_cmpstr (flatpak_ref_get_arch (ref), ==, "m68k");
   g_assert_cmpstr (flatpak_ref_get_branch (ref), ==, "master");
   g_assert_null (flatpak_ref_get_collection_id (ref));
 
@@ -348,7 +348,7 @@ test_ref (void)
 
   g_clear_object (&ref);
 
-  valid = "runtime/org.gnome.Platform/x86_64/stable";
+  valid = "runtime/org.gnome.Platform/m68k/stable";
   ref = flatpak_ref_parse (valid, &error);
   g_assert_no_error (error);
   g_assert (FLATPAK_IS_REF (ref));
@@ -363,7 +363,7 @@ test_ref (void)
                 NULL);
   g_assert_cmpint (kind, ==, FLATPAK_REF_KIND_RUNTIME);
   g_assert_cmpstr (name, ==, "org.gnome.Platform");
-  g_assert_cmpstr (arch, ==, "x86_64");
+  g_assert_cmpstr (arch, ==, "m68k");
   g_assert_cmpstr (branch, ==, "stable");
   g_assert_null (commit);
   g_assert_null (collection_id);
@@ -376,7 +376,7 @@ test_ref (void)
   ref = g_object_new (FLATPAK_TYPE_REF,
                       "kind", FLATPAK_REF_KIND_RUNTIME,
                       "name", "org.gnome.Platform",
-                      "arch", "x86_64",
+                      "arch", "m68k",
                       "branch", "stable",
                       "commit", "0123456789",
                       "collection-id", "org.flathub.Stable",


### PR DESCRIPTION
Various tests fail on non-x86_64 systems, because they hard-code ref names that contain `/x86_64/` for the architecture part. This is a regression since 1.0.x, caused by improved test coverage.

For most of these tests, what we actually want is the architecture of Flatpak itself, so use that.

A few tests just involve parsing refs, and don't actually care what the architecture in the ref is, as long as it matches the test's expectations. Instead of using x86_64 in those tests, I've used an architecture that is unlikely to be a developer's primary system (m68k), so that we can assume that any hard-coded reference to x86_64 is probably a bug.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=914988