### PR TITLE
Quiet install

### DIFF
--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -256,6 +256,13 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--quiet</option></term>
+                <listitem><para>
+                    Produce minimal output that is suitable for inclusion in other tools, such as flatpak-builder.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 


### PR DESCRIPTION
The fancy output we produce now does not fit well into flatpak-builder's output. Add a --quiet option that creates more suitable output for flatpak-builder.
