### PR TITLE
doc: Add a missing comma

### DIFF
--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -218,7 +218,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This updates the [Context] group in the metadata.
-                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -235,7 +235,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -217,7 +217,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -234,7 +234,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -199,7 +199,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths
@@ -217,7 +217,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -351,7 +351,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.


### PR DESCRIPTION
Fix a pervasively copied typo.