### PR TITLE
Handle versions of appstream-glib prior to 0.5.15

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1142,7 +1142,9 @@ as_store_find_app (AsStore *store,
           AsApp *app = g_ptr_array_index (apps, i);
           AsBundle *bundle = as_app_get_bundle_default (app);
           if (bundle &&
+#if AS_CHECK_VERSION(0,5,15)
               as_bundle_get_kind (bundle) == AS_BUNDLE_KIND_FLATPAK &&
+#endif
               g_str_equal (as_bundle_get_id (bundle), ref))
             return app;
         }


### PR DESCRIPTION
These don't have AS_BUNDLE_KIND_FLATPAK, but we can just
assume all bundles are flatpak bundles in the appstream data
we get from flatpak.