### PR TITLE
utils: Convert only non-G_IO_ERROR_CANCELLED errors

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11049,7 +11049,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
         }
       else
         {
-          if (optional)
+          if (optional && !g_cancellable_is_cancelled (cancellable))
             {
               state->summary_fetch_error = g_steal_pointer (&local_error);
               g_debug ("Failed to download optional summary");
@@ -11078,7 +11078,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
       if (!_flatpak_dir_fetch_remote_state_metadata_branch (self, state, only_cached, cancellable, &local_error) &&
           !g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_DOWNGRADE))
         {
-          if (optional)
+          if (optional && !g_cancellable_is_cancelled (cancellable))
             {
               /* This happens for instance in the case where a p2p remote is invalid (wrong signature)
                  and we should just silently fail to update to it. */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -105,12 +105,18 @@ flatpak_error_quark (void)
 gboolean
 flatpak_fail_error (GError **error, FlatpakError code, const char *fmt, ...)
 {
+  GError *new;
+
   if (error == NULL)
     return FALSE;
 
   va_list args;
   va_start (args, fmt);
-  GError *new = g_error_new_valist (FLATPAK_ERROR, code, fmt, args);
+  if (*error != NULL &&
+      g_error_matches (*error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+    new = g_error_new_valist (G_IO_ERROR, G_IO_ERROR_CANCELLED, fmt, args);
+  else
+    new = g_error_new_valist (FLATPAK_ERROR, code, fmt, args);
   va_end (args);
   g_propagate_error (error, g_steal_pointer (&new));
   return FALSE;


### PR DESCRIPTION
utils: Convert only non-G_IO_ERROR_CANCELLED errors
    
Teach flatpak_fail_error to report G_IO_ERROR_CANCELLED
errors without converting to FLATPAK_ERROR domain.
    
Clients like gnome-software already filters out
G_IO_ERROR_CANCELLED error from showing up in the
UI; but still somehow many of these errors still were
ending up in the error-banner. This was due to the fact
that these errors were converted to FLATPAK_ERROR domain
with code as FLATPAK_ERROR_INVALID_DATA and that were not
filtered out by gnome-software.
    
Also, it's actually not right to have something like
FLATPAK_ERROR_CANCELLED and teach gnome-software to
detect it. Hence, the approach here is to preserve the
error domain as G_IO_ERROR and code as G_IO_ERROR_CANCELLED.
    
Also see the reasoning at:
https://github.com/flatpak/flatpak/pull/2932/#discussion_r314676742
