### PR TITLE
CLI: Handle consoles reporting zero size

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6078,6 +6078,11 @@ flatpak_get_window_size (int *rows, int *cols)
 
   if (ioctl (STDOUT_FILENO, TIOCGWINSZ, &w) == 0)
     {
+      /* For whatever reason, in buildbot this returns 0, 0 so add a fallback */
+      if (w.ws_row == 0)
+        w.ws_row = 24;
+      if (w.ws_col == 0)
+        w.ws_col = 80;
       *rows = w.ws_row;
       *cols = w.ws_col;
     }


### PR DESCRIPTION
For whatever reason, in the buildbot environment the TIOCGWINSZ
ioctl returns a 0x0 size, which causes a divide by zero. We
handle this by returning a default 80x24 size.