### PR TITLE
Fully translate a prompt

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -920,21 +920,22 @@ transaction_ready (FlatpakTransaction *transaction)
     {
       FlatpakInstallation *installation = flatpak_transaction_get_installation (transaction);
       const char *name;
+      gboolean ret;
+
+      g_print ("\n");
 
       name = flatpak_installation_get_display_name (installation);
       if (name == NULL)
         name = flatpak_installation_get_id (installation);
-      if (name == NULL)
-        {
-          if (flatpak_installation_get_is_user (installation))
-            name = "user";
-          else
-            name = "system";
-        }
 
-      g_print ("\n");
+      if (name != NULL)
+        ret = flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the %s installation?"), name);
+      else if (flatpak_installation_get_is_user (installation))
+        ret = flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the user installation?"));
+      else
+        ret = flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the system installation?"));
 
-      if (!flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the %s installation?"), name))
+      if (!ret)
         {
           g_list_free_full (ops, g_object_unref);
           return FALSE;


### PR DESCRIPTION
We were not translating the strings 'user' and 'system'
here, although we should.

Closes: #1984