### PR TITLE
Add option to persist paths from /app

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -73,6 +73,7 @@ struct FlatpakContext
   GHashTable            *session_bus_policy;
   GHashTable            *system_bus_policy;
   GHashTable            *generic_policy;
+  GHashTable            *app_persistent;
 };
 
 extern const char *flatpak_context_sockets[];
@@ -85,6 +86,7 @@ void           flatpak_context_free (FlatpakContext *context);
 void           flatpak_context_merge (FlatpakContext *context,
                                       FlatpakContext *other);
 GOptionEntry  *flatpak_context_get_option_entries (void);
+GOptionEntry  *flatpak_context_get_finish_option_entries (void);
 GOptionGroup  *flatpak_context_get_options (FlatpakContext *context);
 gboolean       flatpak_context_load_metadata (FlatpakContext *context,
                                               GKeyFile       *metakey,

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -49,6 +49,7 @@ gboolean flatpak_run_in_transient_unit (const char *app_id,
 #define FLATPAK_METADATA_KEY_PERSISTENT "persistent"
 #define FLATPAK_METADATA_KEY_DEVICES "devices"
 #define FLATPAK_METADATA_KEY_FEATURES "features"
+#define FLATPAK_METADATA_KEY_APP_PERSISTENT "app-persistent"
 
 #define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
 #define FLATPAK_METADATA_KEY_INSTANCE_PATH "instance-path"

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -329,6 +329,21 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
+                <term><option>--app-persist=FILENAME</option></term>
+
+                <listitem><para>
+                      For buggy applications which don't conform to the
+                      <ulink url="https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+                      >freedesktop.org Base Directory Specification</ulink> and try to write into the read-only application
+                      directory, make the (<filename>/app</filename>-relative) path <arg choice="plain">FILENAME</arg> a bind
+                      mount to the corresponding path in the per-application directory of the user, allowing that location to
+                      be used for persistent data. An empty file or empty directory must exist in <filename>/app</filename>.
+                      This updates the [Context] group in the metadata.
+                      This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--persist=FILENAME</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -332,6 +332,27 @@
                     </para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>app-persistent</option> (list)</term>
+                    <listitem><para>
+                      In general, applications should conform to the
+                      <ulink url="https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+                      >freedesktop.org Base Directory Specification</ulink> instead of
+                      writing data into the read-only application directory.
+                    </para>
+                    <para>
+                      List of /app-relative paths to make available at
+                      the corresponding path in the per-application home directory,
+                      allowing the locations to be used for persistent data when
+                      the application needs to write to the read-only application dir.
+                      For instance making "saves" persistent would make "/app/saves"
+                      in the sandbox a bind mount to "~/.var/app/org.my.App/saves",
+                      thus allowing an unmodified application to save data in
+                      the per-application location. The paths must already exist in /app
+                      and must be empty files or empty directories. This option cannot
+                      be overriden by the user. Available since 1.5.
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>persistent</option> (list)</term>
                     <listitem><para>
                       List of homedir-relative paths to make available at


### PR DESCRIPTION
Some proprietary applications write user data into the read-only
application dir and are therefore not compatible with Linux package
managers. To work around the issue, this introduces the context key
app-persistent which, similar to persistent, bind mounts the specified
app-dir paths into the user's per-application home directory.

The options is only available for applications and since the bind mount
can be essential for the app, it can only be set on build-finish and is
not overridable by the user.

### TODO
- Persist files
- Handle --sandbox (there must be bind mounts to temp dirs/files to not break apps)
- Don't write for metadata for runtime (currently it's only ignored when running)

I'm not sure if it's actually worth to handle those application bugs with an native option since there are workarounds (e.g. symlinks into a tmp directory, https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=shadowrun-returns). But I think it's a little bit less ugly.