### PR TITLE
Fix a remote-ls option clash

### DIFF
--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -50,7 +50,7 @@ static GOptionEntry options[] = {
   { "updates", 0, 0, G_OPTION_ARG_NONE, &opt_only_updates, N_("Show only those where updates are available"), NULL },
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Limit to this arch (* for all)"), N_("ARCH") },
   { "all", 'a', 0, G_OPTION_ARG_NONE, &opt_all, N_("List all refs (including locale/debug)"), NULL },
-  { "app-runtime", 'a', 0, G_OPTION_ARG_STRING, &opt_app_runtime, N_("List all applications using RUNTIME"), N_("RUNTIME") },
+  { "app-runtime", 0, 0, G_OPTION_ARG_STRING, &opt_app_runtime, N_("List all applications using RUNTIME"), N_("RUNTIME") },
   { "columns", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_cols, N_("What information to show"), N_("FIELD,…") },
   { NULL }
 };


### PR DESCRIPTION
When the --app-runtime option was added, we inadvertently
added a conflict between the short options for --all and
this new option. To fix this, remove the short option for
--app-runtime.

Closes: #2441