### PR TITLE
testcommon: An i386 Flatpak doesn't support x86_64 apps

### DIFF
--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -48,7 +48,7 @@ test_arches (void)
 
 #if defined(__i386__)
   g_assert_cmpstr (flatpak_get_arch (), ==, "i386");
-  g_assert_true (g_strv_contains (arches, "x86_64"));
+  g_assert_false (g_strv_contains (arches, "x86_64"));
   g_assert_true (g_strv_contains (arches, "i386"));
 #elif defined(__x86_64__)
   g_assert_cmpstr (flatpak_get_arch (), ==, "x86_64");


### PR DESCRIPTION
The compatible architectures are not symmetric: x86_64 and aarch64 can
run i386 and arm binaries, but i386 and arm cannot usually run x86_64
and aarch64 binaries.

This caused test failures on Debian i386 autobuilders.