### PR TITLE
tests: Fix a warning about ignoring the return value of symlink()

### DIFF
--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1917,7 +1917,7 @@ setup_repo (void)
   configure_languages ();
 
   /* another copy of the same repo, with different url */
-  symlink ("test", "repos/copy-of-test");
+  g_assert_cmpint (symlink ("test", "repos/copy-of-test"), ==, 0);
 
   /* another repo, with only the app */
   make_test_app ("test-without-runtime");


### PR DESCRIPTION
Assert it was successful instead. This is probably pointless from the
point of view of testing things (why would symlink() ever realistically
fail but everything else succeed?), but it does shut up a compiler
warning, which gives us a better chance to spot legitimate warnings in
future.

Signed-off-by: Philip Withnall <withnall@endlessm.com>