### PR TITLE
Add action that checks for autosquash commits in pull requests

### DIFF
--- a/.github/workflows/block-autosquash-commits.yml
+++ b/.github/workflows/block-autosquash-commits.yml
@@ -1,0 +1,15 @@
+on: pull_request
+
+name: Pull Requests
+
+jobs:
+  message-check:
+    name: Block Autosquash Commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Block Autosquash Commits
+        uses: xt0rted/block-autosquash-commits-action@v2.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want to block merging for these, to ensure that you autosquash
before merging.

Ideally we'd like automatic (or at least via a bot) autosquashing, but
that is not currently possible.