### PR TITLE
Fix non-srcdir builds

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -37,6 +37,7 @@ testcommon_CFLAGS = \
 	$(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
 	-I$(srcdir)/app \
+	-I$(builddir)/app \
 	$(NULL)
 testcommon_LDADD = \
 	$(AM_LDADD) \


### PR DESCRIPTION
The generated DBus permission header is included by an header in under
app/ that we include from testcommon.c. We already added the app/
directory under the source directory, but we need to include the same
directory under the build directory in order for the compiler to find
the generated header.

Fixes the build in GNOME Continuous, which is failing with:

```
In file included from ../tests/testcommon.c:10:0:
../app/flatpak-builtins-utils.h:28:47: fatal error: flatpak-permission-dbus-generated.h: No such file or directory
compilation terminated.
```