### PR TITLE
dir: Fix GError handling in flatpak_load_deploy_data()

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -576,13 +576,12 @@ flatpak_load_deploy_data (GFile        *deploy_dir,
                           GError      **error)
 {
   g_autoptr(GFile) data_file = NULL;
-  g_autoptr(GError) my_error = NULL;
   char *data = NULL;
   gsize data_size;
   g_autoptr(GVariant) deploy_data = NULL;
 
   data_file = g_file_get_child (deploy_dir, "deploy");
-  if (!g_file_load_contents (data_file, cancellable, &data, &data_size, NULL, &my_error))
+  if (!g_file_load_contents (data_file, cancellable, &data, &data_size, NULL, error))
     return NULL;
 
   deploy_data = g_variant_ref_sink (g_variant_new_from_data (FLATPAK_DEPLOY_DATA_GVARIANT_FORMAT,


### PR DESCRIPTION
Commit b20ee7e26 introduced a bug where flatpak_load_deploy_data()
returns NULL without setting @error in the case that there's a problem
reading the deploy file. I think this is causing a seg fault in
flatpak_installation_list_installed_refs() which tries to print the
error message after calling get_ref() (which indirectly loads the deploy
file).

I didn't personally verify that this fixes the GNOME Builder seg fault
that was reported, but it seems almost certain looking at the provided
stack trace, since get_ref() only returns NULL if
flatpak_dir_get_deploy_data() returns NULL, and that function clearly
sets the error pointer on failure except in flatpak_load_deploy_data().

I'm not sure why the deploy file doesn't exist (or is unreadable) for
the user who reported this seg fault.

Fixes https://github.com/flatpak/flatpak/issues/2717