### PR TITLE
Fix uninstall unused versions

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13579,7 +13579,6 @@ flatpak_dir_find_remote_related_for_metadata (FlatpakDir         *self,
           g_autofree char *extension_collection_id = NULL;
           const char *default_branches[] = { NULL, NULL};
           const char **branches;
-          g_autofree char *checksum = NULL;
           int branch_i;
 
           /* Parse actual extension name */
@@ -13616,6 +13615,7 @@ flatpak_dir_find_remote_related_for_metadata (FlatpakDir         *self,
           for (branch_i = 0; branches[branch_i] != NULL; branch_i++)
             {
               g_autofree char *extension_ref = NULL;
+              g_autofree char *checksum = NULL;
               const char *branch = branches[branch_i];
 
               extension_ref = g_build_filename ("runtime", extension, parts[2], branch, NULL);


### PR DESCRIPTION
Handle 'versions' key when finding local related ref
    
We were only handling the old single-value 'version' key, even though we handled the 'versions' key when finding remote related refs.

The result of this was that some extensions, such as the 19.08 opengl default one was installed by default (as it was found as remote related)  yet still removed with --unused (as it was not locally related).

Fixes https://github.com/flatpak/flatpak/issues/3004
