### PR TITLE
profile: Fix for openbsd ksh.

### DIFF
--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -12,9 +12,9 @@ if command -v flatpak > /dev/null; then
             do
                 share_path=$install_path/exports/share
                 case ":$XDG_DATA_DIRS:" in
-                    *":$share_path:"*) :;;
-                    *":$share_path/:"*) :;;
-                    *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
+                    (*":$share_path:"*) :;;
+                    (*":$share_path/:"*) :;;
+                    (*) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
                 esac
             done
             echo "$new_dirs"


### PR DESCRIPTION
When using OpenBSD ksh `flatpak.sh` gives the following error:

	/etc/profile.d/flatpak.sh[16]: syntax error: `;;' unexpected

By adding in the POSIX compliant optional opening parentheses for the
case statement branches the profile can be made more portable.  This
still works with them more common shells such as bash and zsh and also
still passes `shellcheck` checks.

Aware that using OpenBSD ksh on Linux might be an edge case but there
are probably BSD users who need to use Linux for work such as myself but
still want to use the OBSD shell which has been ported to Linux:
https://github.com/dimkr/loksh

Many thanks to @gumnos for pointing out the fix here via Twitter.