### PR TITLE
table printer: Don't loop forever

### DIFF
--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -446,6 +446,7 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
   if (shrink_columns > 0)
     {
       int shortfall = MAX (width - columns, 0);
+      int last;
       if (shortfall > 0)
         {
           int shrinkable = 0;
@@ -479,20 +480,22 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
                 {
                   int sh = widths[i];
                   if (col && col->title)
-                    sh -= strlen (col->title);
+                    sh = MAX (0, sh - strlen (col->title));
                   else
-                    sh -= 5;
+                    sh = MAX (0, sh - 5);
                   shrinks[i] = shortfall * (sh / (double)shrinkable);
                   leftover -= shrinks[i];
                 }
             }
-          while (leftover > 0)
+          last = leftover + 1;
+          while (leftover > 0 && leftover < last)
             {
+              last = leftover;
               for (i = 0; i < printer->columns->len && i < printer->n_columns; i++)
                 {
                   TableColumn *col = g_ptr_array_index (printer->columns, i);
                   gboolean ellipsize = col ? col->ellipsize : FALSE;
-                  if (ellipsize)
+                  if (ellipsize && shrinks[i] < widths[i])
                     {
                        shrinks[i]++;
                        leftover--;


### PR DESCRIPTION
After ellipsizing nicely, we try to spread the extra
shortfall around, but we need to stop when we've
exhausted the available shrinkage and give up.

Some tables are just too wide.

This was showing up as an infinite loop with

flatpak remote-ls --columns=app,opt flathub