### PR TITLE
Hide cursor

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -960,7 +960,10 @@ transaction_ready (FlatpakTransaction *transaction)
   self->table_height += 3; /* 2 for the added lines and one for the newline from the user after the prompt */
 
   if (flatpak_fancy_output ())
-    redraw (self);
+    {
+      g_print (FLATPAK_ANSI_HIDE_CURSOR);
+      redraw (self);
+    }
 
   return TRUE;
 }
@@ -1065,6 +1068,9 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
   gboolean res;
 
   res = flatpak_transaction_run (transaction, cancellable, &local_error);
+
+  if (flatpak_fancy_output ())
+    g_print (FLATPAK_ANSI_SHOW_CURSOR);
 
   if (res && self->n_ops > 0)
     {

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -42,8 +42,10 @@ typedef enum {
   FLATPAK_HOST_COMMAND_FLAGS_WATCH_BUS = 1 << 1,
 } FlatpakHostCommandFlags;
 
-#define FLATPAK_ANSI_ALT_SCREEN_ON "\x1B[?1049h"
-#define FLATPAK_ANSI_ALT_SCREEN_OFF "\x1B[?1049l"
+#define FLATPAK_ANSI_ALT_SCREEN_ON "\x1b[?1049h"
+#define FLATPAK_ANSI_ALT_SCREEN_OFF "\x1b[?1049l"
+#define FLATPAK_ANSI_HIDE_CURSOR "\x1b[?25l"
+#define FLATPAK_ANSI_SHOW_CURSOR "\x1b[?25h"
 #define FLATPAK_ANSI_BOLD_ON "\x1b[1m"
 #define FLATPAK_ANSI_BOLD_OFF "\x1b[22m"
 #define FLATPAK_ANSI_FAINT_ON "\x1b[2m"


### PR DESCRIPTION
The cursor interferes with our fancy redraw and progress display. Hide it while we are doing that.