### PR TITLE
flatpak-remote: Enforce GPG verification when a collection ID is set

### DIFF
--- a/common/flatpak-remote.c
+++ b/common/flatpak-remote.c
@@ -1298,6 +1298,11 @@ flatpak_remote_commit (FlatpakRemote *self,
 
   if (priv->local_gpg_verify_set)
     {
+      if (!priv->local_gpg_verify &&
+           priv->local_collection_id_set && priv->local_collection_id != NULL)
+        return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                                   _("GPG verification must be enabled when a collection ID is set"));
+
       g_key_file_set_boolean (config, group, "gpg-verify", priv->local_gpg_verify);
 
       if (!priv->local_collection_id_set || priv->local_collection_id == NULL)


### PR DESCRIPTION
Currently the "test_remote()" test calls
flatpak_remote_set_gpg_verify (remote, FALSE) and disables GPG
verification on a remote while a collection ID is set on it, which
should not be possible. The remote-add command enforces that GPG
verification is used if a collection ID is set, but the library API does
not. This commit changes libflatpak to return an error when such an
invalidly configured remote is being committed to disk. Also, update the
unit test to check for the newly added error, and to unset the
collection ID before disabling GPG verification.

Later in the unit test, GPG verification is re-enabled on the remote,
but libflatpak erroneously sets gpg-verify-summary=true in addition to
gpg-verify=true (summary verification is supposed to be disabled when
collections are used, but the library doesn't notice the mistake since a
collection ID isn't set in the same transaction and was already set).

This fix addresses both issues.