### PR TITLE
icon-validator: Use readlink() properly

### DIFF
--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -132,9 +132,17 @@ rerun_in_sandbox (const char *arg_width,
   g_autofree char *err = NULL;
   int status;
   g_autoptr(GError) error = NULL;
-  char validate_icon[256];
+  char validate_icon[PATH_MAX + 1];
+  ssize_t symlink_size;
 
-  readlink ("/proc/self/exe", validate_icon, 256);
+  symlink_size = readlink ("/proc/self/exe", validate_icon, sizeof (validate_icon) - 1);
+  if (symlink_size < 0)
+    {
+      g_printerr ("Error: failed to read /proc/self/exe\n");
+      return 1;
+    }
+
+  validate_icon[symlink_size] = 0;
 
   add_args (args,
             flatpak_get_bwrap (),


### PR DESCRIPTION
This function helpfully does not 0-terminate the buffer, so we have to do that ourselves. Also make the buffer as large as possibly required, and handle errors.