### PR TITLE
install: Print eol warnings before starting to install

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1192,18 +1192,19 @@ print_line_wrapped (int cols, const char *line)
   for (i = 0; words[i]; i++)
     {
        int len = cell_width (words[i]);
-       int space = col > 0;
 
-       if (col + space + len >= cols)
+       if (col > 0 && col + 1 + len > cols)
          {
-           g_print ("\n%s", words[i]);
-           col = len;
+           g_print ("\n");
+           col = 0;
          }
-       else
+       else if (col > 0)
          {
-           g_print ("%*s%s", space, "", words[i]);
-           col = col + space + len;
+           g_print (" ");
+           col += 1;
          }
+       g_print ("%s", words[i]);
+       col += len;
     }
 }
 

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -502,36 +502,6 @@ operation_error (FlatpakTransaction            *transaction,
   return TRUE; /* Continue */
 }
 
-static void
-end_of_lifed (FlatpakTransaction *transaction,
-              const char         *ref,
-              const char         *reason,
-              const char         *rebase)
-{
-  FlatpakCliTransaction *self = FLATPAK_CLI_TRANSACTION (transaction);
-  g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
-  g_autofree char *msg = NULL;
-
-  if (rebase)
-    msg = g_strdup_printf (_("Info: %s is end-of-life, in preference of %s"),
-                           flatpak_ref_get_name (rref), rebase);
-  else if (reason)
-    msg = g_strdup_printf (_("Info: %s is end-of-life, with reason: %s\n"),
-                           flatpak_ref_get_name (rref), reason);
-
-  if (flatpak_fancy_output ())
-    {
-      flatpak_table_printer_set_cell (self->printer, self->progress_row, 0, msg);
-      self->progress_row++;
-      flatpak_table_printer_add_span (self->printer, "");
-      flatpak_table_printer_finish_row (self->printer);
-      redraw (self);
-    }
-  else
-    g_print ("\r%-*s\n", self->table_width, msg);
-}
-
-
 static int
 cmpstringp (const void *p1, const void *p2)
 {
@@ -1089,7 +1059,6 @@ flatpak_cli_transaction_class_init (FlatpakCliTransactionClass *klass)
   transaction_class->operation_done = operation_done;
   transaction_class->operation_error = operation_error;
   transaction_class->choose_remote_for_ref = choose_remote_for_ref;
-  transaction_class->end_of_lifed = end_of_lifed;
   transaction_class->run = flatpak_cli_transaction_run;
 }
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -250,7 +250,8 @@ ${FLATPAK} ${U} remote-ls -d test-repo > remote-ls-log
 assert_file_has_content remote-ls-log "app/org.test.Hello/.*eol=Reason2"
 
 ${FLATPAK} ${U} update -y org.test.Hello > update-log
-assert_file_has_content update-log "org.test.Hello.*Reason2"
+assert_file_has_content update-log "org.test.Hello/.*end-of-life"
+assert_file_has_content update-log "Reason2"
 
 ${FLATPAK} ${U} info org.test.Hello > info-log
 assert_file_has_content info-log "End-of-life: Reason2"

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -738,6 +738,48 @@ test_parse_datetime (void)
   g_assert_false (ret);
 }
 
+static void
+test_print_wrapped (void)
+{
+  GPrintFunc print_func;
+
+  g_assert_null (g_print_buffer);
+  g_print_buffer = g_string_new ("");
+  print_func = g_set_print_handler (my_print_func);
+
+  print_wrapped (20, "Here is some text that I would like to see wrapped, please. "
+                     "How many lines will this print? %d", 4);
+  g_assert_cmpstr (g_print_buffer->str, ==,
+                   "Here is some text\n"
+                   "that I would like to\n"
+                   "see wrapped, please.\n"
+                   "How many lines will\n"
+                   "this print? 4\n");
+
+  g_string_truncate (g_print_buffer, 0);
+
+  print_wrapped (10, "Alongwordtest, andanotherone, and short");
+  g_assert_cmpstr (g_print_buffer->str, ==,
+                   "Alongwordtest,\n"
+                   "andanotherone,\n"
+                   "and short\n");
+
+  g_string_truncate (g_print_buffer, 0);
+
+  print_wrapped (10, "one\ntwo three");
+  g_assert_cmpstr (g_print_buffer->str, ==, "one\ntwo three\n");
+
+  g_string_truncate (g_print_buffer, 0);
+  print_wrapped (10, FLATPAK_ANSI_RED "one" FLATPAK_ANSI_COLOR_RESET " two three");
+  g_assert_cmpstr (g_print_buffer->str, ==,
+                   FLATPAK_ANSI_RED "one" FLATPAK_ANSI_COLOR_RESET " two\n"
+                   "three\n");
+
+  g_set_print_handler (print_func);
+  g_string_free (g_print_buffer, TRUE);
+  g_print_buffer = NULL;
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -766,6 +808,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/app/table-shrink", test_table_shrink);
   g_test_add_func ("/app/table-shrink-more", test_table_shrink_more);
   g_test_add_func ("/app/parse-datetime", test_parse_datetime);
+  g_test_add_func ("/app/print-aligned", test_print_wrapped);
 
   res = g_test_run ();
 


### PR DESCRIPTION
We should inform users that the software they are about to install is end-of-life and won't get updates. And give them a chance to opt out.