### PR TITLE
Fix a parameter type mismatch

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1293,7 +1293,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
       const char *ref, *origin;
       guint32 flags;
 
-      g_variant_get_child (parameters, 0, "&s", &installation);
+      g_variant_get_child (parameters, 0, "^&ay", &installation);
       g_variant_get_child (parameters, 1, "u", &flags);
       g_variant_get_child (parameters, 2, "&s", &ref);
       g_variant_get_child (parameters, 3, "&s", &origin);


### PR DESCRIPTION
GVariant doesn't take it lightly when you are trying to extract
an ay value with an s format. This was causing critical warnings.

(./flatpak-system-helper:5151): GLib-CRITICAL **: 18:02:18.548: the GVariant format string '&s' has a type of 's' but the given value has a type of 'ay'

To catch things like this, I think we should run the testsuite with FLATPAK_SYSTEM_HELPER_ON_SESSION=1 and G_DEBUG=fatal-criticals