### PR TITLE
Use the correct keyring to verify P2P pulls

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -905,14 +905,18 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
   if (g_file_query_exists (repofile, cancellable) &&
       !is_empty_directory (repofile, cancellable))
     {
+      const char *repo_collection_id;
+
       if (!ostree_repo_open (repo, cancellable, error))
         goto out;
 
-      if (!ostree_repo_resolve_rev (repo, full_branch, TRUE, &parent, error))
+      repo_collection_id = ostree_repo_get_collection_id (repo);
+      if (!flatpak_repo_resolve_rev (repo, repo_collection_id, NULL, full_branch, TRUE,
+                                     &parent, cancellable, error))
         goto out;
 
       if (opt_collection_id != NULL &&
-          g_strcmp0 (ostree_repo_get_collection_id (repo), opt_collection_id) != 0)
+          g_strcmp0 (repo_collection_id, opt_collection_id) != 0)
         {
           flatpak_fail (error, "Specified collection ID ‘%s’ doesn’t match collection ID in repository configuration ‘%s’.",
                         opt_collection_id, ostree_repo_get_collection_id (repo));

--- a/app/flatpak-builtins-build-sign.c
+++ b/app/flatpak-builtins-build-sign.c
@@ -60,6 +60,7 @@ flatpak_builtin_build_sign (int argc, char **argv, GCancellable *cancellable, GE
   int i;
   char **iter;
   g_autoptr(GPtrArray) refs = g_ptr_array_new_with_free_func (g_free);
+  const char *collection_id;
 
   context = g_option_context_new (_("LOCATION [ID [BRANCH]] - Sign an application or runtime"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
@@ -97,6 +98,8 @@ flatpak_builtin_build_sign (int argc, char **argv, GCancellable *cancellable, GE
   if (!ostree_repo_open (repo, cancellable, error))
     return FALSE;
 
+  collection_id = ostree_repo_get_collection_id (repo);
+
   if (id)
     {
       g_autofree char *ref = NULL;
@@ -132,7 +135,8 @@ flatpak_builtin_build_sign (int argc, char **argv, GCancellable *cancellable, GE
     {
       const char *ref = g_ptr_array_index (refs, i);
 
-      if (!ostree_repo_resolve_rev (repo, ref, FALSE, &commit_checksum, error))
+      if (!flatpak_repo_resolve_rev (repo, collection_id, NULL, ref, FALSE,
+                                     &commit_checksum, cancellable, error))
         return FALSE;
 
       for (iter = opt_gpg_key_ids; iter && *iter; iter++)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -312,7 +312,9 @@ flatpak_remote_state_ensure_metadata (FlatpakRemoteState *self,
       else if (self->collection_id == NULL && self->summary_fetch_error != NULL)
         error_msg = g_strdup_printf ("summary fetch error: %s", self->summary_fetch_error->message);
 
-      return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Unable to load metadata from remote %s: %s"), self->remote_name,
+      return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                 _("Unable to load metadata from remote %s: %s"),
+                                 self->remote_name,
                                  error_msg != NULL ? error_msg : "unknown error");
     }
 
@@ -350,10 +352,13 @@ flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,
       if (!flatpak_summary_lookup_ref (self->summary, self->collection_id, ref, out_checksum, out_variant))
         {
           if (self->collection_id != NULL)
-            flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("No such ref (%s, %s) in remote %s"), self->collection_id, ref, self->remote_name);
+            return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                       _("No such ref (%s, %s) in remote %s"),
+                                       self->collection_id, ref, self->remote_name);
           else
-            flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("No such ref '%s' in remote %s"), ref, self->remote_name);
-          return FALSE;
+            return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                       _("No such ref '%s' in remote %s"),
+                                       ref, self->remote_name);
         }
     }
   else
@@ -3363,9 +3368,10 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
 
       if (latest_rev == NULL)
         {
-          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("No such ref (%s, %s) in remote %s or elsewhere"),
-                              collection_ref.collection_id, collection_ref.ref_name, state->remote_name);
-          return FALSE;
+          return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                     _("No such ref (%s, %s) in remote %s or elsewhere"),
+                                     collection_ref.collection_id, collection_ref.ref_name,
+                                     state->remote_name);
         }
 
       if (out_results != NULL)
@@ -3376,14 +3382,12 @@ flatpak_dir_find_latest_rev (FlatpakDir               *self,
     }
   else
     {
-      flatpak_remote_state_lookup_ref (state, ref, &latest_rev, NULL, error);
+      if (!flatpak_remote_state_lookup_ref (state, ref, &latest_rev, NULL, error))
+        return FALSE;
       if (latest_rev == NULL)
-        {
-          if (error != NULL && *error == NULL)
-            flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Couldn't find latest checksum for ref %s in remote %s"),
-                                ref, state->remote_name);
-          return FALSE;
-        }
+        return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                   _("Couldn't find latest checksum for ref %s in remote %s"),
+                                   ref, state->remote_name);
 
       if (out_rev != NULL)
         *out_rev = g_steal_pointer (&latest_rev);
@@ -4814,20 +4818,18 @@ flatpak_dir_mirror_oci (FlatpakDir          *self,
   gboolean res;
 
   /* We use the summary so that we can reuse any cached json */
-  flatpak_remote_state_lookup_ref (state, ref, &latest_rev, &summary_element, error);
+  if (!flatpak_remote_state_lookup_ref (state, ref, &latest_rev, &summary_element, error))
+    return FALSE;
   if (latest_rev == NULL)
-    {
-      if (error != NULL && *error == NULL)
-        flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Couldn't find latest checksum for ref %s in remote %s"),
-                            ref, state->remote_name);
-      return FALSE;
-    }
+    return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                               _("Couldn't find latest checksum for ref %s in remote %s"),
+                               ref, state->remote_name);
 
   if (skip_if_current_is != NULL && strcmp (latest_rev, skip_if_current_is) == 0)
     {
-      flatpak_fail_error (error, FLATPAK_ERROR_ALREADY_INSTALLED, _("%s commit %s already installed"),
-                          ref, latest_rev);
-      return FALSE;
+      return flatpak_fail_error (error, FLATPAK_ERROR_ALREADY_INSTALLED,
+                                 _("%s commit %s already installed"),
+                                 ref, latest_rev);
     }
 
   metadata = g_variant_get_child_value (summary_element, 2);
@@ -4887,14 +4889,12 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
   g_autofree char *name = NULL;
 
   /* We use the summary so that we can reuse any cached json */
-  flatpak_remote_state_lookup_ref (state, ref, &latest_rev, &summary_element, error);
+  if (!flatpak_remote_state_lookup_ref (state, ref, &latest_rev, &summary_element, error))
+    return FALSE;
   if (latest_rev == NULL)
-    {
-      if (error != NULL && *error == NULL)
-        flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Couldn't find latest checksum for ref %s in remote %s"),
-                            ref, state->remote_name);
-      return FALSE;
-    }
+    return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                               _("Couldn't find latest checksum for ref %s in remote %s"),
+                               ref, state->remote_name);
 
   metadata = g_variant_get_child_value (summary_element, 2);
   g_variant_lookup (metadata, "xa.oci-repository", "s", &oci_repository);
@@ -5133,13 +5133,13 @@ flatpak_dir_pull (FlatpakDir                           *self,
         }
       else
         {
-          flatpak_remote_state_lookup_ref (state, ref, &rev, NULL, error);
+          if (!flatpak_remote_state_lookup_ref (state, ref, &rev, NULL, error))
+            goto out;
           if (rev == NULL)
             {
-              if (error != NULL && *error == NULL)
-                flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
-                                    _("Couldn't find latest checksum for ref %s in remote %s"),
-                                    ref, state->remote_name);
+              flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                  _("Couldn't find latest checksum for ref %s in remote %s"),
+                                  ref, state->remote_name);
               goto out;
             }
 
@@ -6420,8 +6420,8 @@ export_desktop_file (const char         *app,
 
       if (dbus_name == NULL || strcmp (dbus_name, expected_dbus_name) != 0)
         {
-          flatpak_fail_error (error, FLATPAK_ERROR_EXPORT_FAILED, _("D-Bus service file '%s' has wrong name"), name);
-          return FALSE;
+          return flatpak_fail_error (error, FLATPAK_ERROR_EXPORT_FAILED,
+                                     _("D-Bus service file '%s' has wrong name"), name);
         }
     }
 
@@ -7103,7 +7103,9 @@ extract_extra_data (FlatpakDir   *self,
         }
 
       if (!found)
-        return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Extra data %s missing in detached metadata"), extra_data_source_name);
+        return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                   _("Extra data %s missing in detached metadata"),
+                                   extra_data_source_name);
     }
 
   *created_extra_data = TRUE;
@@ -13250,12 +13252,13 @@ flatpak_dir_fetch_remote_commit (FlatpakDir   *self,
       if (state == NULL)
         return NULL;
 
-      flatpak_remote_state_lookup_ref (state, ref, &latest_commit, NULL, error);
+      if (!flatpak_remote_state_lookup_ref (state, ref, &latest_commit, NULL, error))
+        return NULL;
       if (latest_commit == NULL)
         {
-          if (error != NULL && *error == NULL)
-            flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Couldn't find latest checksum for ref %s in remote %s"),
-                                ref, state->remote_name);
+          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                              _("Couldn't find latest checksum for ref %s in remote %s"),
+                              ref, state->remote_name);
           return NULL;
         }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3594,9 +3594,17 @@ flatpak_dir_do_resolve_p2p_refs (FlatpakDir             *self,
         }
     }
 
+  OstreeRepoPullFlags flags = OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY;
+  /* Do a version check to ensure we have these:
+   * https://github.com/ostreedev/ostree/pull/1821
+   * https://github.com/ostreedev/ostree/pull/1825 */
+#if OSTREE_CHECK_VERSION (2019, 2)
+  flags |= OSTREE_REPO_PULL_FLAGS_MIRROR;
+#endif
+
   g_variant_builder_init (&pull_builder, G_VARIANT_TYPE ("a{sv}"));
   g_variant_builder_add (&pull_builder, "{s@v}", "flags",
-                         g_variant_new_variant (g_variant_new_int32 (OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY)));
+                         g_variant_new_variant (g_variant_new_int32 (flags)));
   g_variant_builder_add (&pull_builder, "{s@v}", "inherit-transaction",
                          g_variant_new_variant (g_variant_new_boolean (TRUE)));
   pull_options = g_variant_ref_sink (g_variant_builder_end (&pull_builder));
@@ -3621,13 +3629,13 @@ flatpak_dir_do_resolve_p2p_refs (FlatpakDir             *self,
       FlatpakDirResolveData *data = datas[i];
       FlatpakDirResolve *resolve = data->resolve;
       g_autoptr(GVariant) commit_data = NULL;
-      g_autofree char *refspec = NULL;
 
       if (resolve->resolved_commit != NULL)
         continue;
 
-      refspec = g_strdup_printf ("%s:%s", resolve->remote, resolve->ref);
-      if (!ostree_repo_resolve_rev (child_repo, refspec, FALSE, &resolve->resolved_commit, error))
+      if (!flatpak_repo_resolve_rev (child_repo, data->collection_ref.collection_id, resolve->remote,
+                                     resolve->ref, FALSE, &resolve->resolved_commit,
+                                     cancellable, error))
         return FALSE;
 
       if (!ostree_repo_load_commit (child_repo, resolve->resolved_commit, &commit_data, NULL, error))
@@ -3653,7 +3661,6 @@ flatpak_dir_resolve_p2p_refs (FlatpakDir         *self,
     {
       FlatpakDirResolve *resolve = resolves[i];
       FlatpakDirResolveData *data = g_new0 (FlatpakDirResolveData, 1);
-      g_autofree char *refspec = g_strdup_printf ("%s:%s", resolve->remote, resolve->ref);
 
       g_assert (resolve->ref != NULL);
       g_assert (resolve->remote != NULL);
@@ -3665,7 +3672,10 @@ flatpak_dir_resolve_p2p_refs (FlatpakDir         *self,
       g_assert (data->collection_ref.collection_id != NULL);
 
       if (resolve->opt_commit == NULL)
-        ostree_repo_resolve_rev (self->repo, refspec, TRUE, &data->local_commit, NULL);
+        {
+          flatpak_repo_resolve_rev (self->repo, data->collection_ref.collection_id, resolve->remote,
+                                    resolve->ref, TRUE, &data->local_commit, cancellable, NULL);
+        }
 
       /* The ostree p2p api doesn't let you mix pulls with specific commit IDs
        * and HEAD (https://github.com/ostreedev/ostree/issues/1622) so we need

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -828,6 +828,14 @@ char *   flatpak_dconf_path_for_app_id (const char *app_id);
 gboolean flatpak_dconf_path_is_similar (const char *path1,
                                         const char *path2);
 
+gboolean flatpak_repo_resolve_rev (OstreeRepo    *repo,
+                                   const char    *collection_id, /* nullable */
+                                   const char    *remote_name, /* nullable */
+                                   const char    *ref_name,
+                                   gboolean       allow_noent,
+                                   char         **out_rev,
+                                   GCancellable  *cancellable,
+                                   GError       **error);
 
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3438,8 +3438,8 @@ flatpak_repo_update (OstreeRepo   *repo,
 
   old_summary = flatpak_repo_load_summary (repo, NULL);
 
-  if (!ostree_repo_resolve_rev (repo, OSTREE_REPO_METADATA_REF,
-                                TRUE, &old_ostree_metadata_checksum, error))
+  if (!flatpak_repo_resolve_rev (repo, collection_id, NULL, OSTREE_REPO_METADATA_REF,
+                                 TRUE, &old_ostree_metadata_checksum, cancellable, error))
     return FALSE;
 
   if (old_summary != NULL &&
@@ -4345,7 +4345,8 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
         g_autofree char *commit_checksum = NULL;
 
         branch = g_strdup_printf ("%s/%s", branch_prefix, arch);
-        if (!ostree_repo_resolve_rev (repo, branch, TRUE, &parent, error))
+        if (!flatpak_repo_resolve_rev (repo, collection_id, NULL, branch, TRUE,
+                                       &parent, cancellable, error))
           return FALSE;
 
         if (i == 0)

--- a/tests/Makefile-test-matrix.am.inc
+++ b/tests/Makefile-test-matrix.am.inc
@@ -18,6 +18,8 @@ TEST_MATRIX= \
 	tests/test-bundle@system-norevokefs.wrap \
 	tests/test-oci-registry@user.wrap \
 	tests/test-oci-registry@system.wrap \
+	tests/test-p2p-security@user,collections.wrap \
+	tests/test-p2p-security@system,collections.wrap \
 	$(NULL)
 TEST_MATRIX_DIST= \
 	tests/test-basic.sh \
@@ -37,4 +39,5 @@ TEST_MATRIX_EXTRA_DIST= \
 	tests/test-repo.sh \
 	tests/test-bundle.sh \
 	tests/test-oci-registry.sh \
+	tests/test-p2p-security.sh \
 	$(NULL)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -140,6 +140,7 @@ TEST_MATRIX_SOURCE = \
 	tests/test-unsigned-summaries.sh \
 	tests/test-update-remote-configuration.sh \
 	tests/test-override.sh \
+	tests/test-p2p-security.sh{user,collections+system,collections} \
 	$(NULL)
 
 update-test-matrix:

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -384,6 +384,27 @@ skip_revokefs_without_fuse () {
     fi
 }
 
+skip_without_p2p () {
+    if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ] ; then
+        return 0
+    else
+        skip "No P2P support enabled"
+    fi
+}
+
+# Usage: skip_without_ostree_version 2019 2
+skip_without_ostree_version () {
+    OSTREE_YEAR_VERSION=$(ostree --version | sed -n "s/^ Version: '\([0-9]\+\)\.[0-9]\+'$/\1/p")
+    OSTREE_RELEASE_VERSION=$(ostree --version | sed -n "s/^ Version: '[0-9]\+\.\([0-9]\+\)'$/\1/p")
+    if [ "$OSTREE_YEAR_VERSION" -gt "$1" ]; then
+        return 0
+    elif [ "$OSTREE_YEAR_VERSION" -eq "$1" ] && [ "$OSTREE_RELEASE_VERSION" -ge "$2" ]; then
+        return 0
+    else
+        skip "OSTree version requirement $1.$2 not met"
+    fi
+}
+
 sed s#@testdir@#${test_builddir}# ${test_srcdir}/session.conf.in > session.conf
 dbus-daemon --fork --config-file=session.conf --print-address=3 --print-pid=4 \
     3> dbus-session-bus-address 4> dbus-session-bus-pid

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/tests/test-p2p-security.sh
+++ b/tests/test-p2p-security.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (C) 2019 Matthew Leeds <matthew.leeds@endlessm.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+skip_without_p2p
+skip_without_ostree_version 2019 2
+
+# Test that for an app A installed from a remote R1, updates for the app are
+# verified using the keyring associated with remote R1, even if remote R2 has
+# configured the same collection ID as R1 and attempts to serve an update for
+# A. In other words, ensure that we only have to trust the remote that is
+# trusted at install time to provide good updates.
+
+echo "1..1"
+
+# First install from a legitimate remote
+setup_repo test org.test.Collection
+install_repo test
+
+INITIAL_COMMIT=$(${FLATPAK} ${U} info -c org.test.Hello)
+if [ "x${INITIAL_COMMIT}" == "x" ]; then
+    assert_not_reached "Can't get installed commit of org.test.Hello"
+fi
+
+GPG_KEY1=$(ostree --repo=${FL_DIR}/repo show ${INITIAL_COMMIT} | sed -n "s/^.*RSA key ID \([[:xdigit:]]\+\)$/\1/p")
+
+# Then add a malicious remote which has the same collection ID but a different GPG key
+GPGPUBKEY="${FL_GPG_HOMEDIR2}/pubring.gpg" GPGARGS="${FL_GPGARGS2}" setup_repo test-impostor org.test.Collection
+
+# Create an update signed by the malicious remote
+sleep 1 # Ensure the timestamp on the new commit is later
+GPGARGS="${FL_GPGARGS2}" make_updated_app test-impostor org.test.Collection
+
+# Updating should fail because the signatures aren't from the legitimate remote
+if G_MESSAGES_DEBUG=all ${FLATPAK} ${U} update -y org.test.Hello >failed-p2p-update-log; then
+    assert_not_reached "Update of org.test.Hello was successful despite malicious commit"
+fi
+assert_file_has_content failed-p2p-update-log "GPG signatures found, but none are in trusted keyring"
+
+COMMIT_AFTER_FAILED_UPDATE=$(${FLATPAK} ${U} info -c org.test.Hello)
+if [ "x${INITIAL_COMMIT}" != "x${COMMIT_AFTER_FAILED_UPDATE}" ]; then
+    assert_not_reached "org.test.Hello was updated from the malicious remote"
+fi
+
+# The legitimate remote should still be able to serve an update
+sleep 1 # Ensure the timestamp on the new commit is later
+make_updated_app test org.test.Collection
+UPDATE_COMMIT=$(ostree --repo=repos/test rev-parse app/org.test.Hello/${ARCH}/master)
+${FLATPAK} ${U} update -y org.test.Hello
+COMMIT_AFTER_SUCCESSFUL_UPDATE=$(${FLATPAK} ${U} info -c org.test.Hello)
+if [ "x${UPDATE_COMMIT}" != "x${COMMIT_AFTER_SUCCESSFUL_UPDATE}" ]; then
+    assert_not_reached "org.test.Hello was not updated"
+fi
+
+GPG_KEY2=$(ostree --repo=${FL_DIR}/repo show ${COMMIT_AFTER_SUCCESSFUL_UPDATE} | sed -n "s/^.*RSA key ID \([[:xdigit:]]\+\)$/\1/p")
+if [ "x${GPG_KEY1}" != "x${GPG_KEY2}" ]; then
+    assert_not_reached "Updated commit not signed with the same GPG key"
+fi
+
+echo "ok updates are verified with the correct remote's keyring"


### PR DESCRIPTION
This is a series of commits which both uncover and fix the bug described in https://github.com/flatpak/flatpak/issues/1447#issuecomment-445347590. The current state of the codebase is not vulnerable to it, arguably by accident, then the commit "
dir: Fix an edge case of resolving collection-refs" makes the bug exploitable. The subsequent commits fix that vulnerability, so that we only use the correct keyring when pulling updates, and add a unit test. As a side effect, they also bring us a step closer to fixing https://github.com/flatpak/flatpak/issues/1832 by making use of mirror pulls a bit more.

This shouldn't be merged until after these two PRs upon which it depends:
https://github.com/ostreedev/ostree/pull/1810
https://github.com/ostreedev/ostree/pull/1825

I think after we get this merged it will be time for https://github.com/flathub/flathub/issues/676