### PR TITLE
cli-transaction: Use Op instead of Change for title

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -870,6 +870,7 @@ transaction_ready (FlatpakTransaction *transaction)
   if (self->installing + self->updating + self->uninstalling > 1)
     {
       flatpak_table_printer_set_column_expand (printer, i, TRUE);
+      /* translators: This is short for operation, the title of a one-char column */
       flatpak_table_printer_set_column_title (printer, i++, _("Op"));
     }
 

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -870,7 +870,7 @@ transaction_ready (FlatpakTransaction *transaction)
   if (self->installing + self->updating + self->uninstalling > 1)
     {
       flatpak_table_printer_set_column_expand (printer, i, TRUE);
-      flatpak_table_printer_set_column_title (printer, i++, _("Change"));
+      flatpak_table_printer_set_column_title (printer, i++, _("Op"));
     }
 
   if (self->installing || self->updating)


### PR DESCRIPTION
This uses less horizontal space, given that all the elements in the
column is one-character strings. Also, Op seems to better describe this
than Change.