### PR TITLE
info, remote-info: Use print_wrapped

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -184,12 +184,14 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       const char *xa_metadata = NULL;
       const char *collection_id = NULL;
 
+      flatpak_get_window_size (&rows, &cols);
+
       if (name)
         {
           if (summary)
-            g_print ("\n%s - %s\n\n", name, summary);
+            print_wrapped (MIN (cols, 80), "\n%s - %s\n", name, summary);
           else
-            g_print ("\n%s\n\n", name);
+            print_wrapped (MIN (cols, 80), "\n%s\n", name);
         }
 
       latest = flatpak_dir_read_latest (dir, origin, ref, NULL, NULL, NULL);
@@ -253,7 +255,6 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
         len = MAX (len, g_utf8_strlen (_("Subdirectories:"), -1));
       len = MAX (len, g_utf8_strlen (_("Extension:"), -1));
 
-      flatpak_get_window_size (&rows, &cols);
       width = cols - (len + 1);
 
       print_aligned (len, _("ID:"), parts[1]);

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -169,6 +169,8 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       const char *version = NULL;
       const char *license = NULL;
 
+      flatpak_get_window_size (&rows, &cols);
+
 #if AS_CHECK_VERSION (0, 6, 1)
       as_store_set_add_flags (store, as_store_get_add_flags (store) | AS_STORE_ADD_FLAG_USE_UNIQUE_ID);
 #endif
@@ -179,7 +181,9 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
         {
           const char *name = as_app_get_localized_name (app);
           const char *comment = as_app_get_localized_comment (app);
-          g_print ("\n%s - %s\n\n", name, comment);
+
+          print_wrapped (MIN (cols, 80), "\n%s - %s\n", name, comment);
+
           version = as_app_get_version (app);
           license = as_app_get_project_license (app);
         }
@@ -243,7 +247,6 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       if (opt_log)
         len = MAX (len, g_utf8_strlen (_("History:"), -1));
 
-      flatpak_get_window_size (&rows, &cols);
       width = cols - (len + 1);
 
       print_aligned (len, _("ID:"), parts[1]);


### PR DESCRIPTION
This makes the NAME - DESCRIPTION line at the top wrap nicely at word boundaries.