### PR TITLE
run: Only compare the lowest 32 ioctl arg bits for TIOCSTI

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2475,7 +2475,7 @@ setup_seccomp (FlatpakBwrap   *bwrap,
     {SCMP_SYS (clone), &SCMP_A0 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
 
     /* Don't allow faking input to the controlling tty (CVE-2017-5226) */
-    {SCMP_SYS (ioctl), &SCMP_A1 (SCMP_CMP_EQ, (int) TIOCSTI)},
+    {SCMP_SYS (ioctl), &SCMP_A1 (SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, (int) TIOCSTI)},
   };
 
   struct


### PR DESCRIPTION
Closes #2782.

I thought SCMP_A1_32 would work, but apparently that just uses a 32-bit compared value instead.

This variant instead uses a mask to grab the 32 bits and compare those. I tested the [CVE 2019-7303 exploit](https://www.exploit-db.com/exploits/46594), and it seems to work.