### PR TITLE
Fix an infinite loop

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -866,10 +866,12 @@ list_has (const char *list,
     {
       p = strstr (p, term);
       len = strlen (term);
-      if (p &&
-          (p == list || p[-1] == ',') &&
+      if (!p)
+        break;
+      if ((p == list || p[-1] == ',') &&
           (p[len] == '\0' || p[len] == ','))
         return TRUE;
+      p++;
     }
 
   return FALSE;


### PR DESCRIPTION
It turns out that --columns=installation,bla was looping
forever, trying to get over the 'all' inside 'installation'.
Don't get stuck there.

It would be good to have unit tests for such internal functions.