### PR TITLE
Autostart

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -235,6 +235,7 @@ collect_exports (GFile          *base,
     "share/icons",                        /* Icons */
     "share/dbus-1/services",              /* D-Bus service files */
     "share/gnome-shell/search-providers", /* Search providers */
+    "share/gnome/autostart",              /* Autostart files*/
     NULL,
   };
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -925,6 +925,10 @@ flatpak_get_allowed_exports (const char     *source_path,
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".desktop"));
     }
+  else if (strcmp (source_path, "share/gnome/autostart") == 0)
+    {
+      g_ptr_array_add (allowed_extensions, g_strdup (".desktop"));
+    }
   else if (flatpak_has_path_prefix (source_path, "share/icons"))
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".svgz"));


### PR DESCRIPTION
Export and rewrite autostart files. We add flatpak run --background to the Exec line and make flatpak check a run-in-background permission when --background is passed. Unfortunately, we have no great desktop-neutral location for exporting autostart files to. For now, this supports /usr/share/gnome/autostart.

This goes together with the rest of the run-in-background support on the portal side in https://github.com/flatpak/xdg-desktop-portal/pull/319