### PR TITLE
Unstable version should be 1.3.0 not 1.3.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_PREREQ([2.63])
 
 m4_define([flatpak_major_version], [1])
 m4_define([flatpak_minor_version], [3])
-m4_define([flatpak_micro_version], [1])
+m4_define([flatpak_micro_version], [0])
 m4_define([flatpak_extra_version], [])
 m4_define([flatpak_interface_age], [0])
 m4_define([flatpak_binary_age],


### PR DESCRIPTION
1.3.0 hasn't been released, so that should be the next unstable version.