### PR TITLE
list: Fix a typo in the docs

### DIFF
--- a/doc/flatpak-list.xml
+++ b/doc/flatpak-list.xml
@@ -309,7 +309,7 @@
         <title>Examples</title>
 
         <para>
-            <command>$ flatpak --user --column=app list</command>
+            <command>$ flatpak --user --columns=app list</command>
         </para>
 <programlisting>
 <command>Application</command>


### PR DESCRIPTION
Its --columns, not --column.

Closes: #2568