### PR TITLE
Show license information

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -93,9 +93,10 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
   const char *alt_id = NULL;
   const char *eol;
   const char *eol_rebase;
-  const char *appdata_name;
-  const char *appdata_summary;
-  const char *appdata_version;
+  const char *name;
+  const char *summary;
+  const char *version;
+  const char *license;
   const char *pref = NULL;
   const char *default_branch = NULL;
   const char *origin = NULL;
@@ -164,9 +165,10 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
   subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
   eol = flatpak_deploy_data_get_eol (deploy_data);
   eol_rebase = flatpak_deploy_data_get_eol_rebase (deploy_data);
-  appdata_name = flatpak_deploy_data_get_appdata_name (deploy_data);
-  appdata_summary = flatpak_deploy_data_get_appdata_summary (deploy_data);
-  appdata_version = flatpak_deploy_data_get_appdata_version (deploy_data);
+  name = flatpak_deploy_data_get_appdata_name (deploy_data);
+  summary = flatpak_deploy_data_get_appdata_summary (deploy_data);
+  version = flatpak_deploy_data_get_appdata_version (deploy_data);
+  license = flatpak_deploy_data_get_appdata_license (deploy_data);
 
   metakey = flatpak_deploy_get_metadata (deploy);
 
@@ -190,12 +192,12 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       int rows, cols;
       int width;
 
-      if (appdata_name)
+      if (name)
         {
-          if (appdata_summary)
-            g_print ("\n%s - %s\n\n", appdata_name, appdata_summary);
+          if (summary)
+            g_print ("\n%s - %s\n\n", name, summary);
           else
-            g_print ("\n%s\n\n", appdata_name);
+            g_print ("\n%s\n\n", name);
         }
 
       latest = flatpak_dir_read_latest (dir, origin, ref, NULL, NULL, NULL);
@@ -224,6 +226,8 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       len = MAX (len, strlen (_("Arch:")));
       len = MAX (len, strlen (_("Branch:")));
       len = MAX (len, strlen (_("Version:")));
+      if (license)
+        len = MAX (len, strlen (_("License:")));
       if (collection_id != NULL)
         len = MAX (len, strlen (_("Collection:")));
       len = MAX (len, strlen (_("Installation:")));
@@ -262,8 +266,10 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       g_print ("%s%*s%s %s\n", on, len, _("Ref:"), off, ref);
       g_print ("%s%*s%s %s\n", on, len, _("Arch:"), off, parts[2]);
       g_print ("%s%*s%s %s\n", on, len, _("Branch:"), off, parts[3]);
-      if (appdata_version)
-        g_print ("%s%*s%s %s\n", on, len, _("Version:"), off, appdata_version);
+      if (version)
+        g_print ("%s%*s%s %s\n", on, len, _("Version:"), off, version);
+      if (license)
+        g_print ("%s%*s%s %s\n", on, len, _("License:"), off, license);
       g_print ("%s%*s%s %s\n", on, len, _("Origin:"), off, origin ? origin : "-");
       if (collection_id)
         g_print ("%s%*s%s %s\n", on, len, _("Collection:"), off, collection_id);

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -225,7 +225,8 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       len = MAX (len, strlen (_("Ref:")));
       len = MAX (len, strlen (_("Arch:")));
       len = MAX (len, strlen (_("Branch:")));
-      len = MAX (len, strlen (_("Version:")));
+      if (version)
+        len = MAX (len, strlen (_("Version:")));
       if (license)
         len = MAX (len, strlen (_("License:")));
       if (collection_id != NULL)

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -161,6 +161,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       g_autoptr(AsStore) store = as_store_new ();
       AsApp *app = NULL;
       const char *version = NULL;
+      const char *license = NULL;
 
 #if AS_CHECK_VERSION (0, 6, 1)
       as_store_set_add_flags (store, as_store_get_add_flags (store) | AS_STORE_ADD_FLAG_USE_UNIQUE_ID);
@@ -174,6 +175,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
           const char *comment = as_app_get_localized_comment (app);
           g_print ("\n%s - %s\n\n", name, comment);
           version = as_app_get_version (app);
+          license = as_app_get_project_license (app);
         }
 
       g_variant_get (commit_v, "(a{sv}aya(say)&s&stayay)", NULL, NULL, NULL,
@@ -212,6 +214,8 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       len = MAX (len, strlen (_("Branch:")));
       if (version != NULL)
         len = MAX (len, strlen (_("Version:")));
+      if (license != NULL)
+        len = MAX (len, strlen (_("License:")));
       if (collection_id != NULL)
         len = MAX (len, strlen (_("Collection:")));
       len = MAX (len, strlen (_("Download:")));
@@ -237,6 +241,8 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       g_print ("%s%*s%s %s\n", on, len, _("Branch:"), off, parts[3]);
       if (version != NULL)
         g_print ("%s%*s%s %s\n", on, len, _("Version:"), off, version);
+      if (license != NULL)
+        g_print ("%s%*s%s %s\n", on, len, _("License:"), off, license);
       if (collection_id != NULL)
         g_print ("%s%*s%s %s\n", on, len, _("Collection:"), off, collection_id);
       g_print ("%s%*s%s %s\n", on, len, _("Download:"), off, formatted_download_size);

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -32,7 +32,7 @@
 /* Version history:
  * The version field was added in flatpak 1.2, anything before is 0.
  *
- * Version 1 added appdata-name/summary/version
+ * Version 1 added appdata-name/summary/version/license
  */
 #define FLATPAK_DEPLOY_VERSION_CURRENT 1
 #define FLATPAK_DEPLOY_VERSION_ANY 0
@@ -331,6 +331,7 @@ const char *        flatpak_deploy_data_get_runtime (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_name (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_summary (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_version (GVariant *deploy_data);
+const char *        flatpak_deploy_data_get_appdata_license (GVariant *deploy_data);
 
 GFile *        flatpak_deploy_get_dir (FlatpakDeploy *deploy);
 GVariant *     flatpak_load_deploy_data (GFile        *deploy_dir,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2169,6 +2169,12 @@ flatpak_deploy_data_get_appdata_version (GVariant *deploy_data)
     return flatpak_deploy_data_get_string (deploy_data, "appdata-version");
 }
 
+const char *
+flatpak_deploy_data_get_appdata_license (GVariant *deploy_data)
+{
+    return flatpak_deploy_data_get_string (deploy_data, "appdata-license");
+}
+
 /*<private>
  * flatpak_deploy_data_get_subpaths:
  *
@@ -2262,12 +2268,16 @@ add_appdata_to_deploy_data (GVariantBuilder *metadata_builder,
     {
       AsApp *app = g_ptr_array_index (apps, 0);
       AsRelease *release = as_app_get_release_default (app);
+      const char *license = as_app_get_project_license (app);
 
       add_locale_metadata_string (metadata_builder, "appdata-name", as_app_get_names (app));
       add_locale_metadata_string (metadata_builder, "appdata-summary", as_app_get_comments (app));
       if (release)
         g_variant_builder_add (metadata_builder, "{s@v}", "appdata-version",
                                g_variant_new_variant (g_variant_new_string (as_release_get_version (release))));
+      if (license)
+        g_variant_builder_add (metadata_builder, "{s@v}", "appdata-license",
+                               g_variant_new_variant (g_variant_new_string (license)));
     }
 }
 

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -756,7 +756,8 @@ get_ref (FlatpakDir   *dir,
                                     flatpak_deploy_data_get_eol_rebase (deploy_data),
                                     flatpak_deploy_data_get_appdata_name (deploy_data),
                                     flatpak_deploy_data_get_appdata_summary (deploy_data),
-                                    flatpak_deploy_data_get_appdata_version (deploy_data));
+                                    flatpak_deploy_data_get_appdata_version (deploy_data),
+                                    flatpak_deploy_data_get_appdata_license (deploy_data));
 }
 
 /**

--- a/common/flatpak-installed-ref-private.h
+++ b/common/flatpak-installed-ref-private.h
@@ -40,6 +40,7 @@ FlatpakInstalledRef *flatpak_installed_ref_new (const char  *full_ref,
                                                 const char  *eol_rebase,
                                                 const char  *appdata_name,
                                                 const char  *appdata_summary,
-                                                const char  *appdata_version);
+                                                const char  *appdata_version,
+                                                const char  *appdata_license);
 
 #endif /* __FLATPAK_INSTALLED_REF_PRIVATE_H__ */

--- a/common/flatpak-installed-ref.c
+++ b/common/flatpak-installed-ref.c
@@ -52,6 +52,7 @@ struct _FlatpakInstalledRefPrivate
   char    *appdata_name;
   char    *appdata_summary;
   char    *appdata_version;
+  char    *appdata_license;
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (FlatpakInstalledRef, flatpak_installed_ref, FLATPAK_TYPE_REF)
@@ -70,6 +71,7 @@ enum {
   PROP_APPDATA_NAME,
   PROP_APPDATA_SUMMARY,
   PROP_APPDATA_VERSION,
+  PROP_APPDATA_LICENSE,
 };
 
 static void
@@ -152,6 +154,11 @@ flatpak_installed_ref_set_property (GObject      *object,
       priv->appdata_version = g_value_dup_string (value);
       break;
 
+    case PROP_APPDATA_LICENSE:
+      g_clear_pointer (&priv->appdata_license, g_free);
+      priv->appdata_license = g_value_dup_string (value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -211,6 +218,10 @@ flatpak_installed_ref_get_property (GObject    *object,
 
     case PROP_APPDATA_VERSION:
       g_value_set_string (value, priv->appdata_version);
+      break;
+
+    case PROP_APPDATA_LICENSE:
+      g_value_set_string (value, priv->appdata_license);
       break;
 
     default:
@@ -303,6 +314,13 @@ flatpak_installed_ref_class_init (FlatpakInstalledRefClass *klass)
                                    g_param_spec_string ("appdata-version",
                                                         "Appdata Version",
                                                         "The default version field from the appdata",
+                                                        NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (object_class,
+                                   PROP_APPDATA_LICENSE,
+                                   g_param_spec_string ("appdata-license",
+                                                        "Appdata License",
+                                                        "The license from the appdata",
                                                         NULL,
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 }
@@ -575,6 +593,24 @@ flatpak_installed_ref_get_appdata_version (FlatpakInstalledRef *self)
   return priv->appdata_version;
 }
 
+/**
+ * flatpak_installed_ref_get_appdata_license:
+ * @self: a #FlatpakInstalledRef
+ *
+ * Returns the license field from the appdata.
+ *
+ * Returns: (transfer none): the license or %NULL
+ *
+ * Since: 1.1.2
+ */
+const char *
+flatpak_installed_ref_get_appdata_license (FlatpakInstalledRef *self)
+{
+  FlatpakInstalledRefPrivate *priv = flatpak_installed_ref_get_instance_private (self);
+
+  return priv->appdata_license;
+}
+
 FlatpakInstalledRef *
 flatpak_installed_ref_new (const char  *full_ref,
                            const char  *commit,
@@ -588,7 +624,8 @@ flatpak_installed_ref_new (const char  *full_ref,
                            const char  *eol_rebase,
                            const char  *appdata_name,
                            const char  *appdata_summary,
-                           const char  *appdata_version)
+                           const char  *appdata_version,
+                           const char  *appdata_license)
 {
   FlatpakRefKind kind = FLATPAK_REF_KIND_APP;
   FlatpakInstalledRef *ref;
@@ -621,6 +658,7 @@ flatpak_installed_ref_new (const char  *full_ref,
                       "appdata-name", appdata_name,
                       "appdata-summary", appdata_summary,
                       "appdata-version", appdata_version,
+                      "appdata-license", appdata_license,
                       NULL);
 
   return ref;

--- a/common/flatpak-installed-ref.c
+++ b/common/flatpak-installed-ref.c
@@ -86,6 +86,10 @@ flatpak_installed_ref_finalize (GObject *object)
   g_strfreev (priv->subpaths);
   g_free (priv->eol);
   g_free (priv->eol_rebase);
+  g_free (priv->appdata_name);
+  g_free (priv->appdata_summary);
+  g_free (priv->appdata_version);
+  g_free (priv->appdata_license);
 
   G_OBJECT_CLASS (flatpak_installed_ref_parent_class)->finalize (object);
 }

--- a/common/flatpak-installed-ref.h
+++ b/common/flatpak-installed-ref.h
@@ -58,6 +58,7 @@ FLATPAK_EXTERN const char  *flatpak_installed_ref_get_latest_commit (FlatpakInst
 FLATPAK_EXTERN const char  *flatpak_installed_ref_get_appdata_name (FlatpakInstalledRef *self);
 FLATPAK_EXTERN const char  *flatpak_installed_ref_get_appdata_summary (FlatpakInstalledRef *self);
 FLATPAK_EXTERN const char  *flatpak_installed_ref_get_appdata_version (FlatpakInstalledRef *self);
+FLATPAK_EXTERN const char  *flatpak_installed_ref_get_appdata_license (FlatpakInstalledRef *self);
 FLATPAK_EXTERN gboolean     flatpak_installed_ref_get_is_current (FlatpakInstalledRef *self);
 FLATPAK_EXTERN GBytes      *flatpak_installed_ref_load_metadata (FlatpakInstalledRef *self,
                                                                  GCancellable        *cancellable,


### PR DESCRIPTION
Now that we have infrastructure for appdata, lets add this field to it before 1.2, so we don't have to bump the version number right away.