### PR TITLE
doc: Mention xdg vars

### DIFF
--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -90,6 +90,15 @@
             <member>PERL5LIB</member>
             <member>XCURSOR_PATH</member>
         </simplelist>
+        <para>
+            Flatpak overrides the XDG environment variables to point sandboxed applications
+            at their writable filesystem locations below <filename>~/.var/app/$APPID/</filename>:
+        </para>
+        <simplelist>
+            <member>XDG_DATA_HOME</member>
+            <member>XDG_CONFIG_HOME</member>
+            <member>XDG_CACHE_HOME</member>
+        </simplelist>
     </refsect1>
 
     <refsect1>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -91,7 +91,7 @@
             <member>XCURSOR_PATH</member>
         </simplelist>
         <para>
-            Flatpak overrides the XDG environment variables to point sandboxed applications
+            Flatpak also overrides the XDG environment variables to point sandboxed applications
             at their writable filesystem locations below <filename>~/.var/app/$APPID/</filename>:
         </para>
         <simplelist>


### PR DESCRIPTION
When I made the list of overridden environment variables,
I forgot the 3 most important ones, XDG_{DATA,CACHE,CONFIG}_HOME.