### PR TITLE
Policy mismatch

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1475,6 +1475,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
                                                           NULL, &error);
       if (result == NULL)
         {
+          g_dbus_error_strip_remote_error (error);
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                                                  "Authorization error: %s", error->message);
           return FALSE;

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1302,7 +1302,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
        * should basically always be allowed */
       if (ref != NULL && g_strcmp0 (ref, OSTREE_REPO_METADATA_REF) == 0)
         {
-          action = "org.freedesktop.Flatpak.update-metadata";
+          action = "org.freedesktop.Flatpak.metadata-update";
         }
       else
         {
@@ -1455,7 +1455,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
   else if (g_strcmp0 (method_name, "UpdateSummary") == 0 ||
            g_strcmp0 (method_name, "GenerateOciSummary") == 0)
     {
-      action = "org.freedesktop.Flatpak.update-metadata";
+      action = "org.freedesktop.Flatpak.metadata-update";
     }
 
   if (action)


### PR DESCRIPTION
We added metadata-update to the PolicyKit policy, but made the system-helper user update-metadata.
Oops

This does show up as errors returned from system-helper calls, but did not make any tests fail :(
