### PR TITLE
Add client side filtering of refs for a remote

### DIFF
--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -58,6 +58,7 @@ static char *comment = NULL;
 static char *description = NULL;
 static char *icon = NULL;
 static char *homepage = NULL;
+static char *filter = NULL;
 
 
 static GOptionEntry add_options[] = {
@@ -241,6 +242,12 @@ get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *change
       *changed = TRUE;
     }
 
+  if (filter)
+    {
+      g_key_file_set_string (config, group, "xa.filter", filter);
+      *changed = TRUE;
+    }
+
   return config;
 }
 
@@ -366,6 +373,13 @@ load_options (const char *filename,
 
   homepage  = g_key_file_get_string (keyfile, FLATPAK_REPO_GROUP,
                                      FLATPAK_REPO_HOMEPAGE_KEY, NULL);
+
+  filter = g_key_file_get_string (keyfile, FLATPAK_REPO_GROUP,
+                                   FLATPAK_REPO_FILTER_KEY, NULL);
+
+  /* Default to empty so we unset previous filter if one was enabled, unless given as arg */
+  if (filter == NULL && opt_filter != NULL)
+    filter = g_strdup ("");
 }
 
 gboolean

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -42,6 +42,7 @@ static gboolean opt_no_deps;
 static gboolean opt_if_not_exists;
 static gboolean opt_disable;
 static int opt_prio = -1;
+static char *opt_filter;
 static char *opt_title;
 static char *opt_comment;
 static char *opt_description;
@@ -78,6 +79,7 @@ static GOptionEntry common_options[] = {
   { "default-branch", 0, 0, G_OPTION_ARG_STRING, &opt_default_branch, N_("Default branch to use for this remote"), N_("BRANCH") },
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id, N_("Collection ID"), N_("COLLECTION-ID") },
   { "gpg-import", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_gpg_import, N_("Import GPG key from FILE (- for stdin)"), N_("FILE") },
+  { "filter", 0, 0, G_OPTION_ARG_FILENAME, &opt_filter, N_("Set path to local filter FILE"), N_("FILE") },
   { "disable", 0, 0, G_OPTION_ARG_NONE, &opt_disable, N_("Disable the remote"), NULL },
   { NULL }
 };
@@ -165,6 +167,12 @@ get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *change
     {
       g_key_file_set_string (config, group, "xa.default-branch", opt_default_branch);
       g_key_file_set_boolean (config, group, "xa.default-branch-is-set", TRUE);
+      *changed = TRUE;
+    }
+
+  if (opt_filter)
+    {
+      g_key_file_set_string (config, group, "xa.filter", opt_filter);
       *changed = TRUE;
     }
 

--- a/app/flatpak-builtins-remote-list.c
+++ b/app/flatpak-builtins-remote-list.c
@@ -50,6 +50,7 @@ static Column all_columns[] = {
   { "title",      N_("Title"),         N_("Show the title"),         0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "url",        N_("URL"),           N_("Show the URL"),           0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "collection", N_("Collection ID"), N_("Show the collection ID"), 0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
+  { "filter",     N_("Filter"),        N_("Show filter file"),       0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "priority",   N_("Priority"),      N_("Show the priority"),      0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "options",    N_("Options"),       N_("Show options"),           0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
   { "comment",    N_("Comment"),       N_("Show comment"),           0, FLATPAK_ELLIPSIZE_MODE_END,  1, 0 },
@@ -118,6 +119,14 @@ list_remotes (GPtrArray *dirs, Column *columns, GCancellable *cancellable, GErro
                   else
                     flatpak_table_printer_add_column (printer, "-");
                 }
+              else if (strcmp (columns[k].name, "filter") == 0)
+                {
+                  g_autofree char *filter = flatpak_dir_get_remote_filter (dir, remote_name);
+                  if (filter)
+                    flatpak_table_printer_add_column (printer, filter);
+                  else
+                    flatpak_table_printer_add_column (printer, "-");
+                }
               else if (strcmp (columns[k].name, "homepage") == 0)
                 {
                   g_autofree char *homepage = flatpak_dir_get_remote_homepage (dir, remote_name);
@@ -160,6 +169,7 @@ list_remotes (GPtrArray *dirs, Column *columns, GCancellable *cancellable, GErro
               else if (strcmp (columns[k].name, "options") == 0)
                 {
                   gboolean gpg_verify = TRUE;
+                  g_autofree char *filter = flatpak_dir_get_remote_filter (dir, remote_name);
 
                   flatpak_table_printer_add_column (printer, ""); /* Options */
 
@@ -182,6 +192,9 @@ list_remotes (GPtrArray *dirs, Column *columns, GCancellable *cancellable, GErro
                                                      &gpg_verify, NULL);
                   if (!gpg_verify)
                     flatpak_table_printer_append_with_comma (printer, "no-gpg-verify");
+
+                  if (filter != NULL && *filter != 0)
+                    flatpak_table_printer_append_with_comma (printer, "filtered");
                 }
             }
 

--- a/app/flatpak-builtins-remote-modify.c
+++ b/app/flatpak-builtins-remote-modify.c
@@ -42,7 +42,9 @@ static gboolean opt_no_deps;
 static gboolean opt_enable;
 static gboolean opt_update_metadata;
 static gboolean opt_disable;
+static gboolean opt_no_filter;
 static int opt_prio = -1;
+static char *opt_filter;
 static char *opt_title;
 static char *opt_comment;
 static char *opt_description;
@@ -77,6 +79,8 @@ static GOptionEntry common_options[] = {
   { "default-branch", 0, 0, G_OPTION_ARG_STRING, &opt_default_branch, N_("Default branch to use for this remote"), N_("BRANCH") },
   { "collection-id", 0, 0, G_OPTION_ARG_STRING, &opt_collection_id, N_("Collection ID"), N_("COLLECTION-ID") },
   { "gpg-import", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_gpg_import, N_("Import GPG key from FILE (- for stdin)"), N_("FILE") },
+  { "no-filter", 0, 0, G_OPTION_ARG_NONE, &opt_no_filter, N_("Disable local filter"), NULL },
+  { "filter", 0, 0, G_OPTION_ARG_FILENAME, &opt_filter, N_("Set path to local filter FILE"), N_("FILE") },
   { "disable", 0, 0, G_OPTION_ARG_NONE, &opt_disable, N_("Disable the remote"), NULL },
   { NULL }
 };
@@ -164,6 +168,12 @@ get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *change
     {
       g_key_file_set_string (config, group, "xa.default-branch", opt_default_branch);
       g_key_file_set_boolean (config, group, "xa.default-branch-is-set", TRUE);
+      *changed = TRUE;
+    }
+
+  if (opt_filter || opt_no_filter)
+    {
+      g_key_file_set_string (config, group, "xa.filter", opt_no_filter ? "" : opt_filter);
       *changed = TRUE;
     }
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -71,6 +71,7 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_REPO_DESCRIPTION_KEY "Description"
 #define FLATPAK_REPO_HOMEPAGE_KEY "Homepage"
 #define FLATPAK_REPO_ICON_KEY "Icon"
+#define FLATPAK_REPO_FILTER_KEY "Filter"
 
 #define FLATPAK_REPO_COLLECTION_ID_KEY "CollectionID"
 #define FLATPAK_REPO_DEPLOY_COLLECTION_ID_KEY "DeployCollectionID"

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -106,6 +106,8 @@ typedef struct
   GError   *summary_fetch_error;
   GVariant *metadata;
   GError   *metadata_fetch_error;
+  GRegex   *allow_refs;
+  GRegex   *deny_refs;
   int       refcount;
 } FlatpakRemoteState;
 
@@ -115,6 +117,8 @@ gboolean flatpak_remote_state_ensure_summary (FlatpakRemoteState *self,
                                               GError            **error);
 gboolean flatpak_remote_state_ensure_metadata (FlatpakRemoteState *self,
                                                GError            **error);
+gboolean flatpak_remote_state_allow_ref (FlatpakRemoteState *self,
+                                         const char *ref);
 gboolean flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,
                                           const char         *ref,
                                           char              **out_checksum,

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -827,6 +827,8 @@ gboolean   flatpak_dir_get_remote_noenumerate (FlatpakDir *self,
                                                const char *remote_name);
 gboolean   flatpak_dir_get_remote_nodeps (FlatpakDir *self,
                                           const char *remote_name);
+char      *flatpak_dir_get_remote_filter (FlatpakDir *self,
+                                          const char *remote_name);
 gboolean   flatpak_dir_get_remote_disabled (FlatpakDir *self,
                                             const char *remote_name);
 gboolean   flatpak_dir_list_remote_refs (FlatpakDir         *self,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11561,7 +11561,12 @@ flatpak_dir_get_remote_filter (FlatpakDir *self,
   g_autofree char *group = get_group (remote_name);
 
   if (config)
-    return g_key_file_get_string (config, group, "xa.filter", NULL);
+    {
+      g_autofree char *filter = g_key_file_get_string (config, group, "xa.filter", NULL);
+
+      if (filter && *filter != 0)
+        return g_steal_pointer (&filter);
+    }
 
   return NULL;
 }

--- a/common/flatpak-remote.h
+++ b/common/flatpak-remote.h
@@ -115,6 +115,9 @@ FLATPAK_EXTERN void          flatpak_remote_set_disabled (FlatpakRemote *self,
 FLATPAK_EXTERN int           flatpak_remote_get_prio (FlatpakRemote *self);
 FLATPAK_EXTERN void          flatpak_remote_set_prio (FlatpakRemote *self,
                                                       int            prio);
+FLATPAK_EXTERN char *        flatpak_remote_get_filter (FlatpakRemote *self);
+FLATPAK_EXTERN void          flatpak_remote_set_filter (FlatpakRemote *self,
+                                                        const char    *filter_path);
 
 FLATPAK_EXTERN FlatpakRemoteType flatpak_remote_get_remote_type (FlatpakRemote *self);
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -191,6 +191,14 @@ gboolean flatpak_id_has_subref_suffix (const char *id);
 char **flatpak_decompose_ref (const char *ref,
                               GError    **error);
 
+gboolean flatpak_parse_filters (const char *data,
+                                GRegex **allow_refs_out,
+                                GRegex **deny_refs_out,
+                                GError **error);
+gboolean flatpak_filters_allow_ref (GRegex *allow_refs,
+                                    GRegex *deny_refs,
+                                    const char *ref);
+
 FlatpakKinds flatpak_kinds_from_bools (gboolean app,
                                        gboolean runtime);
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -769,6 +769,10 @@ gboolean   flatpak_repo_generate_appstream (OstreeRepo   *repo,
                                             guint64       timestamp,
                                             GCancellable *cancellable,
                                             GError      **error);
+void flatpak_appstream_xml_filter (FlatpakXml *appstream,
+                                   GRegex *allow_refs,
+                                   GRegex *deny_refs);
+
 
 gboolean flatpak_allocate_tmpdir (int           tmpdir_dfd,
                                   const char   *tmpdir_relpath,

--- a/doc/flatpak-flatpakrepo.xml
+++ b/doc/flatpak-flatpakrepo.xml
@@ -104,6 +104,20 @@
                     <listitem><para>The url of a webpage describing the remote.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>Filter</option> (string)</term>
+                    <listitem><para>The path of a local file to use to filter remote refs. See
+                       <citerefentry><refentrytitle>flatpak-remote-add</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+                       for details on the format of the file.
+                    </para>
+                    <para>
+                      Note: This field is treated a bit special by flatpak remote-add. If you install a remote with --if-not-exists then
+                      and the remote is already configured, then the filter field of the remote configuration will be update anyway.
+                      And, if the filter field is *not* specified then any existing filters are cleared. The goal here is to allow
+                      a pre-configured filtered remote to be replaced with the regular one if you add the normal upstream (unfiltered)
+                      flatpakrepo file.
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>DeployCollectionID</option> (string)</term>
                     <listitem><para>
                         The collection ID of the remote, if it has one. This uniquely

--- a/doc/flatpak-remote-add.xml
+++ b/doc/flatpak-remote-add.xml
@@ -208,6 +208,36 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--filter=PATH</option></term>
+
+                <listitem><para>
+                  Add a local filter to the remote. A filter file is a list of lines, each
+                  file starting with "allow" or "deny", and then a glob for the ref to
+                  allow or disallow. The globs specify a partial ref (i.e. you can leave out
+                  trailing parts which will then match everything), but otherwise only "*" is
+                  special, matching anything in that part of the ref.
+                </para>
+                <para>
+                  By default all refs are allowed, but if a ref
+                  matches a deny rule it is disallowed unless it
+                  specifically matches an allow rule. This means you
+                  can use this to implement both whitelisting and blacklisting.
+                </para>
+                <para>
+                  Here is an example filter file:
+<programlisting>
+# This is a whitelist style filter as it denies all first
+deny *
+allow runtime/org.freedesktop.*
+allow org.some.app/arm
+allow org.signal.Signal/*/stable
+allow org.signal.Signal.*/*/stable
+</programlisting>
+                </para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--gpg-import=FILE</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -250,6 +250,16 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--no-filter</option></term>
+                <term><option>--filter=FILE</option></term>
+
+                <listitem><para>
+                  Modify the path (or unset) for the local filter used for this remote.
+                  See <citerefentry><refentrytitle>flatpak-remote-add</refentrytitle><manvolnum>1</manvolnum></citerefentry> for details about the filter file format.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--gpg-import=FILE</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remotes.xml
+++ b/doc/flatpak-remotes.xml
@@ -172,6 +172,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term>filter</term>
+
+                <listitem><para>
+                    Show the path to the client-side filter of the remote.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term>collection</term>
 
                 <listitem><para>

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -104,6 +104,7 @@ dist_installed_test_data = \
 	tests/org.test.Hello.png \
 	tests/package_version.txt \
 	tests/session.conf.in \
+	tests/test.filter \
 	$(NULL)
 
 installed_test_keyringdir = $(installed_testdir)/test-keyring

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -86,7 +86,7 @@ assert_not_has_file $FL_DIR/repo/refs/remotes/test-repo/appstream2/$ARCH
 
 assert_has_file $FL_DIR/appstream/test-repo/$ARCH/.timestamp
 assert_has_symlink $FL_DIR/appstream/test-repo/$ARCH/active
-assert_not_has_file $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml
+assert_has_file $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml
 assert_has_file $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml.gz
 
 echo "ok update compat appstream"

--- a/tests/test.filter
+++ b/tests/test.filter
@@ -1,0 +1,2 @@
+deny *
+allow org.test.Platform


### PR DESCRIPTION
If you set the `xa.filter` config option for a remote to the pathname of a filter file, then all refs from that remote are filtered, as well as the deployed appstream file.

Filters are specified as a list of `op glob` where op can be `allow` or `deny`, and the blogs are partial refs where `*` means anything in this part of the ref, and non-specified trailing parts of the ref matches anything.

By default everything is allowed, but if you specify some deny rules all that they match is denied, except if there is an specific allow rule.

Internally this takes all the allow and deny globs and convert them into two combined regular expressions.
    
Some examples:
```
* - match anything
app/* - match all apps
runtime/* - match all runtimes
app/*/x86_64 - match all x86-64 apps
app/org.gnome.*/*/stable - match all stable gnome apps
org.gnome.frogr* - match frogr and extensions
```
    
This means you can do a both whitelisting:
```
deny *
allow org.the.good.app*
```
Or blacklisting:
```
deny org.the.bad.app*
```

Some things are outstanding here:
a) Currently no nice way of actually enabling the filter (CLI/API)
b) No integration with e.g. flatpakref files.
c) If the filter change we don't re-deploy the appstream (until next update)
