### PR TITLE
icon validator: Use exec for the sandboxing

### DIFF
--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -202,7 +202,7 @@ rerun_in_sandbox (const char *arg_width,
     g_debug ("Icon validation: Spawning %s", cmdline);
   }
 
-  if (!g_spawn_sync (NULL, (char **)args->pdata, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &err, &status, &error))
+  if (execvpe (flatpak_get_bwrap (), (char **) args->pdata, NULL) == -1)
     {
       g_debug ("Icon validation: %s", error->message);
       return 1;


### PR DESCRIPTION
We don't really need a separate process here, and
doing things this way makes output from the sandbox
appear outside, thereby giving us meaningful error
messages for invalid icons.

Related: #2669