### PR TITLE
Refuse to let root modify a user repo

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -170,7 +170,7 @@ redraw (FlatpakCliTransaction *self)
   int current_col;
   int skip;
 
-  /* We may have resized and thus reposisioned the cursor since last redraw */
+  /* We may have resized and thus repositioned the cursor since last redraw */
   flatpak_get_window_size (&self->rows, &self->cols);
   if (flatpak_get_cursor_pos (&current_row, &current_col))
     {

--- a/common/flatpak-error.h
+++ b/common/flatpak-error.h
@@ -54,6 +54,8 @@ G_BEGIN_DECLS
  * @FLATPAK_ERROR_RUNTIME_USED: Runtime can't be uninstalled. (Since: 1.0.3)
  * @FLATPAK_ERROR_INVALID_NAME: Application, runtime or remote name is invalid. (Since: 1.0.3)
  * @FLATPAK_ERROR_OUT_OF_SPACE: More disk space needed. (Since: 1.2.0)
+ * @FLATPAK_ERROR_WRONG_USER: An operation is being attempted by the wrong user (such as
+ *                            root operating on a user installation). (Since: 1.2.0)
  *
  * Error codes for library functions.
  */
@@ -77,6 +79,7 @@ typedef enum {
   FLATPAK_ERROR_RUNTIME_USED,
   FLATPAK_ERROR_INVALID_NAME,
   FLATPAK_ERROR_OUT_OF_SPACE,
+  FLATPAK_ERROR_WRONG_USER,
 } FlatpakError;
 
 /**


### PR DESCRIPTION
If the user (erroneously) runs as root while modifying their user
installation, this can cause "permission denied" errors later on when
they try to operate on the installation as their own user. So emit a
warning when preparing to execute a transaction on a user-owned
installation as root.

Fixes https://github.com/flatpak/flatpak/issues/2565