### PR TITLE
profile: Unbreak XDG_DATA_DIRS when debug logging is enabled

### DIFF
--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -2,6 +2,7 @@
 
 new_dirs=$(
     (
+        unset G_MESSAGES_DEBUG
         echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
         flatpak --installations
     ) | (


### PR DESCRIPTION
If G_MESSAGES_DEBUG is set in the shell's start-up scripts, then the
"flatpak --installations" output is contaminated with these strings:
  (flatpak:4558): flatpak-DEBUG: ...

Fallout from 30c29196247103283b1f2c43e2d59b26930a8f8c