### PR TITLE
Use unicode in the CLI

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -288,7 +288,7 @@ progress_changed_cb (FlatpakTransactionProgress *progress,
 
   spin_op_progress (cli, op);
 
-  bar_length = cli->table_width - (strlen (cli->progress_msg) + 4 + 4 + cli->speed_len);
+  bar_length = MIN (20, cli->table_width - (strlen (cli->progress_msg) + 4 + 4 + cli->speed_len));
 
   n_full = (bar_length * percent) / 100;
   partial = (((bar_length * percent) % 100) * G_N_ELEMENTS(partial_blocks) ) / 100;

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -859,7 +859,7 @@ transaction_ready (FlatpakTransaction *transaction)
        * by making the title as long as typical content
        */
       text1 = g_strdup_printf ("< 999.9 kB (%s)", _("partial"));
-      text2 = g_strdup_printf ("123.4 MB / 999.9 MB");
+      text2 = g_strdup_printf ("  123.4 MB / 999.9 MB");
       size = MAX (strlen (text1), strlen (text2));
       text = g_strdup_printf ("%-*s", size, _("Download"));
       flatpak_table_printer_set_column_title (printer, i++, text);

--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -253,10 +253,12 @@ print_row (GString *row_s, gboolean bold, int *skip, int columns)
 {
   int rows;
   char *p, *end;
+  int n_chars;
 
   g_strchomp (row_s->str);
-  if (strlen (row_s->str) > 0)
-    rows = (strlen (row_s->str) + columns - 1) / columns;
+  n_chars = g_utf8_strlen (row_s->str, -1);
+  if (n_chars > 0)
+    rows = (n_chars + columns - 1) / columns;
   else
     rows = 1;
 
@@ -265,7 +267,7 @@ print_row (GString *row_s, gboolean bold, int *skip, int columns)
   while (*skip > 0 && p <= end)
     {
       (*skip)--;
-      p += columns;
+      p = g_utf8_offset_to_pointer  (p, columns);
     }
 
   if (p < end || p == row_s->str)
@@ -327,7 +329,7 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
 
       if (col->title)
         {
-          widths[i] = MAX (widths[i], strlen (col->title));
+          widths[i] = MAX (widths[i], g_utf8_strlen (col->title, -1));
           has_title = TRUE;
         }
     }
@@ -344,7 +346,7 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
           if (cell->span)
             width = 0;
           else
-            width = strlen (cell->text);
+            width = g_utf8_strlen (cell->text, -1);
           widths[j] = MAX (widths[j], width);
           if (cell->align >= 0)
             {


### PR DESCRIPTION
We can use unicode in the spinners, checkbox and progress bars.
With this the progress now looks like this:
```
        ID                                                    Arch              Branch            Remote             Download
 1. [✓] org.gnome.Platform                                    x86_64            3.30              flathub              282,6 MB / 409,8 MB
 2. [✓] org.gnome.Platform.Locale                             x86_64            3.30              flathub               17,1 kB / 222,3 MB
 3. [\] org.freedesktop.Platform.GL.nvidia-410-78             x86_64            1.4               flathub               68,2 MB / 68,6 MB
 4. [ ] org.freedesktop.Platform.html5-codecs                 x86_64            18.08             flathub              < 2,8 MB
 5. [ ] org.gnome.Boxes                                       x86_64            stable            flathub            < 139,4 MB
 6. [ ] org.gnome.Boxes.Locale                                x86_64            stable            flathub              < 6,1 MB (partial)

Installing 3/6... [████████████████████] 100%  11,4 MB/s  00:00
```
