### PR TITLE
build-export: Allow sandboxing on icon validator to be disabled

### DIFF
--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -96,7 +96,7 @@ ln -s -t ${DIR}/files/share/locale ../../share/runtime/locale/fr/share/fr
 
 flatpak build-finish --command=hello.sh ${DIR}
 mkdir -p repos
-flatpak build-export ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR}
+flatpak build-export --disable-sandbox ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR}
 rm -rf ${DIR}
 
 # build a locale extension

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -85,5 +85,5 @@ else
 fi
 
 mkdir -p repos
-flatpak build-export ${collection_args} --runtime ${GPGARGS-} ${REPO} ${DIR}
+flatpak build-export ${collection_args} --disable-sandbox --runtime ${GPGARGS-} ${REPO} ${DIR}
 rm -rf ${DIR}


### PR DESCRIPTION
During build-time tests, bwrap doesn't necessarily work. In particular, official Debian autobuilders can't enter namespaces.

We continue to leave the sandbox enabled in the build-export calls in tests/test-extensions.sh, tests/test-unsigned-summaries.sh and tests/test-update-remote-configuration.sh, which are already skipped if bwrap isn't available. This means we exercise both the normal and --disable-sandbox code paths.

This could also be useful for CI pipelines that are run in environments where bwrap is not allowed, such as inside a container created by something like bwrap (without providing the necessary capabilities to nest containers) - see #2660.