### PR TITLE
Host env

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1318,6 +1318,13 @@ flatpak_run_apply_env_appid (FlatpakBwrap *bwrap,
   flatpak_bwrap_set_env (bwrap, "XDG_DATA_HOME", flatpak_file_get_path_cached (app_dir_data), TRUE);
   flatpak_bwrap_set_env (bwrap, "XDG_CONFIG_HOME", flatpak_file_get_path_cached (app_dir_config), TRUE);
   flatpak_bwrap_set_env (bwrap, "XDG_CACHE_HOME", flatpak_file_get_path_cached (app_dir_cache), TRUE);
+
+  if (g_getenv ("XDG_DATA_HOME"))
+    flatpak_bwrap_set_env (bwrap, "HOST_XDG_DATA_HOME", g_getenv ("XDG_DATA_HOME"), TRUE);
+  if (g_getenv ("XDG_CONFIG_HOME"))
+    flatpak_bwrap_set_env (bwrap, "HOST_XDG_CONFIG_HOME", g_getenv ("XDG_CONFIG_HOME"), TRUE);
+  if (g_getenv ("XDG_CACHE_HOME"))
+    flatpak_bwrap_set_env (bwrap, "HOST_XDG_CACHE_HOME", g_getenv ("XDG_CACHE_HOME"), TRUE);
 }
 
 void

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -99,6 +99,15 @@
             <member>XDG_CONFIG_HOME</member>
             <member>XDG_CACHE_HOME</member>
         </simplelist>
+        <para>
+            The host values of these variables are made available inside the sandbox via these
+            HOST_-prefixed variables:
+        </para>
+        <simplelist>
+            <member>HOST_XDG_DATA_HOME</member>
+            <member>HOST_XDG_CONFIG_HOME</member>
+            <member>HOST_XDG_CACHE_HOME</member>
+        </simplelist>
     </refsect1>
 
     <refsect1>


### PR DESCRIPTION
There are some use cases where apps might legitimately need to know the host values of xdg variables. Since we use them for our own purposes, we can't just propagate them as-is. Instead, set HOST_XDG_{DATA,CONFIG,CACHE}_HOME if the corresponding xdg variables are set on the host.
    
