### PR TITLE
Avoid a potential segfault when skipping columns

### DIFF
--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -364,7 +364,7 @@ string_add_spaces (GString *str, int count)
 }
 
 static gboolean
-colum_is_unique (FlatpakTablePrinter *printer, int col)
+column_is_unique (FlatpakTablePrinter *printer, int col)
 {
   char *first_row = NULL;
   int i;
@@ -431,7 +431,7 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
     {
       TableColumn *col = g_ptr_array_index (printer->columns, i);
 
-      if (col->skip_unique && colum_is_unique (printer, i))
+      if (col->skip_unique && column_is_unique (printer, i))
         col->skip = TRUE;
     }
 

--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -372,6 +372,9 @@ column_is_unique (FlatpakTablePrinter *printer, int col)
   for (i = 0; i < printer->rows->len; i++)
     {
       Row *row = g_ptr_array_index (printer->rows, i);
+      if (col >= row->cells->len)
+        continue;
+
       Cell *cell = g_ptr_array_index (row->cells, col);
 
       if (i == 0)


### PR DESCRIPTION
Idiot me just realized errors were getting dissolved with noninteractive on 1.2.4, so I decided to check it out and ended up fixing something totally unrelated before realizing e1f45a38786ff91702904b616455fce7347e5077 was already a thing. :man_shrugging: 