### PR TITLE
install: Don't search noenumerate remotes

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -347,7 +347,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
                   g_auto(GStrv) refs = NULL;
                   g_autoptr(GError) local_error = NULL;
 
-                  if (flatpak_dir_get_remote_disabled (this_dir, this_remote))
+                  if (flatpak_dir_get_remote_disabled (this_dir, this_remote) ||
+                      flatpak_dir_get_remote_noenumerate (this_dir, this_remote))
                     continue;
 
                   this_default_branch = flatpak_dir_get_remote_default_branch (this_dir, this_remote);


### PR DESCRIPTION
Currently if you don't specify a remote to the install command, it might
suggest that you use an origin remote like "org.gnome.Builder-origin"
which doesn't make much sense since those are tightly tied to the app
installed via bundle that created them. So this commit respects the
"xa.noenumerate" flag that is set on such remotes, so they aren't
searched for refs.