### PR TITLE
common: Fix branch validation docs

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -999,7 +999,7 @@ is_valid_branch_character (gint c)
  *
  * Branch names must only contain the ASCII characters
  * "[A-Z][a-z][0-9]_-.".
- * Branch names may not begin with a digit.
+ * Branch names may not begin with a period.
  * Branch names must contain at least one character.
  *
  * Returns: %TRUE if valid, %FALSE otherwise.


### PR DESCRIPTION
The docs for flatpak_is_valid_branch() say branch names can't start with
a digit but the implementation doesn't enforce this, so change the
enforcement to disallow e.g. "99wip".

The implementation also disallows "." as the leading character for a
branch, so add that to the docs. I'm just guessing that "." was intended
to be disallowed but it makes sense; otherwise the file we create named
with the branch would be hidden.