### PR TITLE
Disable PolicyKit dialogs for --assumeyes

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -693,6 +693,8 @@ flatpak_cli_transaction_new (FlatpakDir *dir,
   g_autoptr(FlatpakInstallation) installation = NULL;
   g_autoptr(FlatpakCliTransaction) self = NULL;
 
+  flatpak_dir_set_no_interaction (dir, disable_interaction);
+
   installation = flatpak_installation_new_for_dir (dir, NULL, error);
   if (installation == NULL)
     return NULL;


### PR DESCRIPTION
The flag is really meant to disable all interaction,
and this includes PolicyKit dialogs.