### PR TITLE
Be stricter about installation IDs

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -738,6 +738,13 @@ is_good_installation_id (const char *id)
       strcmp (id, "system") == 0)
     return FALSE;
 
+  if (!g_str_is_ascii (id) ||
+      strpbrk (id, " /\n"))
+    return FALSE;
+
+  if (strlen (id) > 80)
+    return FALSE;
+
   return TRUE;
 }
 


### PR DESCRIPTION
Avoid unnecessary complications from accepting installation
IDs which won't work well on the commandline or in filenames.