### PR TITLE
Consistently use Unicode ellipsis

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -236,7 +236,7 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
   guint64 timestamp;
   int i;
 
-  context = g_option_context_new (_("DST-REPO [DST-REF]... - Make a new commit from existing commits"));
+  context = g_option_context_new (_("DST-REPO [DST-REF…] - Make a new commit from existing commits"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv, FLATPAK_BUILTIN_FLAG_NO_DIR, NULL, cancellable, error))

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -203,7 +203,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   g_autofree char *pid_path = NULL;
   g_autoptr(GFile) app_id_dir = NULL;
 
-  context = g_option_context_new (_("DIRECTORY [COMMAND [args...]] - Build in directory"));
+  context = g_option_context_new (_("DIRECTORY [COMMAND [ARGUMENT…]] - Build in directory"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   rest_argc = 0;

--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -447,7 +447,7 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
   FlatpakKinds kinds;
   OstreeRepo *src_repo;
 
-  context = g_option_context_new (_("MOUNT-PATH REF [REF...] - Copy apps and/or runtimes onto removable media"));
+  context = g_option_context_new (_("MOUNT-PATH [REF…] - Copy apps or runtimes onto removable media"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,

--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -82,7 +82,7 @@ flatpak_builtin_enter (int           argc,
   g_autoptr(GPtrArray) instances = NULL;
   int j;
 
-  context = g_option_context_new (_("INSTANCE [COMMAND [args...]] - Run a command inside a running sandbox"));
+  context = g_option_context_new (_("INSTANCE [COMMAND [ARGUMENT…]] - Run a command inside a running sandbox"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   rest_argc = 0;

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -247,7 +247,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
   g_autoptr(FlatpakDir) dir_with_remote = NULL;
   gboolean auto_remote = FALSE;
 
-  context = g_option_context_new (_("[LOCATION/REMOTE] [REF...] - Install applications or runtimes"));
+  context = g_option_context_new (_("[LOCATION/REMOTE] [REF…] - Install applications or runtimes"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,
@@ -280,7 +280,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
 
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
 
-  g_print (_("Looking for matches...\n"));
+  g_print (_("Looking for matches…\n"));
 
   if (!auto_remote &&
       (g_path_is_absolute (argv[1]) ||

--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -340,13 +340,13 @@ flatpak_builtin_repair (int argc, char **argv, GCancellable *cancellable, GError
         /* If so, is it deployed, and from this remote? */
         if (remote == NULL || g_strcmp0 (origin, remote) != 0)
           {
-            g_print (_("Removing non-deployed ref %s...\n"), refspec);
+            g_print (_("Removing non-deployed ref %s…\n"), refspec);
             (void) ostree_repo_set_ref_immediate (repo, remote, ref_name, NULL, cancellable, NULL);
             continue;
           }
       }
 
-    g_print (_("Verifying %s...\n"), refspec);
+    g_print (_("Verifying %s…\n"), refspec);
 
     status = fsck_commit (repo, checksum, object_status_cache);
     if (status != FSCK_STATUS_OK)

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -94,7 +94,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
   g_autoptr(GError) local_error = NULL;
   g_autoptr(GPtrArray) dirs = NULL;
 
-  context = g_option_context_new (_("APP [args...] - Run an app"));
+  context = g_option_context_new (_("APP [ARGUMENT…] - Run an app"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   rest_argc = 0;

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -177,7 +177,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
   FlatpakKinds kinds;
   g_autoptr(GHashTable) uninstall_dirs = NULL;
 
-  context = g_option_context_new (_("REF... - Uninstall an application"));
+  context = g_option_context_new (_("[REF…] - Uninstall an application"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -81,7 +81,7 @@ flatpak_builtin_update (int           argc,
   g_autoptr(GPtrArray) transactions = NULL;
   gboolean has_updates;
 
-  context = g_option_context_new (_("[REF...] - Update applications or runtimes"));
+  context = g_option_context_new (_("[REF…] - Update applications or runtimes"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   if (!flatpak_option_context_parse (context, options, &argc, &argv,
@@ -135,7 +135,7 @@ flatpak_builtin_update (int           argc,
 
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
 
-  g_print (_("Looking for updates...\n"));
+  g_print (_("Looking for updates…\n"));
 
   for (j = 0; j == 0 || j < n_prefs; j++)
     {

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -367,23 +367,23 @@ new_operation (FlatpakTransaction          *transaction,
     case FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE:
     case FLATPAK_TRANSACTION_OPERATION_INSTALL:
       if (self->n_ops == 1)
-        text = g_strdup (_("Installing..."));
+        text = g_strdup (_("Installing…"));
       else
-        text = g_strdup_printf (("Installing %d/%d..."), self->op, self->n_ops);
+        text = g_strdup_printf (("Installing %d/%d…"), self->op, self->n_ops);
       break;
 
     case FLATPAK_TRANSACTION_OPERATION_UPDATE:
       if (self->n_ops == 1)
-        text = g_strdup (_("Updating..."));
+        text = g_strdup (_("Updating…"));
       else
-        text = g_strdup_printf (_("Updating %d/%d..."), self->op, self->n_ops);
+        text = g_strdup_printf (_("Updating %d/%d…"), self->op, self->n_ops);
       break;
 
     case FLATPAK_TRANSACTION_OPERATION_UNINSTALL:
       if (self->n_ops == 1)
-        text = g_strdup (_("Uninstalling..."));
+        text = g_strdup (_("Uninstalling…"));
       else
-        text = g_strdup_printf (_("Uninstalling %d/%d..."), self->op, self->n_ops);
+        text = g_strdup_printf (_("Uninstalling %d/%d…"), self->op, self->n_ops);
       break;
 
     default:

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -759,7 +759,7 @@ flatpak_context_verify_filesystem (const char *filesystem_and_mode,
     return TRUE;
 
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
-               _("Unknown filesystem location %s, valid locations are: host, home, xdg-*[/...], ~/dir, /dir"), filesystem);
+               _("Unknown filesystem location %s, valid locations are: host, home, xdg-*[/…], ~/dir, /dir"), filesystem);
   return FALSE;
 }
 


### PR DESCRIPTION
Now that we're moving away from a pure ASCII esthetic,
it looks odd to me to have a mixture of 3 dots and
proper ellipsis, so switch everything over to use
U+2026 instead of 3 dots.

Some minor other formatting and string changes
are included here as well.