### PR TITLE
Fix a system-helper crash

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1885,7 +1885,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
       g_variant_get_child (parameters, 1, "u", &flags);
       g_variant_get_child (parameters, 2, "&s", &ref);
       g_variant_get_child (parameters, 3, "&s", &origin);
-      g_variant_get_child (parameters, 5, "&s", &installation);
+      g_variant_get_child (parameters, 6, "&s", &installation);
 
       /* For metadata updates, redirect to the metadata-update action which
        * should basically always be allowed */


### PR DESCRIPTION
As seen in https://github.com/flatpak/flatpak/issues/2829, the system-helper crashes while trying to access an as parameter as s. Looking at the likely culprits for this, I find that the permission check for Deploy has an off-by-one error where it tries to get the installation, but passes the offset for the previous_ids  parameter.

It would be less error-prone to use introspection data and refer to parameters by name here.