### PR TITLE
Check for missing sentinels in NULL-terminated varargs

### DIFF
--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -48,7 +48,7 @@ void          flatpak_bwrap_add_noinherit_fd (FlatpakBwrap *bwrap,
 void          flatpak_bwrap_add_fd (FlatpakBwrap *bwrap,
                                     int           fd);
 void          flatpak_bwrap_add_args (FlatpakBwrap *bwrap,
-                                      ...);
+                                      ...) G_GNUC_NULL_TERMINATED;
 void          flatpak_bwrap_add_arg_printf (FlatpakBwrap *bwrap,
                                             const char   *format,
                                             ...) G_GNUC_PRINTF (2, 3);

--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -87,6 +87,7 @@ validate_icon (const char *arg_width,
   return 0;
 }
 
+G_GNUC_NULL_TERMINATED
 static void
 add_args (GPtrArray *argv_array, ...)
 {


### PR DESCRIPTION
---

While reusing FlatpakBwrap code in another project, I got this wrong for `flatpak_bwrap_add_args()` in a few places. The attribute means the compiler will tell us if we do this.