### PR TITLE
build-update-repo: Add --static-delta-jobs option

### DIFF
--- a/doc/flatpak-build-update-repo.xml
+++ b/doc/flatpak-build-update-repo.xml
@@ -155,6 +155,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--static-delta-jobs=NUM-JOBS</option></term>
+
+                <listitem><para>
+                  Limit the number of parallel jobs creating static deltas. The default is the number of cpus.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--prune</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
We ran into some issues on flathub where a build with very large
files caused the parallel delta generation to use a lot of paging,
essentially blocking progress. This option can at least allow you
to make progress in that case, although we should ideally have
a better solution.