### PR TITLE
profile: Only alter XDG_DATA_DIRS if flatpak is still installed

### DIFF
--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -1,24 +1,26 @@
-# set XDG_DATA_DIRS to include Flatpak installations
+if command -v flatpak > /dev/null; then
+    # set XDG_DATA_DIRS to include Flatpak installations
 
-new_dirs=$(
-    (
-        unset G_MESSAGES_DEBUG
-        echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
-        flatpak --installations
-    ) | (
-        new_dirs=
-        while read -r install_path
-        do
-            share_path=$install_path/exports/share
-            case ":$XDG_DATA_DIRS:" in
-                *":$share_path:"*) :;;
-                *":$share_path/:"*) :;;
-                *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
-            esac
-        done
-        echo "$new_dirs"
+    new_dirs=$(
+        (
+            unset G_MESSAGES_DEBUG
+            echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
+            flatpak --installations
+        ) | (
+            new_dirs=
+            while read -r install_path
+            do
+                share_path=$install_path/exports/share
+                case ":$XDG_DATA_DIRS:" in
+                    *":$share_path:"*) :;;
+                    *":$share_path/:"*) :;;
+                    *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
+                esac
+            done
+            echo "$new_dirs"
+        )
     )
-)
 
-export XDG_DATA_DIRS
-XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+    export XDG_DATA_DIRS
+    XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+fi


### PR DESCRIPTION
In some OSs, removing a package does not immediately remove its
configuration files in /etc. In particular, `dpkg --remove` or
`apt-get remove` in Debian derivatives leaves configuration files intact
so that the package can be reinstalled later without having to
reconfigure it, with `dpkg --purge` or `apt-get purge` used to remove
the configuration files too.

Signed-off-by: Simon McVittie <smcv@collabora.com>  
Closes: #2840

---

Best reviewed with `git diff --ignore-all-space` or `git diff --ignore-space-change`.