### PR TITLE
session-helper: Don't crash on NameOwnerChanged

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -423,11 +423,14 @@ name_owner_changed (GDBusConnection *connection,
     {
       GHashTableIter iter;
       PidData *pid_data = NULL;
+      gpointer value = NULL;
       GList *list = NULL, *l;
 
       g_hash_table_iter_init (&iter, client_pid_data_hash);
-      while (g_hash_table_iter_next (&iter, NULL, (gpointer *)pid_data))
+      while (g_hash_table_iter_next (&iter, NULL, &value))
         {
+          pid_data = value;
+
           if (pid_data->watch_bus && g_str_equal (pid_data->client, name))
             list = g_list_prepend (list, pid_data);
         }


### PR DESCRIPTION
There was a typo here: `(gpointer *) pid_data` should have been
`(gpointer *) &pid_data`, so that `g_hash_table_iter_next()` would make
`pid_data` a pointer to a `PidData` struct. Instead, the previous
implementation left `pid_data` set to `NULL`, leading to a `NULL` dereference
and segmentation fault whenever a name fell off the bus while a watched
client existed.

Instead of directly inserting the missing "&", I've used a pattern
that avoids needing the cast, in an attempt to make it more obviously
correct.