### PR TITLE
Create origin subfolder for icons as per appstream spec

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -49,6 +49,7 @@
 #include <gio/gunixoutputstream.h>
 #include <gio/gunixinputstream.h>
 
+#define APPSTREAM_ORIGIN_NAME "flatpak"
 
 /* This is also here so the common code can report these errors to the lib */
 static const GDBusErrorEntry flatpak_error_entries[] = {
@@ -3722,7 +3723,7 @@ flatpak_appstream_xml_new (void)
   appstream_components->attribute_names[0] = g_strdup ("version");
   appstream_components->attribute_values[0] = g_strdup ("0.8");
   appstream_components->attribute_names[1] = g_strdup ("origin");
-  appstream_components->attribute_values[1] = g_strdup ("flatpak");
+  appstream_components->attribute_values[1] = g_strdup (APPSTREAM_ORIGIN_NAME);
 
   return appstream_root;
 }
@@ -3826,6 +3827,7 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
     g_autoptr(GBytes) xml_gz_data = NULL;
     g_autoptr(OstreeMutableTree) mtree = ostree_mutable_tree_new ();
     g_autoptr(OstreeMutableTree) icons_mtree = NULL;
+    g_autoptr(OstreeMutableTree) origin_mtree = NULL;
     g_autoptr(OstreeMutableTree) size1_mtree = NULL;
     g_autoptr(OstreeMutableTree) size2_mtree = NULL;
     const char *compat_arch;
@@ -3839,10 +3841,13 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
     if (!flatpak_mtree_create_dir (repo, mtree, "icons", &icons_mtree, error))
       return FALSE;
 
-    if (!flatpak_mtree_create_dir (repo, icons_mtree, "64x64", &size1_mtree, error))
+    if (!flatpak_mtree_create_dir (repo, icons_mtree, APPSTREAM_ORIGIN_NAME, &origin_mtree, error))
       return FALSE;
 
-    if (!flatpak_mtree_create_dir (repo, icons_mtree, "128x128", &size2_mtree, error))
+    if (!flatpak_mtree_create_dir (repo, origin_mtree, "64x64", &size1_mtree, error))
+      return FALSE;
+
+    if (!flatpak_mtree_create_dir (repo, origin_mtree, "128x128", &size2_mtree, error))
       return FALSE;
 
     appstream_root = flatpak_appstream_xml_new ();


### PR DESCRIPTION
The appstream specification (https://www.freedesktop.org/software/appstream/docs/sect-AppStream-IconCache.html) states:

> All icons of type cached must be placed in /usr/share/app-info/icons/%{origin}/%{size}/ or /var/cache/app-info/icons/%{origin}/%{size}/, where origin is the AppStream data origin defined in the AppStream data file

This holds true for the internal directory structure of flatpaks when building them. However, the appstream directory checked out from the remotes (typically at `/var/lib/flatpak/appstream` doesn't follow this pattern, when it would be useful for it to do so.

The current directory structure looks a little like this:
```
/var/lib/flatpak/appstream/flathub/x86_64/active/
├── appstream.xml
├── appstream.xml.gz
└── icons
    ├── 128x128 [472 entries exceeds filelimit, not opening dir]
    └── 64x64 [508 entries exceeds filelimit, not opening dir]
```

Whereas I propose it should look like this:
```
/var/lib/flatpak/appstream/flathub/x86_64/active/
├── appstream.xml
├── appstream.xml.gz
└── icons
    └── flatpak
        ├── 128x128 [472 entries exceeds filelimit, not opening dir]
        └── 64x64 [508 entries exceeds filelimit, not opening dir]
```

This would allow pointing libappstream at each top level `active` folder and it would be able to pick up all of the icons for all of the components. Whereas the current structure doesn't allow the icons to be located as there isn't the extra `%{origin}` subfolder.

I appreciate that this may not be a bug due to the `/var/lib/flatpak/appstream` folder not being one of the folders mentioned in the spec, but it would make handling the appstream data much more efficient if this was the case. Currently, the xml file has to be pre-processed to calculate absolute paths to the icons first.

Also, I believe another thing that would make sense would be allowing the origin to be configured at the command line when running `build-update-repo` instead of having it hardcoded to `flatpak`. As the origin field in appstream is typically used to denote the repository name, rather than the packaging format. I'd be happy to do this as a separate PR if it would be considered as something worthwhile.

I'm not fully aware of the implications of this PR in terms of storage in ostree repos or if there are any applications or scripts expecting there to not be an extra subdirectory there, but I'm open to feedback or other solutions to this issue.