### PR TITLE
Add support for getting remote info from the cache

### DIFF
--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -143,7 +143,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
   if (commit_v == NULL)
     return FALSE;
 
-  state = flatpak_dir_get_remote_state (preferred_dir, remote, cancellable, error);
+  state = flatpak_dir_get_remote_state (preferred_dir, remote, FALSE, cancellable, error);
   if (state == NULL)
     return FALSE;
 

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -433,7 +433,7 @@ flatpak_builtin_remote_ls (int argc, char **argv, GCancellable *cancellable, GEr
             return FALSE;
         }
 
-      state = flatpak_dir_get_remote_state (preferred_dir, argv[1], cancellable, error);
+      state = flatpak_dir_get_remote_state (preferred_dir, argv[1], FALSE, cancellable, error);
       if (state == NULL)
         return FALSE;
 
@@ -468,7 +468,7 @@ flatpak_builtin_remote_ls (int argc, char **argv, GCancellable *cancellable, GEr
               if (flatpak_dir_get_remote_disabled (dir, remote_name))
                 continue;
 
-              state = flatpak_dir_get_remote_state (dir, remote_name,
+              state = flatpak_dir_get_remote_state (dir, remote_name, FALSE,
                                                     cancellable, error);
               if (state == NULL)
                 return FALSE;

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -39,6 +39,7 @@ static gboolean opt_runtime;
 static gboolean opt_app;
 static gboolean opt_all;
 static gboolean opt_only_updates;
+static gboolean opt_cached;
 static char *opt_arch;
 static char *opt_app_runtime;
 static const char **opt_cols;
@@ -52,6 +53,7 @@ static GOptionEntry options[] = {
   { "all", 'a', 0, G_OPTION_ARG_NONE, &opt_all, N_("List all refs (including locale/debug)"), NULL },
   { "app-runtime", 0, 0, G_OPTION_ARG_STRING, &opt_app_runtime, N_("List all applications using RUNTIME"), N_("RUNTIME") },
   { "columns", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_cols, N_("What information to show"), N_("FIELD,…") },
+  { "cached", 0, 0, G_OPTION_ARG_NONE, &opt_cached, N_("Use local caches even if they are stale"), NULL },
   { NULL }
 };
 
@@ -433,7 +435,7 @@ flatpak_builtin_remote_ls (int argc, char **argv, GCancellable *cancellable, GEr
             return FALSE;
         }
 
-      state = flatpak_dir_get_remote_state (preferred_dir, argv[1], FALSE, cancellable, error);
+      state = get_remote_state (preferred_dir, argv[1], opt_cached, cancellable, error);
       if (state == NULL)
         return FALSE;
 
@@ -468,8 +470,8 @@ flatpak_builtin_remote_ls (int argc, char **argv, GCancellable *cancellable, GEr
               if (flatpak_dir_get_remote_disabled (dir, remote_name))
                 continue;
 
-              state = flatpak_dir_get_remote_state (dir, remote_name, FALSE,
-                                                    cancellable, error);
+              state = get_remote_state (dir, remote_name, opt_cached,
+                                        cancellable, error);
               if (state == NULL)
                 return FALSE;
 

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1318,3 +1318,29 @@ print_wrapped (int         cols,
       g_print ("\n");
     }
 }
+
+FlatpakRemoteState *
+get_remote_state (FlatpakDir   *dir,
+                  const char   *remote,
+                  gboolean      cached,
+                  GCancellable *cancellable,
+                  GError      **error)
+{
+  g_autoptr(GError) local_error = NULL;
+  FlatpakRemoteState *state;
+
+  state = flatpak_dir_get_remote_state (dir, remote, cached, cancellable, &local_error);
+  if (state == NULL && g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_CACHED))
+    {
+      g_clear_error (&local_error);
+      state = flatpak_dir_get_remote_state (dir, remote, FALSE, cancellable, &local_error);
+    }
+
+  if (state == NULL)
+    {
+      g_propagate_error (error, g_steal_pointer (&local_error));
+      return NULL;
+    }
+
+  return state;
+}

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -173,4 +173,10 @@ void print_wrapped (int         columns,
                     const char *text,
                     ...) G_GNUC_PRINTF (2, 3);
 
+FlatpakRemoteState * get_remote_state (FlatpakDir   *dir,
+                                       const char   *remote,
+                                       gboolean      cached,
+                                       GCancellable *cancellable,
+                                       GError      **error);
+
 #endif /* __FLATPAK_BUILTINS_UTILS_H__ */

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -282,9 +282,11 @@ typedef enum {
 typedef enum {
   FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NONE = 0,
   FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NO_INTERACTION = 1 << 0,
+  FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_ONLY_CACHED = 1 << 1,
 } FlatpakHelperGenerateOciSummaryFlags;
 
-#define FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_ALL (FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NO_INTERACTION)
+#define FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_ALL (FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NO_INTERACTION |\
+                                                       FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_ONLY_CACHED)
 
 typedef enum {
   FLATPAK_PULL_FLAGS_NONE = 0,
@@ -856,6 +858,7 @@ gboolean flatpak_dir_update_remote_configuration_for_state (FlatpakDir         *
                                                             GError            **error);
 FlatpakRemoteState * flatpak_dir_get_remote_state (FlatpakDir   *self,
                                                    const char   *remote,
+                                                   gboolean      only_cached,
                                                    GCancellable *cancellable,
                                                    GError      **error);
 FlatpakRemoteState * flatpak_dir_get_remote_state_for_summary (FlatpakDir   *self,
@@ -866,6 +869,7 @@ FlatpakRemoteState * flatpak_dir_get_remote_state_for_summary (FlatpakDir   *sel
                                                                GError      **error);
 gboolean flatpak_dir_remote_make_oci_summary (FlatpakDir   *self,
                                               const char   *remote,
+                                              gboolean      only_cached,
                                               GBytes      **out_summary,
                                               GCancellable *cancellable,
                                               GError      **error);

--- a/common/flatpak-error.h
+++ b/common/flatpak-error.h
@@ -56,6 +56,7 @@ G_BEGIN_DECLS
  * @FLATPAK_ERROR_OUT_OF_SPACE: More disk space needed. (Since: 1.2.0)
  * @FLATPAK_ERROR_WRONG_USER: An operation is being attempted by the wrong user (such as
  *                            root operating on a user installation). (Since: 1.2.0)
+ * @FLATPAK_ERROR_NOT_CACHED: Cached data was requested, but it was not available. (Since: 1.4.0)
  *
  * Error codes for library functions.
  */
@@ -80,6 +81,7 @@ typedef enum {
   FLATPAK_ERROR_INVALID_NAME,
   FLATPAK_ERROR_OUT_OF_SPACE,
   FLATPAK_ERROR_WRONG_USER,
+  FLATPAK_ERROR_NOT_CACHED,
 } FlatpakError;
 
 /**

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -2355,7 +2355,7 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state (dir, remote_or_uri, cancellable, error);
+  state = flatpak_dir_get_remote_state (dir, remote_or_uri, FALSE, cancellable, error);
   if (state == NULL)
     return NULL;
 
@@ -2419,7 +2419,7 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state (dir, remote_name, cancellable, error);
+  state = flatpak_dir_get_remote_state (dir, remote_name, FALSE, cancellable, error);
   if (state == NULL)
     return NULL;
 

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -2343,6 +2343,31 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
                                             GCancellable        *cancellable,
                                             GError             **error)
 {
+  return flatpak_installation_list_remote_refs_sync_full (self, remote_or_uri, 0, cancellable, error);
+}
+
+/**
+ * flatpak_installation_list_remote_refs_sync_full:
+ * @self: a #FlatpakInstallation
+ * @remote_or_uri: the name or URI of the remote
+ * @flags: set of #FlatpakQueryFlags
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Lists all the applications and runtimes in a remote.
+ *
+ * Returns: (transfer container) (element-type FlatpakRemoteRef): a GPtrArray of
+ *   #FlatpakRemoteRef instances
+ *
+ * Since: 1.3.3
+ */
+GPtrArray *
+flatpak_installation_list_remote_refs_sync_full (FlatpakInstallation *self,
+                                                 const char          *remote_or_uri,
+                                                 FlatpakQueryFlags    flags,
+                                                 GCancellable        *cancellable,
+                                                 GError             **error)
+{
   g_autoptr(FlatpakDir) dir = NULL;
   g_autoptr(GPtrArray) refs = g_ptr_array_new_with_free_func (g_object_unref);
   g_autoptr(FlatpakRemoteState) state = NULL;
@@ -2355,7 +2380,7 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state (dir, remote_or_uri, FALSE, cancellable, error);
+  state = flatpak_dir_get_remote_state (dir, remote_or_uri, (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) != 0, cancellable, error);
   if (state == NULL)
     return NULL;
 
@@ -2404,6 +2429,40 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
                                             GCancellable        *cancellable,
                                             GError             **error)
 {
+  return flatpak_installation_fetch_remote_ref_sync_full (self, remote_name,
+                                                          kind, name, arch, branch, 0,
+                                                          cancellable, error);
+}
+
+/**
+ * flatpak_installation_fetch_remote_ref_sync_full:
+ * @self: a #FlatpakInstallation
+ * @remote_name: the name of the remote
+ * @kind: what this ref contains (an #FlatpakRefKind)
+ * @name: name of the app/runtime to fetch
+ * @arch: (nullable): which architecture to fetch (default: current architecture)
+ * @branch: (nullable): which branch to fetch (default: 'master')
+ * @flags: set of #FlatpakQueryFlags
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Gets the current remote branch of a ref in the remote.
+ *
+ * Returns: (transfer full): a #FlatpakRemoteRef instance, or %NULL
+ *
+ * Since: 1.3.3
+ */
+FlatpakRemoteRef *
+flatpak_installation_fetch_remote_ref_sync_full (FlatpakInstallation *self,
+                                                 const char          *remote_name,
+                                                 FlatpakRefKind       kind,
+                                                 const char          *name,
+                                                 const char          *arch,
+                                                 const char          *branch,
+                                                 FlatpakQueryFlags    flags,
+                                                 GCancellable        *cancellable,
+                                                 GError             **error)
+{
   g_autoptr(FlatpakDir) dir = NULL;
   g_autoptr(GHashTable) ht = NULL;
   g_autoptr(FlatpakRemoteState) state = NULL;
@@ -2419,7 +2478,7 @@ flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state (dir, remote_name, FALSE, cancellable, error);
+  state = flatpak_dir_get_remote_state (dir, remote_name, (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) != 0, cancellable, error);
   if (state == NULL)
     return NULL;
 

--- a/common/flatpak-installation.h
+++ b/common/flatpak-installation.h
@@ -122,6 +122,22 @@ typedef enum {
 } FlatpakLaunchFlags;
 
 /**
+ * FlatpakQueryFlags:
+ * @FLATPAK_QUERY_FLAGS_NONE: Default
+ * @FLATPAK_QUERY_FLAGS_ONLY_CACHED: Don't do any network i/o, but only return cached data.
+ * This can return stale data, or a #FLATPAK_ERROR_NOT_CACHED error, however it is a
+ * lot more efficient if you're doing many requests.
+ *
+ * Flags to alter the behavior of e.g flatpak_installation_list_remote_refs_full().
+ *
+ * Since: 1.3.3
+ */
+typedef enum {
+  FLATPAK_QUERY_FLAGS_NONE        = 0,
+  FLATPAK_QUERY_FLAGS_ONLY_CACHED = (1 << 0),
+} FlatpakQueryFlags;
+
+/**
  * FlatpakStorageType:
  * @FLATPAK_STORAGE_TYPE_DEFAULT: default
  * @FLATPAK_STORAGE_TYPE_HARD_DISK: installation is on a hard disk
@@ -369,6 +385,11 @@ FLATPAK_EXTERN GPtrArray    *    flatpak_installation_list_remote_refs_sync (Fla
                                                                              const char          *remote_or_uri,
                                                                              GCancellable        *cancellable,
                                                                              GError             **error);
+FLATPAK_EXTERN GPtrArray    *    flatpak_installation_list_remote_refs_sync_full (FlatpakInstallation *self,
+                                                                                  const char          *remote_or_uri,
+                                                                                  FlatpakQueryFlags    flags,
+                                                                                  GCancellable        *cancellable,
+                                                                                  GError             **error);
 FLATPAK_EXTERN FlatpakRemoteRef  *flatpak_installation_fetch_remote_ref_sync (FlatpakInstallation *self,
                                                                               const char          *remote_name,
                                                                               FlatpakRefKind       kind,
@@ -377,6 +398,15 @@ FLATPAK_EXTERN FlatpakRemoteRef  *flatpak_installation_fetch_remote_ref_sync (Fl
                                                                               const char          *branch,
                                                                               GCancellable        *cancellable,
                                                                               GError             **error);
+FLATPAK_EXTERN FlatpakRemoteRef  *flatpak_installation_fetch_remote_ref_sync_full (FlatpakInstallation *self,
+                                                                                   const char          *remote_name,
+                                                                                   FlatpakRefKind       kind,
+                                                                                   const char          *name,
+                                                                                   const char          *arch,
+                                                                                   const char          *branch,
+                                                                                   FlatpakQueryFlags    flags,
+                                                                                   GCancellable        *cancellable,
+                                                                                   GError             **error);
 FLATPAK_EXTERN gboolean          flatpak_installation_update_appstream_sync (FlatpakInstallation *self,
                                                                              const char          *remote_name,
                                                                              const char          *arch,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -70,6 +70,9 @@ static const GDBusErrorEntry flatpak_error_entries[] = {
   {FLATPAK_ERROR_REMOTE_USED,           "org.freedesktop.Flatpak.Error.RemoteUsed"}, /* Since: 1.0.3 */
   {FLATPAK_ERROR_RUNTIME_USED,          "org.freedesktop.Flatpak.Error.RuntimeUsed"}, /* Since: 1.0.3 */
   {FLATPAK_ERROR_INVALID_NAME,          "org.freedesktop.Flatpak.Error.InvalidName"}, /* Since: 1.0.3 */
+  {FLATPAK_ERROR_OUT_OF_SPACE,          "org.freedesktop.Flatpak.Error.OutOfSpace"}, /* Since: 1.2.0 */
+  {FLATPAK_ERROR_WRONG_USER,            "org.freedesktop.Flatpak.Error.WrongUser"}, /* Since: 1.2.0 */
+  {FLATPAK_ERROR_NOT_CACHED,            "org.freedesktop.Flatpak.Error.NotCached"}, /* Since: 1.3.3 */
 };
 
 typedef struct archive FlatpakAutoArchiveRead;

--- a/doc/flatpak-remote-info.xml
+++ b/doc/flatpak-remote-info.xml
@@ -102,6 +102,16 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--cached</option></term>
+
+                <listitem><para>
+                  Prefer to use locally cached information if possible, even though it
+                  may be out of date. This is faster, but risks returning stale information.
+                  Also, some information is not cached so will not be available.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--runtime</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -101,6 +101,15 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--cached</option></term>
+
+                <listitem><para>
+                  Prefer to use locally cached information if possible, even though it
+                  may be out of date. This is faster, but risks returning stale information.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-d</option></term>
                 <term><option>--show-details</option></term>
 

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -2051,7 +2051,12 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
   else if (g_strcmp0 (method_name, "UpdateSummary") == 0 ||
            g_strcmp0 (method_name, "GenerateOciSummary") == 0)
     {
+      guint32 flags;
       action = "org.freedesktop.Flatpak.metadata-update";
+
+      /* all of these methods have flags as first argument, and 1 << 0 as 'no-interaction' */
+      g_variant_get_child (parameters, 0, "u", &flags);
+      no_interaction = (flags & (1 << 0)) != 0;
     }
 
   if (action)

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -545,7 +545,7 @@ handle_deploy (FlatpakSystemHelper   *object,
           return TRUE;
         }
 
-      state = flatpak_dir_get_remote_state (system, arg_origin, NULL, &error);
+      state = flatpak_dir_get_remote_state (system, arg_origin, FALSE, NULL, &error);
       if (state == NULL)
         {
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
@@ -1796,6 +1796,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
 {
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
+  gboolean only_cached;
   gboolean is_oci;
 
   g_debug ("GenerateOciSummary %u %s %s", arg_flags, arg_origin, arg_installation);
@@ -1814,6 +1815,8 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
       return TRUE;
     }
 
+  only_cached = (arg_flags & FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_ONLY_CACHED) != 0;
+
   if (!flatpak_dir_ensure_repo (system, NULL, &error))
     {
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
@@ -1829,7 +1832,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
       return TRUE;
     }
 
-  if (!flatpak_dir_remote_make_oci_summary (system, arg_origin, NULL, NULL, &error))
+  if (!flatpak_dir_remote_make_oci_summary (system, arg_origin, only_cached, NULL, NULL, &error))
     {
       flatpak_invocation_return_error (invocation, error, "Failed to update OCI summary");
       return TRUE;


### PR DESCRIPTION
This adds some libflatpak APIs for getting FlatpakRemoteRefs without network I/O, as well as --cached options to flatpak remote-ls and remote-info.

This should fix https://github.com/flatpak/flatpak/issues/2817