### PR TITLE
installation: Don't return an error checking for updates offline

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1139,13 +1139,10 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
         return NULL;
 
       if (results[0] == NULL)
-        {
-          flatpak_fail (error, _("No remotes found which provide these refs: [%s]"), refs_str->str);
-          return NULL;
-        }
+        g_debug ("No remotes found which provide these refs: [%s]", refs_str->str);
     }
 
-  for (i = 0; i < installed->len; i++)
+  for (i = 0; i < installed->len && results[0] != NULL; i++)
     {
       FlatpakInstalledRef *installed_ref = g_ptr_array_index (installed, i);
       const char *remote_name = flatpak_installed_ref_get_origin (installed_ref);

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1425,7 +1425,7 @@ flatpak_installation_list_remotes_by_type (FlatpakInstallation     *self,
  * Lists the static remotes, in priority (highest first) order. For same
  * priority, an earlier added remote comes before a later added one.
  *
- * Returns: (transfer container) (element-type FlatpakRemote): an GPtrArray of
+ * Returns: (transfer container) (element-type FlatpakRemote): a GPtrArray of
  *   #FlatpakRemote instances
  */
 GPtrArray *
@@ -1760,7 +1760,8 @@ flatpak_installation_update_remote_sync (FlatpakInstallation *self,
  *
  * Looks up a remote by name.
  *
- * Returns: (transfer full): a #FlatpakRemote instances, or %NULL error
+ * Returns: (transfer full): a #FlatpakRemote instance, or %NULL with @error
+ *   set
  */
 FlatpakRemote *
 flatpak_installation_get_remote_by_name (FlatpakInstallation *self,

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1733,7 +1733,7 @@ run_test_subprocess (char                 **argv,
 static void
 make_bundle (void)
 {
-  g_autofree char *repo_url = g_strdup_printf ("http://127.0.01:%s/test", httpd_port);
+  g_autofree char *repo_url = g_strdup_printf ("http://127.0.0.1:%s/test", httpd_port);
   g_autofree char *arg2 = g_strdup_printf ("--repo-url=%s", repo_url);
   g_autofree char *path = g_build_filename (testdir, "bundles", NULL);
   g_autofree char *file = g_build_filename (path, "hello.flatpak", NULL);
@@ -3400,7 +3400,7 @@ test_bundle (void)
   g_autofree char *path = NULL;
   g_autoptr(GFile) file2 = NULL;
   g_autofree char *origin = NULL;
-  g_autofree char *repo_url = g_strdup_printf ("http://127.0.01:%s/test", httpd_port);
+  g_autofree char *repo_url = g_strdup_printf ("http://127.0.0.1:%s/test", httpd_port);
   g_autoptr(GBytes) metadata = NULL;
   g_autoptr(GBytes) appstream = NULL;
   g_autoptr(GBytes) icon = NULL;

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -2255,11 +2255,11 @@ end_of_lifed (FlatpakTransaction *transaction,
 }
 
 static gboolean
-add_new_remote (FlatpakTransaction *transaction,
-                const char         *reason,
-                const char         *from_id,
-                const char         *suggested_name,
-                const char         *url)
+add_new_remote (FlatpakTransaction             *transaction,
+                FlatpakTransactionRemoteReason  reason,
+                const char                     *from_id,
+                const char                     *suggested_name,
+                const char                     *url)
 {
   g_assert_not_reached ();
   return TRUE;
@@ -2700,11 +2700,11 @@ test_transaction_install_uninstall (void)
 static int remote_added;
 
 static gboolean
-add_new_remote2 (FlatpakTransaction *transaction,
-                 const char         *reason,
-                 const char         *from_id,
-                 const char         *suggested_name,
-                 const char         *url)
+add_new_remote2 (FlatpakTransaction             *transaction,
+                 FlatpakTransactionRemoteReason  reason,
+                 const char                     *from_id,
+                 const char                     *suggested_name,
+                 const char                     *url)
 {
   remote_added++;
   g_assert_cmpstr (suggested_name, ==, "my-little-repo");
@@ -2836,11 +2836,11 @@ assert_remote_not_in_installation (FlatpakInstallation *installation,
 }
 
 static gboolean
-add_new_remote3 (FlatpakTransaction *transaction,
-                 const char         *reason,
-                 const char         *from_id,
-                 const char         *suggested_name,
-                 const char         *url)
+add_new_remote3 (FlatpakTransaction             *transaction,
+                 FlatpakTransactionRemoteReason  reason,
+                 const char                     *from_id,
+                 const char                     *suggested_name,
+                 const char                     *url)
 {
   return TRUE;
 }


### PR DESCRIPTION
In commit b8a3075d8 I changed a few places to check if the array
returned by ostree_repo_find_remotes_finish() is empty, which would mean
either none of the configured remotes (or P2P sources) provide the
requested refs, or the one(s) that do are offline. That was mostly
correct but in the case of
flatpak_installation_list_installed_refs_for_update() we don't want to
treat empty results as an error, because otherwise GNOME Software prints
an error message when offline: "No remotes found which provide these
refs: ...".

So this commit makes list_installed_refs_for_update() return an empty
array in case it can't find any updates (we don't distinguish "remotes
checked and provide no updates" from "remotes couldn't be reached").
This matches the behavior of the non-P2P code: the for loop above which
handles remotes without collection IDs prints a debug message if an
error is encountered.