### PR TITLE
permission-reset: Add an --all option

### DIFF
--- a/app/flatpak-builtins-permission-reset.c
+++ b/app/flatpak-builtins-permission-reset.c
@@ -37,7 +37,10 @@
 #include "flatpak-utils-private.h"
 #include "flatpak-run-private.h"
 
+static gboolean opt_all;
+
 static GOptionEntry options[] = {
+  { "all", 0, 0, G_OPTION_ARG_NONE, &opt_all, N_("Reset all permissions"), NULL },
   { NULL }
 };
 
@@ -77,7 +80,7 @@ remove_for_app (XdpDbusPermissionStore *store,
       g_variant_iter_init (&iter, permissions);
       while (g_variant_iter_loop (&iter, "{s@as}", &key, &value))
         {
-          if (strcmp (key, app_id) == 0)
+          if (app_id == NULL || strcmp (key, app_id) == 0)
             continue;
 
           g_variant_builder_add (&builder, "{s@as}", key, value);
@@ -139,10 +142,13 @@ flatpak_builtin_permission_reset (int argc, char **argv,
                                      NULL, cancellable, error))
     return FALSE;
 
-  if (argc != 2)
+  if ((opt_all && argc != 1) || (!opt_all && argc != 2))
     return usage_error (context, _("Wrong number of arguments"), error);
 
-  app_id = argv[1];
+  if (opt_all)
+    app_id = NULL;
+  else
+    app_id = argv[1];
 
   return reset_permissions_for_app (app_id, error);
 }

--- a/doc/flatpak-permission-reset.xml
+++ b/doc/flatpak-permission-reset.xml
@@ -34,6 +34,11 @@
                 <arg choice="opt" rep="repeat">OPTION</arg>
                 <arg choice="plain">APP_ID</arg>
             </cmdsynopsis>
+            <cmdsynopsis>
+                <command>flatpak permission-reset</command>
+                <arg choice="opt" rep="repeat">OPTION</arg>
+                <arg choice="plain">--all</arg>
+            </cmdsynopsis>
     </refsynopsisdiv>
 
     <refsect1>
@@ -59,6 +64,14 @@
         <para>The following options are understood:</para>
 
         <variablelist>
+            <varlistentry>
+                <term><option>--all</option></term>
+
+                <listitem><para>
+                    Remove permissions for all applications.
+                </para></listitem>
+            </varlistentry>
+
             <varlistentry>
                 <term><option>-h</option></term>
                 <term><option>--help</option></term>


### PR DESCRIPTION
This lets users do a 'factory reset' of the permission store.