### PR TITLE
installation: Fix wrong transfer annotation of GPtrArray

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -217,7 +217,7 @@ flatpak_get_supported_arches (void)
  * Lists the system installations according to the current configuration and current
  * availability (e.g. doesn't return a configured installation if not reachable).
  *
- * Returns: (transfer container) (element-type FlatpakInstallation): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakInstallation): a #GPtrArray of
  *   #FlatpakInstallation instances
  *
  * Since: 0.8
@@ -875,7 +875,7 @@ flatpak_installation_get_current_installed_app (FlatpakInstallation *self,
  *
  * Lists the installed references.
  *
- * Returns: (transfer container) (element-type FlatpakInstalledRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakInstalledRef): a #GPtrArray of
  *   #FlatpakInstalledRef instances
  */
 GPtrArray *
@@ -933,7 +933,7 @@ flatpak_installation_list_installed_refs (FlatpakInstallation *self,
  *
  * Lists the installed references of a specific kind.
  *
- * Returns: (transfer container) (element-type FlatpakInstalledRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakInstalledRef): a #GPtrArray of
  *   #FlatpakInstalledRef instances
  */
 GPtrArray *
@@ -997,7 +997,7 @@ _ostree_collection_ref_free0 (OstreeCollectionRef *ref)
  * it can have local updates available that has not been deployed. Look
  * at commit vs latest_commit on installed apps for this.
  *
- * Returns: (transfer container) (element-type FlatpakInstalledRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakInstalledRef): a #GPtrArray of
  *   #FlatpakInstalledRef instances, or %NULL on error
  */
 GPtrArray *
@@ -1323,7 +1323,7 @@ list_remotes_for_configured_remote (FlatpakInstallation *self,
  *
  * Lists only the remotes whose type is included in the @types argument.
  *
- * Returns: (transfer container) (element-type FlatpakRemote): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakRemote): a #GPtrArray of
  *   #FlatpakRemote instances
  */
 GPtrArray *
@@ -1422,7 +1422,7 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
  * Lists the static remotes, in priority (highest first) order. For same
  * priority, an earlier added remote comes before a later added one.
  *
- * Returns: (transfer container) (element-type FlatpakRemote): an GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakRemote): an GPtrArray of
  *   #FlatpakRemote instances
  */
 GPtrArray *
@@ -2421,7 +2421,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
  *
  * Lists all the applications and runtimes in a remote.
  *
- * Returns: (transfer container) (element-type FlatpakRemoteRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakRemoteRef): a #GPtrArray of
  *   #FlatpakRemoteRef instances
  */
 GPtrArray *
@@ -2443,7 +2443,7 @@ flatpak_installation_list_remote_refs_sync (FlatpakInstallation *self,
  *
  * Lists all the applications and runtimes in a remote.
  *
- * Returns: (transfer container) (element-type FlatpakRemoteRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakRemoteRef): a #GPtrArray of
  *   #FlatpakRemoteRef instances
  *
  * Since: 1.3.3
@@ -2759,7 +2759,7 @@ flatpak_installation_create_monitor (FlatpakInstallation *self,
  * The commit property of each FlatpakRelatedRef is not guaranteed to be
  * non-%NULL.
  *
- * Returns: (transfer container) (element-type FlatpakRelatedRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakRelatedRef): a #GPtrArray of
  *   #FlatpakRelatedRef instances
  *
  * Since: 0.6.7
@@ -2824,7 +2824,7 @@ flatpak_installation_list_remote_related_refs_sync (FlatpakInstallation *self,
  * looking for related refs to uninstall, or when you're planning to use
  * FLATPAK_UPDATE_FLAGS_NO_PULL to install previously pulled refs.
  *
- * Returns: (transfer container) (element-type FlatpakRelatedRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakRelatedRef): a #GPtrArray of
  *   #FlatpakRelatedRef instances
  *
  * Since: 0.6.7
@@ -3035,7 +3035,7 @@ find_used_refs (FlatpakDir *dir,
  * A reference is used if it is either an application, or an sdk,
  * or the runtime of a used ref, or an extension of a used ref.
  *
- * Returns: (transfer container) (element-type FlatpakInstalledRef): a GPtrArray of
+ * Returns: (transfer full) (element-type FlatpakInstalledRef): a #GPtrArray of
  *   #FlatpakInstalledRef instances
  *
  * Since: 1.1.2


### PR DESCRIPTION
At the receiver point of view, if someone want to add a GObject to the GPtrArray, it has to increase the reference itself. By setting a `(transfer container)` it means that the user don't have to increase a reference before adding an object there as the user still "owns" it.