### PR TITLE
Fix issues with XDG_RUNTIME_DIR being /var/run which is a symlink

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -653,7 +653,7 @@ get_xdg_user_dir_from_string (const char  *filesystem,
       if (config_key)
         *config_key = NULL;
       if (dir)
-        *dir = g_get_user_runtime_dir ();
+        *dir = flatpak_get_real_xdg_runtime_dir ();
       return TRUE;
     }
 
@@ -2087,8 +2087,9 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
 
   if (app_id_dir != NULL)
     {
+      g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
       g_autofree char *run_user_app_dst = g_strdup_printf ("/run/user/%d/app/%s", getuid (), app_id);
-      g_autofree char *run_user_app_src = g_build_filename (g_get_user_runtime_dir (), "app", app_id, NULL);
+      g_autofree char *run_user_app_src = g_build_filename (user_runtime_dir, "app", app_id, NULL);
 
       if (glnx_shutil_mkdir_p_at (AT_FDCWD,
                                   run_user_app_src,

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -90,6 +90,10 @@ void flatpak_debug2 (const char *format,
 gint flatpak_strcmp0_ptr (gconstpointer a,
                           gconstpointer b);
 
+/* Sometimes this is /var/run which is a symlink, causing weird issues when we pass
+ * it as a path into the sandbox */
+char * flatpak_get_real_xdg_runtime_dir (void);
+
 gboolean  flatpak_has_path_prefix (const char *str,
                                    const char *prefix);
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -223,6 +223,14 @@ flatpak_strcmp0_ptr (gconstpointer a,
   return g_strcmp0 (*(char * const *) a, *(char * const *) b);
 }
 
+/* Sometimes this is /var/run which is a symlink, causing weird issues when we pass
+ * it as a path into the sandbox */
+char *
+flatpak_get_real_xdg_runtime_dir (void)
+{
+  return realpath (g_get_user_runtime_dir (), NULL);
+}
+
 /* Compares if str has a specific path prefix. This differs
    from a regular prefix in two ways. First of all there may
    be multiple slashes separating the path elements, and


### PR DESCRIPTION
Whenever we use $XDG_RUNTIME_DIR and expose it somehow in the sandbox
we fully resolve the path, because if (as happens on gentoo for instance)
it contains /var/run -> ../run, then flatpak thinks we need to
add the /var/run symlink in the runtime even though we already
exposed that.