### PR TITLE
Don't let g_warnings disrupt us

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -176,11 +176,7 @@ message_handler (const gchar   *log_domain,
                  const gchar   *message,
                  gpointer       user_data)
 {
-  /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
-    g_printerr ("F: %s\n", message);
-  else
-    g_printerr ("%s: %s\n", g_get_prgname (), message);
+  g_printerr ("F: %s\n", message);
 }
 
 static GOptionContext *


### PR DESCRIPTION
Some code paths deep inside flatpak-dir.c use
g_warning to report non-fatal errors. This disrupts
our table formatting without showing up visibly
in the output (since it gets wiped out by the next
redraw). Improve things by installing our own
message handler and showing these messages properly
inside our table, like other errors.