### PR TITLE
appdata: Ignore allowed attributes

### DIFF
--- a/common/flatpak-appdata.c
+++ b/common/flatpak-appdata.c
@@ -148,9 +148,12 @@ start_element (GMarkupParseContext *context,
                                        attribute_names,
                                        attribute_values,
                                        error,
+                                       G_MARKUP_COLLECT_STRING, "version", &version,
                                        G_MARKUP_COLLECT_STRING | G_MARKUP_COLLECT_OPTIONAL, "timestamp", &timestamp,
                                        G_MARKUP_COLLECT_STRING | G_MARKUP_COLLECT_OPTIONAL, "date", &date,
-                                       G_MARKUP_COLLECT_STRING, "version", &version,
+                                       G_MARKUP_COLLECT_STRING | G_MARKUP_COLLECT_OPTIONAL, "date_eol", NULL,
+                                       G_MARKUP_COLLECT_STRING | G_MARKUP_COLLECT_OPTIONAL, "urgency", NULL,
+                                       G_MARKUP_COLLECT_STRING | G_MARKUP_COLLECT_OPTIONAL, "type", NULL,
                                        G_MARKUP_COLLECT_INVALID))
         {
           guint64 ts = 0;

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -473,7 +473,7 @@ test_parse_appdata (void)
     "      <release timestamp=\"1525132800\" version=\"0.1.0\"/>\n"
     "      <release timestamp=\"1525000800\" date=\"2018-05-02\" version=\"0.0.2\"/>\n"
     "      <release date=\"2017-05-02\" version=\"0.0.3\"/>\n"
-    "      <release timestamp=\"1000000000\" version=\"0.0.1\"/>\n"
+    "      <release timestamp=\"1000000000\" version=\"0.0.1\" type=\"stable\" urgency=\"low\"/>\n"
     "    </releases>\n"
     "    <project_license>anything goes</project_license>\n"
     "  </component>\n"


### PR DESCRIPTION
We only interested in a few of the attributes of some
tags, but we shouldn't fail if other valid attributes
are present.

Add some of the allowed attributes to the <release> element
in the appdata test and verify that we can still parse it.

Closes: #2670 