### PR TITLE
Enforce a more permissive umask

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -769,6 +769,14 @@ main (int    argc,
   int ret;
   struct sigaction action;
 
+  /* The child repo shared between the client process and the
+     system-helper really needs to support creating files that
+     are readable by others, so override the umask to 022.
+     Ideally this should be set when needed, but umask is thread-unsafe
+     so there is really no local way to fix this.
+  */
+  umask(022);
+
   memset (&action, 0, sizeof (struct sigaction));
   action.sa_handler = handle_sigterm;
   sigaction (SIGTERM, &action, NULL);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1035,8 +1035,8 @@ flatpak_ensure_system_user_cache_dir_location (GError **error)
   if (stat (path, &st_buf) == 0 &&
       /* Must be owned by us */
       st_buf.st_uid == getuid () &&
-      /* and not writeable by others */
-      (st_buf.st_mode & 0022) == 0)
+      /* and not writeable by others, but readable */
+      (st_buf.st_mode & 0777) == 0755)
     return g_file_new_for_path (path);
 
   path = g_strdup ("/var/tmp/flatpak-cache-XXXXXX");

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -67,6 +67,14 @@
 
  * The FlatpakTransaction API is threadsafe in the sense that it is safe to run two
  * transactions at the same time, in different threads (or processes).
+ *
+ * Note: Transactions (or any other install/update operation) to a
+ * system installation rely on the ability to create files that are readable
+ * by other users. Some users set a umask that prohibits this. Unfortunately
+ * there is no good way to work around this in a threadsafe, local way, so
+ * such setups will break by default. The flatpak commandline app works
+ * around this by calling umask(022) in the early setup, and it is recommended
+ * that other apps using libflatpak do this too.
  */
 
 /* This is an internal-only element of FlatpakTransactionOperationType */

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -2207,6 +2207,14 @@ main (int    argc,
     { NULL }
   };
 
+  /* The child repo shared between the client process and the
+     system-helper really needs to support creating files that
+     are readable by others, so override the umask to 022
+     Ideally this should be set when needed, but umask is thread-unsafe
+     so there is really no local way to fix this.
+  */
+  umask(022);
+
   setlocale (LC_ALL, "");
 
   g_setenv ("GIO_USE_VFS", "local", TRUE);


### PR DESCRIPTION
We enforce an umask of 022 (no world/group writable) in the cli and the system helper. This is necessary, because we need to create ostree repositories shared between the helper and the client, and a more strict umask breaks this.
    
It would be nice if we could just set this in a thread-local way when needed, but unfortunately umask() is not threadsafe or overridable in any local way.
    
This unfortunately means this it will not automatically work for libflatpak users...
