### PR TITLE
dir: Delete some outdated comments

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7841,8 +7841,6 @@ flatpak_dir_install (FlatpakDir          *self,
 
           flatpak_flags |= FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA;
 
-          /* Don’t resolve a rev or OstreeRepoFinderResult set early; the pull
-           * code will do this. */
           if (!flatpak_dir_pull (self, state, ref, opt_commit, NULL, subpaths,
                                  child_repo,
                                  flatpak_flags,
@@ -7884,8 +7882,6 @@ flatpak_dir_install (FlatpakDir          *self,
 
   if (!no_pull)
     {
-      /* Don’t resolve a rev or OstreeRepoFinderResult set early; the pull
-       * code will do this. */
       if (!flatpak_dir_pull (self, state, ref, opt_commit, NULL, opt_subpaths, NULL,
                              flatpak_flags, OSTREE_REPO_PULL_FLAGS_NONE,
                              progress, cancellable, error))


### PR DESCRIPTION
It's no longer true that it's the pull code's job to resolve a ref to a
specific commit. Ever since commit 66eee3c2c this is the job of the
resolve_ops() function used by FlatpakTransaction (at least, when a
transaction is being used). So update a couple comments to avoid
confusion.