### PR TITLE
dir: include NULL url in flatpak_dir_log() call

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8072,7 +8072,7 @@ flatpak_dir_deploy_install (FlatpakDir   *self,
   ret = TRUE;
 
   commit = flatpak_dir_read_active (self, ref, cancellable);
-  flatpak_dir_log (self, "deploy install", origin, ref, commit, old_active,
+  flatpak_dir_log (self, "deploy install", origin, ref, commit, old_active, NULL,
                    "Installed %s from %s", ref, origin);
 
 out:


### PR DESCRIPTION
I spotted this line in the output from `flatpak history`:

    Jun  4 16:17:20	deploy install	com.discordapp.Discord	x86_64	stable	system	flathub	8a0fc700c701		Installed %s from %s	root (test)	flatpak-system-helper (gnome-software)	1.3.3

This is because the format string is passed as the 'url' parameter, the
first format parameter (the ref) is passed as the 'format' parameter,
and 'origin' is ignored because (fortunately) as far as I know, no
character significant to printf (like '%') is permitted in ref names.

Fix this by passing a NULL 'url', like the neighbouring call in
flatpak_dir_deploy_update().