### PR TITLE
Skip some tests if we can't use FUSE

### DIFF
--- a/tests/test-build-update-repo.sh
+++ b/tests/test-build-update-repo.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_revokefs_without_fuse
 
 echo "1..5"
 

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 #FLATPAK=flatpak
 . $(dirname $0)/libtest.sh
 
+skip_revokefs_without_fuse
+
 # This test looks for specific localized strings.
 export LC_ALL=C
 

--- a/tests/test-info.sh
+++ b/tests/test-info.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_revokefs_without_fuse
+
 echo "1..7"
 
 setup_repo

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_revokefs_without_fuse
+
 reset_overrides () {
     ${FLATPAK} override --user --reset org.test.Hello
     ${FLATPAK} override --user --show org.test.Hello > info

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_revokefs_without_fuse
 
 echo "1..30"
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_revokefs_without_fuse
 
 echo "1..15"
 

--- a/tests/test-unsigned-summaries.sh
+++ b/tests/test-unsigned-summaries.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_revokefs_without_fuse
 
 echo "1..7"
 

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_revokefs_without_fuse
 
 echo "1..3"
 


### PR DESCRIPTION
On some systems we can't make use of FUSE, especially on the same
locked-down systems where distribution packages are typically built.
For example, official Debian autobuilders (buildds) are configured to
disallow module loading after boot has finished as a form of security
hardening, some build chroots don't have a valid /etc/mtab, and Docker
containers give us uid 0 but not CAP_SYS_ADMIN.

These checks are taken from libostree.