### PR TITLE
session-helper: Relax directory permission for Toolbox containers

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -842,7 +842,7 @@ main (int    argc,
     g_debug ("p11-kit not found");
 
   monitor_dir = g_build_filename (flatpak_dir, "monitor", NULL);
-  if (g_mkdir_with_parents (monitor_dir, 0700) != 0)
+  if (g_mkdir_with_parents (monitor_dir, 0755) != 0)
     {
       g_print ("Can't create %s\n", monitor_dir);
       exit (1);


### PR DESCRIPTION
Toolbox [1] containers, like Flatpak containers, need to keep some
configuration files synchronized with the host. eg., /etc/localtime,
/etc/resolv.conf, etc.. The easiest way to keep them updated is to bind
mount the entire /etc from the host at some location inside the
container, and then replace the container's copy of the files with
symbolic links to the bind mounted copies.

However, this doesn't work when the host's copy of a configuration file
is itself a symbolic link to a location outside /etc. eg.,
/etc/localtime, which points somewhere inside /usr/share/zoneinfo. In
that case the host needs to be actively monitored via inotify(7) and
an updated copy of the file needs to maintained in a separate
directory, which can be bind mounted into the container.

This monitoring infrastructure is already present in Flatpak and it
makes sense to leverage it for Toolbox containers too.

However, Flatpak containers have only one user, the current one logged
into the host, whereas Toolbox containers have a longer list of users
like the host itself. Therefore, if the directory getting bind mounted
(ie., $XDG_RUNTIME_DIR/.flatpak-helper/monitor) isn't world readable,
then some users inside the container won't be able to read the
configuration file. eg., this will fail:
  $ sudo -u operator cat /run/host/monitor/localtime

Relaxing the directory permissions on the host shouldn't pose a
security risk. They are copies of originals that are world readable
anyway.

[1] https://github.com/debarshiray/toolbox