### PR TITLE
Forward --devel from a calling instance in flatpak-spawn

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -533,7 +533,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                       id, NULL,
                                       runtime_ref,
                                       app_id_dir, app_context, NULL,
-                                      FALSE, TRUE,
+                                      FALSE, TRUE, TRUE,
                                       &app_info_path,
                                       &instance_id_host_dir,
                                       error))

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -67,6 +67,7 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_EXTRA_ARGS "extra-args"
 #define FLATPAK_METADATA_KEY_SANDBOX "sandbox"
 #define FLATPAK_METADATA_KEY_BUILD "build"
+#define FLATPAK_METADATA_KEY_DEVEL "devel"
 
 #define FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY "Session Bus Policy"
 #define FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY "System Bus Policy"
@@ -156,6 +157,7 @@ gboolean flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
                                         FlatpakContext *cmdline_context,
                                         gboolean        sandbox,
                                         gboolean        build,
+                                        gboolean        devel,
                                         char          **app_info_path_out,
                                         char          **host_instance_id_host_dir_out,
                                         GError        **error);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1724,6 +1724,7 @@ flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
                                FlatpakContext *cmdline_context,
                                gboolean        sandbox,
                                gboolean        build,
+                               gboolean        devel,
                                char          **app_info_path_out,
                                char          **instance_id_host_dir_out,
                                GError        **error)
@@ -1827,6 +1828,9 @@ flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
   if (build)
     g_key_file_set_boolean (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
                             FLATPAK_METADATA_KEY_BUILD, TRUE);
+  if (devel)
+    g_key_file_set_boolean (keyfile, FLATPAK_METADATA_GROUP_INSTANCE,
+                            FLATPAK_METADATA_KEY_DEVEL, TRUE);
 
   if (cmdline_context)
     {
@@ -2823,7 +2827,7 @@ regenerate_ld_cache (GPtrArray    *base_argv_array,
 
   if (!WIFEXITED (exit_status) || WEXITSTATUS (exit_status) != 0)
     {
-      flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, 
+      flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED,
                           _("ldconfig failed, exit status %d"), exit_status);
       return -1;
     }
@@ -3102,7 +3106,7 @@ flatpak_run_app (const char     *app_ref,
                                       runtime_files, runtime_deploy_data, runtime_extensions,
                                       app_ref_parts[1], app_ref_parts[3],
                                       runtime_ref, app_id_dir, app_context, extra_context,
-                                      sandboxed, FALSE,
+                                      sandboxed, FALSE, flags & FLATPAK_RUN_FLAG_DEVEL,
                                       &app_info_path, &instance_id_host_dir, error))
     return FALSE;
 

--- a/portal/flatpak-portal-app-info.h
+++ b/portal/flatpak-portal-app-info.h
@@ -33,6 +33,7 @@
 #define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
 #define FLATPAK_METADATA_KEY_RUNTIME_COMMIT "runtime-commit"
 #define FLATPAK_METADATA_KEY_SHARED "shared"
+#define FLATPAK_METADATA_KEY_DEVEL "devel"
 #define FLATPAK_METADATA_KEY_INSTANCE_PATH "instance-path"
 
 GKeyFile * flatpak_invocation_lookup_app_info (GDBusMethodInvocation *invocation,

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -322,6 +322,7 @@ handle_spawn (PortalFlatpak         *object,
   g_auto(GStrv) sandbox_expose = NULL;
   g_auto(GStrv) sandbox_expose_ro = NULL;
   gboolean sandboxed;
+  gboolean devel;
 
   app_info = g_object_get_data (G_OBJECT (invocation), "app-info");
   g_assert (app_info != NULL);
@@ -391,6 +392,9 @@ handle_spawn (PortalFlatpak         *object,
                                           FLATPAK_METADATA_KEY_RUNTIME_COMMIT, NULL);
   shares = g_key_file_get_string_list (app_info, FLATPAK_METADATA_GROUP_CONTEXT,
                                        FLATPAK_METADATA_KEY_SHARED, NULL, NULL);
+
+  devel = g_key_file_get_boolean (app_info, FLATPAK_METADATA_GROUP_INSTANCE,
+                                  FLATPAK_METADATA_KEY_DEVEL, NULL);
 
   g_variant_lookup (arg_options, "sandbox-expose", "^as", &sandbox_expose);
   g_variant_lookup (arg_options, "sandbox-expose-ro", "^as", &sandbox_expose_ro);
@@ -523,6 +527,9 @@ handle_spawn (PortalFlatpak         *object,
       for (i = 0; extra_args != NULL && extra_args[i] != NULL; i++)
         g_ptr_array_add (flatpak_argv, g_strdup (extra_args[i]));
     }
+
+  if (devel)
+    g_ptr_array_add (flatpak_argv, g_strdup ("--devel"));
 
   /* Inherit launcher network access from launcher, unless
      NO_NETWORK set. */


### PR DESCRIPTION
Closes #2493. I just went along with exposing devel in app-info for now, since I can just change it later if needed.