### PR TITLE
app: Fix support for "NAME BRANCH" syntax

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -406,7 +406,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
     }
 
   /* Backwards compat for old "REMOTE NAME [BRANCH]" argument version */
-  if (argc == 4 && looks_like_branch (argv[3]))
+  if (argc == 4 && flatpak_is_valid_name (argv[2], NULL) && looks_like_branch (argv[3]))
     {
       target_branch = g_strdup (argv[3]);
       n_prefs = 1;

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -198,7 +198,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
   n_prefs = argc - 1;
 
   /* Backwards compat for old "NAME [BRANCH]" argument version */
-  if (argc == 3 && looks_like_branch (argv[2]))
+  if (argc == 3 && flatpak_is_valid_name (argv[1], NULL) && looks_like_branch (argv[2]))
     {
       default_branch = argv[2];
       n_prefs = 1;

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -322,6 +322,13 @@ ${FLATPAK} ${U} uninstall -y platform
 
 echo "ok typo correction works for uninstall"
 
+${FLATPAK} ${U} install -y test-repo org.test.Hello master
+
+${FLATPAK} ${U} uninstall -y org.test.Hello master
+${FLATPAK} ${U} uninstall -y org.test.Platform master
+
+echo "ok install and uninstall support 'NAME BRANCH' syntax"
+
 ${FLATPAK} ${U} install -y --no-deploy test-repo org.test.Hello
 
 ${FLATPAK} ${U} list -d > list-log

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..26"
+echo "1..27"
 
 #Regular repo
 setup_repo


### PR DESCRIPTION
The uninstall command supports the syntax "flatpak uninstall
org.gnome.Builder stable" as an alternative to "flatpak uninstall
org.gnome.Builder//stable", but this support was broken by the fuzzy
matching (partial ref) feature. Since that syntax only supported full
app IDs not partial ones, assume it's being used if the first argument
is a full app ID and the second argument looks like a branch. This means
we don't support the syntax "flatpak uninstall builder stable" (unless
you're trying to uninstall an app called stable).

Similarly, fix the install command's support for the syntax "flatpak
install flathub org.gnome.Builder stable".

Also, add a unit test for both of the above.

Fixes https://github.com/flatpak/flatpak/issues/2395