### PR TITLE
app: Avoid a critical libpolkit error

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -657,7 +657,7 @@ main (int    argc,
       GVariantBuilder opt_builder;
       g_autoptr(GVariant) options = NULL;
 
-      subject = polkit_unix_process_new_for_owner (getpid (), 0, -1);
+      subject = polkit_unix_process_new_for_owner (getpid (), 0, getuid ());
 
       g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
       if (g_strcmp0 (g_getenv ("FLATPAK_FORCE_TEXT_AUTH"), "1") != 0)


### PR DESCRIPTION
Currently the flatpak install command reliably produces this error:

** (flatpak:21996): CRITICAL **: 22:38:52.472: polkit_unix_process_set_property: assertion 'val != -1' failed

This is caused by a recent patch to polkit[1] to address CVE-2018-19788,
which apparently means you can't pass -1 to
polkit_unix_process_new_for_owner() for the uid. So change Flatpak to
pass the actual UID instead.

[1] https://gitlab.freedesktop.org/polkit/polkit/commit/2cb40c4d5feeaa09325522bd7d97910f1b59e379