### PR TITLE
Add a quiet transaction class

### DIFF
--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -77,6 +77,8 @@ flatpak_SOURCES = \
 	app/flatpak-complete.h \
 	app/flatpak-cli-transaction.c \
 	app/flatpak-cli-transaction.h \
+	app/flatpak-quiet-transaction.c \
+	app/flatpak-quiet-transaction.h \
 	app/parse-datetime.h \
 	$(polkit_sources) \
 	$(NULL)

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -160,7 +160,7 @@ install_bundle (FlatpakDir *dir,
   if (!flatpak_transaction_add_install_bundle (transaction, file, gpg_data, error))
     return FALSE;
 
-  if (!flatpak_cli_transaction_run (transaction, cancellable, error))
+  if (!flatpak_transaction_run (transaction, cancellable, error))
     return FALSE;
 
   return TRUE;
@@ -224,7 +224,7 @@ install_from (FlatpakDir *dir,
   if (!flatpak_transaction_add_install_flatpakref (transaction, file_data, error))
     return FALSE;
 
-  if (!flatpak_cli_transaction_run (transaction, cancellable, error))
+  if (!flatpak_transaction_run (transaction, cancellable, error))
     return FALSE;
 
   return TRUE;
@@ -484,7 +484,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
         }
     }
 
-  if (!flatpak_cli_transaction_run (transaction, cancellable, error))
+  if (!flatpak_transaction_run (transaction, cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -474,8 +474,14 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
       if (!flatpak_resolve_matching_refs (remote, dir, opt_yes, refs, id, &ref, error))
         return FALSE;
 
-      if (!flatpak_cli_transaction_add_install (transaction, remote, ref, (const char **) opt_subpaths, error))
-        return FALSE;
+      if (!flatpak_transaction_add_install (transaction, remote, ref, (const char **)opt_subpaths, error))
+        {
+          if (!g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ALREADY_INSTALLED))
+            return FALSE;
+
+          g_printerr (_("Skipping: %s\n"), (*error)->message);
+          g_clear_error (error);
+        }
     }
 
   if (!flatpak_cli_transaction_run (transaction, cancellable, error))

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -34,6 +34,7 @@
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"
 #include "flatpak-cli-transaction.h"
+#include "flatpak-quiet-transaction.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-error.h"
 #include "flatpak-chain-input-stream-private.h"
@@ -52,6 +53,7 @@ static gboolean opt_bundle;
 static gboolean opt_from;
 static gboolean opt_yes;
 static gboolean opt_reinstall;
+static gboolean opt_noninteractive;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to install for"), N_("ARCH") },
@@ -68,6 +70,7 @@ static GOptionEntry options[] = {
   { "subpath", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_subpaths, N_("Only install this subpath"), N_("PATH") },
   { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
   { "reinstall", 0, 0, G_OPTION_ARG_NONE, &opt_reinstall, N_("Uninstall first if already installed"), NULL },
+  { "noninteractive", 0, 0, G_OPTION_ARG_NONE, &opt_noninteractive, N_("Produce minimal output and don't ask questions"), NULL },
   { NULL }
 };
 
@@ -146,7 +149,10 @@ install_bundle (FlatpakDir *dir,
         return FALSE;
     }
 
-  transaction = flatpak_cli_transaction_new (dir, opt_yes, TRUE, error);
+  if (opt_noninteractive)
+    transaction = flatpak_quiet_transaction_new (dir, error);
+  else
+    transaction = flatpak_cli_transaction_new (dir, opt_yes, TRUE, error);
   if (transaction == NULL)
     return FALSE;
 
@@ -209,7 +215,10 @@ install_from (FlatpakDir *dir,
       file_data = g_bytes_new_take (g_steal_pointer (&data), data_len);
     }
 
-  transaction = flatpak_cli_transaction_new (dir, opt_yes, TRUE, error);
+  if (opt_noninteractive)
+    transaction = flatpak_quiet_transaction_new (dir, error);
+  else
+    transaction = flatpak_cli_transaction_new (dir, opt_yes, TRUE, error);
   if (transaction == NULL)
     return FALSE;
 
@@ -280,7 +289,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
 
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
 
-  g_print (_("Looking for matches…\n"));
+  if (!opt_noninteractive)
+    g_print (_("Looking for matches…\n"));
 
   if (!auto_remote &&
       (g_path_is_absolute (argv[1]) ||
@@ -418,7 +428,10 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
 
   default_branch = flatpak_dir_get_remote_default_branch (dir, remote);
 
-  transaction = flatpak_cli_transaction_new (dir, opt_yes, TRUE, error);
+  if (opt_noninteractive)
+    transaction = flatpak_quiet_transaction_new (dir, error);
+  else
+    transaction = flatpak_cli_transaction_new (dir, opt_yes, TRUE, error);
   if (transaction == NULL)
     return FALSE;
 

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -167,7 +167,15 @@ install_bundle (FlatpakDir *dir,
     return FALSE;
 
   if (!flatpak_transaction_run (transaction, cancellable, error))
-    return FALSE;
+    {
+      if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
+        {
+          g_clear_error (error);
+          return TRUE;
+        }
+
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -234,7 +242,15 @@ install_from (FlatpakDir *dir,
     return FALSE;
 
   if (!flatpak_transaction_run (transaction, cancellable, error))
-    return FALSE;
+    {
+      if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
+        {
+          g_clear_error (error);
+          return TRUE;
+        }
+
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -498,7 +514,15 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
     }
 
   if (!flatpak_transaction_run (transaction, cancellable, error))
-    return FALSE;
+    {
+      if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
+        {
+          g_clear_error (error);
+          return TRUE;
+        }
+
+      return FALSE;
+    }
 
   return TRUE;
 }

--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -34,7 +34,7 @@
 #include "flatpak-utils-private.h"
 #include "flatpak-table-printer.h"
 #include "flatpak-error.h"
-#include "flatpak-cli-transaction.h"
+#include "flatpak-quiet-transaction.h"
 
 static GOptionEntry options[] = {
   { NULL }
@@ -367,7 +367,7 @@ flatpak_builtin_repair (int argc, char **argv, GCancellable *cancellable, GError
   if (!flatpak_dir_list_refs (dir, "runtime", &runtime_refs, cancellable, NULL))
     return FALSE;
 
-  transaction = flatpak_cli_transaction_new (dir, TRUE, FALSE, error);
+  transaction = flatpak_quiet_transaction_new (dir, error);
   if (transaction == NULL)
     return FALSE;
 

--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -392,7 +392,7 @@ flatpak_builtin_repair (int argc, char **argv, GCancellable *cancellable, GError
   if (!flatpak_transaction_is_empty (transaction))
     {
       g_print (_("Reinstalling removed refs\n"));
-      if (!flatpak_cli_transaction_run (transaction, cancellable, error))
+      if (!flatpak_transaction_run (transaction, cancellable, error))
         return FALSE;
     }
 

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -349,7 +349,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
           return FALSE;
       }
 
-    if (!flatpak_cli_transaction_run (transaction, cancellable, error))
+    if (!flatpak_transaction_run (transaction, cancellable, error))
       return FALSE;
 
     if (opt_delete_data)

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -33,6 +33,7 @@
 #include "flatpak-builtins-utils.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-cli-transaction.h"
+#include "flatpak-quiet-transaction.h"
 #include <flatpak-dir-private.h>
 #include <flatpak-installation-private.h>
 #include "flatpak-error.h"
@@ -47,6 +48,7 @@ static gboolean opt_all;
 static gboolean opt_yes;
 static gboolean opt_unused;
 static gboolean opt_delete_data;
+static gboolean opt_noninteractive;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to uninstall"), N_("ARCH") },
@@ -59,6 +61,7 @@ static GOptionEntry options[] = {
   { "unused", 0, 0, G_OPTION_ARG_NONE, &opt_unused, N_("Uninstall unused"), NULL },
   { "delete-data", 0, 0, G_OPTION_ARG_NONE, &opt_delete_data, N_("Delete app data"), NULL },
   { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
+  { "noninteractive", 0, 0, G_OPTION_ARG_NONE, &opt_noninteractive, N_("Produce minimal output and don't ask questions"), NULL },
   { NULL }
 };
 
@@ -330,7 +333,10 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
   {
     g_autoptr(FlatpakTransaction) transaction = NULL;
 
-    transaction = flatpak_cli_transaction_new (udir->dir, opt_yes, TRUE, error);
+    if (opt_noninteractive)
+      transaction = flatpak_quiet_transaction_new (udir->dir, error);
+    else
+      transaction = flatpak_cli_transaction_new (udir->dir, opt_yes, TRUE, error);
     if (transaction == NULL)
       return FALSE;
 

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -356,7 +356,15 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
       }
 
     if (!flatpak_transaction_run (transaction, cancellable, error))
-      return FALSE;
+      {
+        if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
+          {
+            g_clear_error (error);
+            return TRUE;
+          }
+
+        return FALSE;
+      }
 
     if (opt_delete_data)
       {

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -242,7 +242,7 @@ flatpak_builtin_update (int           argc,
       if (flatpak_transaction_is_empty (transaction))
         continue;
 
-      if (!flatpak_cli_transaction_run (transaction, cancellable, error))
+      if (!flatpak_transaction_run (transaction, cancellable, error))
         return FALSE;
 
       if (!flatpak_transaction_is_empty (transaction))

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -252,14 +252,18 @@ flatpak_builtin_update (int           argc,
         continue;
 
       if (!flatpak_transaction_run (transaction, cancellable, error))
-        return FALSE;
+        {
+          if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
+            {
+              g_clear_error (error);
+              return TRUE;
+            }
+
+          return FALSE;
+        }
 
       if (!flatpak_transaction_is_empty (transaction))
         has_updates = TRUE;
-
-      if (FLATPAK_IS_CLI_TRANSACTION (transaction) &&
-          flatpak_cli_transaction_was_aborted (transaction))
-        return TRUE;
     }
 
   if (!has_updates)

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1065,30 +1065,6 @@ flatpak_cli_transaction_new (FlatpakDir *dir,
 }
 
 gboolean
-flatpak_cli_transaction_add_install (FlatpakTransaction *transaction,
-                                     const char         *remote,
-                                     const char         *ref,
-                                     const char        **subpaths,
-                                     GError            **error)
-{
-  g_autoptr(GError) local_error = NULL;
-
-  if (!flatpak_transaction_add_install (transaction, remote, ref, subpaths, &local_error))
-    {
-      if (g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_ALREADY_INSTALLED))
-        {
-          g_printerr (_("Skipping: %s\n"), local_error->message);
-          return TRUE;
-        }
-
-      g_propagate_error (error, g_steal_pointer (&local_error));
-      return FALSE;
-    }
-
-  return TRUE;
-}
-
-gboolean
 flatpak_cli_transaction_run (FlatpakTransaction *transaction,
                              GCancellable       *cancellable,
                              GError            **error)

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -62,7 +62,7 @@ struct _FlatpakCliTransaction
 
 struct _FlatpakCliTransactionClass
 {
-  FlatpakCliTransactionClass parent_class;
+  FlatpakTransactionClass parent_class;
 };
 
 G_DEFINE_TYPE (FlatpakCliTransaction, flatpak_cli_transaction, FLATPAK_TYPE_TRANSACTION);

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1018,6 +1018,10 @@ flatpak_cli_transaction_init (FlatpakCliTransaction *self)
 {
 }
 
+static gboolean flatpak_cli_transaction_run (FlatpakTransaction *transaction,
+                                             GCancellable       *cancellable,
+                                             GError            **error);
+
 static void
 flatpak_cli_transaction_class_init (FlatpakCliTransactionClass *klass)
 {
@@ -1032,6 +1036,7 @@ flatpak_cli_transaction_class_init (FlatpakCliTransactionClass *klass)
   transaction_class->operation_error = operation_error;
   transaction_class->choose_remote_for_ref = choose_remote_for_ref;
   transaction_class->end_of_lifed = end_of_lifed;
+  transaction_class->run = flatpak_cli_transaction_run;
 }
 
 FlatpakTransaction *
@@ -1064,7 +1069,7 @@ flatpak_cli_transaction_new (FlatpakDir *dir,
   return (FlatpakTransaction *) g_steal_pointer (&self);
 }
 
-gboolean
+static gboolean
 flatpak_cli_transaction_run (FlatpakTransaction *transaction,
                              GCancellable       *cancellable,
                              GError            **error)
@@ -1074,7 +1079,7 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
   g_autoptr(GError) local_error = NULL;
   gboolean res;
 
-  res = flatpak_transaction_run (transaction, cancellable, &local_error);
+  res = FLATPAK_TRANSACTION_CLASS (flatpak_cli_transaction_parent_class)->run (transaction, cancellable, &local_error);
 
   if (flatpak_fancy_output ())
     g_print (FLATPAK_ANSI_SHOW_CURSOR);

--- a/app/flatpak-cli-transaction.h
+++ b/app/flatpak-cli-transaction.h
@@ -32,6 +32,4 @@ FlatpakTransaction * flatpak_cli_transaction_new (FlatpakDir * dir,
                                                   gboolean stop_on_first_error,
                                                   GError * *error);
 
-gboolean flatpak_cli_transaction_was_aborted (FlatpakTransaction *transaction);
-
 #endif /* __FLATPAK_CLI_TRANSACTION_H__ */

--- a/app/flatpak-cli-transaction.h
+++ b/app/flatpak-cli-transaction.h
@@ -34,8 +34,4 @@ FlatpakTransaction * flatpak_cli_transaction_new (FlatpakDir * dir,
 
 gboolean flatpak_cli_transaction_was_aborted (FlatpakTransaction *transaction);
 
-gboolean flatpak_cli_transaction_run (FlatpakTransaction *transaction,
-                                      GCancellable       *cancellable,
-                                      GError            **error);
-
 #endif /* __FLATPAK_CLI_TRANSACTION_H__ */

--- a/app/flatpak-cli-transaction.h
+++ b/app/flatpak-cli-transaction.h
@@ -32,11 +32,6 @@ FlatpakTransaction * flatpak_cli_transaction_new (FlatpakDir * dir,
                                                   gboolean stop_on_first_error,
                                                   GError * *error);
 
-gboolean flatpak_cli_transaction_add_install (FlatpakTransaction *self,
-                                              const char         *remote,
-                                              const char         *ref,
-                                              const char        **subpaths,
-                                              GError            **error);
 gboolean flatpak_cli_transaction_was_aborted (FlatpakTransaction *transaction);
 
 gboolean flatpak_cli_transaction_run (FlatpakTransaction *transaction,

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+
+#include "flatpak-quiet-transaction.h"
+#include "flatpak-transaction-private.h"
+#include "flatpak-installation-private.h"
+#include "flatpak-run-private.h"
+#include "flatpak-table-printer.h"
+#include "flatpak-utils-private.h"
+#include "flatpak-error.h"
+#include <glib/gi18n.h>
+
+
+struct _FlatpakQuietTransaction
+{
+  FlatpakTransaction parent;
+};
+
+struct _FlatpakQuietTransactionClass
+{
+  FlatpakTransactionClass parent_class;
+};
+
+G_DEFINE_TYPE (FlatpakQuietTransaction, flatpak_quiet_transaction, FLATPAK_TYPE_TRANSACTION);
+
+static int
+choose_remote_for_ref (FlatpakTransaction *transaction,
+                       const char         *for_ref,
+                       const char         *runtime_ref,
+                       const char * const *remotes)
+{
+  return 0;
+}
+
+static gboolean
+add_new_remote (FlatpakTransaction            *transaction,
+                FlatpakTransactionRemoteReason reason,
+                const char                    *from_id,
+                const char                    *remote_name,
+                const char                    *url)
+{
+  return TRUE;
+}
+
+static void
+new_operation (FlatpakTransaction          *transaction,
+               FlatpakTransactionOperation *op,
+               FlatpakTransactionProgress  *progress)
+{
+  FlatpakTransactionOperationType op_type = flatpak_transaction_operation_get_operation_type (op);
+  const char *ref = flatpak_transaction_operation_get_ref (op);
+
+  switch (op_type)
+    {
+    case FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE:
+    case FLATPAK_TRANSACTION_OPERATION_INSTALL:
+      g_print (_("Installing %s\n"), ref);
+      break;
+
+    case FLATPAK_TRANSACTION_OPERATION_UPDATE:
+      g_print (_("Updating %s\n"), ref);
+      break;
+
+    case FLATPAK_TRANSACTION_OPERATION_UNINSTALL:
+      g_print (_("Uninstalling %s\n"), ref);
+      break;
+
+    default:
+      g_assert_not_reached ();
+      break;
+    }
+}
+
+static void
+flatpak_quiet_transaction_init (FlatpakQuietTransaction *transaction)
+{
+}
+
+static void
+flatpak_quiet_transaction_class_init (FlatpakQuietTransactionClass *class)
+{
+  FlatpakTransactionClass *transaction_class = FLATPAK_TRANSACTION_CLASS (class);
+
+  transaction_class->choose_remote_for_ref = choose_remote_for_ref;
+  transaction_class->add_new_remote = add_new_remote;
+  transaction_class->new_operation = new_operation;
+}
+
+FlatpakTransaction *
+flatpak_quiet_transaction_new (FlatpakDir  *dir,
+                               GError     **error)
+{
+  g_autoptr(FlatpakQuietTransaction) self = NULL;
+  g_autoptr(FlatpakInstallation) installation = NULL;
+
+  installation = flatpak_installation_new_for_dir (dir, NULL, error);
+  if (installation == NULL)
+    return NULL;
+
+  flatpak_installation_set_no_interaction (installation, TRUE);
+
+  self = g_initable_new (FLATPAK_TYPE_QUIET_TRANSACTION,
+                         NULL, error,
+                         "installation", installation,
+                         NULL);
+
+  if (self == NULL)
+    return NULL;
+
+  flatpak_transaction_add_default_dependency_sources (FLATPAK_TRANSACTION (self));
+
+  return FLATPAK_TRANSACTION (g_steal_pointer (&self));
+}

--- a/app/flatpak-quiet-transaction.h
+++ b/app/flatpak-quiet-transaction.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#ifndef __FLATPAK_QUIET_TRANSACTION_H__
+#define __FLATPAK_QUIET_TRANSACTION_H__
+
+#include "flatpak-transaction.h"
+#include "flatpak-dir-private.h"
+
+#define FLATPAK_TYPE_QUIET_TRANSACTION flatpak_quiet_transaction_get_type ()
+G_DECLARE_FINAL_TYPE (FlatpakQuietTransaction, flatpak_quiet_transaction, FLATPAK, QUIET_TRANSACTION, FlatpakTransaction)
+
+FlatpakTransaction * flatpak_quiet_transaction_new (FlatpakDir  *dir,
+                                                    GError     **error);
+
+#endif /* __FLATPAK_QUIET_TRANSACTION_H__ */

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -897,6 +897,10 @@ flatpak_transaction_add_new_remote (FlatpakTransaction            *transaction,
   return FALSE;
 }
 
+static gboolean flatpak_transaction_real_run (FlatpakTransaction  *transaction,
+                                              GCancellable        *cancellable,
+                                              GError             **error);
+
 static void
 flatpak_transaction_class_init (FlatpakTransactionClass *klass)
 {
@@ -904,6 +908,7 @@ flatpak_transaction_class_init (FlatpakTransactionClass *klass)
 
   klass->ready = flatpak_transaction_ready;
   klass->add_new_remote = flatpak_transaction_add_new_remote;
+  klass->run = flatpak_transaction_real_run;
   object_class->finalize = flatpak_transaction_finalize;
   object_class->get_property = flatpak_transaction_get_property;
   object_class->set_property = flatpak_transaction_set_property;
@@ -2723,6 +2728,14 @@ gboolean
 flatpak_transaction_run (FlatpakTransaction *self,
                          GCancellable       *cancellable,
                          GError            **error)
+{
+  return FLATPAK_TRANSACTION_GET_CLASS (self)->run (self, cancellable, error);
+}
+
+static gboolean
+flatpak_transaction_real_run (FlatpakTransaction *self,
+                              GCancellable       *cancellable,
+                              GError            **error)
 {
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
   GList *l, *next;

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -121,7 +121,12 @@ struct _FlatpakTransactionClass
                               const char                    *from_id,
                               const char                    *remote_name,
                               const char                    *url);
-  gpointer padding[10];
+
+  gboolean (*run)            (FlatpakTransaction  *transaction,
+                              GCancellable        *cancellable,
+                              GError             **error);
+                   
+  gpointer padding[9];
 };
 
 FLATPAK_EXTERN

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -256,6 +256,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--noninteractive</option></term>
+                <listitem><para>
+                    Produce minimal output and avoid most questions. This is suitable for use in
+                    non-interactive situations, e.g. in a build script.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 

--- a/doc/flatpak-uninstall.xml
+++ b/doc/flatpak-uninstall.xml
@@ -164,6 +164,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--noninteractive</option></term>
+                <listitem><para>
+                    Produce minimal output and avoid most questions. This is suitable for use in
+                    non-interactive situations, e.g. in a build script.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--app</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-update.xml
+++ b/doc/flatpak-update.xml
@@ -223,6 +223,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--noninteractive</option></term>
+                <listitem><para>
+                    Produce minimal output and avoid most questions. This is suitable for use in
+                    non-interactive situations, e.g. in a build script.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--force-remove</option></term>
                 <listitem><para>
                     Remove old files even if they're in use by a running application.


### PR DESCRIPTION
This is a more systematic approach: Introduce a new transaction implementation, and use it where the output of FlatpakCliTransaction is not appropriate. 

This adds --noninteractive options to the install, update and uninstall commands.