### PR TITLE
doc/flatpak: Document FLATPAK_SYSTEM_CACHE_DIR

### DIFF
--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -563,6 +563,18 @@
                     </para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><envar>FLATPAK_SYSTEM_CACHE_DIR</envar></term>
+
+                    <listitem><para>
+                      The location where temporary child repositories will be created during pulls
+                      into the system-wide installation.  If this is not set, a directory in
+                      <filename>/var/tmp/</filename> is used. This is useful because it is more
+                      likely to be on the same filesystem as the system repository (thus increasing
+                      the chances for e.g. reflink copying), and we can avoid filling the user's
+                      home directory with temporary data.
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><envar>FLATPAK_CONFIG_DIR</envar></term>
 
                     <listitem><para>


### PR DESCRIPTION
This environment variable has been used for a while; it's just
undocumented. Copy some information from a comment in flatpak-dir.c.