### PR TITLE
system-helper: Add default return at end of polkit rules

### DIFF
--- a/system-helper/org.freedesktop.Flatpak.rules.in
+++ b/system-helper/org.freedesktop.Flatpak.rules.in
@@ -8,4 +8,6 @@ polkit.addRule(function(action, subject) {
         subject.isInGroup("@privileged_group@")) {
             return polkit.Result.YES;
     }
+
+    return polkit.Result.NOT_HANDLED;
 });


### PR DESCRIPTION
This is not a functional change: the default return value is equivalent
to polkit.Result.NOT_HANDLED. However, this makes the behaviour more
obvious.

Signed-off-by: Philip Withnall <withnall@endlessm.com>