### PR TITLE
build-commit-from: Fix handling of ostree.collection-refs-binding

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -511,7 +511,7 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
           if (strcmp (key, "xa.ref") == 0 ||
               strcmp (key, "xa.from_commit") == 0 ||
               strcmp (key, "ostree.collection-binding") == 0 ||
-              strcmp (key, "ostree.collections-binding") == 0 ||
+              strcmp (key, "ostree.collection-refs-binding") == 0 ||
               strcmp (key, "ostree.ref-binding") == 0)
             continue;
 


### PR DESCRIPTION
In a previous iteration of the work for supporting multiple collection
bindings on a commit[1][2] the key ostree.collections-binding was used,
but it was decided that ostree.collection-refs-binding makes more sense.
So update build-commit-from in one place where the old key was still
being used. This impact of this bug is that we would overwrite the value
of ostree.collection-refs-binding on the new commit with the one on the
source commit (which may not have all the same collection-refs
associated with it).  However since the libostree support for that key
hasn't been merged that wouldn't cause any problems yet.

[1] https://github.com/flatpak/flatpak/pull/2634
[2] https://github.com/ostreedev/ostree/pull/1805