### PR TITLE
Validate exported icons

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,7 @@ include app/Makefile.am.inc
 include session-helper/Makefile.am.inc
 include portal/Makefile.am.inc
 include system-helper/Makefile.am.inc
+include icon-validator/Makefile.am.inc
 include tests/Makefile.am.inc
 
 if !WITH_SYSTEM_DBUS_PROXY

--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -157,5 +157,6 @@ flatpak_CFLAGS = \
 	-DFLATPAK_COMPILATION \
         -I$(srcdir)/app \
         -I$(builddir)/app \
+        -DLIBEXECDIR=\"$(libexecdir)\" \
         -DLOCALEDIR=\"$(localedir)\" \
 	$(NULL)

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -12,6 +12,7 @@ pkg_install sudo which attr fuse bison \
     dconf-devel \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree
+pkg_install gdk-pixbuf2-modules # needed to make icon validation work
 pkg_install_builddeps flatpak
 
 build --enable-gtk-doc ${CONFIGOPTS:-}

--- a/configure.ac
+++ b/configure.ac
@@ -272,6 +272,8 @@ PKG_CHECK_MODULES(JSON, [json-glib-1.0])
 
 PKG_CHECK_MODULES(APPSTREAM_GLIB, [appstream-glib >= 0.5.10])
 
+PKG_CHECK_MODULES(GDK_PIXBUF, [gdk-pixbuf-2.0])
+
 AC_ARG_ENABLE([seccomp],
               AC_HELP_STRING([--disable-seccomp],
                              [Disable seccomp]),

--- a/icon-validator/Makefile.am.inc
+++ b/icon-validator/Makefile.am.inc
@@ -1,0 +1,8 @@
+libexec_PROGRAMS += \
+        flatpak-validate-icon \
+        $(NULL)
+
+flatpak_validate_icon_SOURCES = icon-validator/validate-icon.c
+flatpak_validate_icon_LDADD = $(GDK_PIXBUF_LIBS)
+flatpak_validate_icon_CFLAGS = $(GDK_PIXBUF_CFLAGS)
+

--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include <gdk-pixbuf/gdk-pixbuf.h>
+
+static int
+validate_icon (int max_width,
+               int max_height,
+               const char *filename)
+{
+  GdkPixbufFormat *format;
+  int width, height;
+  const char *name;
+  const char *allowed_formats[] = { "png", "jpeg", "svg", NULL };
+  g_autoptr(GdkPixbuf) pixbuf = NULL;
+  g_autoptr(GError) error = NULL;
+
+  format = gdk_pixbuf_get_file_info (filename, &width, &height);
+  if (format == NULL) 
+    {
+      g_printerr ("Format not recognized\n");
+      return 1;
+    }
+
+  name = gdk_pixbuf_format_get_name (format);
+  if (!g_strv_contains (allowed_formats, name))
+    {
+      g_printerr ("Format %s not accepted\n", name);
+      return 1;
+    }
+
+  if (width > max_width || height > max_height)
+    {
+      g_printerr ("Image too large (%dx%d)\n", width, height);
+      return 1;
+    }
+
+  pixbuf = gdk_pixbuf_new_from_file (filename, &error);
+  if (pixbuf == NULL)
+    {
+      g_printerr ("Failed to load image: %s\n", error->message);
+      return 1;
+    }
+
+  return 0;
+}
+
+int
+main (int argc, char *argv[])
+{
+  int width;
+  int height;
+  const char *path;
+
+  if (argc != 4)
+    {
+      g_printerr ("Usage: %s WIDTH HEIGHT PATH\n", argv[0]);
+      return 1;
+    }
+
+  width = g_ascii_strtoll (argv[1], NULL, 10);
+  if (width <= 16 || width > 4096)
+    {
+      g_printerr ("Bad width limit: %s\n", argv[1]);
+      return 1;
+    }
+
+  height = g_ascii_strtoll (argv[2], NULL, 10);
+  if (height <= 16 || height > 4096)
+    {
+      g_printerr ("Bad height limit: %s\n", argv[2]);
+      return 1;
+    }
+
+  path = argv[3];
+
+  return validate_icon (width, height, path);
+}

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -1,6 +1,7 @@
 AM_TESTS_ENVIRONMENT = FLATPAK_TESTS_DEBUG=1 \
 	FLATPAK_CONFIG_DIR=/dev/null \
 	FLATPAK_TRIGGERSDIR=$$(cd $(top_srcdir) && pwd)/triggers \
+	FLATPAK_VALIDATE_ICON=$$(cd $(top_builddir) && pwd)/flatpak-validate-icon \
 	FLATPAK_DBUSPROXY=$$(cd $(top_builddir) && pwd)/flatpak-dbus-proxy \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
 	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH} \


### PR DESCRIPTION
This moves the icon validator from xdg-desktop-portal over here and uses it during build-export to validate all the exported icons.

Closes: #2517 