### PR TITLE
Add tests for private apis

### DIFF
--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -26,11 +26,46 @@ polkit_sources = \
 	$(NULL)
 endif
 
+noinst_LTLIBRARIES += libflatpak-app.la
+
+libflatpak_app_la_SOURCES = \
+	app/flatpak-builtins-utils.h \
+	app/flatpak-builtins-utils.c \
+	app/flatpak-table-printer.c \
+	app/flatpak-table-printer.h \
+	$(NULL)
+
+libflatpak_app_la_LIBADD = \
+	$(AM_LDADD) \
+	$(BASE_LIBS) \
+	$(OSTREE_LIBS) \
+	$(SOUP_LIBS) \
+	$(JSON_LIBS) \
+	$(APPSTREAM_GLIB_LIBS) \
+	$(SYSTEMD_LIBS) \
+	$(POLKIT_LIBS) \
+	libglnx.la \
+	libflatpak-common.la \
+	$(NULL)
+
+libflatpak_app_la_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(BASE_CFLAGS) \
+	$(OSTREE_CFLAGS) \
+	$(SOUP_CFLAGS) \
+	$(JSON_CFLAGS) \
+	$(APPSTREAM_GLIB_CFLAGS) \
+	 $(SYSTEMD_CFLAGS) \
+	$(POLKIT_CFLAGS) \
+	-DFLATPAK_COMPILATION \
+        -I$(srcdir)/app \
+        -I$(builddir)/app \
+        -DLOCALEDIR=\"$(localedir)\" \
+	$(NULL)
+
 flatpak_SOURCES = \
 	app/flatpak-main.c \
 	app/flatpak-builtins.h \
-	app/flatpak-builtins-utils.h \
-	app/flatpak-builtins-utils.c \
 	app/flatpak-builtins-remote-add.c \
 	app/flatpak-builtins-remote-modify.c \
 	app/flatpak-builtins-remote-delete.c \
@@ -71,8 +106,6 @@ flatpak_SOURCES = \
 	app/flatpak-builtins-create-usb.c \
 	app/flatpak-builtins-kill.c \
 	app/flatpak-builtins-history.c \
-	app/flatpak-table-printer.c \
-	app/flatpak-table-printer.h \
 	app/flatpak-complete.c \
 	app/flatpak-complete.h \
 	app/flatpak-cli-transaction.c \
@@ -94,10 +127,31 @@ app/parse-datetime.c: app/parse-datetime.y Makefile
 BUILT_SOURCES += $(flatpak_dbus_built_sources)
 CLEANFILES += app/parse-datetime.c $(flatpak_dbus_built_sources)
 
-flatpak_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(APPSTREAM_GLIB_LIBS) $(SYSTEMD_LIBS) $(POLKIT_LIBS) \
-	libglnx.la libflatpak-common.la
-flatpak_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) $(SYSTEMD_CFLAGS) $(POLKIT_CFLAGS) \
+flatpak_LDADD = \
+	$(AM_LDADD) \
+	$(BASE_LIBS) \
+	$(OSTREE_LIBS) \
+	$(SOUP_LIBS) \
+	$(JSON_LIBS) \
+	$(APPSTREAM_GLIB_LIBS) \
+	$(SYSTEMD_LIBS) \
+	$(POLKIT_LIBS) \
+	libglnx.la \
+	libflatpak-app.la \
+	libflatpak-common.la \
+	$(NULL)
+
+flatpak_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(BASE_CFLAGS) \
+	$(OSTREE_CFLAGS) \
+	$(SOUP_CFLAGS) \
+	$(JSON_CFLAGS) \
+	$(APPSTREAM_GLIB_CFLAGS) \
+	$(SYSTEMD_CFLAGS) \
+	$(POLKIT_CFLAGS) \
 	-DFLATPAK_COMPILATION \
         -I$(srcdir)/app \
         -I$(builddir)/app \
-        -DLOCALEDIR=\"$(localedir)\"
+        -DLOCALEDIR=\"$(localedir)\" \
+	$(NULL)

--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -33,6 +33,11 @@ libflatpak_app_la_SOURCES = \
 	app/flatpak-builtins-utils.c \
 	app/flatpak-table-printer.c \
 	app/flatpak-table-printer.h \
+	app/parse-datetime.h \
+	$(NULL)
+
+nodist_libflatpak_app_la_SOURCES = \
+	app/parse-datetime.c \
 	$(NULL)
 
 libflatpak_app_la_LIBADD = \
@@ -118,7 +123,6 @@ flatpak_SOURCES = \
 
 nodist_flatpak_SOURCES = \
 	$(flatpak_dbus_built_sources) \
-	app/parse-datetime.c \
 	$(NULL)
 
 app/parse-datetime.c: app/parse-datetime.y Makefile

--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -493,7 +493,17 @@ update_metadata (GFile *base, FlatpakContext *arg_context, gboolean is_runtime, 
     }
 
   if (opt_require_version)
-    g_key_file_set_string (keyfile, group, "required-flatpak", opt_require_version);
+    {
+      g_autoptr(GError) local_error = NULL;
+
+      g_key_file_set_string (keyfile, group, "required-flatpak", opt_require_version);
+      if (!flatpak_check_required_version ("test", keyfile, &local_error) &&
+          g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_INVALID_DATA))
+        {
+          flatpak_fail (error, _("Invalid --require-version argument: %s"), opt_require_version);
+          goto out;
+        }
+    }
 
   app_context = flatpak_context_new ();
   if (inherited_context)

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -840,18 +840,18 @@ column_filter (Column *columns,
 {
   g_auto(GStrv) cols = g_strsplit (col_arg, ",", 0);
   int n_cols = g_strv_length (cols);
-  Column *result = g_new0 (Column, n_cols + 1);
+  g_autofree Column *result = g_new0 (Column, n_cols + 1);
   int i;
 
   for (i = 0; i < n_cols; i++)
     {
       int idx = find_column (columns, cols[i], error);
       if (idx < 0)
-        return FALSE;
+        return NULL;
       result[i] = columns[idx];
     }
 
-  return result;
+  return g_steal_pointer (&result);
 }
 
 static gboolean

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -91,6 +91,7 @@ const char * flatpak_path_match_prefix (const char *pattern,
                                         const char *path);
 
 void     flatpak_disable_fancy_output (void);
+void     flatpak_enable_fancy_output (void);
 gboolean flatpak_fancy_output (void);
 
 const char * flatpak_get_arch (void);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -591,19 +591,25 @@ flatpak_get_gtk_theme (void)
   return (const char *) gtk_theme;
 }
 
-static gboolean no_fancy_output;
+static int fancy_output = -1;
 
 void
 flatpak_disable_fancy_output (void)
 {
-  no_fancy_output = TRUE;
+  fancy_output = FALSE;
+}
+
+void
+flatpak_enable_fancy_output (void)
+{
+  fancy_output = TRUE;
 }
 
 gboolean
 flatpak_fancy_output (void)
 {
-  if (no_fancy_output)
-    return FALSE;
+  if (fancy_output != -1)
+    return fancy_output;
 
   if (g_strcmp0 (g_getenv ("FLATPAK_FANCY_OUTPUT"), "0") == 0)
     return FALSE;

--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -184,6 +184,32 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--end-of-life=REASON</option></term>
+
+                <listitem><para>
+                    Mark build as end-of-life
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--timestamp=TIMESTAMP</option></term>
+
+                <listitem><para>
+                    Override the timestamp of the commit. Use an ISO 8601 formatted
+                    date, or NOW for the current time
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--disable-fsync</option></term>
+
+                <listitem><para>
+                    Don't fsync when writing to the repository. This can result in data loss in exceptional situations, but can improve performance when
+                    working with temporary or test repositories.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -173,7 +173,7 @@
                 <term><option>--timestamp=DATE</option></term>
 
                 <listitem><para>
-                    Use the specified ISO 8601 formatted date in the commit metadata and, if <option>--update-appstream</option> is used, the appstream data.
+                    Use the specified ISO 8601 formatted date or NOW, for the current time, in the commit metadata and, if <option>--update-appstream</option> is used, the appstream data.
                 </para></listitem>
             </varlistentry>
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -13,15 +13,39 @@ else
 AM_TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
 endif
 
-testlibrary_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) -DFLATPAK_COMPILATION
+testlibrary_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(BASE_CFLAGS) \
+	$(OSTREE_CFLAGS) \
+	-DFLATPAK_COMPILATION \
+	$(NULL)
 testlibrary_LDADD = \
+	$(AM_LDADD) \
+	$(BASE_LIBS) \
+	$(OSTREE_LIBS) \
+	libglnx.la \
+	libflatpak.la \
+	$(NULL)
+testlibrary_SOURCES = tests/testlibrary.c
+
+testcommon_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(BASE_CFLAGS) \
+	$(OSTREE_CFLAGS) \
+	$(SOUP_CFLAGS) \
+	$(JSON_CFLAGS) \
+	-DFLATPAK_COMPILATION \
+	$(NULL)
+testcommon_LDADD = \
              $(AM_LDADD) \
              $(BASE_LIBS) \
              $(OSTREE_LIBS) \
+	     $(SOUP_LIBS) \
+	     $(JSON_LIBS) \
              libglnx.la \
-             libflatpak.la \
+             libflatpak-common.la \
              $(NULL)
-testlibrary_SOURCES = tests/testlibrary.c
+testcommon_SOURCES = tests/testcommon.c
 
 tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
@@ -127,7 +151,7 @@ test_scripts = ${TEST_MATRIX}
 dist_test_scripts = ${TEST_MATRIX_DIST}
 dist_installed_test_extra_scripts += ${TEST_MATRIX_EXTRA_DIST}
 
-test_programs = testlibrary
+test_programs = testlibrary testcommon
 test_extra_programs = tests/httpcache
 
 @VALGRIND_CHECK_RULES@

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -34,17 +34,21 @@ testcommon_CFLAGS = \
 	$(OSTREE_CFLAGS) \
 	$(SOUP_CFLAGS) \
 	$(JSON_CFLAGS) \
+	$(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
+	-I$(srcdir)/app \
 	$(NULL)
 testcommon_LDADD = \
-             $(AM_LDADD) \
-             $(BASE_LIBS) \
-             $(OSTREE_LIBS) \
-	     $(SOUP_LIBS) \
-	     $(JSON_LIBS) \
-             libglnx.la \
-             libflatpak-common.la \
-             $(NULL)
+	$(AM_LDADD) \
+	$(BASE_LIBS) \
+	$(OSTREE_LIBS) \
+	$(SOUP_LIBS) \
+	$(JSON_LIBS) \
+	$(APPSTREAM_GLIB_LIBS) \     
+	libglnx.la \
+	libflatpak-common.la \
+	libflatpak-app.la \
+	$(NULL)
 testcommon_SOURCES = tests/testcommon.c
 
 tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -74,6 +74,9 @@ gzip -c > ${DIR}/files/share/app-info/xmls/${APP_ID}.xml.gz <<EOF
       <category>Utility</category>
     </categories>
     <icon height="64" width="64" type="cached">64x64/org.gnome.gedit.png</icon>
+    <releases>
+      <release timestamp="1525132800" version="0.0.1"/>
+    </releases>
   </component>
 </components>
 EOF

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -310,29 +310,18 @@ test_number_prompt (void)
   g_print_buffer = NULL;
 }
 
-#if !GLIB_CHECK_VERSION(2, 59, 0)
-static gboolean
-g_strv_equal (const char * const *strv1,
-              const char * cosnt *strv2)
+static void
+assert_strv_equal (char **strv1,
+                   char **strv2)
 {
-  g_return_val_if_fail (strv1 != NULL, FALSE);
-  g_return_val_if_fail (strv2 != NULL, FALSE);
-
   if (strv1 == strv2)
-    return TRUE;
+    return;
 
   for (; *strv1 != NULL && *strv2 != NULL; strv1++, strv2++)
-    {
-      if (!g_str_equal (*strv1, *strv2))
-        return FALSE;
-    }
+    g_assert_true (g_str_equal (*strv1, *strv2));
 
-  return (*strv1 == NULL && *strv2 == NULL);
+  g_assert_true (*strv1 == NULL && *strv2 == NULL);
 }
-#endif
-
-#define assert_strv_equal(s1,s2) \
-  g_assert_true (g_strv_equal ((const char * const *)s1, (const char * const *)s2))
 
 static void
 test_subpaths_merge (void)

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1,0 +1,377 @@
+#include "config.h"
+
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <glib.h>
+#include "flatpak.h"
+#include "flatpak-utils-private.h"
+
+static void
+test_has_path_prefix (void)
+{
+  g_assert_true (flatpak_has_path_prefix ("/a/prefix/foo/bar", "/a/prefix"));
+  g_assert_true (flatpak_has_path_prefix ("/a///prefix/foo/bar", "/a/prefix"));
+  g_assert_true (flatpak_has_path_prefix ("/a/prefix/foo/bar", "/a/prefix/"));
+  g_assert_true (flatpak_has_path_prefix ("/a/prefix/foo/bar", "/a/prefix//"));
+  g_assert_true (flatpak_has_path_prefix ("/a/prefix/foo/bar", ""));
+  g_assert_false (flatpak_has_path_prefix ("/a/prefixfoo/bar", "/a/prefix"));
+}
+
+static void
+test_path_match_prefix (void)
+{
+  g_assert_cmpstr (flatpak_path_match_prefix ("/?/pre*", "/a/prefix/x"), ==, "/x");
+  g_assert_cmpstr (flatpak_path_match_prefix ("/a/prefix/*", "/a/prefix/"), ==, "");
+  g_assert_null (flatpak_path_match_prefix ("/?/pre?", "/a/prefix/x"));
+}
+
+static void
+test_fancy_output (void)
+{
+  g_assert_false (flatpak_fancy_output ()); /* always false in tests */
+}
+
+static void
+test_arches (void)
+{
+  const char **arches = flatpak_get_arches ();
+
+#if defined(__i386__)
+  g_assert_cmpstr (flatpak_get_arch (), ==, "i386");
+  g_assert_true (g_strv_contains (arches, "x86_64"));
+  g_assert_true (g_strv_contains (arches, "i386"));
+#elif defined(__x86_64__)
+  g_assert_cmpstr (flatpak_get_arch (), ==, "x86_64");
+  g_assert_true (g_strv_contains (arches, "x86_64"));
+  g_assert_true (g_strv_contains (arches, "i386"));
+  g_assert_true (flatpak_is_linux32_arch ("i386"));
+  g_assert_false (flatpak_is_linux32_arch ("x86_64"));
+#else
+  g_assert_true (g_strv_contains (arches, flatpak_get_arch ()));
+#endif
+}
+
+static void
+test_extension_matches (void)
+{
+  g_assert_true (flatpak_extension_matches_reason ("org.foo.bar", "", TRUE));
+  g_assert_false (flatpak_extension_matches_reason ("org.foo.nosuchdriver", "active-gl-driver", TRUE));
+  g_assert_false (flatpak_extension_matches_reason ("org.foo.nosuchtheme", "active-gtk-theme", TRUE));
+  g_assert_false (flatpak_extension_matches_reason ("org.foo.nosuchtheme", "have-intel-gpu", TRUE));
+  g_assert_false (flatpak_extension_matches_reason ("org.foo.nonono", "on-xdg-desktop-nosuchdesktop", TRUE));
+  g_assert_false (flatpak_extension_matches_reason ("org.foo.nonono", "active-gl-driver;active-gtk-theme", TRUE));
+}
+
+static void
+test_valid_name (void)
+{
+  g_assert_false (flatpak_is_valid_name ("", NULL));
+  g_assert_false (flatpak_is_valid_name ("org", NULL));
+  g_assert_false (flatpak_is_valid_name ("org.", NULL));
+  g_assert_false (flatpak_is_valid_name ("org..", NULL));
+  g_assert_false (flatpak_is_valid_name ("org..test", NULL));
+  g_assert_false (flatpak_is_valid_name ("org.flatpak", NULL));
+  g_assert_false (flatpak_is_valid_name ("org.1flatpak.test", NULL));
+  g_assert_false (flatpak_is_valid_name ("org.flat-pak.test", NULL));
+  g_assert_false (flatpak_is_valid_name ("org.-flatpak.test", NULL));
+  g_assert_false (flatpak_is_valid_name ("org.flat,pak.test", NULL));
+
+  g_assert_true (flatpak_is_valid_name ("org.flatpak.test", NULL));
+  g_assert_true (flatpak_is_valid_name ("org.FlatPak.TEST", NULL));
+  g_assert_true (flatpak_is_valid_name ("org0.f1atpak.test", NULL));
+  g_assert_true (flatpak_is_valid_name ("org.flatpak.-test", NULL));
+  g_assert_true (flatpak_is_valid_name ("org.flatpak._test", NULL));
+  g_assert_true (flatpak_is_valid_name ("org.flat_pak__.te--st", NULL));
+}
+
+typedef struct
+{
+  const gchar *str;
+  guint base;
+  gint min;
+  gint max;
+  gint expected;
+  gboolean should_fail;
+} TestData;
+
+const TestData test_data[] = {
+  /* typical cases for unsigned */
+  { "-1",10, 0, 2, 0, TRUE  },
+  { "1", 10, 0, 2, 1, FALSE },
+  { "+1",10, 0, 2, 0, TRUE  },
+  { "0", 10, 0, 2, 0, FALSE },
+  { "+0",10, 0, 2, 0, TRUE  },
+  { "-0",10, 0, 2, 0, TRUE  },
+  { "2", 10, 0, 2, 2, FALSE },
+  { "+2",10, 0, 2, 0, TRUE  },
+  { "3", 10, 0, 2, 0, TRUE  },
+  { "+3",10, 0, 2, 0, TRUE  },
+
+  /* min == max cases for unsigned */
+  { "2",10, 2, 2, 2, FALSE  },
+  { "3",10, 2, 2, 0, TRUE   },
+  { "1",10, 2, 2, 0, TRUE   },
+
+  /* invalid inputs */
+  { "",   10,  0,  2,  0, TRUE },
+  { "a",  10,  0,  2,  0, TRUE },
+  { "1a", 10,  0,  2,  0, TRUE },
+
+  /* leading/trailing whitespace */
+  { " 1",10,  0,  2,  0, TRUE },
+  { "1 ",10,  0,  2,  0, TRUE },
+
+  /* hexadecimal numbers */
+  { "a",    16,   0, 15, 10, FALSE },
+  { "0xa",  16,   0, 15,  0, TRUE  },
+  { "-0xa", 16,   0, 15,  0, TRUE  },
+  { "+0xa", 16,   0, 15,  0, TRUE  },
+  { "- 0xa",16,   0, 15,  0, TRUE  },
+  { "+ 0xa",16,   0, 15,  0, TRUE  },
+};
+
+static void
+test_string_to_unsigned (void)
+{
+  gsize idx;
+
+  for (idx = 0; idx < G_N_ELEMENTS (test_data); ++idx)
+    {
+      GError *error = NULL;
+      const TestData *data = &test_data[idx];
+      gboolean result;
+      gint value;
+      guint64 value64 = 0;
+      result = flatpak_utils_ascii_string_to_unsigned (data->str,
+                                                       data->base,
+                                                       data->min,
+                                                       data->max,
+                                                       &value64,
+                                                       &error);
+      value = value64;
+      g_assert_cmpint (value, ==, value64);
+
+      if (data->should_fail)
+        {
+          g_assert_false (result);
+          g_assert_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+          g_clear_error (&error);
+        }
+      else
+        {
+          g_assert_true (result);
+          g_assert_no_error (error);
+          g_assert_cmpint (value, ==, data->expected);
+        }
+    }
+}
+
+typedef struct {
+  const char *a;
+  const char *b;
+  int distance;
+} Levenshtein;
+
+static Levenshtein levenshtein_tests[] = {
+  { "", "", 0 },
+  { "abcdef", "abcdef", 0 },
+  { "kitten", "sitting", 3 },
+  { "Saturday", "Sunday", 3 }
+};
+
+static void
+test_levenshtein (void)
+{
+  gsize idx;
+
+  for (idx = 0; idx < G_N_ELEMENTS (levenshtein_tests); idx++)
+    {
+      Levenshtein *data = &levenshtein_tests[idx];
+
+      g_assert_cmpint (flatpak_levenshtein_distance (data->a, data->b), ==, data->distance);
+      g_assert_cmpint (flatpak_levenshtein_distance (data->b, data->a), ==, data->distance);
+    }
+}
+
+static GString *g_print_buffer;
+
+static void
+my_print_func (const char *string)
+{
+  g_string_append (g_print_buffer, string);
+}
+
+static void
+test_format_choices (void)
+{
+  GPrintFunc print_func;
+  const char *choices[] = { "one", "two", "three", NULL };
+
+  g_assert_null (g_print_buffer);
+  g_print_buffer = g_string_new ("");
+  print_func = g_set_print_handler (my_print_func);
+
+  flatpak_format_choices (choices, "A prompt for %d choices:", 3);
+
+  g_assert_cmpstr (g_print_buffer->str, ==,
+                   "A prompt for 3 choices:\n\n"
+                   "  1) one\n"
+                   "  2) two\n"
+                   "  3) three\n"
+                   "\n");
+
+  g_set_print_handler (print_func);
+  g_string_free (g_print_buffer, TRUE);
+  g_print_buffer = NULL;
+}
+
+static void
+test_yes_no_prompt (void)
+{
+  GPrintFunc print_func;
+  gboolean ret;
+
+  g_assert_null (g_print_buffer);
+  g_print_buffer = g_string_new ("");
+  print_func = g_set_print_handler (my_print_func);
+
+  /* not a tty, so flatpak_yes_no_prompt will auto-answer 'n' */
+  ret = flatpak_yes_no_prompt (TRUE, "Prompt %d ?", 1);
+  g_assert_false (ret);
+  g_assert_cmpstr (g_print_buffer->str, ==, "Prompt 1 ? [Y/n]: n\n");
+  g_string_truncate (g_print_buffer, 0);
+
+  ret = flatpak_yes_no_prompt (FALSE, "Prompt %d ?", 2);
+  g_assert_false (ret);
+  g_assert_cmpstr (g_print_buffer->str, ==, "Prompt 2 ? [y/n]: n\n");
+
+  g_set_print_handler (print_func);
+  g_string_free (g_print_buffer, TRUE);
+  g_print_buffer = NULL;
+}
+
+static void
+test_number_prompt (void)
+{
+  GPrintFunc print_func;
+  gboolean ret;
+
+  g_assert_null (g_print_buffer);
+  g_print_buffer = g_string_new ("");
+  print_func = g_set_print_handler (my_print_func);
+
+  /* not a tty, so flatpak_number_prompt will auto-answer '0' */
+  ret = flatpak_number_prompt (TRUE, 0, 8, "Prompt %d ?", 1);
+  g_assert_false (ret);
+  g_assert_cmpstr (g_print_buffer->str, ==, "Prompt 1 ? [0-8]: 0\n");
+  g_string_truncate (g_print_buffer, 0);
+
+  ret = flatpak_number_prompt (FALSE, 1, 3, "Prompt %d ?", 2);
+  g_assert_false (ret);
+  g_assert_cmpstr (g_print_buffer->str, ==, "Prompt 2 ? [1-3]: 0\n");
+
+  g_set_print_handler (print_func);
+  g_string_free (g_print_buffer, TRUE);
+  g_print_buffer = NULL;
+}
+
+#if !GLIB_CHECK_VERSION(2, 60, 0)
+static gboolean
+g_strv_equal (char **strv1,
+              char **strv2)
+{
+  g_return_val_if_fail (strv1 != NULL, FALSE);
+  g_return_val_if_fail (strv2 != NULL, FALSE);
+
+  if (strv1 == strv2)
+    return TRUE;
+
+  for (; *strv1 != NULL && *strv2 != NULL; strv1++, strv2++)
+    {
+      if (!g_str_equal (*strv1, *strv2))
+        return FALSE;
+    }
+
+  return (*strv1 == NULL && *strv2 == NULL);
+}
+#endif
+
+static void
+test_subpaths_merge (void)
+{
+  char *empty[] = { NULL };
+  char *buba[] = { "bu", "ba", NULL };
+  char *bla[] = { "bla", "ba", NULL };
+  char *bla_sorted[] = { "ba", "bla", NULL };
+  char *bubabla[] = { "ba", "bla", "bu", NULL };
+  g_auto(GStrv) res = NULL;
+
+  res = flatpak_subpaths_merge (NULL, bla);
+  g_assert_true (g_strv_equal (res, bla));
+  g_clear_pointer (&res, g_strfreev);
+  
+  res = flatpak_subpaths_merge (bla, NULL);
+  g_assert_true (g_strv_equal (res, bla));
+  g_clear_pointer (&res, g_strfreev);
+  
+  res = flatpak_subpaths_merge (empty, bla);
+  g_assert_true (g_strv_equal (res, empty));
+  g_clear_pointer (&res, g_strfreev);
+  
+  res = flatpak_subpaths_merge (bla, empty);
+  g_assert_true (g_strv_equal (res, empty));
+  g_clear_pointer (&res, g_strfreev);
+  
+  res = flatpak_subpaths_merge (buba, bla);
+  g_assert_true (g_strv_equal (res, bubabla));
+  g_clear_pointer (&res, g_strfreev);
+  
+  res = flatpak_subpaths_merge (bla, buba);
+  g_assert_true (g_strv_equal (res, bubabla));
+  g_clear_pointer (&res, g_strfreev);
+
+  res = flatpak_subpaths_merge (bla, bla);
+  g_assert_true (g_strv_equal (res, bla_sorted));
+  g_clear_pointer (&res, g_strfreev);
+}
+
+static void
+test_lang_from_locale (void)
+{
+  g_autofree char *lang = NULL;
+
+  lang = flatpak_get_lang_from_locale ("en_US.utf8");
+  g_assert_cmpstr (lang, ==, "en");
+  g_clear_pointer (&lang, g_free);
+
+  lang = flatpak_get_lang_from_locale ("sv_FI@euro");
+  g_assert_cmpstr (lang, ==, "sv");
+}
+
+int
+main (int argc, char *argv[])
+{
+  int res;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/common/has-path-prefix", test_has_path_prefix);
+  g_test_add_func ("/common/path-match-prefix", test_path_match_prefix);
+  g_test_add_func ("/common/fancy-output", test_fancy_output);
+  g_test_add_func ("/common/arches", test_arches);
+  g_test_add_func ("/common/extension-matches", test_extension_matches);
+  g_test_add_func ("/common/valid-name", test_valid_name);
+  g_test_add_func ("/common/string-to-unsigned", test_string_to_unsigned);
+  g_test_add_func ("/common/levenshtein", test_levenshtein);
+  g_test_add_func ("/common/format-choices", test_format_choices);
+  g_test_add_func ("/common/yes-no-prompt", test_yes_no_prompt);
+  g_test_add_func ("/common/number-prompt", test_number_prompt);
+  g_test_add_func ("/common/subpaths-merge", test_subpaths_merge);
+  g_test_add_func ("/common/lang-from-locale", test_lang_from_locale);
+
+  res = g_test_run ();
+
+  return res;
+}

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -312,8 +312,8 @@ test_number_prompt (void)
 
 #if !GLIB_CHECK_VERSION(2, 59, 0)
 static gboolean
-g_strv_equal (char **strv1,
-              char **strv2)
+g_strv_equal (const char * const *strv1,
+              const char * cosnt *strv2)
 {
   g_return_val_if_fail (strv1 != NULL, FALSE);
   g_return_val_if_fail (strv2 != NULL, FALSE);

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -215,6 +215,11 @@ test_format_choices (void)
 {
   GPrintFunc print_func;
   const char *choices[] = { "one", "two", "three", NULL };
+  const char *many_choices[] = {
+    "one", "two", "three", "four", "five", "six",
+    "seven", "eight", "nine", "ten", "eleven",
+    NULL
+  };
 
   g_assert_null (g_print_buffer);
   g_print_buffer = g_string_new ("");
@@ -224,11 +229,32 @@ test_format_choices (void)
 
   g_assert_cmpstr (g_print_buffer->str, ==,
                    "A prompt for 3 choices:\n\n"
-                   "  1) one\n"
-                   "  2) two\n"
-                   "  3) three\n"
+                   "   1) one\n"
+                   "   2) two\n"
+                   "   3) three\n"
                    "\n");
 
+  g_string_truncate (g_print_buffer, 0);
+
+  flatpak_format_choices (many_choices, "A prompt for %d choices:", 11);
+  g_assert_cmpstr (g_print_buffer->str, ==,
+                   "A prompt for 11 choices:\n\n"
+                   "   1) one\n"
+                   "   2) two\n"
+                   "   3) three\n"
+                   "   4) four\n"
+                   "   5) five\n"
+                   "   6) six\n"
+                   "   7) seven\n"
+                   "   8) eight\n"
+                   "   9) nine\n"
+                   "  10) ten\n"
+                   "  11) eleven\n"
+                   "\n");
+
+  g_string_truncate (g_print_buffer, 0);
+
+  g_set_print_handler (print_func);
   g_set_print_handler (print_func);
   g_string_free (g_print_buffer, TRUE);
   g_print_buffer = NULL;
@@ -284,7 +310,7 @@ test_number_prompt (void)
   g_print_buffer = NULL;
 }
 
-#if !GLIB_CHECK_VERSION(2, 60, 0)
+#if !GLIB_CHECK_VERSION(2, 59, 0)
 static gboolean
 g_strv_equal (char **strv1,
               char **strv2)
@@ -305,6 +331,9 @@ g_strv_equal (char **strv1,
 }
 #endif
 
+#define assert_strv_equal(s1,s2) \
+  g_assert_true (g_strv_equal ((const char * const *)s1, (const char * const *)s2))
+
 static void
 test_subpaths_merge (void)
 {
@@ -316,31 +345,31 @@ test_subpaths_merge (void)
   g_auto(GStrv) res = NULL;
 
   res = flatpak_subpaths_merge (NULL, bla);
-  g_assert_true (g_strv_equal (res, bla));
+  assert_strv_equal (res, bla);
   g_clear_pointer (&res, g_strfreev);
   
   res = flatpak_subpaths_merge (bla, NULL);
-  g_assert_true (g_strv_equal (res, bla));
+  assert_strv_equal (res, bla);
   g_clear_pointer (&res, g_strfreev);
   
   res = flatpak_subpaths_merge (empty, bla);
-  g_assert_true (g_strv_equal (res, empty));
+  assert_strv_equal (res, empty);
   g_clear_pointer (&res, g_strfreev);
   
   res = flatpak_subpaths_merge (bla, empty);
-  g_assert_true (g_strv_equal (res, empty));
+  assert_strv_equal (res, empty);
   g_clear_pointer (&res, g_strfreev);
   
   res = flatpak_subpaths_merge (buba, bla);
-  g_assert_true (g_strv_equal (res, bubabla));
+  assert_strv_equal (res, bubabla);
   g_clear_pointer (&res, g_strfreev);
   
   res = flatpak_subpaths_merge (bla, buba);
-  g_assert_true (g_strv_equal (res, bubabla));
+  assert_strv_equal (res, bubabla);
   g_clear_pointer (&res, g_strfreev);
 
   res = flatpak_subpaths_merge (bla, bla);
-  g_assert_true (g_strv_equal (res, bla_sorted));
+  assert_strv_equal (res, bla_sorted);
   g_clear_pointer (&res, g_strfreev);
 }
 


### PR DESCRIPTION
Rearrange the build with convenience libraries, and add a test that links against those, so we can test some of the private apis that we rely on.