### PR TITLE
list, remote-ls: Avoid a stray newline

### DIFF
--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -374,9 +374,12 @@ print_table_for_refs (gboolean print_apps,
 
   flatpak_table_printer_sort (printer, (GCompareFunc)flatpak_compare_ref);
 
-  flatpak_get_window_size (&rows, &cols);
-  flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
-  g_print ("\n");
+  if (flatpak_table_printer_get_current_row (printer) > 0)
+    {
+      flatpak_get_window_size (&rows, &cols);
+      flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
+      g_print ("\n");
+    }
 
   flatpak_table_printer_free (printer);
 

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -372,9 +372,12 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
         }
     }
 
-  flatpak_get_window_size (&rows, &cols);
-  flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
-  g_print ("\n");
+  if (flatpak_table_printer_get_current_row (printer) > 0)
+    {
+      flatpak_get_window_size (&rows, &cols);
+      flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
+      g_print ("\n");
+    }
 
   flatpak_table_printer_free (printer);
 


### PR DESCRIPTION
If we have nothing to print, don't print a stray newline.