### PR TITLE
build-export: error out with sizes checked if the icon is too large

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -392,7 +392,7 @@ validate_icon_file (GFile *file, GError **error)
   if (!g_spawn_check_exit_status (status, NULL))
     {
       g_debug ("Icon validation: %s", err);
-      return flatpak_fail (error, "%s is not a valid icon: %s", name, err);
+      return flatpak_fail (error, "%s is not a valid 512x512 icon: %s", name, err);
     }
 
   return TRUE;


### PR DESCRIPTION
This makes it arguably more friendly in case the build fails.
Now it's more clear which size the user has obey.