### PR TITLE
Add a first-run warning

### DIFF
--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -149,4 +149,6 @@ const char *as_app_get_localized_name (AsApp *app);
 const char *as_app_get_localized_comment (AsApp *app);
 const char *as_app_get_version (AsApp *app);
 
+void print_wrapped (int columns, const char *text, ...) G_GNUC_PRINTF (2, 3);
+
 #endif /* __FLATPAK_BUILTINS_UTILS_H__ */

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -231,7 +231,7 @@ check_environment (void)
   int i;
   int rows, cols;
 
-  /* Avoid intering with tests */
+  /* Avoid interfering with tests */
   if (g_getenv ("FLATPAK_SYSTEM_DIR") || g_getenv ("FLATPAK_USER_DIR"))
     return;
 
@@ -260,7 +260,7 @@ check_environment (void)
       print_wrapped (cols,
                      _("Note that the directories %s are not in the search path "
                        "set by the XDG_DATA_DIRS environment variable, so applications "
-                       "installed by flatpak may not appear in your desktop until the "
+                       "installed by Flatpak may not appear on your desktop until the "
                        "session is restarted."),
                        missing);
       g_print ("\n");
@@ -274,7 +274,7 @@ check_environment (void)
       print_wrapped (cols,
                      _("Note that the directory %s is not in the search path "
                        "set by the XDG_DATA_DIRS environment variable, so applications "
-                       "installed by flatpak may not appear in your desktop until the "
+                       "installed by Flatpak may not appear on your desktop until the "
                        "session is restarted."),
                        missing);
       g_print ("\n");

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -220,6 +220,67 @@ flatpak_option_context_new_with_commands (FlatpakCommand *commands)
   return context;
 }
 
+static void
+check_environment (void)
+{
+  const char * const *dirs;
+  gboolean has_system = FALSE;
+  gboolean has_user = FALSE;
+  g_autofree char *system_exports = NULL;
+  g_autofree char *user_exports = NULL;
+  int i;
+  int rows, cols;
+
+  /* Avoid intering with tests */
+  if (g_getenv ("FLATPAK_SYSTEM_DIR") || g_getenv ("FLATPAK_USER_DIR"))
+    return;
+
+  system_exports = g_build_filename (FLATPAK_SYSTEMDIR, "exports/share", NULL);
+  user_exports = g_build_filename (g_get_user_data_dir (), "flatpak/exports/share", NULL);
+
+  dirs = g_get_system_data_dirs ();
+  for (i = 0; dirs[i]; i++)
+    {
+       if (g_str_has_prefix (dirs[i], system_exports))
+         has_system = TRUE;
+       if (g_str_has_prefix (dirs[i], user_exports))
+         has_user = TRUE;
+    }
+
+  flatpak_get_window_size (&rows, &cols);
+  if (cols > 80)
+    cols = 80;
+
+  if (!has_system && !has_user)
+    {
+      g_autofree char *missing = NULL;
+      missing = g_strdup_printf ("\n\n '%s'\n '%s'\n\n", system_exports, user_exports);
+      g_print ("\n");
+      /* Translators: this text is automatically wrapped, don't insert line breaks */
+      print_wrapped (cols,
+                     _("Note that the directories %s are not in the search path "
+                       "set by the XDG_DATA_DIRS environment variable, so applications "
+                       "installed by flatpak may not appear in your desktop until the "
+                       "session is restarted."),
+                       missing);
+      g_print ("\n");
+    }
+  else if (!has_system || !has_user)
+    {
+      g_autofree char *missing = NULL;
+      missing = g_strdup_printf ("\n\n '%s'\n\n", !has_system ? system_exports : user_exports);
+      g_print ("\n");
+      /* Translators: this text is automatically wrapped, don't insert line breaks */
+      print_wrapped (cols,
+                     _("Note that the directory %s is not in the search path "
+                       "set by the XDG_DATA_DIRS environment variable, so applications "
+                       "installed by flatpak may not appear in your desktop until the "
+                       "session is restarted."),
+                       missing);
+      g_print ("\n");
+    }
+}
+
 gboolean
 flatpak_option_context_parse (GOptionContext     *context,
                               const GOptionEntry *main_entries,
@@ -561,6 +622,8 @@ flatpak_run (int      argc,
 
   prgname = g_strdup_printf ("%s %s", g_get_prgname (), command_name);
   g_set_prgname (prgname);
+
+  check_environment ();
 
   if (!command->fn (argc, argv, cancellable, &error))
     goto out;

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -231,6 +231,10 @@ check_environment (void)
   int i;
   int rows, cols;
 
+  /* Don't recommend restarting the session when we're not in one */
+  if (!g_getenv ("DBUS_SESSION_BUS_ADDRESS"))
+    return;
+
   /* Avoid interfering with tests */
   if (g_getenv ("FLATPAK_SYSTEM_DIR") || g_getenv ("FLATPAK_USER_DIR"))
     return;


### PR DESCRIPTION
When you install flatpak and don't restart your session, the environment will not be set up properly for the desktop to find installed flatpak apps. Warn if we detect this situation.

The warning looks like this:

> XDG_DATA_DIRS= ./flatpak list
> 
> Note that the directories 
> 
>  '/var/lib/flatpak/exports/share'
>  '/home/mclasen/.local/share/flatpak/exports/share'
> 
> are not in the search path set by the XDG_DATA_DIRS
> environment variable, so applications installed by
> flatpak may not work until the session is restarted.

We are careful to only emit the warning when an actual flatpak command is used, so we don't disturb the output of e.g. `flatpak --installations`, which is used to set up the very environment variable that we are complaining about here.

We also back off if we are likely in a test situation.