### PR TITLE
Fix xml syntax in org.freedesktop.portal.Flatpak.xml

### DIFF
--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -111,7 +111,6 @@
                The files must be in the <filename>sandbox</filename> subdirectory of
                the instance directory (i.e. <filename>~/.var/app/$APP_ID/sandbox</filename>).
              </para></listitem>
-             </para></listitem>
            </varlistentry>
          </variablelist>
 


### PR DESCRIPTION
A bit concerning that this does not break the build.
It did break the docs build in xdg-desktop-portal.