### PR TITLE
list/remote-ls/search: Split description field

### DIFF
--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -54,8 +54,9 @@ static GOptionEntry options[] = {
 };
 
 static Column all_columns[] = {
-  { "description",  N_("Description"),    N_("Show the description"),    1, FLATPAK_ELLIPSIZE_MODE_END, 1, 1 },
-  { "application",  N_("Application"),    N_("Show the application ID"), 1, FLATPAK_ELLIPSIZE_MODE_START, 0, 1 },
+  { "name",         N_("Name"),           N_("Show the name"),           1, FLATPAK_ELLIPSIZE_MODE_END, 1, 1 },
+  { "description",  N_("Description"),    N_("Show the description"),    1, FLATPAK_ELLIPSIZE_MODE_END, 1, 0 },
+  { "application",  N_("Application ID"), N_("Show the application ID"), 1, FLATPAK_ELLIPSIZE_MODE_START, 0, 1 },
   { "version",      N_("Version"),        N_("Show the version"),        1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
   { "branch",       N_("Branch"),         N_("Show the branch"),         1, FLATPAK_ELLIPSIZE_MODE_NONE, 0, 1 },
   { "arch",         N_("Arch"),           N_("Show the architecture"),   1, FLATPAK_ELLIPSIZE_MODE_NONE, 0, 1, 1 },
@@ -284,15 +285,15 @@ print_table_for_refs (gboolean      print_apps,
 
           for (k = 0; columns[k].name; k++)
             {
-              if (strcmp (columns[k].name, "description") == 0)
+              if (strcmp (columns[k].name, "name") == 0)
                 {
-                  g_autofree char *description = NULL;
                   const char *name = appdata_name ? appdata_name : strrchr (parts[1], '.') + 1;
 
-                  if (appdata_summary)
-                    description =  g_strconcat (name, " - ", appdata_summary, NULL);
-                  else
-                    description =  g_strdup (name);
+                  flatpak_table_printer_add_column (printer, name);
+                }
+              else if (strcmp (columns[k].name, "description") == 0)
+                {
+                  const char *description = appdata_summary ? appdata_summary : "";
                   flatpak_table_printer_add_column (printer, description);
                 }
               else if (strcmp (columns[k].name, "version") == 0)

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -56,8 +56,9 @@ static GOptionEntry options[] = {
 };
 
 static Column all_columns[] = {
-  { "description",    N_("Description"),    N_("Show the description"),    1, FLATPAK_ELLIPSIZE_MODE_END, 1, 1 },
-  { "application",    N_("Application"),    N_("Show the application ID"), 1, FLATPAK_ELLIPSIZE_MODE_START, 0, 1 },
+  { "name",           N_("Name"),           N_("Show the name"),           1, FLATPAK_ELLIPSIZE_MODE_END, 1, 1 },
+  { "description",    N_("Description"),    N_("Show the description"),    1, FLATPAK_ELLIPSIZE_MODE_END, 1, 0 },
+  { "application",    N_("Application ID"),    N_("Show the application ID"), 1, FLATPAK_ELLIPSIZE_MODE_START, 0, 1 },
   { "version",        N_("Version"),        N_("Show the version"),        1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
   { "branch",         N_("Branch"),         N_("Show the branch"),         1, FLATPAK_ELLIPSIZE_MODE_NONE, 0, 1 },
   { "arch",           N_("Arch"),           N_("Show the architecture"),   1, FLATPAK_ELLIPSIZE_MODE_NONE, 0, 0 },
@@ -137,7 +138,8 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
           strcmp (columns[j].name, "installed-size") == 0 ||
           strcmp (columns[j].name, "runtime") == 0)
         need_cache_data = TRUE;
-      if (strcmp (columns[j].name, "description") == 0 ||
+      if (strcmp (columns[j].name, "name") == 0 ||
+          strcmp (columns[j].name, "description") == 0 ||
           strcmp (columns[j].name, "version") == 0)
         need_appstream_data = TRUE;
     }
@@ -292,18 +294,22 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
 
           for (j = 0; columns[j].name; j++)
             {
-              if (strcmp (columns[j].name, "description") == 0)
+              if (strcmp (columns[j].name, "name") == 0)
                 {
+                  const char *name = NULL;
+
                   if (app)
-                    {
-                      g_autofree char *description = NULL;
-                      const char *name = as_app_get_localized_name (app);
-                      const char *comment = as_app_get_localized_comment (app);
-                      description = g_strconcat (name, " - ", comment, NULL);
-                      flatpak_table_printer_add_column (printer, description);
-                    }
-                  else
-                    flatpak_table_printer_add_column (printer, parts[1]);
+                    name = as_app_get_localized_name (app);
+
+                  flatpak_table_printer_add_column (printer, name ? name : strrchr (parts[1], '.') + 1);
+                }
+              else if (strcmp (columns[j].name, "description") == 0)
+                {
+                  const char *comment = NULL;
+                  if (app)
+                      comment = as_app_get_localized_comment (app);
+
+                  flatpak_table_printer_add_column (printer, comment);
                 }
               else if (strcmp (columns[j].name, "version") == 0)
                 flatpak_table_printer_add_column (printer, app ? as_app_get_version (app) : "");

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -62,7 +62,7 @@ static Column all_columns[] = {
   { "version",        N_("Version"),        N_("Show the version"),        1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
   { "branch",         N_("Branch"),         N_("Show the branch"),         1, FLATPAK_ELLIPSIZE_MODE_NONE, 0, 1 },
   { "arch",           N_("Arch"),           N_("Show the architecture"),   1, FLATPAK_ELLIPSIZE_MODE_NONE, 0, 0 },
-  { "origin",         N_("Origin"),         N_("Show the origin remote"),  1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
+  { "origin",         N_("Origin"),         N_("Show the origin remote"),  1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1, 1 },
   { "ref",            N_("Ref"),            N_("Show the ref"),            1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "commit",         N_("Commit"),         N_("Show the active commit"),  1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "runtime",        N_("Runtime"),        N_("Show the runtime"),        1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -39,8 +39,9 @@ static GOptionEntry options[] = {
 };
 
 static Column all_columns[] = {
+  { "name",        N_("Name"),        N_("Show the name"),               1, FLATPAK_ELLIPSIZE_MODE_END, 1, 1 },
   { "description", N_("Description"), N_("Show the description"),        1, FLATPAK_ELLIPSIZE_MODE_END, 1, 1 },
-  { "application", N_("Application"), N_("Show the application ID"),     1, FLATPAK_ELLIPSIZE_MODE_START, 1, 1 },
+  { "application", N_("Application ID"), N_("Show the application ID"),     1, FLATPAK_ELLIPSIZE_MODE_START, 1, 1 },
   { "version",     N_("Version"),     N_("Show the version"),            1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
 #if AS_CHECK_VERSION (0, 6, 1)
   { "branch",      N_("Branch"),      N_("Show the application branch"), 1, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
@@ -219,8 +220,10 @@ print_app (Column *columns, MatchResult *res, FlatpakTablePrinter *printer)
 
   for (i = 0; columns[i].name; i++)
     {
+      if (strcmp (columns[i].name, "name") == 0)
+        flatpak_table_printer_add_column (printer, name);
       if (strcmp (columns[i].name, "description") == 0)
-        flatpak_table_printer_add_column (printer, description);
+        flatpak_table_printer_add_column (printer, comment);
       else if (strcmp (columns[i].name, "application") == 0)
         flatpak_table_printer_add_column (printer, id);
       else if (strcmp (columns[i].name, "version") == 0)

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -215,7 +215,6 @@ print_app (Column *columns, MatchResult *res, FlatpakTablePrinter *printer)
   const char *id = as_app_get_id_filename (res->app);
   const char *name = as_app_get_localized_name (res->app);
   const char *comment = as_app_get_localized_comment (res->app);
-  g_autofree char *description = g_strconcat (name, " - ", comment, NULL);
   guint i;
 
   for (i = 0; columns[i].name; i++)

--- a/doc/flatpak-list.xml
+++ b/doc/flatpak-list.xml
@@ -190,6 +190,14 @@
 
         <variablelist>
             <varlistentry>
+                <term>name</term>
+
+                <listitem><para>
+                    Show the name
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term>description</term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -199,6 +199,14 @@
 
         <variablelist>
             <varlistentry>
+                <term>name</term>
+
+                <listitem><para>
+                    Show the name
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term>description</term>
 
                 <listitem><para>

--- a/doc/flatpak-search.xml
+++ b/doc/flatpak-search.xml
@@ -127,6 +127,14 @@
 
         <variablelist>
             <varlistentry>
+                <term>name</term>
+
+                <listitem><para>
+                    Show the name
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term>description</term>
 
                 <listitem><para>

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -185,6 +185,7 @@ description
 help
 installation
 latest
+name
 options
 origin
 ref
@@ -215,6 +216,7 @@ arch,branch
 arch,description
 arch,installation
 arch,latest
+arch,name
 arch,options
 arch,origin
 arch,ref


### PR DESCRIPTION
Instead of combining name and comment we split them into two columns.
We also disable the comment column by default for list and remote-ls
 as it is very poor in long tables. However, it is still there for search
 where it seems more useful.
    
Also, the Application column title changed to Application ID to make
 it clearer what it is compared to the "Name" column.