### PR TITLE
oci: Handle cancellations for appstream

### DIFF
--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -2465,6 +2465,9 @@ flatpak_oci_index_make_appstream (SoupSession  *soup_session,
         }
     }
 
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return NULL;
+
   if (!flatpak_appstream_xml_root_to_data (appstream_root,
                                            &bytes, NULL, error))
     return NULL;


### PR DESCRIPTION
When an appstream update is cancelled while downloading
icons, properly fail. Otherwise, the next update attempt
will see an up-to-date timestamp, think everyhing is ok
and not download the missing icons.

Closes: https://github.com/flatpak/flatpak/issues/2835