### PR TITLE
wip: Add a general filter facility to flatpak list

### DIFF
--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -158,6 +158,7 @@ print_table_for_refs (GPtrArray * refs_array,
   g_autofree char *match_branch = NULL;
   const char *runtime_filter = NULL;
   const char *kind_filter = NULL;
+  const char *origin_filter = NULL;
   const char *arch_filter = NULL;
   int rows, cols;
 
@@ -170,6 +171,8 @@ print_table_for_refs (GPtrArray * refs_array,
         runtime_filter = filters[i] + strlen ("runtime=");
       else if (g_str_has_prefix (filters[i], "kind="))
         kind_filter = filters[i] + strlen ("kind=");
+      else if (g_str_has_prefix (filters[i], "origin="))
+        origin_filter = filters[i] + strlen ("origin=");
       else if (g_str_has_prefix (filters[i], "arch="))
         arch_filter = filters[i] + strlen ("arch=");
       else
@@ -283,7 +286,14 @@ print_table_for_refs (GPtrArray * refs_array,
                 continue;
             }
 
+
           repo = flatpak_deploy_data_get_origin (deploy_data);
+
+          if (origin_filter)
+            {
+              if (strcmp (origin_filter, repo) != 0)
+                continue;
+            }
 
           active = flatpak_deploy_data_get_commit (deploy_data);
           alt_id = flatpak_deploy_data_get_alt_id (deploy_data);


### PR DESCRIPTION
Add a --match option that takes a list of filters, in the following form:

```
Available filters:
   runtime=RUNTIME           Show apps with this runtime
   kind=[app|runtime|all]    Show refs of this kind
   origin=REMOTE             Show refs from this remote
   arch=ARCH                 Show refs with the given arch
   permissions=PERMISSION    Show apps with the given permission, e.g. network
   help                      Show available filters
```

This can supersede the existing --app-runtime, --all/--app/--runtime and --arch options.

The ability to filter by origin and by network access has been requested before.

I am not 100% sold on this, but it seems useful enough to consider, and it can be expanded in the future to cover other conditions (e.g. other permissions, or, say "SIZE > 100MB").

If we go with this, I'll implement the equivalent for remote-ls.