### PR TITLE
Only install polkit agent when needed

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -524,6 +524,61 @@ find_similar_command (const char *word)
   return commands[best].name;
 }
 
+static gpointer
+install_polkit_agent (void)
+{
+  gpointer agent = NULL;
+
+#ifdef USE_SYSTEM_HELPER
+  PolkitAgentListener *listener = NULL;
+  g_autoptr(GError) local_error = NULL;
+
+  /* Install a polkit agent as fallback, in case we're running on a console */
+  listener = flatpak_polkit_agent_text_listener_new (NULL, &local_error);
+  if (listener == NULL)
+    {
+      g_debug ("Failed to create polkit agent listener: %s", local_error->message);
+    }
+  else
+    {
+      g_autoptr(AutoPolkitSubject) subject = NULL;
+      GVariantBuilder opt_builder;
+      g_autoptr(GVariant) options = NULL;
+
+      subject = polkit_unix_process_new_for_owner (getpid (), 0, getuid ());
+
+      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+      if (g_strcmp0 (g_getenv ("FLATPAK_FORCE_TEXT_AUTH"), "1") != 0)
+        g_variant_builder_add (&opt_builder, "{sv}", "fallback", g_variant_new_boolean (TRUE));
+      options = g_variant_ref_sink (g_variant_builder_end (&opt_builder));
+
+      agent = polkit_agent_listener_register_with_options (listener,
+                                                           POLKIT_AGENT_REGISTER_FLAGS_RUN_IN_THREAD,
+                                                           subject,
+                                                           NULL,
+                                                           options,
+                                                           NULL,
+                                                           &local_error);
+      if (agent == NULL)
+        {
+          g_debug ("Failed to register polkit agent listener: %s", local_error->message);
+        }
+      g_object_unref (listener);
+    }
+#endif
+
+  return agent;
+}
+
+static void
+uninstall_polkit_agent (gpointer agent)
+{
+#ifdef USE_SYSTEM_HELPER
+  if (agent)
+    polkit_agent_listener_unregister (agent);
+#endif
+}
+
 static int
 flatpak_run (int      argc,
              char   **argv,
@@ -535,6 +590,7 @@ flatpak_run (int      argc,
   g_autofree char *prgname = NULL;
   gboolean success = FALSE;
   const char *command_name = NULL;
+  __attribute__((cleanup (uninstall_polkit_agent))) gpointer polkit_agent = NULL;
 
   command = extract_command (&argc, argv, &command_name);
 
@@ -634,6 +690,8 @@ flatpak_run (int      argc,
 
   check_environment ();
 
+  polkit_agent = install_polkit_agent ();
+
   if (!command->fn (argc, argv, cancellable, &error))
     goto out;
 
@@ -708,10 +766,6 @@ main (int    argc,
   GError *error = NULL;
   g_autofree const char *old_env = NULL;
   int ret;
-#ifdef USE_SYSTEM_HELPER
-  PolkitAgentListener *listener = NULL;
-  gpointer agent = NULL;
-#endif
   struct sigaction action;
 
   memset (&action, 0, sizeof (struct sigaction));
@@ -744,49 +798,7 @@ main (int    argc,
   if (argc >= 4 && strcmp (argv[1], "complete") == 0)
     return complete (argc, argv);
 
-#ifdef USE_SYSTEM_HELPER
-  /* Install a polkit agent as fallback, in case we're running on a console */
-  listener = flatpak_polkit_agent_text_listener_new (NULL, &error);
-  if (listener == NULL)
-    {
-      g_debug ("Failed to create polkit agent listener: %s", error->message);
-      g_clear_error (&error);
-    }
-  else
-    {
-      g_autoptr(AutoPolkitSubject) subject = NULL;
-      GVariantBuilder opt_builder;
-      g_autoptr(GVariant) options = NULL;
-
-      subject = polkit_unix_process_new_for_owner (getpid (), 0, getuid ());
-
-      g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
-      if (g_strcmp0 (g_getenv ("FLATPAK_FORCE_TEXT_AUTH"), "1") != 0)
-        g_variant_builder_add (&opt_builder, "{sv}", "fallback", g_variant_new_boolean (TRUE));
-      options = g_variant_ref_sink (g_variant_builder_end (&opt_builder));
-
-      agent = polkit_agent_listener_register_with_options (listener,
-                                                           POLKIT_AGENT_REGISTER_FLAGS_RUN_IN_THREAD,
-                                                           subject,
-                                                           NULL,
-                                                           options,
-                                                           NULL,
-                                                           &error);
-      if (agent == NULL)
-        {
-          g_debug ("Failed to register polkit agent listener: %s", error->message);
-          g_clear_error (&error);
-        }
-      g_object_unref (listener);
-    }
-#endif
-
   ret = flatpak_run (argc, argv, &error);
-
-#ifdef USE_SYSTEM_HELPER
-  if (agent)
-    polkit_agent_listener_unregister (agent);
-#endif
 
   if (error != NULL)
     {

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -571,11 +571,11 @@ install_polkit_agent (void)
 }
 
 static void
-uninstall_polkit_agent (gpointer agent)
+uninstall_polkit_agent (gpointer *agent)
 {
 #ifdef USE_SYSTEM_HELPER
-  if (agent)
-    polkit_agent_listener_unregister (agent);
+  if (*agent)
+    polkit_agent_listener_unregister (*agent);
 #endif
 }
 


### PR DESCRIPTION
We don't need a polkit agent for simple things like flatpak --installations. Only install it for running actual commands.

This avoids logs like:

Feb 02 16:15:11 localhost.localdomain polkitd[763]: Registered Authentication Agent for unix-process:17792:1540651 (system bus name :1.2265 [flatpak --installations], object path /org/freedesktop/PolicyKit1/Aut>
Feb 02 16:15:11 localhost.localdomain polkitd[763]: Unregistered Authentication Agent for unix-process:17792:1540651 (system bus name :1.2265, object path /org/freedesktop/PolicyKit1/AuthenticationAgent, locale>
