### PR TITLE
Expand environment variables

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -506,7 +506,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                           "--bind", flatpak_file_get_path_cached (var_tmp), "/var/tmp",
                           NULL);
 
-  flatpak_run_apply_env_vars (bwrap, app_context);
+  flatpak_run_apply_env_vars (bwrap, app_context, id);
 
   if (is_app)
     {

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -66,7 +66,7 @@ struct FlatpakContext
   FlatpakContextDevices  devices_valid;
   FlatpakContextFeatures features;
   FlatpakContextFeatures features_valid;
-  GHashTable            *env_vars;
+  GPtrArray             *env_vars;
   GHashTable            *persistent;
   GHashTable            *filesystems;
   GHashTable            *session_bus_policy;

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2201,3 +2201,22 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
   if (exports_out)
     *exports_out = g_steal_pointer (&exports);
 }
+
+FlatpakContext *
+flatpak_context_load_for_deploy (FlatpakDeploy *deploy,
+                                 GError       **error)
+{
+  g_autoptr(FlatpakContext) context = NULL;
+  g_autoptr(FlatpakContext) overrides = NULL;
+  g_autoptr(GKeyFile) metakey = NULL;
+
+  metakey = flatpak_deploy_get_metadata (deploy);
+  context = flatpak_app_compute_permissions (metakey, NULL, error);
+  if (context == NULL)
+    return NULL;
+
+  overrides = flatpak_deploy_get_overrides (deploy);
+  flatpak_context_merge (context, overrides);
+
+  return g_steal_pointer (&context);
+}

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -130,7 +130,8 @@ void     flatpak_run_apply_env_default (FlatpakBwrap *bwrap,
 void     flatpak_run_apply_env_appid (FlatpakBwrap *bwrap,
                                       GFile        *app_dir);
 void      flatpak_run_apply_env_vars (FlatpakBwrap   *bwrap,
-                                      FlatpakContext *context);
+                                      FlatpakContext *context,
+                                      const char     *app_id);
 FlatpakContext *flatpak_app_compute_permissions (GKeyFile *app_metadata,
                                                  GKeyFile *runtime_metadata,
                                                  GError  **error);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3177,7 +3177,6 @@ flatpak_run_app (const char     *app_ref,
     }
 
   flatpak_run_apply_env_default (bwrap, use_ld_so_cache);
-  flatpak_run_apply_env_vars (bwrap, app_context, app_ref_parts[1]);
 
   if (real_app_id_dir)
     {
@@ -3266,6 +3265,8 @@ flatpak_run_app (const char     *app_ref,
   if (!flatpak_run_add_environment_args (bwrap, app_info_path, flags,
                                          app_ref_parts[1], app_context, app_id_dir, &exports, cancellable, error))
     return FALSE;
+
+  flatpak_run_apply_env_vars (bwrap, app_context, app_ref_parts[1]);
 
   flatpak_run_add_journal_args (bwrap);
   add_font_path_args (bwrap);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2850,25 +2850,6 @@ add_rest_args (FlatpakBwrap   *bwrap,
   return TRUE;
 }
 
-FlatpakContext *
-flatpak_context_load_for_deploy (FlatpakDeploy *deploy,
-                                 GError       **error)
-{
-  g_autoptr(FlatpakContext) context = NULL;
-  g_autoptr(FlatpakContext) overrides = NULL;
-  g_autoptr(GKeyFile) metakey = NULL;
-
-  metakey = flatpak_deploy_get_metadata (deploy);
-  context = flatpak_app_compute_permissions (metakey, NULL, error);
-  if (context == NULL)
-    return NULL;
-
-  overrides = flatpak_deploy_get_overrides (deploy);
-  flatpak_context_merge (context, overrides);
-
-  return g_steal_pointer (&context);
-}
-
 static char *
 calculate_ld_cache_checksum (GVariant   *app_deploy_data,
                              GVariant   *runtime_deploy_data,

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -701,6 +701,9 @@ void flatpak_format_choices (const char **choices,
                              const char *prompt,
                              ...) G_GNUC_PRINTF (2, 3);
 
+char *flatpak_expand_env_vars (const char  *unexpanded,
+                               char       **env);
+
 typedef void (*FlatpakProgressCallback)(const char *status,
                                         guint       progress,
                                         gboolean    estimating,

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -511,6 +511,9 @@ key=v1;v2;
         <para>
             <command>$ flatpak run --command=bash org.gnome.Sdk</command>
         </para>
+        <para>
+            <command>$ flatpak run --env=PATH=\$PATH:${XDG_DATA_HOME}/bin --command=bash org.gnome.Sdk</command>
+        </para>
 
     </refsect1>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -112,6 +112,16 @@
             Flatpak sets the environment variable <envar>FLATPAK_ID</envar> to the application
             ID of the running app.
         </para>
+        <para>
+            Flatpak expands variable references in environment variables that are set via
+            <option>--env</option>, via overrides, or via the Context section of application
+            metadata. Typical shell syntax for parameter expansion such as ${PARAMETER},
+            ${PARAMETER:-WORD} and ${PARAMETER:+WORD} is supported.
+        </para>
+        <para>
+            Note that variable expansion happens in the order in which the variables are defined,
+            first in application metadata, then in overrides, and last in the run commandline.
+        </para>
     </refsect1>
 
     <refsect1>


### PR DESCRIPTION
Support variable references in environemtn variables that
are set via --env, for example --env=PYTHONPATH=$XDG_DATA_HOME/python.
Only a fixed set of environment variables are currently expanded:

XDG_DATA_HOME
XDG_CONFIG_HOME
XDG_CACHE_HOME
PATH
HOME

The expansion happens during sandbox setup, ie. when flatpak run
is called. flatpak override will save the variable references
unexpanded.

Closes: #1415