### PR TITLE
Check HTTP return codes

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -206,7 +206,9 @@ install_from (FlatpakDir *dir,
   if (g_str_has_prefix (filename, "http:") ||
       g_str_has_prefix (filename, "https:"))
     {
-      file_data = download_uri (filename, error);
+      g_autoptr(SoupSession) soup_session = NULL;
+      soup_session = flatpak_create_soup_session (PACKAGE_STRING);
+      file_data = flatpak_load_http_uri (soup_session, filename, 0, NULL, NULL, cancellable, error);
       if (file_data == NULL)
         {
           g_prefix_error (error, "Can't load uri %s: ", filename);

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -183,8 +183,10 @@ load_options (const char *filename,
     {
       const char *options_data;
       gsize options_size;
+      g_autoptr(SoupSession) soup_session = NULL;
 
-      bytes = download_uri (filename, &error);
+      soup_session = flatpak_create_soup_session (PACKAGE_STRING);
+      bytes = flatpak_load_http_uri (soup_session, filename, 0, NULL, NULL, NULL, &error);
 
       if (bytes == NULL)
         {

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -92,65 +92,6 @@ looks_like_branch (const char *branch)
   return TRUE;
 }
 
-static SoupSession *
-get_soup_session (void)
-{
-  static SoupSession *soup_session = NULL;
-
-  if (soup_session == NULL)
-    {
-      const char *http_proxy;
-
-      soup_session = soup_session_new_with_options (SOUP_SESSION_USER_AGENT, "flatpak-builder ",
-                                                    SOUP_SESSION_SSL_USE_SYSTEM_CA_FILE, TRUE,
-                                                    SOUP_SESSION_USE_THREAD_CONTEXT, TRUE,
-                                                    SOUP_SESSION_TIMEOUT, 60,
-                                                    SOUP_SESSION_IDLE_TIMEOUT, 60,
-                                                    NULL);
-      http_proxy = g_getenv ("http_proxy");
-      if (http_proxy)
-        {
-          g_autoptr(SoupURI) proxy_uri = soup_uri_new (http_proxy);
-          if (!proxy_uri)
-            g_warning ("Invalid proxy URI '%s'", http_proxy);
-          else
-            g_object_set (soup_session, SOUP_SESSION_PROXY_URI, proxy_uri, NULL);
-        }
-    }
-
-  return soup_session;
-}
-
-GBytes *
-download_uri (const char *url,
-              GError    **error)
-{
-  SoupSession *session;
-  g_autoptr(SoupRequest) req = NULL;
-  g_autoptr(GInputStream) input = NULL;
-  g_autoptr(GOutputStream) out = NULL;
-
-  session = get_soup_session ();
-
-  req = soup_session_request (session, url, error);
-  if (req == NULL)
-    return NULL;
-
-  input = soup_request_send (req, NULL, error);
-  if (input == NULL)
-    return NULL;
-
-  out = g_memory_output_stream_new_resizable ();
-  if (!g_output_stream_splice (out,
-                               input,
-                               G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET | G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE,
-                               NULL,
-                               error))
-    return NULL;
-
-  return g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (out));
-}
-
 FlatpakDir *
 flatpak_find_installed_pref (const char *pref, FlatpakKinds kinds, const char *default_arch, const char *default_branch,
                              gboolean search_all, gboolean search_user, gboolean search_system, char **search_installations,

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -52,8 +52,6 @@ RemoteDirPair * remote_dir_pair_new (const char *remote_name,
                                      FlatpakDir *dir);
 
 gboolean    looks_like_branch (const char *branch);
-GBytes *    download_uri (const char *url,
-                          GError    **error);
 
 GBytes * flatpak_load_gpg_keys (char        **gpg_import,
                                 GCancellable *cancellable,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4059,9 +4059,6 @@ ensure_soup_session (FlatpakDir *self)
 
       soup_session = flatpak_create_soup_session (PACKAGE_STRING);
 
-      if (g_getenv ("OSTREE_DEBUG_HTTP"))
-        soup_session_add_feature (soup_session, (SoupSessionFeature *) soup_logger_new (SOUP_LOGGER_LOG_BODY, 500));
-
       g_once_init_leave (&self->soup_session, soup_session);
     }
 }

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -504,6 +504,9 @@ flatpak_create_soup_session (const char *user_agent)
         g_object_set (soup_session, SOUP_SESSION_PROXY_URI, proxy_uri, NULL);
     }
 
+  if (g_getenv ("OSTREE_DEBUG_HTTP"))
+    soup_session_add_feature (soup_session, (SoupSessionFeature *) soup_logger_new (SOUP_LOGGER_LOG_BODY, 500));
+
   return soup_session;
 }
 

--- a/tests/httpcache.c
+++ b/tests/httpcache.c
@@ -3,7 +3,7 @@
 int
 main (int argc, char *argv[])
 {
-  SoupSession *session = flatpak_create_soup_session (PACKAGE_STRING);
+  g_autoptr(SoupSession) session = flatpak_create_soup_session (PACKAGE_STRING);
   GError *error = NULL;
   const char *url, *dest;
   int flags = 0;

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..27"
+echo "1..28"
 
 #Regular repo
 setup_repo
@@ -168,6 +168,14 @@ if [ x${USE_COLLECTIONS_IN_CLIENT-} != xyes ] ; then
 fi
 
 echo "ok missing remote name auto-corrects for install"
+
+port=$(cat httpd-port-main)
+if ${FLATPAK} ${U} install -y http://127.0.0.1:${port}/nonexistent.flatpakref 2> install-error-log; then
+    assert_not_reached "Should not be able to install a nonexistent flatpakref"
+fi
+assert_file_has_content install-error-log "Server returned status 404: Not Found"
+
+echo "ok install fails gracefully for 404 URLs"
 
 ${FLATPAK} ${U} uninstall -y org.test.Platform org.test.Hello
 


### PR DESCRIPTION
Currently Flatpak does not check the response code of HTTP requests that
are made by the download_uri() function, so if for example a 404 is hit
that function will just return NULL without setting the error pointer.
This commit fixes the issue by checking the status code and setting the
error for unsuccessful ones.

Fixes https://github.com/flatpak/flatpak/issues/2727