### PR TITLE
Allow running apply_extra for extensions

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7375,6 +7375,9 @@ apply_extra_data (FlatpakDir   *self,
   runtime = g_key_file_get_string (metakey, group,
                                    FLATPAK_METADATA_KEY_RUNTIME, error);
   if (runtime == NULL)
+    runtime = g_key_file_get_string (metakey, FLATPAK_METADATA_GROUP_EXTENSION_OF,
+                                     FLATPAK_METADATA_KEY_RUNTIME, NULL);
+  if (runtime == NULL)
     return FALSE;
 
   runtime_ref = g_build_filename ("runtime", runtime, NULL);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1642,11 +1642,13 @@ add_deps (FlatpakTransaction          *self,
   g_autofree char *runtime_remote = NULL;
   FlatpakTransactionOperation *runtime_op = NULL;
 
-  if (!g_str_has_prefix (op->ref, "app/"))
+  if (!op->resolved_metakey)
     return TRUE;
 
-  if (op->resolved_metakey)
+  if (g_str_has_prefix (op->ref, "app/"))
     runtime_ref = g_key_file_get_string (op->resolved_metakey, "Application", "runtime", NULL);
+  else
+    runtime_ref = g_key_file_get_string (op->resolved_metakey, "ExtensionOf", "runtime", NULL);
 
   if (runtime_ref == NULL)
     return TRUE;

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -499,7 +499,7 @@
                 <varlistentry>
                     <term><option>build</option> (boolean)</term>
                     <listitem><para>
-                        Whether this instance was created by flatpak build. 
+                        Whether this instance was created by flatpak build.
                     </para></listitem>
                 </varlistentry>
                 <varlistentry>
@@ -803,6 +803,15 @@
                     <listitem><para>
                         The ref of the runtime or application that this extension
                         belongs to. Available since 0.9.1.
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>runtime</option> (string)</term>
+                    <listitem><para>
+                        The runtime this extension will be inside of. If it is an
+                        app extension, this is the app's runtime; otherwise, this
+                        is identical to ref, without the runtime/ prefix.
+                        Available since 1.5.0.
                     </para></listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
Prior to this, an extension couldn't use extra-data, because there was no indication of where to run apply_extra. In order to work around this, build-init now sets ExtensionOf.runtime, and then apply_extra is run inside of the indicated runtime.