### PR TITLE
Work around deadlocks in g_spawn by manually clo-exec:ing fds

### DIFF
--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -39,6 +39,7 @@
 
 #include "flatpak-bwrap-private.h"
 #include "flatpak-utils-private.h"
+#include "flatpak-utils-base-private.h"
 
 static void
 clear_fd (gpointer data)
@@ -330,6 +331,8 @@ flatpak_bwrap_child_setup_cb (gpointer user_data)
 {
   GArray *fd_array = user_data;
   int i;
+
+  flatpak_close_fds_workaround (3);
 
   /* If no fd_array was specified, don't care. */
   if (fd_array == NULL)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6248,10 +6248,11 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
           commandline = flatpak_quote_argv ((const char **) bwrap->argv->pdata, -1);
           g_debug ("Running '%s'", commandline);
 
+          /* We use LEAVE_DESCRIPTORS_OPEN to work around dead-lock, see flatpak_close_fds_workaround */
           if (!g_spawn_sync ("/",
                              (char **) bwrap->argv->pdata,
                              NULL,
-                             G_SPAWN_SEARCH_PATH,
+                             G_SPAWN_SEARCH_PATH | G_SPAWN_LEAVE_DESCRIPTORS_OPEN,
                              flatpak_bwrap_child_setup_cb, bwrap->fds,
                              NULL, NULL,
                              NULL, &trigger_error))

--- a/common/flatpak-utils-base-private.h
+++ b/common/flatpak-utils-base-private.h
@@ -30,5 +30,6 @@ char * flatpak_readlink (const char *path,
 char * flatpak_resolve_link (const char *path,
                              GError    **error);
 char * flatpak_canonicalize_filename (const char *path);
+void   flatpak_close_fds_workaround (int start_fd);
 
 #endif /* __FLATPAK_UTILS_BASE_H__ */

--- a/common/flatpak-utils-base.c
+++ b/common/flatpak-utils-base.c
@@ -98,3 +98,19 @@ flatpak_canonicalize_filename (const char *path)
   g_autoptr(GFile) file = g_file_new_for_path (path);
   return g_file_get_path (file);
 }
+
+/* There is a dead-lock in glib versions before 2.60 when it closes
+ * the fds. See:  https://gitlab.gnome.org/GNOME/glib/merge_requests/490
+ * This was hitting the test-suite a lot, so we work around it by using
+ * the G_SPAWN_LEAVE_DESCRIPTORS_OPEN/G_SUBPROCESS_FLAGS_INHERIT_FDS flag
+ * and setting CLOEXEC ourselves.
+ */
+void
+flatpak_close_fds_workaround (int start_fd)
+{
+  int max_open_fds = sysconf (_SC_OPEN_MAX);
+  int fd;
+
+  for (fd = start_fd; fd < max_open_fds; fd++)
+    fcntl (fd, F_SETFD, FD_CLOEXEC);
+}

--- a/portal/Makefile.am.inc
+++ b/portal/Makefile.am.inc
@@ -34,6 +34,6 @@ flatpak_portal_SOURCES = \
 BUILT_SOURCES += $(nodist_flatpak_portal_SOURCES)
 CLEANFILES += $(nodist_flatpak_portal_SOURCES)
 
-flatpak_portal_LDADD = $(AM_LDADD) $(BASE_LIBS)
+flatpak_portal_LDADD = $(AM_LDADD) $(BASE_LIBS) libflatpak-common-base.la libglnx.la
 flatpak_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) -DFLATPAK_COMPILATION
 flatpak_portal_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/portal


### PR DESCRIPTION
As per https://gitlab.gnome.org/GNOME/glib/merge_requests/490
there is a bug in glib < 2.60 where g_spawn_* can sometimes deadlock
due to using malloc in the child func to close fds.

We work around this in places where the code is (potentially) threaded
by passing glib flags to leave fds alone and then do a very naive
(but safe) fd cloexec loop ourselves.

I got this when trying to get the CI running on an ubuntu 18.08 (github actions) vm, which has an older glib, but in the end I fixed that by picking up glib 2.60 from a custom ppa. I'm not 100% sure this is enough to fix all issues though because I think some hangs were from elsewhere. For example, ostree uses g_spawn to spawn gpg. So, if this is not a full solution, and if the race condition is pretty small and fixed in later versions, do we care about this?