### PR TITLE
Rename list commands

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -88,15 +88,17 @@ static FlatpakCommand commands[] = {
 
   /* translators: please keep the leading newline and space */
   { N_("\n Manage file access") },
+  { "documents", N_("List exported files"), flatpak_builtin_document_list, flatpak_complete_document_list },
   { "document-export", N_("Grant an application access to a specific file"), flatpak_builtin_document_export, flatpak_complete_document_export },
   { "document-unexport", N_("Revoke access to a specific file"), flatpak_builtin_document_unexport, flatpak_complete_document_unexport },
   { "document-info", N_("Show information about a specific file"), flatpak_builtin_document_info, flatpak_complete_document_info },
-  { "document-list", N_("List exported files"), flatpak_builtin_document_list, flatpak_complete_document_list },
+  { "document-list", NULL, flatpak_builtin_document_list, flatpak_complete_document_list, TRUE },
 
   /* translators: please keep the leading newline and space */
   { N_("\n Manage dynamic permissions") },
+  { "permissions", N_("List permissions"), flatpak_builtin_permission_list, flatpak_complete_permission_list },
   { "permission-remove", N_("Remove item from permission store"), flatpak_builtin_permission_remove, flatpak_complete_permission_remove },
-  { "permission-list", N_("List permissions"), flatpak_builtin_permission_list, flatpak_complete_permission_list },
+  { "permission-list", NULL, flatpak_builtin_permission_list, flatpak_complete_permission_list, TRUE },
   { "permission-show", N_("Show app permissions"), flatpak_builtin_permission_show, flatpak_complete_permission_show },
   { "permission-reset", N_("Reset app permissions"), flatpak_builtin_permission_reset, flatpak_complete_permission_reset },
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -39,9 +39,9 @@ man1 = \
 	flatpak-document-export.1	\
 	flatpak-document-unexport.1	\
 	flatpak-document-info.1		\
-	flatpak-document-list.1		\
+	flatpak-documents.1		\
 	flatpak-permission-remove.1	\
-	flatpak-permission-list.1	\
+	flatpak-permissions.1		\
 	flatpak-permission-show.1	\
 	flatpak-permission-reset.1	\
 	flatpak-build-init.1		\

--- a/doc/flatpak-docs.xml.in
+++ b/doc/flatpak-docs.xml.in
@@ -37,7 +37,7 @@
       <xi:include href="@srcdir@/flatpak-create-usb.xml"/>
       <xi:include href="@srcdir@/flatpak-document-export.xml"/>
       <xi:include href="@srcdir@/flatpak-document-info.xml"/>
-      <xi:include href="@srcdir@/flatpak-document-list.xml"/>
+      <xi:include href="@srcdir@/flatpak-documents.xml"/>
       <xi:include href="@srcdir@/flatpak-document-unexport.xml"/>
       <xi:include href="@srcdir@/flatpak-enter.xml"/>
       <xi:include href="@srcdir@/flatpak-history.xml"/>
@@ -48,7 +48,7 @@
       <xi:include href="@srcdir@/flatpak-make-current.xml"/>
       <xi:include href="@srcdir@/flatpak-override.xml"/>
       <xi:include href="@srcdir@/flatpak-permission-remove.xml"/>
-      <xi:include href="@srcdir@/flatpak-permission-list.xml"/>
+      <xi:include href="@srcdir@/flatpak-permissions.xml"/>
       <xi:include href="@srcdir@/flatpak-permission-show.xml"/>
       <xi:include href="@srcdir@/flatpak-permission-reset.xml"/>
       <xi:include href="@srcdir@/flatpak-ps.xml"/>

--- a/doc/flatpak-document-export.xml
+++ b/doc/flatpak-document-export.xml
@@ -217,7 +217,7 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-document-unexport</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-document-info</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-document-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-documents</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-document-info.xml
+++ b/doc/flatpak-document-info.xml
@@ -108,7 +108,7 @@ permissions:
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-document-export</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-document-unexport</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-document-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-documents</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-document-unexport.xml
+++ b/doc/flatpak-document-unexport.xml
@@ -88,7 +88,7 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-document-export</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-document-info</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-document-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-documents</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-documents.xml
+++ b/doc/flatpak-documents.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
     "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
 
-<refentry id="flatpak-document-list">
+<refentry id="flatpak-documents">
 
     <refentryinfo>
-        <title>flatpak document-list</title>
+        <title>flatpak documents</title>
         <productname>flatpak</productname>
 
         <authorgroup>
@@ -19,18 +19,18 @@
     </refentryinfo>
 
     <refmeta>
-        <refentrytitle>flatpak document-list</refentrytitle>
+        <refentrytitle>flatpak documents</refentrytitle>
         <manvolnum>1</manvolnum>
     </refmeta>
 
     <refnamediv>
-        <refname>flatpak-document-list</refname>
+        <refname>flatpak-documents</refname>
         <refpurpose>List exported files</refpurpose>
     </refnamediv>
 
     <refsynopsisdiv>
             <cmdsynopsis>
-                <command>flatpak document-list</command>
+                <command>flatpak documents</command>
                 <arg choice="opt" rep="repeat">OPTION</arg>
                 <arg choice="opt">APPID</arg>
             </cmdsynopsis>

--- a/doc/flatpak-permission-remove.xml
+++ b/doc/flatpak-permission-remove.xml
@@ -93,7 +93,7 @@
 
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>

--- a/doc/flatpak-permission-reset.xml
+++ b/doc/flatpak-permission-reset.xml
@@ -92,7 +92,7 @@
 
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>

--- a/doc/flatpak-permission-show.xml
+++ b/doc/flatpak-permission-show.xml
@@ -100,7 +100,7 @@
 
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>

--- a/doc/flatpak-permissions.xml
+++ b/doc/flatpak-permissions.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
     "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
 
-<refentry id="flatpak-permission-list">
+<refentry id="flatpak-permissions">
 
     <refentryinfo>
-        <title>flatpak permission-list</title>
+        <title>flatpak permissions</title>
         <productname>flatpak</productname>
 
         <authorgroup>
@@ -19,18 +19,18 @@
     </refentryinfo>
 
     <refmeta>
-        <refentrytitle>flatpak permission-list</refentrytitle>
+        <refentrytitle>flatpak permissions</refentrytitle>
         <manvolnum>1</manvolnum>
     </refmeta>
 
     <refnamediv>
-        <refname>flatpak-permission-list</refname>
+        <refname>flatpak-permissions</refname>
         <refpurpose>List permissions</refpurpose>
     </refnamediv>
 
     <refsynopsisdiv>
             <cmdsynopsis>
-                <command>flatpak permission-list</command>
+                <command>flatpak permissions</command>
                 <arg choice="opt" rep="repeat">OPTION</arg>
                 <arg choice="opt">TABLE</arg>
                 <arg choice="opt">ID</arg>

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -299,7 +299,7 @@
                 </para></listitem>
             </varlistentry>
             <varlistentry>
-                <term><citerefentry><refentrytitle>flatpak-document-list</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
+                <term><citerefentry><refentrytitle>flatpak-documents</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
                     List exported files.
@@ -318,7 +318,7 @@
                 </para></listitem>
             </varlistentry>
             <varlistentry>
-                <term><citerefentry><refentrytitle>flatpak-permission-list</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
+                <term><citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
 
                 <listitem><para>
                     List permissions.

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -56,8 +56,8 @@ echo "ok gl drivers"
 
 for cmd in install update uninstall list info config repair create-usb \
            search run override make-current enter ps document-export \
-           document-unexport document-info document-list permission-remove \
-           permission-list permission-show permission-reset remotes remote-add \
+           document-unexport document-info documents permission-remove \
+           permissions permission-show permission-reset remotes remote-add \
            remote-modify remote-delete remote-ls remote-info build-init \
            build build-finish build-export build-bundle build-import-bundle \
            build-sign build-update-repo build-commit-from repo kill history;
@@ -70,7 +70,7 @@ done
 
 echo "ok command help"
 
-for cmd in list ps remote-ls remotes document-list history;
+for cmd in list ps remote-ls remotes documents history;
 do
   ${FLATPAK} $cmd --columns=help > help_out
 


### PR DESCRIPTION
Rename permission-list and document-list to
permissions and documents, for consistency with
how we handle remotes. The old command names
are kept as hidden aliases.

Closes: #2131