### PR TITLE
Handle out-of-space errors nicer

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -467,6 +467,8 @@ operation_error (FlatpakTransaction            *transaction,
     msg = g_strdup_printf (_("%s not installed"), flatpak_ref_get_name (rref));
   else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NEED_NEW_FLATPAK))
     msg = g_strdup_printf (_("%s needs a later flatpak version"), flatpak_ref_get_name (rref));
+  else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_OUT_OF_SPACE))
+    msg = g_strdup (_("Not enough disk space to complete this operation"));
   else
     msg = g_strdup (error->message);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3841,6 +3841,22 @@ get_common_pull_options (GVariantBuilder     *builder,
 }
 
 static gboolean
+translate_ostree_repo_pull_errors (GError **error)
+{
+  if (*error)
+    {
+      if (strstr ((*error)->message, "min-free-space-size") ||
+          strstr ((*error)->message, "min-free-space-percent"))
+        {
+          (*error)->domain = FLATPAK_ERROR;
+          (*error)->code = FLATPAK_ERROR_OUT_OF_SPACE;
+        }
+    }
+
+  return FALSE;
+}
+
+static gboolean
 repo_pull (OstreeRepo                           *self,
            const char                           *remote_name,
            const char                          **dirs_to_pull,
@@ -3999,7 +4015,7 @@ repo_pull (OstreeRepo                           *self,
 
       if (!ostree_repo_pull_with_options (self, remote_name, options,
                                           progress, cancellable, error))
-        return FALSE;
+        return translate_ostree_repo_pull_errors (error);
     }
 
   if (old_commit &&
@@ -4904,6 +4920,8 @@ repo_pull_local_untrusted (FlatpakDir          *self,
   options = g_variant_ref_sink (g_variant_builder_end (&builder));
   res = ostree_repo_pull_with_options (repo, url, options,
                                        progress, cancellable, error);
+  if (!res)
+    translate_ostree_repo_pull_errors (error);
 
   if (progress)
     ostree_async_progress_finish (progress);

--- a/common/flatpak-error.h
+++ b/common/flatpak-error.h
@@ -53,6 +53,7 @@ G_BEGIN_DECLS
  * @FLATPAK_ERROR_REMOTE_USED: Remote can't be uninstalled. (Since: 1.0.3)
  * @FLATPAK_ERROR_RUNTIME_USED: Runtime can't be uninstalled. (Since: 1.0.3)
  * @FLATPAK_ERROR_INVALID_NAME: Application, runtime or remote name is invalid. (Since: 1.0.3)
+ * @FLATPAK_ERROR_OUT_OF_SPACE: More disk space needed. (Since: 1.2.0)
  *
  * Error codes for library functions.
  */
@@ -75,6 +76,7 @@ typedef enum {
   FLATPAK_ERROR_REMOTE_USED,
   FLATPAK_ERROR_RUNTIME_USED,
   FLATPAK_ERROR_INVALID_NAME,
+  FLATPAK_ERROR_OUT_OF_SPACE,
 } FlatpakError;
 
 /**


### PR DESCRIPTION
Ostree just gives us a generic G_IO_ERROR_FAILED (boo!),
so we need to scrape the message to infer that this was
out-of-space. Translate this to an explicit error code
that we handle in the UI.