### PR TITLE
run: Fix completion

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -248,7 +248,8 @@ flatpak_complete_run (FlatpakCompletion *completion)
   g_option_context_add_group (context, flatpak_context_get_options (arg_context));
 
   if (!flatpak_option_context_parse (context, options, &completion->argc, &completion->argv,
-                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS, NULL, NULL, NULL))
+                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS | FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO,
+                                     NULL, NULL, NULL))
     return FALSE;
 
   switch (completion->argc)


### PR DESCRIPTION
We should probably just use OPTIONAL_REPO throughout in complete implementations 