### PR TITLE
flatpak.sh: Avoid bashism (to support dash)

### DIFF
--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -1,6 +1,7 @@
 # set XDG_DATA_DIRS to include Flatpak installations
 
 new_dirs=
+(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak" && flatpak --installations) |
 while read -r install_path
 do
     share_path=$install_path/exports/share
@@ -9,7 +10,7 @@ do
         *":$share_path/:"*) :;;
         *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
     esac
-done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; flatpak --installations)
+done
 
 export XDG_DATA_DIRS
 XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"


### PR DESCRIPTION
Use a pipe instead of process substitution in flatpak.sh so that it
works when /bin/sh points to dash instead of bash (and hopefully other
shells too). Otherwise gdm fails to start a session on Endless OS with
the error:

Jan 15 12:29:10 endless /etc/gdm3/Xsession[1608]: /etc/gdm3/Xsession:
12: /etc/profile.d/flatpak.sh: Syntax error: redirection unexpected

Fixes https://github.com/flatpak/flatpak/issues/2594