### PR TITLE
common/flatpak-dir-private.h: Fix order of arguments

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -901,8 +901,8 @@ GPtrArray * flatpak_dir_find_local_related_for_metadata (FlatpakDir   *self,
                                                          GCancellable *cancellable,
                                                          GError      **error);
 GPtrArray * flatpak_dir_find_local_related (FlatpakDir   *self,
-                                            const char   *remote_name,
                                             const char   *ref,
+                                            const char   *remote_name,
                                             gboolean      deployed,
                                             GCancellable *cancellable,
                                             GError      **error);


### PR DESCRIPTION
This issue was introduced by commit 5da7a0411.

Fixes https://github.com/flatpak/flatpak/issues/2966