### PR TITLE
OCI: Use system helper to generate summary for OCI remotes

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -735,6 +735,11 @@ FlatpakRemoteState * flatpak_dir_get_remote_state_for_summary (FlatpakDir   *sel
                                                                GBytes       *opt_summary_sig,
                                                                GCancellable *cancellable,
                                                                GError      **error);
+gboolean flatpak_dir_remote_make_oci_summary (FlatpakDir   *self,
+                                              const char   *remote,
+                                              GBytes      **out_summary,
+                                              GCancellable *cancellable,
+                                              GError      **error);
 FlatpakRemoteState * flatpak_dir_get_remote_state_optional (FlatpakDir   *self,
                                                             const char   *remote,
                                                             GCancellable *cancellable,

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -144,6 +144,11 @@
       <arg type='s' name='installation' direction='in'/>
     </method>
 
+    <method name="GenerateOciSummary">
+      <arg type='s' name='origin' direction='in'/>
+      <arg type='s' name='installation' direction='in'/>
+    </method>
+
   </interface>
 
 </node>


### PR DESCRIPTION
The OCI support relies on downloading a json index and converting it
to a ostree-style summary, which we the use in all sorts of operations
in the client code. Currently this happens in the user code, which means
that it will fail (due to permissions) in the system installation case.

We could do the conversion as the user, but when eventually installing
something the system-helper will anyway do this download and
conversion, so that would only double the work and risk things going out
of sync. Also, the OCI index is not gpg signed, so we can't realy on
downloads done as the user.

So, the solution done here is to add a GenerateOciSummary
system-helper call which we use instead of directly generating the
oci summary.

This fixes https://github.com/flatpak/flatpak/issues/2350