### PR TITLE
Various fixes for --noninteractive and quiet transactions

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -305,6 +305,9 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
   if (argc == 2)
     auto_remote = TRUE;
 
+  if (opt_noninteractive)
+    opt_yes = TRUE; /* Implied */
+
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
 
   if (!opt_noninteractive)

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -169,10 +169,7 @@ install_bundle (FlatpakDir *dir,
   if (!flatpak_transaction_run (transaction, cancellable, error))
     {
       if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
-        {
-          g_clear_error (error);
-          return TRUE;
-        }
+        g_clear_error (error); /* Don't report on stderr */
 
       return FALSE;
     }
@@ -246,10 +243,7 @@ install_from (FlatpakDir *dir,
   if (!flatpak_transaction_run (transaction, cancellable, error))
     {
       if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
-        {
-          g_clear_error (error);
-          return TRUE;
-        }
+        g_clear_error (error); /* Don't report on stderr */
 
       return FALSE;
     }
@@ -521,10 +515,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
   if (!flatpak_transaction_run (transaction, cancellable, error))
     {
       if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
-        {
-          g_clear_error (error);
-          return TRUE;
-        }
+        g_clear_error (error); /* Don't report on stderr */
 
       return FALSE;
     }

--- a/app/flatpak-builtins-remote-delete.c
+++ b/app/flatpak-builtins-remote-delete.c
@@ -114,10 +114,8 @@ flatpak_builtin_remote_delete (int argc, char **argv, GCancellable *cancellable,
           if (!flatpak_transaction_run (transaction, cancellable, error))
             {
               if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
-                {
-                  g_clear_error (error);
-                  return TRUE;
-                }
+                g_clear_error (error);  /* Don't report on stderr */
+
               return FALSE;
             }
         }

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -373,10 +373,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
     if (!flatpak_transaction_run (transaction, cancellable, error))
       {
         if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
-          {
-            g_clear_error (error);
-            return TRUE;
-          }
+          g_clear_error (error); /* Don't report on stderr */
 
         return FALSE;
       }

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -100,6 +100,9 @@ flatpak_builtin_update (int           argc,
       return TRUE;
     }
 
+  if (opt_noninteractive)
+    opt_yes = TRUE; /* Implied */
+
   prefs = &argv[1];
   n_prefs = argc - 1;
 

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -277,10 +277,7 @@ flatpak_builtin_update (int           argc,
       if (!flatpak_transaction_run (transaction, cancellable, error))
         {
           if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
-            {
-              g_clear_error (error);
-              return TRUE;
-            }
+            g_clear_error (error);  /* Don't report on stderr */
 
           return FALSE;
         }

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -698,14 +698,15 @@ flatpak_run (int      argc,
 
   success = TRUE;
 out:
-  g_assert (success || error);
+  /* Note: We allow failures with NULL error (it means don't print anything), useful when e.g. the user aborted */
+  g_assert (!success || error == NULL);
 
   if (error)
     {
       g_propagate_error (res_error, error);
-      return 1;
     }
-  return 0;
+
+  return success ? 0 : 1;
 }
 
 static int

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -125,7 +125,6 @@ operation_error (FlatpakTransaction            *transaction,
   g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
   g_autofree char *msg = NULL;
   gboolean non_fatal = (detail & FLATPAK_TRANSACTION_ERROR_DETAILS_NON_FATAL) != 0;
-  g_autofree char *text = NULL;
 
   if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_SKIPPED))
     {

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -146,7 +146,8 @@ operation_error (FlatpakTransaction            *transaction,
   else
     msg = g_strdup (error->message);
 
-  g_printerr (_("Failed to %s %s: %s\n"),
+  g_printerr (_("%s Failed to %s %s: %s\n"),
+              non_fatal ? _("Warning:") : _("Error:"),
               op_type_to_string (op_type),
               flatpak_ref_get_name (rref),
               msg);
@@ -184,7 +185,8 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
       if (!flatpak_transaction_add_uninstall (transaction, ref, &error) ||
           !flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error))
         {
-          g_printerr (_("Failed to rebase %s to %s: %s\n"), flatpak_ref_get_name (rref), rebased_to_ref, error->message);
+          g_printerr (_("Failed to rebase %s to %s: %s\n"),
+                      flatpak_ref_get_name (rref), rebased_to_ref, error->message);
           self->got_error = TRUE;
           return FALSE;
         }
@@ -208,7 +210,7 @@ flatpak_quiet_transaction_run (FlatpakTransaction *transaction,
   if (self->got_error)
     {
       g_clear_error (error);
-      return flatpak_fail (error, _("There were one or more errors"));
+      return FALSE; /* Don't report on stderr, we already reported */
     }
 
   if (!res)

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -33,6 +33,7 @@
 struct _FlatpakQuietTransaction
 {
   FlatpakTransaction parent;
+  gboolean got_error;
 };
 
 struct _FlatpakQuietTransactionClass
@@ -90,6 +91,133 @@ new_operation (FlatpakTransaction          *transaction,
     }
 }
 
+static char *
+op_type_to_string (FlatpakTransactionOperationType operation_type)
+{
+  switch (operation_type)
+    {
+    case FLATPAK_TRANSACTION_OPERATION_INSTALL:
+      return _("install");
+
+    case FLATPAK_TRANSACTION_OPERATION_UPDATE:
+      return _("update");
+
+    case FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE:
+      return _("install bundle");
+
+    case FLATPAK_TRANSACTION_OPERATION_UNINSTALL:
+      return _("uninstall");
+
+    default:
+      return "Unknown type"; /* Should not happen */
+    }
+}
+
+static gboolean
+operation_error (FlatpakTransaction            *transaction,
+                 FlatpakTransactionOperation   *op,
+                 const GError                  *error,
+                 FlatpakTransactionErrorDetails detail)
+{
+  FlatpakQuietTransaction *self = FLATPAK_QUIET_TRANSACTION (transaction);
+  FlatpakTransactionOperationType op_type = flatpak_transaction_operation_get_operation_type (op);
+  const char *ref = flatpak_transaction_operation_get_ref (op);
+  g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
+  g_autofree char *msg = NULL;
+  gboolean non_fatal = (detail & FLATPAK_TRANSACTION_ERROR_DETAILS_NON_FATAL) != 0;
+  g_autofree char *text = NULL;
+
+  if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_SKIPPED))
+    {
+      g_print (_("Info: %s was skipped"), flatpak_ref_get_name (rref));
+      return TRUE;
+    }
+
+  if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_ALREADY_INSTALLED))
+    msg = g_strdup_printf (_("%s already installed"), flatpak_ref_get_name (rref));
+  else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED))
+    msg = g_strdup_printf (_("%s not installed"), flatpak_ref_get_name (rref));
+  else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED))
+    msg = g_strdup_printf (_("%s not installed"), flatpak_ref_get_name (rref));
+  else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NEED_NEW_FLATPAK))
+    msg = g_strdup_printf (_("%s needs a later flatpak version"), flatpak_ref_get_name (rref));
+  else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_OUT_OF_SPACE))
+    msg = g_strdup (_("Not enough disk space to complete this operation"));
+  else
+    msg = g_strdup (error->message);
+
+  g_printerr (_("Failed to %s %s: %s\n"),
+              op_type_to_string (op_type),
+              flatpak_ref_get_name (rref),
+              msg);
+
+  if (non_fatal)
+    return TRUE; /* Continue */
+
+  self->got_error = TRUE;
+
+  return non_fatal; /* Continue if non-fatal */
+}
+
+static gboolean
+end_of_lifed_with_rebase (FlatpakTransaction *transaction,
+                          const char         *remote,
+                          const char         *ref,
+                          const char         *reason,
+                          const char         *rebased_to_ref,
+                          const char        **previous_ids)
+{
+  FlatpakQuietTransaction *self = FLATPAK_QUIET_TRANSACTION (transaction);
+  g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
+
+  if (rebased_to_ref)
+    g_print (_("Info: %s is end-of-life, in preference of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
+  else if (reason)
+    g_print (_("Info: %s is end-of-life, with reason: %s\n"), flatpak_ref_get_name (rref), reason);
+
+  if (rebased_to_ref && remote)
+    {
+      g_autoptr(GError) error = NULL;
+
+      g_print (_("Updating to rebased version\n"));
+
+      if (!flatpak_transaction_add_uninstall (transaction, ref, &error) ||
+          !flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error))
+        {
+          g_printerr (_("Failed to rebase %s to %s: %s\n"), flatpak_ref_get_name (rref), rebased_to_ref, error->message);
+          self->got_error = TRUE;
+          return FALSE;
+        }
+
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+static gboolean
+flatpak_quiet_transaction_run (FlatpakTransaction *transaction,
+                               GCancellable       *cancellable,
+                               GError            **error)
+{
+  FlatpakQuietTransaction *self = FLATPAK_QUIET_TRANSACTION (transaction);
+  gboolean res;
+
+  res = FLATPAK_TRANSACTION_CLASS (flatpak_quiet_transaction_parent_class)->run (transaction, cancellable, error);
+
+  if (self->got_error)
+    {
+      g_clear_error (error);
+      return flatpak_fail (error, _("There were one or more errors"));
+    }
+
+  if (!res)
+    return FALSE;
+
+  return TRUE;
+}
+
+
 static void
 flatpak_quiet_transaction_init (FlatpakQuietTransaction *transaction)
 {
@@ -103,6 +231,9 @@ flatpak_quiet_transaction_class_init (FlatpakQuietTransactionClass *class)
   transaction_class->choose_remote_for_ref = choose_remote_for_ref;
   transaction_class->add_new_remote = add_new_remote;
   transaction_class->new_operation = new_operation;
+  transaction_class->operation_error = operation_error;
+  transaction_class->end_of_lifed_with_rebase = end_of_lifed_with_rebase;
+  transaction_class->run = flatpak_quiet_transaction_run;
 }
 
 FlatpakTransaction *

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -211,7 +211,7 @@ UPDATE_REPO_ARGS=--title=new-title update_repo
 assert_file_has_content repos/test/config new-title
 
 # This should make us automatically pick up the new metadata
-${FLATPAK} ${U} install test-repo org.test.Platform
+${FLATPAK} ${U} install -y test-repo org.test.Platform
 ${FLATPAK} ${U} remotes -d | grep ^test-repo > repo-info
 assert_file_has_content repo-info "new-title"
 


### PR DESCRIPTION
This fixes install --noninteractive not reporting errors, but also cleans up the error report handling a bit in general, and ensuring we always return the right exit code.