### PR TITLE
transaction: Introduce free disk space checking

### DIFF
--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -183,6 +183,9 @@ FLATPAK_EXTERN
 void                flatpak_transaction_set_no_deploy (FlatpakTransaction *self,
                                                        gboolean            no_deploy);
 FLATPAK_EXTERN
+void                flatpak_transaction_set_enable_diskspace_check (FlatpakTransaction *self,
+                                                                    gboolean            enable_diskspace_check);
+FLATPAK_EXTERN
 void                flatpak_transaction_set_disable_static_deltas (FlatpakTransaction *self,
                                                                    gboolean            disable_static_deltas);
 FLATPAK_EXTERN

--- a/configure.ac
+++ b/configure.ac
@@ -282,6 +282,16 @@ if test "x$enable_sandboxed_triggers" = "xno"; then
       [Define if sandboxed triggers are disabled])
 fi
 
+AC_ARG_ENABLE([diskspace-check],
+              AC_HELP_STRING([--enable-diskspace-check],
+                             [Enables diskspace check for installs or updates]),
+              [],
+              [enable_diskspace_check=no])
+if test "x$enable_diskspace_check" = "xyes"; then
+   AC_DEFINE([ENABLE_DISKSPACE_CHECK], [1],
+      [Define if diskspace check is enabled])
+fi
+
 PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
 
 PKG_CHECK_MODULES(JSON, [json-glib-1.0])


### PR DESCRIPTION
This commit introduces free disk space checks for the filesystem
on which the current FlatpakInstalltation resides. This can help
client programs such as GNOME Software to optionally enable this
check via flatpak_transaction_set_enable_diskspace_check and guard
the user against overfilling their disks(especially during autoupdates),
behind their back. This also saves users quite a bit of network I/O
bandwidth as this check is done before the actual fetch/pull operations
have begun.

This has become more convenient because of the FlatpakTransaction
API, which allows us to lookup all refs and their metadata involved
in the transaction.

Diskspace checking is disabled by default. It can be enabled via
configure-time parameter --enable-diskspace-check or by using
flatpak_transaction_set_enable_diskspace_check API.

In the case of install operations, all refs' installed sizes are summed
up to be compared against the free diskspace. In case of updates, if
the ref is a runtime, we deliberately skip it's installed sizes as
runtime updates have typically quite less delta size.

The sizes computed here are not exact sizes but a good heuristics
to determine the success or failure of a transaction. Sizes might be
lower if there are objects present locally but we seem to consider
worst case here and pro-actively save the free disk-space sizes. This
is typically important on systems having 32/64 eMMC storage(like
Endless systems) or where the network bandwidth is expensive.