### PR TITLE
Allow overriding bus names to none

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1679,10 +1679,13 @@ flatpak_context_save_metadata (FlatpakContext *context,
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
       FlatpakPolicy policy = GPOINTER_TO_INT (value);
-      if (policy > 0)
-        g_key_file_set_string (metakey,
-                               FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
-                               (char *) key, flatpak_policy_to_string (policy));
+
+      if (flatten && (policy == 0))
+        continue;
+
+      g_key_file_set_string (metakey,
+                             FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                             (char *) key, flatpak_policy_to_string (policy));
     }
 
   g_key_file_remove_group (metakey, FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY, NULL);
@@ -1690,10 +1693,13 @@ flatpak_context_save_metadata (FlatpakContext *context,
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
       FlatpakPolicy policy = GPOINTER_TO_INT (value);
-      if (policy > 0)
-        g_key_file_set_string (metakey,
-                               FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
-                               (char *) key, flatpak_policy_to_string (policy));
+
+      if (flatten && (policy == 0))
+        continue;
+
+      g_key_file_set_string (metakey,
+                             FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                             (char *) key, flatpak_policy_to_string (policy));
     }
 
   g_key_file_remove_group (metakey, FLATPAK_METADATA_GROUP_ENVIRONMENT, NULL);

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1067,6 +1067,21 @@ option_talk_name_cb (const gchar *option_name,
 }
 
 static gboolean
+option_no_talk_name_cb (const gchar *option_name,
+                        const gchar *value,
+                        gpointer     data,
+                        GError     **error)
+{
+  FlatpakContext *context = data;
+
+  if (!flatpak_verify_dbus_name (value, error))
+    return FALSE;
+
+  flatpak_context_set_session_bus_policy (context, value, FLATPAK_POLICY_NONE);
+  return TRUE;
+}
+
+static gboolean
 option_system_own_name_cb (const gchar *option_name,
                            const gchar *value,
                            gpointer     data,
@@ -1093,6 +1108,21 @@ option_system_talk_name_cb (const gchar *option_name,
     return FALSE;
 
   flatpak_context_set_system_bus_policy (context, value, FLATPAK_POLICY_TALK);
+  return TRUE;
+}
+
+static gboolean
+option_system_no_talk_name_cb (const gchar *option_name,
+                               const gchar *value,
+                               gpointer     data,
+                               GError     **error)
+{
+  FlatpakContext *context = data;
+
+  if (!flatpak_verify_dbus_name (value, error))
+    return FALSE;
+
+  flatpak_context_set_system_bus_policy (context, value, FLATPAK_POLICY_NONE);
   return TRUE;
 }
 
@@ -1205,8 +1235,10 @@ static GOptionEntry context_options[] = {
   { "env", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_env_cb, N_("Set environment variable"), N_("VAR=VALUE") },
   { "own-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_own_name_cb, N_("Allow app to own name on the session bus"), N_("DBUS_NAME") },
   { "talk-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_talk_name_cb, N_("Allow app to talk to name on the session bus"), N_("DBUS_NAME") },
+  { "no-talk-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_no_talk_name_cb, N_("Don't allow app to talk to name on the session bus"), N_("DBUS_NAME") },
   { "system-own-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_system_own_name_cb, N_("Allow app to own name on the system bus"), N_("DBUS_NAME") },
   { "system-talk-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_system_talk_name_cb, N_("Allow app to talk to name on the system bus"), N_("DBUS_NAME") },
+  { "system-no-talk-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_system_no_talk_name_cb, N_("Don't allow app to talk to name on the system bus"), N_("DBUS_NAME") },
   { "add-policy", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_add_generic_policy_cb, N_("Add generic policy option"), N_("SUBSYSTEM.KEY=VALUE") },
   { "remove-policy", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_remove_generic_policy_cb, N_("Remove generic policy option"), N_("SUBSYSTEM.KEY=VALUE") },
   { "persist", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_CALLBACK, &option_persist_cb, N_("Persist home directory"), N_("FILENAME") },

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -278,6 +278,16 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
+                <term><option>--no-talk-name=NAME</option></term>
+
+                <listitem><para>
+                    Don't allow the application to talk to the well-known name <arg choice="plain">NAME</arg> on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--system-own-name=NAME</option></term>
 
                 <listitem><para>
@@ -293,6 +303,17 @@ key=v1;v2;
 
                 <listitem><para>
                     Allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--system-no-talk-name=NAME</option></term>
+
+                <listitem><para>
+                    Don't allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the system bus.
                     If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -414,6 +414,17 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
+                <term><option>--no-talk-name=NAME</option></term>
+
+                <listitem><para>
+                    Don't allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the session bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--system-own-name=NAME</option></term>
 
                 <listitem><para>
@@ -429,6 +440,17 @@ key=v1;v2;
 
                 <listitem><para>
                     Allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the system bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--system-no-talk-name=NAME</option></term>
+
+                <listitem><para>
+                    Don't allow the application to talk to the well known name <arg choice="plain">NAME</arg> on the system bus.
                     If <arg choice="plain">NAME</arg> ends with .*, it allows the application to talk to all matching names.
                     This overrides to the Context section from the application metadata.
                     This option can be used multiple times.

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -91,11 +91,14 @@ reset_overrides
 
 ${FLATPAK} override --user --own-name=org.foo.Own org.test.Hello
 ${FLATPAK} override --user --talk-name=org.foo.Talk org.test.Hello
+${FLATPAK} override --user --talk-name=org.foo.NoTalk org.test.Hello
+${FLATPAK} override --user --no-talk-name=org.foo.NoTalk org.test.Hello
 ${FLATPAK} override --user --show org.test.Hello > override
 
 assert_file_has_content override "^\[Session Bus Policy\]$"
 assert_file_has_content override "^org\.foo\.Own=own$"
 assert_file_has_content override "^org\.foo\.Talk=talk$"
+assert_file_has_content override "^org\.foo\.NoTalk=none$"
 
 echo "ok override session bus names"
 
@@ -103,11 +106,14 @@ reset_overrides
 
 ${FLATPAK} override --user --system-own-name=org.foo.Own.System org.test.Hello
 ${FLATPAK} override --user --system-talk-name=org.foo.Talk.System org.test.Hello
+${FLATPAK} override --user --system-talk-name=org.foo.NoTalk.System org.test.Hello
+${FLATPAK} override --user --system-no-talk-name=org.foo.NoTalk.System org.test.Hello
 ${FLATPAK} override --user --show org.test.Hello > override
 
 assert_file_has_content override "^\[System Bus Policy\]$"
 assert_file_has_content override "^org\.foo\.Own\.System=own$"
 assert_file_has_content override "^org\.foo\.Talk\.System=talk$"
+assert_file_has_content override "^org\.foo\.NoTalk\.System=none$"
 
 echo "ok override system bus names"
 


### PR DESCRIPTION
flatpak override could set a bus name policy to
talk or own, but not to none. Fix this oversight.

Closes: https://github.com/flatpak/flatpak/issues/2722