### PR TITLE
Systemhelper errors

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -749,6 +749,8 @@ on_bus_acquired (GDBusConnection *connection,
 
   g_debug ("Bus acquired, creating skeleton");
 
+  g_dbus_connection_set_exit_on_close (connection, FALSE);
+
   portal = portal_flatpak_skeleton_new ();
 
   g_dbus_connection_signal_subscribe (connection,

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1505,6 +1505,8 @@ on_bus_acquired (GDBusConnection *connection,
 
   g_debug ("Bus acquired, creating skeleton");
 
+  g_dbus_connection_set_exit_on_close (connection, FALSE);
+
   helper = flatpak_system_helper_skeleton_new ();
 
   flatpak_system_helper_set_version (FLATPAK_SYSTEM_HELPER (helper), 2);


### PR DESCRIPTION
system-helper: Introduce a helper for errors
    
Be more systematic about returning FLATPAK_ERROR unmodified and wrap everything else in a G_DBUS_ERROR_FAILED.
    
Closes: #2391
