### PR TITLE
create-usb: Delete local repo summary if it exists

### DIFF
--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -738,6 +738,11 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
       }
   }
 
+  /* Delete the local source repo summary if it exists. Old versions of this
+   * command erroneously created it and if it's outdated that causes problems. */
+  if (!flatpak_dir_update_summary (dir, TRUE, cancellable, error))
+    return FALSE;
+
   /* Now use code copied from `ostree create-usb` to do the actual copying. We
    * can't just call out to `ostree` because (a) flatpak doesn't have a
    * dependency on the ostree command line tools and (b) we need to only pull

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -273,9 +273,11 @@ typedef enum {
 typedef enum {
   FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_NONE = 0,
   FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_NO_INTERACTION = 1 << 0,
+  FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_DELETE = 1 << 1,
 } FlatpakHelperUpdateSummaryFlags;
 
-#define FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_ALL (FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_NO_INTERACTION)
+#define FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_ALL (FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_NO_INTERACTION |\
+                                                 FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_DELETE)
 
 typedef enum {
   FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NONE = 0,
@@ -721,6 +723,7 @@ gboolean    flatpak_dir_run_triggers (FlatpakDir   *self,
                                       GCancellable *cancellable,
                                       GError      **error);
 gboolean    flatpak_dir_update_summary (FlatpakDir   *self,
+                                        gboolean      delete,
                                         GCancellable *cancellable,
                                         GError      **error);
 gboolean    flatpak_dir_cleanup_removed (FlatpakDir   *self,

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1751,6 +1751,7 @@ handle_update_summary (FlatpakSystemHelper   *object,
 {
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
+  gboolean delete_summary;
 
   g_debug ("UpdateSummary %u %s", arg_flags, arg_installation);
 
@@ -1773,10 +1774,11 @@ handle_update_summary (FlatpakSystemHelper   *object,
       g_dbus_method_invocation_return_gerror (invocation, error);
       return TRUE;
     }
-
-  if (!flatpak_dir_update_summary (system, NULL, &error))
+  delete_summary = (arg_flags & FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_DELETE) != 0;
+  if (!flatpak_dir_update_summary (system, delete_summary, NULL, &error))
     {
-      flatpak_invocation_return_error (invocation, error, "Error updating summary");
+      flatpak_invocation_return_error (invocation, error, "Error %s summary",
+                                       delete_summary ? "deleting" : "updating");
       return TRUE;
     }
 


### PR DESCRIPTION
Old versions of the create-usb command created a summary file in the
local repo being pulled from (e.g. /var/lib/flatpak/repo) but this
summary generation turned out not to be necessary and was removed. So
any computer which used the create-usb command before commit 7c5751a4f
will have a leftover /var/lib/flatpak/repo/summary file which becomes
outdated as apps are updated and installed. This causes problems for the
next invocation of (a recent version of) the create-usb command which
will use the outdated summary during the pull and fail with an error
message like:

error: Importing 3b1293596e9aa67f6fd0daeae477cb94603a4e8ca9e825f446d3dd04a2b5d5ec.commit:
fstatat(3b/1293596e9aa67f6fd0daeae477cb94603a4e8ca9e825f446d3dd04a2b5d5ec.commit): No such file or directory

So this commit makes the create-usb command delete the summary if it
exists before pulling onto the repo on the USB drive. This means USB
copies will work again for any users that used the USB app copy feature
in Endless OS 3.4.7.