### PR TITLE
Nicer formatting for many choices

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5415,7 +5415,7 @@ flatpak_format_choices (const char **choices,
 
   g_print ("%s\n\n", s);
   for (i = 0; choices[i]; i++)
-    g_print ("  %d) %s\n", i+1, choices[i]);
+    g_print ("  %2d) %s\n", i+1, choices[i]);
   g_print ("\n");
 }
 


### PR DESCRIPTION
'flatpak install sdk' offers me 34 choices, so double digits
seem very realistic here. Make the numbers line up in this
case.