### PR TITLE
session-helper: Drop the unused RequestMonitor api

### DIFF
--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -27,10 +27,6 @@
   <interface name='org.freedesktop.Flatpak.SessionHelper'>
     <property name="version" type="u" access="read"/>
 
-    <method name="RequestMonitor">
-      <arg type='ay' name='path' direction='out'/>
-    </method>
-
     <method name="RequestSession">
       <arg type='a{sv}' name='data' direction='out'/>
     </method>

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -67,17 +67,6 @@ pid_data_free (PidData *data)
 }
 
 static gboolean
-handle_request_monitor (FlatpakSessionHelper  *object,
-                        GDBusMethodInvocation *invocation,
-                        gpointer               user_data)
-{
-  flatpak_session_helper_complete_request_monitor (object, invocation,
-                                                   monitor_dir);
-
-  return TRUE;
-}
-
-static gboolean
 handle_request_session (FlatpakSessionHelper  *object,
                         GDBusMethodInvocation *invocation,
                         gpointer               user_data)
@@ -472,7 +461,6 @@ on_bus_acquired (GDBusConnection *connection,
 
   flatpak_session_helper_set_version (FLATPAK_SESSION_HELPER (helper), 1);
 
-  g_signal_connect (helper, "handle-request-monitor", G_CALLBACK (handle_request_monitor), NULL);
   g_signal_connect (helper, "handle-request-session", G_CALLBACK (handle_request_session), NULL);
 
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (helper),


### PR DESCRIPTION
Nothing is using this now that we have RequestSession.
No need to carry this around.