### PR TITLE
Don't leak dbus_session_socket from flatpak_run_add_session_dbus_args

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -572,7 +572,7 @@ flatpak_run_add_session_dbus_args (FlatpakBwrap   *app_bwrap,
 {
   gboolean unrestricted, no_proxy;
   const char *dbus_address = g_getenv ("DBUS_SESSION_BUS_ADDRESS");
-  char *dbus_session_socket = NULL;
+  g_autofree char *dbus_session_socket = NULL;
   g_autofree char *sandbox_socket_path = g_strdup_printf ("/run/user/%d/bus", getuid ());
   g_autofree char *sandbox_dbus_address = g_strdup_printf ("unix:path=/run/user/%d/bus", getuid ());
 


### PR DESCRIPTION
The function was already leaking the result of
extract_unix_path_from_dbus_address() in the case where that call
succeeded. Since commit 0e545799 it would also leak the result of
g_build_filename in the case where it checked $XDG_RUNTIME_DIR/bus.