### PR TITLE
Add support for rebasing previous app versions when eol_rebase is given

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -45,6 +45,8 @@ static gboolean opt_force;
 static char **opt_gpg_key_ids;
 static char *opt_gpg_homedir;
 static char *opt_endoflife;
+static char **opt_endoflife_rebase;
+static char **opt_endoflife_rebase_new;
 static char *opt_timestamp;
 static char **opt_extra_collection_ids;
 
@@ -61,6 +63,7 @@ static GOptionEntry options[] = {
   { "gpg-sign", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_gpg_key_ids, N_("GPG Key ID to sign the commit with"), N_("KEY-ID") },
   { "gpg-homedir", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_homedir, N_("GPG Homedir to use when looking for keyrings"), N_("HOMEDIR") },
   { "end-of-life", 0, 0, G_OPTION_ARG_STRING, &opt_endoflife, N_("Mark build as end-of-life"), N_("REASON") },
+  { "end-of-life-rebase", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_endoflife_rebase, N_("Mark refs matching the OLDID prefix as end-of-life, to be replaced with the given NEWID"), N_("OLDID=NEWID") },
   { "timestamp", 0, 0, G_OPTION_ARG_STRING, &opt_timestamp, N_("Override the timestamp of the commit (NOW for current time)"), N_("TIMESTAMP") },
   { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
   { NULL }
@@ -260,6 +263,35 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
 
   if (opt_src_repo == NULL && opt_src_ref == NULL)
     return flatpak_fail (error, _("Either --src-repo or --src-ref must be specified."));
+
+  /* Always create a commit if we're eol:ing, even though the app is the same */
+  if (opt_endoflife != NULL || opt_endoflife_rebase != NULL)
+    opt_force = TRUE;
+
+  if (opt_endoflife_rebase)
+    {
+      opt_endoflife_rebase_new = g_new0 (char *, g_strv_length (opt_endoflife_rebase));
+
+      for (i = 0; opt_endoflife_rebase[i] != NULL; i++)
+        {
+          char *rebase_old = opt_endoflife_rebase[i];
+          char *rebase_new = strchr (rebase_old, '=');
+
+          if (rebase_new == NULL) {
+            return usage_error (context, _("Invalid argument format of use  --end-of-life-rebase=OLDID=NEWID"), error);
+          }
+          *rebase_new = 0;
+          rebase_new++;
+
+          if (!flatpak_is_valid_name (rebase_old, error))
+            return glnx_prefix_error (error, _("Invalid name %s in --end-of-life-rebase"), rebase_old);
+
+          if (!flatpak_is_valid_name (rebase_new, error))
+            return glnx_prefix_error (error, _("Invalid name %s in --end-of-life-rebase"), rebase_new);
+
+          opt_endoflife_rebase_new[i] = rebase_new;
+        }
+    }
 
   if (opt_timestamp)
     {
@@ -519,12 +551,36 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
               strcmp (key, OSTREE_COMMIT_META_KEY_ENDOFLIFE) == 0)
             continue;
 
+          if (opt_endoflife_rebase &&
+              strcmp (key, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE) == 0)
+            continue;
+
           g_variant_builder_add_value (&metadata_builder, child);
         }
 
       if (opt_endoflife && *opt_endoflife)
         g_variant_builder_add (&metadata_builder, "{sv}", OSTREE_COMMIT_META_KEY_ENDOFLIFE,
                                g_variant_new_string (opt_endoflife));
+
+      if (opt_endoflife_rebase)
+        {
+          g_auto(GStrv) dst_ref_parts = g_strsplit (dst_ref, "/", 0);
+
+          for (j = 0; opt_endoflife_rebase[j] != NULL; j++)
+            {
+              const char *old_prefix = opt_endoflife_rebase[j];
+
+              if (flatpak_has_name_prefix (dst_ref_parts[1], old_prefix))
+                {
+                  g_autofree char *new_id = g_strconcat (opt_endoflife_rebase_new[j], dst_ref_parts[1] + strlen(old_prefix), NULL);
+                  g_autofree char *rebased_ref = g_build_filename (dst_ref_parts[0], new_id, dst_ref_parts[2], dst_ref_parts[3], NULL);
+
+                  g_variant_builder_add (&metadata_builder, "{sv}", OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE,
+                                         g_variant_new_string (rebased_ref));
+                  break;
+                }
+            }
+        }
 
       timestamp = ostree_commit_get_timestamp (src_commitv);
       if (opt_timestamp)

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -543,7 +543,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
     return FALSE;
 
   if (!flatpak_run_add_environment_args (bwrap, app_info_path, run_flags, id,
-                                         app_context, app_id_dir, NULL, cancellable, error))
+                                         app_context, app_id_dir, NULL, NULL, cancellable, error))
     return FALSE;
 
   for (i = 0; opt_bind_mounts != NULL && opt_bind_mounts[i] != NULL; i++)

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -326,7 +326,11 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
     {
       app_files = g_object_ref (res_files);
       if (opt_with_appdir)
-        app_id_dir = flatpak_ensure_data_dir (id, cancellable, NULL);
+        {
+          app_id_dir = flatpak_get_data_dir (id);
+          if (!flatpak_ensure_data_dir (app_id_dir, cancellable, NULL))
+            g_clear_object (&app_id_dir);
+        }
     }
   else if (is_extension)
     {

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -128,6 +128,7 @@ void flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
                                               FlatpakBwrap    *bwrap,
                                               const char      *app_id,
                                               GFile           *app_id_dir,
+                                              GPtrArray       *extra_app_id_dirs,
                                               FlatpakExports **exports_out);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakContext, flatpak_context_free)

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -351,6 +351,9 @@ const char *        flatpak_deploy_data_get_appdata_name (GVariant *deploy_data)
 const char *        flatpak_deploy_data_get_appdata_summary (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_version (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_license (GVariant *deploy_data);
+const char **       flatpak_deploy_data_get_previous_ids (GVariant *deploy_data,
+                                                          gsize    *length);
+
 
 GFile *        flatpak_deploy_get_dir (FlatpakDeploy *deploy);
 GVariant *     flatpak_load_deploy_data (GFile        *deploy_dir,

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -165,6 +165,7 @@ typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION = 1 << 4,
   FLATPAK_HELPER_DEPLOY_FLAGS_APP_HINT = 1 << 5,
   FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT = 1 << 6,
+  FLATPAK_HELPER_DEPLOY_FLAGS,
 } FlatpakHelperDeployFlags;
 
 #define FLATPAK_HELPER_DEPLOY_FLAGS_ALL (FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE | \
@@ -609,19 +610,21 @@ gboolean    flatpak_dir_deploy (FlatpakDir          *self,
                                 const char          *ref,
                                 const char          *checksum_or_latest,
                                 const char * const * subpaths,
-                                GVariant            *old_deploy_data,
+                                const char * const * previous_ids,
                                 GCancellable        *cancellable,
                                 GError             **error);
 gboolean    flatpak_dir_deploy_update (FlatpakDir   *self,
                                        const char   *ref,
                                        const char   *checksum,
                                        const char  **opt_subpaths,
+                                       const char  **opt_previous_ids,
                                        GCancellable *cancellable,
                                        GError      **error);
 gboolean   flatpak_dir_deploy_install (FlatpakDir   *self,
                                        const char   *ref,
                                        const char   *origin,
                                        const char  **subpaths,
+                                       const char  **previous_ids,
                                        gboolean      reinstall,
                                        GCancellable *cancellable,
                                        GError      **error);
@@ -635,6 +638,7 @@ gboolean   flatpak_dir_install (FlatpakDir          *self,
                                 const char          *ref,
                                 const char          *opt_commit,
                                 const char         **subpaths,
+                                const char         **previous_ids,
                                 OstreeAsyncProgress *progress,
                                 GCancellable        *cancellable,
                                 GError             **error);
@@ -679,6 +683,7 @@ gboolean   flatpak_dir_update (FlatpakDir                           *self,
                                const char                           *checksum_or_latest,
                                const OstreeRepoFinderResult * const *results,
                                const char                          **opt_subpaths,
+                               const char                          **opt_previous_ids,
                                OstreeAsyncProgress                  *progress,
                                GCancellable                         *cancellable,
                                GError                              **error);
@@ -913,6 +918,8 @@ typedef struct
   GBytes *resolved_metadata;
   guint64 download_size;
   guint64 installed_size;
+  char   *eol;
+  char   *eol_rebase;
 } FlatpakDirResolve;
 
 FlatpakDirResolve *flatpak_dir_resolve_new (const char *remote,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7026,7 +7026,7 @@ apply_extra_data (FlatpakDir   *self,
                                          FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY |
                                          FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY,
                                          id,
-                                         app_context, NULL, NULL, cancellable, error))
+                                         app_context, NULL, NULL, NULL, cancellable, error))
     return FALSE;
 
   flatpak_bwrap_add_arg (bwrap, "/app/bin/apply_extra");

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2304,6 +2304,25 @@ flatpak_deploy_data_get_eol_rebase (GVariant *deploy_data)
   return flatpak_deploy_data_get_string (deploy_data, "eolr");
 }
 
+const char **
+flatpak_deploy_data_get_previous_ids (GVariant *deploy_data, gsize *length)
+{
+  g_autoptr(GVariant) metadata = g_variant_get_child_value (deploy_data, 4);
+  g_autoptr(GVariant) previous_ids_v = NULL;
+  const char **previous_ids = NULL;
+
+  previous_ids_v = g_variant_lookup_value (metadata, "previous-ids", NULL);
+  if (previous_ids_v)
+    previous_ids = g_variant_get_strv (previous_ids_v, length);
+  else
+    {
+      if (length != NULL)
+        *length = 0;
+    }
+
+  return previous_ids;
+}
+
 const char *
 flatpak_deploy_data_get_runtime (GVariant *deploy_data)
 {
@@ -2438,15 +2457,16 @@ add_appdata_to_deploy_data (GVariantBuilder *metadata_builder,
 }
 
 static GVariant *
-flatpak_dir_new_deploy_data (FlatpakDir *self,
-                             GFile      *deploy_dir,
-                             GVariant   *commit_metadata,
-                             GKeyFile   *metadata,
-                             const char *id,
-                             const char *origin,
-                             const char *commit,
-                             char      **subpaths,
-                             guint64     installed_size)
+flatpak_dir_new_deploy_data (FlatpakDir         *self,
+                             GFile              *deploy_dir,
+                             GVariant           *commit_metadata,
+                             GKeyFile           *metadata,
+                             const char         *id,
+                             const char         *origin,
+                             const char         *commit,
+                             char              **subpaths,
+                             guint64             installed_size,
+                             const char * const *previous_ids)
 {
   char *empty_subpaths[] = {NULL};
   GVariantBuilder metadata_builder;
@@ -2478,6 +2498,10 @@ flatpak_dir_new_deploy_data (FlatpakDir *self,
   if (application_runtime)
     g_variant_builder_add (&metadata_builder, "{s@v}", "runtime",
                            g_variant_new_variant (g_variant_new_string (application_runtime)));
+
+  if (previous_ids)
+    g_variant_builder_add (&metadata_builder, "{s@v}", "previous-ids",
+                           g_variant_new_variant (g_variant_new_strv (previous_ids, -1)));
 
   add_appdata_to_deploy_data (&metadata_builder, deploy_dir, id);
 
@@ -7038,6 +7062,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autofree char *metadata_contents = NULL;
   g_auto(GStrv) ref_parts = NULL;
   gboolean is_app;
+  g_autofree const char **previous_ids = NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -7311,6 +7336,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                 G_FILE_CREATE_REPLACE_DESTINATION, NULL, cancellable, error))
     return TRUE;
 
+  if (old_deploy_data)
+    previous_ids = flatpak_deploy_data_get_previous_ids (old_deploy_data, NULL);
 
   export = g_file_get_child (checkoutdir, "export");
 
@@ -7407,7 +7434,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                              origin,
                                              checksum,
                                              (char **) subpaths,
-                                             installed_size);
+                                             installed_size,
+                                             previous_ids);
 
   deploy_data_file = g_file_get_child (checkoutdir, "deploy");
   if (!flatpak_variant_save (deploy_data_file, deploy_data, cancellable, error))

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6137,16 +6137,17 @@ format_flatpak_run_args_from_run_opts (GStrv flatpak_run_args)
 }
 
 static gboolean
-export_desktop_file (const char   *app,
-                     const char   *branch,
-                     const char   *arch,
-                     GKeyFile     *metadata,
-                     int           parent_fd,
-                     const char   *name,
-                     struct stat  *stat_buf,
-                     char        **target,
-                     GCancellable *cancellable,
-                     GError      **error)
+export_desktop_file (const char         *app,
+                     const char         *branch,
+                     const char         *arch,
+                     GKeyFile           *metadata,
+                     const char * const *previous_ids,
+                     int                 parent_fd,
+                     const char         *name,
+                     struct stat        *stat_buf,
+                     char              **target,
+                     GCancellable       *cancellable,
+                     GError            **error)
 {
   gboolean ret = FALSE;
   glnx_autofd int desktop_fd = -1;
@@ -6209,6 +6210,68 @@ export_desktop_file (const char   *app,
 
       /* Add a marker so consumers can easily find out that this launches a sandbox */
       g_key_file_set_string (keyfile, G_KEY_FILE_DESKTOP_GROUP, "X-Flatpak", app);
+
+      /* If the app has been renamed, add its old .desktop filename to
+       * X-Flatpak-RenamedFrom in the new .desktop file, taking care not to
+       * introduce duplicates.
+       */
+      if (previous_ids != NULL)
+        {
+          const char *X_FLATPAK_RENAMED_FROM = "X-Flatpak-RenamedFrom";
+          g_auto(GStrv) renamed_from = g_key_file_get_string_list (keyfile,
+                                                                   G_KEY_FILE_DESKTOP_GROUP,
+                                                                   X_FLATPAK_RENAMED_FROM,
+                                                                   NULL, NULL);
+          g_autoptr(GPtrArray) merged = g_ptr_array_new_with_free_func (g_free);
+          g_autoptr(GHashTable) seen = g_hash_table_new (g_str_hash, g_str_equal);
+          const char *new_suffix;
+          gsize i;
+
+
+          for (i = 0; renamed_from != NULL && renamed_from[i] != NULL; i++)
+            {
+              if (!g_hash_table_contains (seen, renamed_from[i]))
+                {
+                  gchar *copy = g_strdup (renamed_from[i]);
+                  g_hash_table_insert (seen, copy, copy);
+                  g_ptr_array_add (merged, g_steal_pointer (&copy));
+                }
+            }
+
+          /* If an app was renamed from com.example.Foo to net.example.Bar, and
+           * the new version exports net.example.Bar-suffix.desktop, we assume the
+           * old version exported com.example.Foo-suffix.desktop.
+           *
+           * This assertion is true because
+           * flatpak_name_matches_one_wildcard_prefix() is called on all
+           * exported files before we get here.
+           */
+          g_assert (g_str_has_prefix (name, app));
+          /* ".desktop" for the "main" desktop file; something like
+           * "-suffix.desktop" for extra ones.
+           */
+          new_suffix = name + strlen (app);
+
+          for (i = 0; previous_ids[i] != NULL; i++)
+            {
+              g_autofree gchar *previous_desktop = g_strconcat (previous_ids[i], new_suffix, NULL);
+              if (!g_hash_table_contains (seen, previous_desktop))
+                {
+                  g_hash_table_insert (seen, previous_desktop, previous_desktop);
+                  g_ptr_array_add (merged, g_steal_pointer (&previous_desktop));
+                }
+            }
+
+          if (merged->len > 0)
+            {
+              g_ptr_array_add (merged, NULL);
+              g_key_file_set_string_list (keyfile,
+                                          G_KEY_FILE_DESKTOP_GROUP,
+                                          X_FLATPAK_RENAMED_FROM,
+                                          (const char * const *) merged->pdata,
+                                          merged->len - 1);
+            }
+        }
     }
 
   groups = g_key_file_get_groups (keyfile, NULL);
@@ -6301,16 +6364,17 @@ out:
 }
 
 static gboolean
-rewrite_export_dir (const char     *app,
-                    const char     *branch,
-                    const char     *arch,
-                    GKeyFile       *metadata,
-                    FlatpakContext *context,
-                    int             source_parent_fd,
-                    const char     *source_name,
-                    const char     *source_path,
-                    GCancellable   *cancellable,
-                    GError        **error)
+rewrite_export_dir (const char         *app,
+                    const char         *branch,
+                    const char         *arch,
+                    GKeyFile           *metadata,
+                    const char * const *previous_ids,
+                    FlatpakContext     *context,
+                    int                 source_parent_fd,
+                    const char         *source_name,
+                    const char         *source_path,
+                    GCancellable       *cancellable,
+                    GError            **error)
 {
   gboolean ret = FALSE;
   g_auto(GLnxDirFdIterator) source_iter = {0};
@@ -6362,7 +6426,7 @@ rewrite_export_dir (const char     *app,
         {
           g_autofree char *path = g_build_filename (source_path, dent->d_name, NULL);
 
-          if (!rewrite_export_dir (app, branch, arch, metadata, context,
+          if (!rewrite_export_dir (app, branch, arch, metadata, previous_ids, context,
                                    source_iter.fd, dent->d_name,
                                    path, cancellable, error))
             goto out;
@@ -6405,7 +6469,7 @@ rewrite_export_dir (const char     *app,
           if (g_str_has_suffix (dent->d_name, ".desktop") ||
               g_str_has_suffix (dent->d_name, ".service"))
             {
-              if (!export_desktop_file (app, branch, arch, metadata,
+              if (!export_desktop_file (app, branch, arch, metadata, previous_ids,
                                         source_iter.fd, dent->d_name, &stbuf, &new_name, cancellable, error))
                 goto out;
             }
@@ -6455,13 +6519,14 @@ out:
 }
 
 static gboolean
-flatpak_rewrite_export_dir (const char   *app,
-                            const char   *branch,
-                            const char   *arch,
-                            GKeyFile     *metadata,
-                            GFile        *source,
-                            GCancellable *cancellable,
-                            GError      **error)
+flatpak_rewrite_export_dir (const char         *app,
+                            const char         *branch,
+                            const char         *arch,
+                            GKeyFile           *metadata,
+                            const char * const *previous_ids,
+                            GFile              *source,
+                            GCancellable       *cancellable,
+                            GError            **error)
 {
   gboolean ret = FALSE;
   g_autoptr(GFile) parent = g_file_get_parent (source);
@@ -6485,7 +6550,7 @@ flatpak_rewrite_export_dir (const char   *app,
     return FALSE;
 
   /* The fds are closed by this call */
-  if (!rewrite_export_dir (app, branch, arch, metadata, context,
+  if (!rewrite_export_dir (app, branch, arch, metadata, previous_ids, context,
                            parentfd, name, source_path,
                            cancellable, error))
     goto out;
@@ -7408,7 +7473,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
         return FALSE;
 
       if (!flatpak_rewrite_export_dir (ref_parts[1], ref_parts[3], ref_parts[2],
-                                       keyfile, export,
+                                       keyfile, previous_ids, export,
                                        cancellable,
                                        error))
         return FALSE;

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1897,7 +1897,7 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_DEPLOY) != 0,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_STATIC_DELTAS) != 0,
                             FALSE, FALSE, state,
-                            ref, NULL, (const char **) subpaths,
+                            ref, NULL, (const char **) subpaths, NULL,
                             ostree_progress, cancellable, error))
     goto out;
 
@@ -2070,7 +2070,7 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
                            FALSE, FALSE, FALSE, state,
                            ref, target_commit,
                            (const OstreeRepoFinderResult * const *) check_results,
-                           (const char **) subpaths,
+                           (const char **) subpaths, NULL,
                            ostree_progress, cancellable, error))
     goto out;
 

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -136,9 +136,9 @@ FlatpakContext *flatpak_app_compute_permissions (GKeyFile *app_metadata,
                                                  GKeyFile *runtime_metadata,
                                                  GError  **error);
 GFile *flatpak_get_data_dir (const char *app_id);
-GFile *flatpak_ensure_data_dir (const char   *app_id,
-                                GCancellable *cancellable,
-                                GError      **error);
+gboolean flatpak_ensure_data_dir (GFile        *app_id_dir,
+                                  GCancellable *cancellable,
+                                  GError      **error);
 
 gboolean flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
                                       GFile          *runtime_files,

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -121,6 +121,7 @@ gboolean flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
                                            const char      *app_id,
                                            FlatpakContext  *context,
                                            GFile           *app_id_dir,
+                                           GPtrArray       *previous_app_id_dirs,
                                            FlatpakExports **exports_out,
                                            GCancellable    *cancellable,
                                            GError         **error);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1136,7 +1136,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
         }
     }
 
-  flatpak_context_append_bwrap_filesystem (context, bwrap, app_id, app_id_dir, &exports);
+  flatpak_context_append_bwrap_filesystem (context, bwrap, app_id, app_id_dir, NULL, &exports);
 
   if (context->sockets & FLATPAK_CONTEXT_SOCKET_WAYLAND)
     {

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -95,9 +95,9 @@ struct _FlatpakTransactionClass
 {
   GObjectClass parent_class;
 
-  void         (*new_operation)        (FlatpakTransaction          *transaction,
-                                        FlatpakTransactionOperation *operation,
-                                        FlatpakTransactionProgress  *progress);
+  void (*new_operation)        (FlatpakTransaction          *transaction,
+                                FlatpakTransactionOperation *operation,
+                                FlatpakTransactionProgress  *progress);
   void (*operation_done)       (FlatpakTransaction          *transaction,
                                 FlatpakTransactionOperation *operation,
                                 const char                  *commit,
@@ -114,6 +114,12 @@ struct _FlatpakTransactionClass
                                 const char         *ref,
                                 const char         *reason,
                                 const char         *rebase);
+  gboolean (*end_of_lifed_with_rebase) (FlatpakTransaction *transaction,
+                                        const char         *remote,
+                                        const char         *ref,
+                                        const char         *reason,
+                                        const char         *rebased_to_ref,
+                                        const char        **previous_ids);
   gboolean (*ready)            (FlatpakTransaction *transaction);
 
   gboolean (*add_new_remote) (FlatpakTransaction            *transaction,
@@ -219,6 +225,13 @@ gboolean            flatpak_transaction_add_install (FlatpakTransaction *self,
                                                      const char         *ref,
                                                      const char        **subpaths,
                                                      GError            **error);
+FLATPAK_EXTERN
+gboolean            flatpak_transaction_add_rebase (FlatpakTransaction *self,
+                                                    const char         *remote,
+                                                    const char         *ref,
+                                                    const char        **subpaths,
+                                                    const char        **previous_ids,
+                                                    GError            **error);
 FLATPAK_EXTERN
 gboolean            flatpak_transaction_add_install_bundle (FlatpakTransaction *self,
                                                             GFile              *file,

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -120,6 +120,8 @@ const char * flatpak_get_bwrap (void);
 
 char *flatpak_get_timezone (void);
 
+char **flatpak_strv_merge (char   **strv1,
+                           char   **strv2);
 char **flatpak_subpaths_merge (char **subpaths1,
                                char **subpaths2);
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -182,6 +182,8 @@ gboolean flatpak_is_valid_name (const char *string,
                                 GError    **error);
 gboolean flatpak_is_valid_branch (const char *string,
                                   GError    **error);
+gboolean flatpak_has_name_prefix (const char *string,
+                                  const char *name);
 
 char * flatpak_make_valid_id_prefix (const char *orig_id);
 gboolean flatpak_id_has_subref_suffix (const char *id);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -822,6 +822,22 @@ out:
 }
 
 gboolean
+flatpak_has_name_prefix (const char *string,
+                         const char *name)
+{
+  const char *rest;
+
+  if (!g_str_has_prefix (string, name))
+    return FALSE;
+
+  rest = string + strlen (name);
+  return
+    *rest == 0 ||
+    *rest == '.' ||
+    !is_valid_name_character (*rest, FALSE);
+}
+
+gboolean
 flatpak_name_matches_one_wildcard_prefix (const char         *name,
                                           const char * const *wildcarded_prefixes,
                                           gboolean            require_exact_match)

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5690,46 +5690,56 @@ flatpak_format_choices (const char **choices,
   g_print ("\n");
 }
 
+char **
+flatpak_strv_merge (char   **strv1,
+                    char   **strv2)
+{
+  GPtrArray *array;
+  int i;
+
+  /* Maybe either (or both) is unspecified */
+  if (strv1 == NULL)
+    return g_strdupv (strv2);
+  if (strv2 == NULL)
+    return g_strdupv (strv1);
+
+  /* Combine both */
+  array = g_ptr_array_new ();
+
+  for (i = 0; strv1[i] != NULL; i++)
+    {
+      if (!flatpak_g_ptr_array_contains_string (array, strv1[i]))
+        g_ptr_array_add (array, g_strdup (strv1[i]));
+    }
+
+  for (i = 0; strv2[i] != NULL; i++)
+    {
+      if (!flatpak_g_ptr_array_contains_string (array, strv2[i]))
+        g_ptr_array_add (array, g_strdup (strv2[i]));
+    }
+
+  g_ptr_array_add (array, NULL);
+  return (char **) g_ptr_array_free (array, FALSE);
+}
+
 /* In this NULL means don't care about these paths, while
    an empty array means match anything */
 char **
 flatpak_subpaths_merge (char **subpaths1,
                         char **subpaths2)
 {
-  GPtrArray *array;
-  int i;
+  char **res;
 
-  /* Maybe either (or both) is unspecified */
-  if (subpaths1 == NULL)
-    return g_strdupv (subpaths2);
-  if (subpaths2 == NULL)
+  if (subpaths1 != NULL && subpaths1[0] == NULL)
     return g_strdupv (subpaths1);
-
-  /* Check for any "everything" match */
-  if (subpaths1[0] == NULL)
-    return g_strdupv (subpaths1);
-  if (subpaths2[0] == NULL)
+  if (subpaths2 != NULL && subpaths2[0] == NULL)
     return g_strdupv (subpaths2);
 
-  /* Combine both */
-  array = g_ptr_array_new ();
+  res = flatpak_strv_merge (subpaths1, subpaths2);
+  if (res)
+    qsort (res, g_strv_length (res), sizeof (const char *), flatpak_strcmp0_ptr);
 
-  for (i = 0; subpaths1[i] != NULL; i++)
-    {
-      if (!flatpak_g_ptr_array_contains_string (array, subpaths1[i]))
-        g_ptr_array_add (array, g_strdup (subpaths1[i]));
-    }
-
-  for (i = 0; subpaths2[i] != NULL; i++)
-    {
-      if (!flatpak_g_ptr_array_contains_string (array, subpaths2[i]))
-        g_ptr_array_add (array, g_strdup (subpaths2[i]));
-    }
-
-  g_ptr_array_sort (array, flatpak_strcmp0_ptr);
-  g_ptr_array_add (array, NULL);
-
-  return (char **) g_ptr_array_free (array, FALSE);
+  return res;
 }
 
 char *

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -69,6 +69,7 @@
       <arg type='s' name='ref' direction='in'/>
       <arg type='s' name='origin' direction='in'/>
       <arg type='as' name='subpaths' direction='in'/>
+      <arg type='as' name='previous_ids' direction='in'/>
       <arg type='s' name='installation' direction='in'/>
     </method>
 

--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -202,6 +202,18 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--end-of-life-rebase=OLDID=NEWID</option></term>
+
+                <listitem><para>
+                    Mark new refs as end-of-life. Unlike <option>--end-of-life</option>,
+                    this one takes an ID that supercedes the current one. By the user's
+                    request, the application data may be preserved for the new application.
+                    Note, this is actually a prefix match, so if you say org.the.app=org.new.app,
+                    then something like org.the.app.Locale will be rebased to org.new.app.Locale.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--timestamp=TIMESTAMP</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -187,6 +187,16 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--end-of-life-rebase=ID</option></term>
+
+                <listitem><para>
+                    Mark the build as end-of-life. Unlike <option>--end-of-life</option>,
+                    this one takes an ID that supercedes the current one. By the user's
+                    request, the application data may be preserved for the new application.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--disable-fsync</option></term>
 
                 <listitem><para>

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -377,6 +377,7 @@ handle_deploy (FlatpakSystemHelper   *object,
                const gchar           *arg_ref,
                const gchar           *arg_origin,
                const gchar *const    *arg_subpaths,
+               const gchar *const    *arg_previous_ids,
                const gchar           *arg_installation)
 {
   g_autoptr(FlatpakDir) system = NULL;
@@ -661,8 +662,10 @@ handle_deploy (FlatpakSystemHelper   *object,
     {
       if (deploy_dir && !reinstall)
         {
-          if (!flatpak_dir_deploy_update (system, arg_ref,
-                                          NULL, (const char **) arg_subpaths, NULL, &error))
+          if (!flatpak_dir_deploy_update (system, arg_ref, NULL,
+                                          (const char **) arg_subpaths,
+                                          (const char **) arg_previous_ids,
+                                          NULL, &error))
             {
               flatpak_invocation_return_error (invocation, error, "Error deploying");
               return TRUE;
@@ -672,8 +675,8 @@ handle_deploy (FlatpakSystemHelper   *object,
         {
           if (!flatpak_dir_deploy_install (system, arg_ref, arg_origin,
                                            (const char **) arg_subpaths,
-                                           reinstall,
-                                           NULL, &error))
+                                           (const char **) arg_previous_ids,
+                                           reinstall, NULL, &error))
             {
               flatpak_invocation_return_error (invocation, error, "Error deploying");
               return TRUE;

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -54,6 +54,16 @@ Exec=hello.sh
 Icon=$APP_ID
 MimeType=x-test/Hello;
 EOF
+cat > ${DIR}/files/share/applications/org.test.Hello.Again.desktop <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Hello Again
+Exec=hello.sh --again
+Icon=$APP_ID
+MimeType=x-test/Hello;
+X-Flatpak-RenamedFrom=hello-again.desktop;
+EOF
 
 mkdir -p ${DIR}/files/share/icons/hicolor/64x64/apps
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/${APP_ID}.png

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -28,7 +28,7 @@ name=$APP_ID
 runtime=org.test.Platform/$ARCH/$BRANCH
 sdk=org.test.Platform/$ARCH/$BRANCH
 
-[Extension org.test.Hello.Locale]
+[Extension $APP_ID.Locale]
 directory=share/runtime/locale
 autodelete=true
 locale-subset=true

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -395,11 +395,11 @@ test_subpaths_merge (void)
   g_auto(GStrv) res = NULL;
 
   res = flatpak_subpaths_merge (NULL, bla);
-  assert_strv_equal (res, bla);
+  assert_strv_equal (res, bla_sorted);
   g_clear_pointer (&res, g_strfreev);
 
   res = flatpak_subpaths_merge (bla, NULL);
-  assert_strv_equal (res, bla);
+  assert_strv_equal (res, bla_sorted);
   g_clear_pointer (&res, g_strfreev);
 
   res = flatpak_subpaths_merge (empty, bla);


### PR DESCRIPTION
This is definitely a much bigger PR than I first anticipated :sweat_smile: 

In essence, it combines previous downstream work by Endless with some additions I made to result in a complete solution for handling eol_rebase:

- A new deploy data attribute previous-ids has been added, representing the EOL'd IDs an app is replacing.
- `flatpak build-export` gained `--eol-rebase=...`.
- If the user installs or updates an app that's been EOL'd, Flatpak will print a message asking if the user would like to install replacement. If yes, then a new transaction is created to install the new one and uninstall the old one *in that order*. During installation, the new app will have its previous-ids set to the old ref + any it may have had.
- When running an app, the newest data directory from previous-ids will be renamed to become the new app's data directory (unless the new app was already installed, in which case nothing occurs). For any old apps, their data directories are symlinked onto the new app's data directory. (This was originally done by Endless, but I refactored a large amount of it to make it more robust in the last commit.)

**EDIT:** Also yeah, I just noticed the commit order is screwed up, will be fixed soon.