### PR TITLE
profile: Don't rely on bash syntax

### DIFF
--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -1,15 +1,23 @@
 # set XDG_DATA_DIRS to include Flatpak installations
 
-new_dirs=
-while read -r install_path
-do
-    share_path=$install_path/exports/share
-    case ":$XDG_DATA_DIRS:" in
-        *":$share_path:"*) :;;
-        *":$share_path/:"*) :;;
-        *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
-    esac
-done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; flatpak --installations)
+new_dirs=$(
+    (
+        echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
+        flatpak --installations
+    ) | (
+        new_dirs=
+        while read -r install_path
+        do
+            share_path=$install_path/exports/share
+            case ":$XDG_DATA_DIRS:" in
+                *":$share_path:"*) :;;
+                *":$share_path/:"*) :;;
+                *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
+            esac
+        done
+        echo "$new_dirs"
+    )
+)
 
 export XDG_DATA_DIRS
 XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"


### PR DESCRIPTION
In Debian, we reuse flatpak.sh in /etc/X11/Xsession.d (which is sourced
by /bin/sh, normally dash) so that these environment variables become
part of the X11 session environment. We might also have
non-bash-compatible shells that read profile.d (I'm not sure).