### PR TITLE
Do not break ABI and cause gnome-software to crash

### DIFF
--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -114,12 +114,6 @@ struct _FlatpakTransactionClass
                                 const char         *ref,
                                 const char         *reason,
                                 const char         *rebase);
-  gboolean (*end_of_lifed_with_rebase) (FlatpakTransaction *transaction,
-                                        const char         *remote,
-                                        const char         *ref,
-                                        const char         *reason,
-                                        const char         *rebased_to_ref,
-                                        const char        **previous_ids);
   gboolean (*ready)            (FlatpakTransaction *transaction);
 
   gboolean (*add_new_remote) (FlatpakTransaction            *transaction,
@@ -131,8 +125,14 @@ struct _FlatpakTransactionClass
   gboolean (*run)            (FlatpakTransaction *transaction,
                               GCancellable       *cancellable,
                               GError            **error);
+  gboolean (*end_of_lifed_with_rebase) (FlatpakTransaction *transaction,
+                                        const char         *remote,
+                                        const char         *ref,
+                                        const char         *reason,
+                                        const char         *rebased_to_ref,
+                                        const char        **previous_ids);
 
-  gpointer padding[9];
+  gpointer padding[8];
 };
 
 FLATPAK_EXTERN


### PR DESCRIPTION
This restores the ABI to the pre-1.4.0 version. This moves the new signal to
the *end* of the struct and also correctly decrements the padding.

Fixes https://github.com/flatpak/flatpak/issues/2957, although we probably need
a 1.4.1 release with this included pretty quickly to avoid chaos.