### PR TITLE
extra_data: In system-helper case, canonicalize uid/gid

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6700,7 +6700,10 @@ apply_extra_data (FlatpakDir   *self,
                      error))
     return FALSE;
 
-  if (!flatpak_canonicalize_permissions (AT_FDCWD, flatpak_file_get_path_cached (extra_files), error))
+  if (!flatpak_canonicalize_permissions (AT_FDCWD, flatpak_file_get_path_cached (extra_files),
+                                         getuid() == 0 ? 0 : -1,
+                                         getuid() == 0 ? 0 : -1,
+                                         error))
     return FALSE;
 
   if (exit_status != 0)

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -479,6 +479,8 @@ gboolean flatpak_rm_rf (GFile        *dir,
 
 gboolean flatpak_canonicalize_permissions (int           parent_dfd,
                                            const char   *rel_path,
+                                           int           uid,
+                                           int           gid,
                                            GError      **error);
 
 char * flatpak_readlink (const char *path,


### PR DESCRIPTION
Make sure all files produced by apply_extra are owned by root.