### PR TITLE
system-helper: Fix a seg fault on Deploy

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1293,10 +1293,10 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
       const char *ref, *origin;
       guint32 flags;
 
-      g_variant_get_child (parameters, 0, "^&ay", &installation);
       g_variant_get_child (parameters, 1, "u", &flags);
       g_variant_get_child (parameters, 2, "&s", &ref);
       g_variant_get_child (parameters, 3, "&s", &origin);
+      g_variant_get_child (parameters, 5, "&s", &installation);
 
       /* For metadata updates, redirect to the modify-repo action since they
        * should basically always be allowed */


### PR DESCRIPTION
The first element put in the variant created by
flatpak_dir_system_helper_call_deploy() is the repo path, but this is being
treated as the installation ID in flatpak_authorize_method_handler(),
which results in a seg fault when dir_get_system() returns NULL and this
NULL is passed to dir_ref_is_installed(). Fix the seg fault by getting
the correct element from the variant.