### PR TITLE
Actually always return non-null from flatpak_dir_get_display_name()

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -950,7 +950,7 @@ transaction_ready (FlatpakTransaction *transaction)
   if (!self->disable_interaction)
     {
       FlatpakInstallation *installation = flatpak_transaction_get_installation (transaction);
-      const char *name;
+      g_autofree char *name = NULL;
       const char *id;
       gboolean ret;
 
@@ -964,8 +964,7 @@ transaction_ready (FlatpakTransaction *transaction)
       else if (g_strcmp0 (id, "default") == 0)
         ret = flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the system installation?"));
       else
-        ret = flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the %s installation?"),
-                                           name ? name : id);
+        ret = flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the %s?"), name);
 
       if (!ret)
         {

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -950,7 +950,7 @@ transaction_ready (FlatpakTransaction *transaction)
   if (!self->disable_interaction)
     {
       FlatpakInstallation *installation = flatpak_transaction_get_installation (transaction);
-      g_autofree char *name = NULL;
+      const char *name;
       const char *id;
       gboolean ret;
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -365,7 +365,7 @@ gboolean    flatpak_dir_get_no_interaction (FlatpakDir *self);
 GFile *     flatpak_dir_get_path (FlatpakDir *self);
 GFile *     flatpak_dir_get_changed_path (FlatpakDir *self);
 const char *flatpak_dir_get_id (FlatpakDir *self);
-const char *flatpak_dir_get_display_name (FlatpakDir *self);
+char       *flatpak_dir_get_display_name (FlatpakDir *self);
 char *      flatpak_dir_get_name (FlatpakDir *self);
 const char *flatpak_dir_get_name_cached (FlatpakDir *self);
 gint        flatpak_dir_get_priority (FlatpakDir *self);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1710,16 +1710,21 @@ flatpak_dir_get_name_cached (FlatpakDir *self)
   return (const char *)name;
 }
 
-const char *
+char *
 flatpak_dir_get_display_name (FlatpakDir *self)
 {
   if (self->user)
-    return _("User installation");
+    return g_strdup (_("User installation"));
 
   if (self->extra_data != NULL)
-    return self->extra_data->display_name;
+    {
+      if (self->extra_data->display_name)
+        return g_strdup (self->extra_data->display_name);
 
-  return NULL;
+      return g_strdup_printf (_("System (%s) installation"), self->extra_data->id);
+    }
+
+  return g_strdup (SYSTEM_DIR_DEFAULT_DISPLAY_NAME);
 }
 
 gint

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -78,6 +78,7 @@ struct _FlatpakInstallationPrivate
      flatpak_installation_drop_caches(), so every user needs to keep its own reference alive until
      done. */
   FlatpakDir *dir_unlocked;
+  char *display_name;
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE (FlatpakInstallation, flatpak_installation, G_TYPE_OBJECT)
@@ -98,6 +99,7 @@ flatpak_installation_finalize (GObject *object)
   FlatpakInstallationPrivate *priv = flatpak_installation_get_instance_private (self);
 
   g_object_unref (priv->dir_unlocked);
+  g_free (priv->display_name);
 
   G_OBJECT_CLASS (flatpak_installation_parent_class)->finalize (object);
 }
@@ -531,9 +533,13 @@ flatpak_installation_get_id (FlatpakInstallation *self)
 const char *
 flatpak_installation_get_display_name (FlatpakInstallation *self)
 {
+  FlatpakInstallationPrivate *priv = flatpak_installation_get_instance_private (self);
   g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir_maybe_no_repo (self);
 
-  return flatpak_dir_get_display_name (dir);
+  if (priv->display_name == NULL)
+    priv->display_name = flatpak_dir_get_display_name (dir);
+
+  return (const char *)priv->display_name;
 }
 
 /**

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -130,7 +130,7 @@ test_multiple_system_installations (void)
   static InstallationExtraData expected_installations[] = {
     { "extra-installation-2", "Extra system installation 2", 25, FLATPAK_STORAGE_TYPE_SDCARD},
     { "extra-installation-1", "Extra system installation 1", 10, FLATPAK_STORAGE_TYPE_MMC},
-    { "extra-installation-3", NULL, 0, FLATPAK_STORAGE_TYPE_DEFAULT},
+    { "extra-installation-3", "System (extra-installation-3) installation", 0, FLATPAK_STORAGE_TYPE_DEFAULT},
     { "default", "Default system installation", 0, FLATPAK_STORAGE_TYPE_DEFAULT},
   };
 


### PR DESCRIPTION
This also changes this to a non-const as we need to generate it.