### PR TITLE
Improve flatpak_installation_get_id/display_name()

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1670,6 +1670,9 @@ flatpak_dir_get_changed_path (FlatpakDir *self)
 const char *
 flatpak_dir_get_id (FlatpakDir *self)
 {
+  if (self->user)
+    return "user";
+
   if (self->extra_data != NULL)
     return self->extra_data->id;
 
@@ -1709,6 +1712,9 @@ flatpak_dir_get_name_cached (FlatpakDir *self)
 const char *
 flatpak_dir_get_display_name (FlatpakDir *self)
 {
+  if (self->user)
+    return _("User installation");
+
   if (self->extra_data != NULL)
     return self->extra_data->display_name;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -63,7 +63,7 @@
 #define SYSCONF_REMOTES_DIR "remotes.d"
 
 #define SYSTEM_DIR_DEFAULT_ID "default"
-#define SYSTEM_DIR_DEFAULT_DISPLAY_NAME "Default system directory"
+#define SYSTEM_DIR_DEFAULT_DISPLAY_NAME _("Default system installation")
 #define SYSTEM_DIR_DEFAULT_STORAGE_TYPE FLATPAK_DIR_STORAGE_TYPE_DEFAULT
 #define SYSTEM_DIR_DEFAULT_PRIORITY 0
 

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -63,7 +63,7 @@
  * To get a list of all configured installations, use flatpak_get_system_installations(),
  * together with flatpak_installation_new_user().
  *
- * The FlatpakInstallatio nAPI is threadsafe in the sense that it is safe to run two
+ * The FlatpakInstallation API is threadsafe in the sense that it is safe to run two
  * operations at the same time, in different threads (or processes).
  */
 
@@ -500,6 +500,9 @@ flatpak_installation_get_path (FlatpakInstallation *self)
  *
  * Returns the ID of the installation for @self.
  *
+ * The ID for the default system installation is "default".
+ * The ID for the user installation is 'user'.
+ *
  * Returns: (transfer none): a string with the installation's ID
  *
  * Since: 0.8
@@ -517,6 +520,9 @@ flatpak_installation_get_id (FlatpakInstallation *self)
  * @self: a #FlatpakInstallation
  *
  * Returns the display name of the installation for @self.
+ *
+ * Note that this function may return %NULL if the installation
+ * does not have a display name.
  *
  * Returns: (transfer none): a string with the installation's display name
  *

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -501,7 +501,7 @@ flatpak_installation_get_path (FlatpakInstallation *self)
  * Returns the ID of the installation for @self.
  *
  * The ID for the default system installation is "default".
- * The ID for the user installation is 'user'.
+ * The ID for the user installation is "user".
  *
  * Returns: (transfer none): a string with the installation's ID
  *

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -131,7 +131,7 @@ test_multiple_system_installations (void)
     { "extra-installation-2", "Extra system installation 2", 25, FLATPAK_STORAGE_TYPE_SDCARD},
     { "extra-installation-1", "Extra system installation 1", 10, FLATPAK_STORAGE_TYPE_MMC},
     { "extra-installation-3", NULL, 0, FLATPAK_STORAGE_TYPE_DEFAULT},
-    { "default", "Default system directory", 0, FLATPAK_STORAGE_TYPE_DEFAULT},
+    { "default", "Default system installation", 0, FLATPAK_STORAGE_TYPE_DEFAULT},
   };
 
   g_autoptr(GPtrArray) system_dirs = NULL;


### PR DESCRIPTION
Arrange for flatpak_installation_get_id() and flatpak_instllation_get_display_name() to always return non-NULL strings, for a nicer api. They are only useful in output, and having to check for NULL is just an unnecessary hassle.