### PR TITLE
Improve robustness of readlink uses

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2237,18 +2237,7 @@ char *
 flatpak_readlink (const char *path,
                   GError    **error)
 {
-  char buf[PATH_MAX + 1];
-  ssize_t symlink_size;
-
-  symlink_size = readlink (path, buf, sizeof (buf) - 1);
-  if (symlink_size < 0)
-    {
-      glnx_set_error_from_errno (error);
-      return NULL;
-    }
-
-  buf[symlink_size] = 0;
-  return g_strdup (buf);
+  return glnx_readlinkat_malloc (-1, path, NULL, error);
 }
 
 char *

--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -144,7 +144,7 @@ rerun_in_sandbox (const char *arg_width,
   ssize_t symlink_size;
 
   symlink_size = readlink ("/proc/self/exe", validate_icon, sizeof (validate_icon) - 1);
-  if (symlink_size < 0)
+  if (symlink_size < 0 || (size_t) symlink_size >= sizeof (validate_icon))
     {
       g_printerr ("Error: failed to read /proc/self/exe\n");
       return 1;

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -905,7 +905,7 @@ main (int    argc,
     }
 
   exe_path_len = readlink ("/proc/self/exe", exe_path, sizeof (exe_path) - 1);
-  if (exe_path_len > 0)
+  if (exe_path_len > 0 && (size_t) exe_path_len < sizeof (exe_path))
     {
       exe_path[exe_path_len] = 0;
       GFileMonitor *monitor;


### PR DESCRIPTION
readlink() and readlinkat() have weird semantics: they return the number of bytes they would have written if there was enough space, even if that's larger than the buffer. Flatpak didn't always cope with this, and it looks as though it might write `\0` outside the buffer if a symlink target is longer than `PATH_MAX`.

`glnx_readlinkat_malloc()` takes care to do the right thing in all situations, so use that where possible.

In the icon validator and the portal, which don't currently use libglnx, treat an excessively long symlink target as an error instead.