### PR TITLE
dir: Match prefix when looking for extensions

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13729,7 +13729,7 @@ local_match_prefix (FlatpakDir *self,
 
   /* Also check deploys. In case remote-delete --force is run, we can end up
    * with a deploy without a corresponding ref in the repo. */
-  flatpak_dir_collect_deployed_refs (self, parts[0], parts[1], parts[2], parts[3], matches, NULL, NULL);
+  flatpak_dir_collect_deployed_refs (self, parts[0], parts_prefix, parts[2], parts[3], matches, NULL, NULL);
 
   return matches;
 }


### PR DESCRIPTION
When looking for deployed extensions, use the same prefix as when
looking for extension refs. E.g. look for refs that start with
"io.github.Hexchat.Plugin." rather than "io.github.Hexchat.Plugin".

This is a follow-up to https://github.com/flatpak/flatpak/pull/3067#discussion_r322173197