### PR TITLE
[RFC] Use an executable wrapper instead of GTestDBus

### DIFF
--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -21,4 +21,5 @@ cd ${tempdir}
 if [[ $bn == *.wrap ]]; then
     WRAPPER=${srcd}/test-wrapper.sh
 fi
-$WRAPPER ${srcd}/${bn} -k --tap
+export FLATPAK_SYSTEM_HELPER_ON_SESSION=1
+${DBUS_RUN_SESSION-dbus-run-session} -- $WRAPPER ${srcd}/${bn} -k --tap

--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,7 @@ else
    AM_CONDITIONAL([WITH_SYSTEM_DBUS_PROXY], [false])
 fi
 
+AC_PATH_PROG([DBUS_RUN_SESSION], [dbus-run-session], [dbus-run-session])
 
 AC_CHECK_FUNCS(fdwalk)
 LIBGLNX_CONFIGURE

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -1,9 +1,12 @@
-AM_TESTS_ENVIRONMENT = FLATPAK_TESTS_DEBUG=1 \
+AM_TESTS_ENVIRONMENT = \
+	DBUS_RUN_SESSION=$(DBUS_RUN_SESSION) \
+	FLATPAK_TESTS_DEBUG=1 \
 	FLATPAK_TRIGGERSDIR=$$(cd $(top_srcdir) && pwd)/triggers \
 	FLATPAK_DBUSPROXY=$$(cd $(top_builddir) && pwd)/flatpak-dbus-proxy \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
 	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH} \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
+	XDG_DATA_HOME=$$(cd $(top_builddir) && pwd)/tests \
 	$(NULL)
 
 if WITH_SYSTEM_BWRAP

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -28,21 +28,21 @@ tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFL
 tests_httpcache_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(APPSTREAM_GLIB_LIBS) \
 	libglnx.la libflatpak-common.la
 
-tests/services/org.freedesktop.Flatpak.service: session-helper/org.freedesktop.Flatpak.service.in
-	mkdir -p tests/services
+tests/dbus-1/services/org.freedesktop.Flatpak.service: session-helper/org.freedesktop.Flatpak.service.in
+	mkdir -p tests/dbus-1/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" $< > $@
 
-tests/services/org.freedesktop.Flatpak.SystemHelper.service: system-helper/org.freedesktop.Flatpak.SystemHelper.service.in
-	mkdir -p tests/services
+tests/dbus-1/services/org.freedesktop.Flatpak.SystemHelper.service: system-helper/org.freedesktop.Flatpak.SystemHelper.service.in
+	mkdir -p tests/dbus-1/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" -e "s|\@extraargs\@| --session --no-idle-exit|" $< > $@
 
-tests/libtest.sh: tests/services/org.freedesktop.Flatpak.service tests/services/org.freedesktop.Flatpak.SystemHelper.service
+tests/libtest.sh: tests/dbus-1/services/org.freedesktop.Flatpak.service tests/dbus-1/services/org.freedesktop.Flatpak.SystemHelper.service
 
 install-test-data-hook:
 if ENABLE_INSTALLED_TESTS
-	mkdir -p $(DESTDIR)$(installed_testdir)/services
-	ln -sf $(dbus_servicedir)/org.freedesktop.Flatpak.service $(DESTDIR)$(installed_testdir)/services/
-	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" -e "s|\@extraargs\@| --session --no-idle-exit|" $(top_srcdir)/system-helper/org.freedesktop.Flatpak.SystemHelper.service.in > $(DESTDIR)$(installed_testdir)/services/org.freedesktop.Flatpak.SystemHelper.service
+	mkdir -p $(DESTDIR)$(installed_testdir)/dbus-1/services
+	ln -sf $(dbus_servicedir)/org.freedesktop.Flatpak.service $(DESTDIR)$(installed_testdir)/dbus-1/services/
+	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" -e "s|\@extraargs\@| --session --no-idle-exit|" $(top_srcdir)/system-helper/org.freedesktop.Flatpak.SystemHelper.service.in > $(DESTDIR)$(installed_testdir)/dbus-1/services/org.freedesktop.Flatpak.SystemHelper.service
 endif
 
 tests/package_version.txt: Makefile
@@ -131,7 +131,7 @@ test_extra_programs = tests/httpcache
 VALGRIND_SUPPRESSIONS_FILES=tests/flatpak.supp tests/glib.supp
 EXTRA_DIST += tests/flatpak.supp tests/glib.supp tests/Makefile-test-matrix.am.inc tests/expand-test-matrix.sh tests/test-wrapper.sh
 DISTCLEANFILES += \
-	tests/services/org.freedesktop.Flatpak.service \
-	tests/services/org.freedesktop.Flatpak.SystemHelper.service \
+	tests/dbus-1/services/org.freedesktop.Flatpak.service \
+	tests/dbus-1/services/org.freedesktop.Flatpak.SystemHelper.service \
 	tests/package_version.txt \
 	$(NULL)

--- a/tests/session.conf.in
+++ b/tests/session.conf.in
@@ -10,7 +10,7 @@
 
   <listen>unix:tmpdir=/tmp</listen>
 
-  <servicedir>@testdir@/services</servicedir>
+  <servicedir>@testdir@/dbus-1/services</servicedir>
 
   <!-- disabled for now; this causes gnome-keyring to be spawned, which can
        interfere with user's real keyrings, as well as causing long delays

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1539,8 +1539,6 @@ copy_gpg (void)
   g_free (dest);
 }
 
-GTestDBus *test_bus = NULL;
-
 static void
 global_setup (void)
 {
@@ -1548,7 +1546,6 @@ global_setup (void)
   g_autofree char *configdir = NULL;
   g_autofree char *datadir = NULL;
   g_autofree char *homedir = NULL;
-  g_autofree char *services_dir = NULL;
 
   testdir = g_strdup ("/tmp/flatpak-test-XXXXXX");
   g_mkdtemp (testdir);
@@ -1609,15 +1606,6 @@ global_setup (void)
   g_assert_cmpstr (g_get_user_data_dir (), ==, datadir);
   g_assert_cmpstr (g_get_user_runtime_dir (), ==, flatpak_runtimedir);
 
-  g_setenv ("FLATPAK_SYSTEM_HELPER_ON_SESSION", "1", TRUE);
-
-  test_bus = g_test_dbus_new (G_TEST_DBUS_NONE);
-
-  services_dir = g_test_build_filename (G_TEST_BUILT, "dbus-1", "services", NULL);
-  g_test_dbus_add_service_dir (test_bus, services_dir);
-
-  g_test_dbus_up (test_bus);
-
   copy_gpg ();
   setup_multiple_installations ();
   setup_repo ();
@@ -1631,8 +1619,6 @@ global_teardown (void)
 
   if (g_getenv ("SKIP_TEARDOWN"))
     return;
-
-  g_test_dbus_down (test_bus);
 
   argv[2] = gpg_homedir;
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1613,7 +1613,7 @@ global_setup (void)
 
   test_bus = g_test_dbus_new (G_TEST_DBUS_NONE);
 
-  services_dir = g_test_build_filename (G_TEST_BUILT, "services", NULL);
+  services_dir = g_test_build_filename (G_TEST_BUILT, "dbus-1", "services", NULL);
   g_test_dbus_add_service_dir (test_bus, services_dir);
 
   g_test_dbus_up (test_bus);


### PR DESCRIPTION
This is one possible way to solve #2422:

* Put D-Bus .service files in dbus-1/services

    This lets us make use of them by manipulating XDG_DATA_HOME instead of setting an explicit services directory.

* Use dbus-run-session to make built services available to testlibrary

    This avoids needing to use GTestDBus for build-time tests.
    
    For installed-tests, we are more interested in testing the installed system than in testing an artificial environment, so we'll use the real session bus on the installed system.

* Revert "tests: Use g_test_dbus in testlibrary"
    
    This reverts commit 682a93646db90c429e8bd1a239bee97357344868. GTestDBus has problems with global state, and in particular causes this test to hang when run as an installed test.

Resolves: #2422