### PR TITLE
Use raw mode

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -994,6 +994,7 @@ transaction_ready (FlatpakTransaction *transaction)
   if (flatpak_fancy_output ())
     {
       flatpak_hide_cursor ();
+      flatpak_enable_raw_mode ();
       redraw (self);
     }
 
@@ -1082,7 +1083,10 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
   res = FLATPAK_TRANSACTION_CLASS (flatpak_cli_transaction_parent_class)->run (transaction, cancellable, error);
 
   if (flatpak_fancy_output ())
-    flatpak_show_cursor ();
+    {
+      flatpak_disable_raw_mode ();
+      flatpak_show_cursor ();
+    }
 
   if (res && self->n_ops > 0)
     {

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -696,7 +696,8 @@ complete (int    argc,
 static void
 handle_sigterm (int signum)
 {
-   flatpak_show_cursor ();
+  flatpak_disable_raw_mode ();
+  flatpak_show_cursor ();
   _exit (1);
 }
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -61,6 +61,9 @@ gboolean flatpak_get_cursor_pos  (int *row, int *col);
 void flatpak_hide_cursor (void);
 void flatpak_show_cursor (void);
 
+void flatpak_enable_raw_mode (void);
+void flatpak_disable_raw_mode (void);
+
 /* https://bugzilla.gnome.org/show_bug.cgi?id=766370 */
 #if !GLIB_CHECK_VERSION (2, 49, 3)
 #define FLATPAK_VARIANT_BUILDER_INITIALIZER {{0, }}

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6129,3 +6129,27 @@ flatpak_show_cursor (void)
 {
   write (STDOUT_FILENO, FLATPAK_ANSI_SHOW_CURSOR, strlen (FLATPAK_ANSI_SHOW_CURSOR));
 }
+
+void
+flatpak_enable_raw_mode (void)
+{
+  struct termios raw;
+
+  tcgetattr (STDIN_FILENO, &raw);
+
+  raw.c_lflag &= ~(ECHO | ICANON);
+
+  tcsetattr (STDIN_FILENO, TCSAFLUSH, &raw);
+}
+
+void
+flatpak_disable_raw_mode (void)
+{
+  struct termios raw;
+
+  tcgetattr (STDIN_FILENO, &raw);
+
+  raw.c_lflag |= (ECHO | ICANON);
+
+  tcsetattr (STDIN_FILENO, TCSAFLUSH, &raw);
+}


### PR DESCRIPTION
By hitting backspace during the cli transaction progress display, we can make partial escape sequences show up in the visible output. Prevent that by switching the terminal to raw mode.