### PR TITLE
 update: Fix OCI updates in the system repo

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9104,22 +9104,6 @@ flatpak_dir_update (FlatpakDir                           *self,
       if (no_pull)
         {
         }
-      else if ((!gpg_verify_summary && state->collection_id == NULL) || !gpg_verify)
-        {
-          /* The remote is not gpg verified, so we don't want to allow installation via
-             a download in the home directory, as there is no way to verify you're not
-             injecting anything into the remote. However, in the case of a remote
-             configured to a local filesystem we can just let the system helper do
-             the installation, as it can then avoid network i/o and be certain the
-             data comes from the right place.
-
-             If @collection_id is non-%NULL, we can verify the refs in commit
-             metadata, so don’t need to verify the summary. */
-          if (g_str_has_prefix (url, "file:"))
-            helper_flags |= FLATPAK_HELPER_DEPLOY_FLAGS_LOCAL_PULL;
-          else
-            return flatpak_fail_error (error, FLATPAK_ERROR_UNTRUSTED, _("Can't pull from untrusted non-gpg verified remote"));
-        }
       else if (is_oci)
         {
           g_autoptr(FlatpakOciRegistry) registry = NULL;
@@ -9135,6 +9119,22 @@ flatpak_dir_update (FlatpakDir                           *self,
 
           if (!flatpak_dir_mirror_oci (self, registry, state, ref, NULL, progress, cancellable, error))
             return FALSE;
+        }
+      else if ((!gpg_verify_summary && state->collection_id == NULL) || !gpg_verify)
+        {
+          /* The remote is not gpg verified, so we don't want to allow installation via
+             a download in the home directory, as there is no way to verify you're not
+             injecting anything into the remote. However, in the case of a remote
+             configured to a local filesystem we can just let the system helper do
+             the installation, as it can then avoid network i/o and be certain the
+             data comes from the right place.
+
+             If @collection_id is non-%NULL, we can verify the refs in commit
+             metadata, so don’t need to verify the summary. */
+          if (g_str_has_prefix (url, "file:"))
+            helper_flags |= FLATPAK_HELPER_DEPLOY_FLAGS_LOCAL_PULL;
+          else
+            return flatpak_fail_error (error, FLATPAK_ERROR_UNTRUSTED, _("Can't pull from untrusted non-gpg verified remote"));
         }
       else
         {

--- a/tests/oci-registry-server.py
+++ b/tests/oci-registry-server.py
@@ -194,6 +194,12 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
                 "Labels": {},
             }
 
+            # Delete old versions
+            for i in images:
+                if tag in i['Tags']:
+                    images.remove(i)
+                    del manifests[i['Digest']]
+
             images.append(image)
 
             modified()

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -94,7 +94,11 @@ echo "ok detached icons"
 
 # Try installing from the remote
 
-${FLATPAK} ${U} install -y oci-registry org.test.Platform
+${FLATPAK} ${U} install -y oci-registry org.test.Hello
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandbox$'
+
 echo "ok install"
 
 # Remove the app from the registry, check that things were removed properly
@@ -140,6 +144,7 @@ ${FLATPAK} update ${U} --appstream oci-registry
 assert_has_file $base/oci/oci-registry.index.gz
 assert_has_file $base/oci/oci-registry.summary
 assert_has_dir $base/appstream/oci-registry
+${FLATPAK} ${U} -y uninstall org.test.Hello
 ${FLATPAK} ${U} -y uninstall org.test.Platform
 ${FLATPAK} ${U} remote-delete oci-registry
 assert_not_has_file $base/oci/oci-registry.index.gz


### PR DESCRIPTION
We need to check whether the remote is gpg verified after handling the oci case, because OCI is fine to update systemwide without gpg verification (in fact it doesn't support verification).

This just reorders the code, matching what is done in the install case already.

This also adds test for this (that are broken before the last commit, and ok after it).

@owtaylor Does this look right to you?
