### PR TITLE
remote-delete: Manually delete origin remotes if no refs were removed

### DIFF
--- a/app/flatpak-builtins-remote-delete.c
+++ b/app/flatpak-builtins-remote-delete.c
@@ -47,6 +47,7 @@ flatpak_builtin_remote_delete (int argc, char **argv, GCancellable *cancellable,
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GPtrArray) dirs = NULL;
   g_autoptr(FlatpakDir) preferred_dir = NULL;
+  gboolean removed_all_refs = FALSE;
   const char *remote_name;
 
   context = g_option_context_new (_("NAME - Delete a remote repository"));
@@ -118,10 +119,12 @@ flatpak_builtin_remote_delete (int argc, char **argv, GCancellable *cancellable,
 
               return FALSE;
             }
+
+          removed_all_refs = TRUE;
         }
     }
 
-  if (g_str_has_suffix (remote_name, "-origin"))
+  if (g_str_has_suffix (remote_name, "-origin") && removed_all_refs)
     // The remote has already been deleted because all its refs were deleted.
     return TRUE;
 


### PR DESCRIPTION
There are a few cases where -origin remotes don't get removed when
their refs are uninstalled, most notably when xa.noenumerate is set, or
somehow the uninstall gets interrupted at the wrong time. Regardless
of the reason, the remote could never be removed after this, unless a
new ref is installed from it and then removed, or noenumerate is set.

Closes: #2920