### PR TITLE
Bind mount local fonts dir according to FHS

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1581,6 +1581,16 @@ add_font_path_args (FlatpakBwrap *bwrap)
                               SYSTEM_FONTS_DIR);
     }
 
+  if (g_file_test ("/usr/local/share/fonts", G_FILE_TEST_EXISTS))
+    {
+      flatpak_bwrap_add_args (bwrap,
+                              "--ro-bind", "/usr/local/share/fonts", "/run/host/local-fonts",
+                              NULL);
+      g_string_append_printf (xml_snippet,
+                              "\t<remap-dir as-path=\"%s\">/run/host/local-fonts</remap-dir>\n",
+                              "/usr/local/share/fonts");
+    }
+
   system_cache_dirs = g_strsplit (SYSTEM_FONT_CACHE_DIRS, ":", 0);
   for (i = 0; system_cache_dirs[i] != NULL; i++)
     {


### PR DESCRIPTION
Fixes #924

According to FHS system-wide fonts can be stored in both `/usr/share/fonts` and `/usr/local/share/fonts`, and generally the former one is ruled by the package manager and system admins should put custom fonts in the latter dir

This patch may be revised to use configurable directories https://github.com/flatpak/flatpak/blob/1.4.0/configure.ac#L133