### PR TITLE
Show the cursor on exit

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -993,7 +993,7 @@ transaction_ready (FlatpakTransaction *transaction)
 
   if (flatpak_fancy_output ())
     {
-      g_print (FLATPAK_ANSI_HIDE_CURSOR);
+      flatpak_hide_cursor ();
       redraw (self);
     }
 
@@ -1082,7 +1082,7 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
   res = FLATPAK_TRANSACTION_CLASS (flatpak_cli_transaction_parent_class)->run (transaction, cancellable, error);
 
   if (flatpak_fancy_output ())
-    g_print (FLATPAK_ANSI_SHOW_CURSOR);
+    flatpak_show_cursor ();
 
   if (res && self->n_ops > 0)
     {

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -621,6 +621,13 @@ complete (int    argc,
   return 0;
 }
 
+static void
+handle_sigterm (int signum)
+{
+   flatpak_show_cursor ();
+  _exit (1);
+}
+
 int
 main (int    argc,
       char **argv)
@@ -632,6 +639,13 @@ main (int    argc,
   PolkitAgentListener *listener = NULL;
   gpointer agent = NULL;
 #endif
+  struct sigaction action;
+
+  memset (&action, 0, sizeof (struct sigaction));
+  action.sa_handler = handle_sigterm;
+  sigaction (SIGTERM, &action, NULL);
+  sigaction (SIGHUP, &action, NULL);
+  sigaction (SIGINT, &action, NULL);
 
   setlocale (LC_ALL, "");
   bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -58,6 +58,8 @@ typedef enum {
 
 void flatpak_get_window_size (int *rows, int *cols);
 gboolean flatpak_get_cursor_pos  (int *row, int *col);
+void flatpak_hide_cursor (void);
+void flatpak_show_cursor (void);
 
 /* https://bugzilla.gnome.org/show_bug.cgi?id=766370 */
 #if !GLIB_CHECK_VERSION (2, 49, 3)

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6117,3 +6117,15 @@ flatpak_get_cursor_pos (int* row, int *col)
 
   return res == 2;
 }
+
+void
+flatpak_hide_cursor (void)
+{
+  write (STDOUT_FILENO, FLATPAK_ANSI_HIDE_CURSOR, strlen (FLATPAK_ANSI_HIDE_CURSOR));
+}
+
+void
+flatpak_show_cursor (void)
+{
+  write (STDOUT_FILENO, FLATPAK_ANSI_SHOW_CURSOR, strlen (FLATPAK_ANSI_SHOW_CURSOR));
+}


### PR DESCRIPTION
When a running cli transaction is interupted by Ctrl-C, we exit with a hidden cursor. Add a signal handler which shows the cursor before exiting.
    
Closes: #2561
