### PR TITLE
Column completion

### DIFF
--- a/app/flatpak-builtins-document-list.c
+++ b/app/flatpak-builtins-document-list.c
@@ -212,6 +212,7 @@ flatpak_complete_document_list (FlatpakCompletion *completion)
     case 1: /* APPID */
       flatpak_complete_options (completion, global_entries);
       flatpak_complete_options (completion, options);
+      flatpak_complete_columns (completion, all_columns);
 
       user_dir = flatpak_dir_get_user ();
       {

--- a/app/flatpak-builtins-history.c
+++ b/app/flatpak-builtins-history.c
@@ -487,5 +487,6 @@ flatpak_complete_history (FlatpakCompletion *completion)
 {
   flatpak_complete_options (completion, global_entries);
   flatpak_complete_options (completion, options);
+  flatpak_complete_columns (completion, all_columns);
   return TRUE;
 }

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -467,5 +467,6 @@ flatpak_complete_list (FlatpakCompletion *completion)
   flatpak_complete_options (completion, global_entries);
   flatpak_complete_options (completion, options);
   flatpak_complete_options (completion, user_entries);
+  flatpak_complete_columns (completion, all_columns);
   return TRUE;
 }

--- a/app/flatpak-builtins-ps.c
+++ b/app/flatpak-builtins-ps.c
@@ -184,6 +184,7 @@ flatpak_complete_ps (FlatpakCompletion *completion)
     case 1:
       flatpak_complete_options (completion, global_entries);
       flatpak_complete_options (completion, options);
+      flatpak_complete_columns (completion, all_columns);
       break;
 
     default:

--- a/app/flatpak-builtins-remote-list.c
+++ b/app/flatpak-builtins-remote-list.c
@@ -202,6 +202,7 @@ flatpak_complete_remote_list (FlatpakCompletion *completion)
       flatpak_complete_options (completion, global_entries);
       flatpak_complete_options (completion, options);
       flatpak_complete_options (completion, user_entries);
+      flatpak_complete_columns (completion, all_columns);
 
       break;
     }

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -517,6 +517,7 @@ flatpak_complete_remote_ls (FlatpakCompletion *completion)
       flatpak_complete_options (completion, global_entries);
       flatpak_complete_options (completion, options);
       flatpak_complete_options (completion, user_entries);
+      flatpak_complete_columns (completion, all_columns);
 
       for (i = 0; i < dirs->len; i++)
         {

--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -35,7 +35,10 @@ flatpak_completion_debug (const gchar *format, ...)
   static FILE *f = NULL;
 
   va_start (var_args, format);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   s = g_strdup_vprintf (format, var_args);
+#pragma GCC diagnostic pop
   if (f == NULL)
     f = fopen ("/tmp/flatpak-completion-debug.txt", "a+");
   fprintf (f, "%s\n", s);
@@ -387,6 +390,69 @@ flatpak_complete_options (FlatpakCompletion *completion,
         }
       e++;
     }
+}
+
+static void
+flatpak_complete_column (FlatpakCompletion *completion,
+                         char **used,
+                         const char *column)
+{
+  g_autoptr(GString) s = NULL;
+
+  s = g_string_new ("");
+
+  if (used[0] != NULL)
+    {
+      int i;
+
+      if (g_strv_contains ((const char * const *)used, column))
+        return;
+
+      const char *last = NULL;
+      last = used[g_strv_length (used) - 1];
+      if (!g_str_has_prefix (column, last))
+        return;
+
+      for (i = 0; used[i + 1]; i++)
+        {
+          g_string_append (s, used[i]);
+          g_string_append_c (s, ',');
+        }
+    }
+
+  g_string_append (s, column);
+  flatpak_completion_debug ("completing column: %s", s->str);
+
+  g_print ("%s\n", s->str);
+}
+
+void
+flatpak_complete_columns (FlatpakCompletion *completion,
+                          Column            *columns)
+{
+  int i;
+  const char *list = NULL;
+  g_auto(GStrv) used = NULL;
+
+  if (!g_str_has_prefix (completion->cur, "--columns="))
+    return;
+
+  list = completion->cur + strlen ("--columns=");
+  if (strcmp (list, "all") == 0 ||
+      strcmp (list, "help") == 0)
+    return;
+
+  used = g_strsplit (list, ",", 0);
+  flatpak_completion_debug ("complete columns, used: '%s'", list);
+
+  if (g_strv_length (used) <= 1)
+    {
+      flatpak_complete_column (completion, used, "all");
+      flatpak_complete_column (completion, used, "help");
+    }
+
+  for (i = 0; columns[i].name; i++)
+    flatpak_complete_column (completion, used, columns[i].name);
 }
 
 void

--- a/app/flatpak-complete.h
+++ b/app/flatpak-complete.h
@@ -23,6 +23,7 @@
 
 #include <ostree.h>
 #include "flatpak-dir-private.h"
+#include "flatpak-builtins-utils.h"
 
 struct FlatpakCompletion
 {
@@ -58,6 +59,8 @@ void               flatpak_complete_file (FlatpakCompletion *completion,
 void               flatpak_complete_dir (FlatpakCompletion *completion);
 void               flatpak_complete_options (FlatpakCompletion *completion,
                                              GOptionEntry      *entries);
+void               flatpak_complete_columns (FlatpakCompletion *completion,
+                                             Column            *columns);
 void               flatpak_completion_free (FlatpakCompletion *completion);
 void               flatpak_complete_context (FlatpakCompletion *completion);
 


### PR DESCRIPTION
I've investigated how to do completion for --columns.

It turns out that bash completion can't really deal with , as word separator, since that is a global readline config, and , is not among the default word break chars.

This branch allows to use : instead for separating columns, and implements completion for it.

Note that we were excluding : as word break char before; I had to remove that. I don't know if that has any bad consequences for other options. Can't really think of any.