### PR TITLE
Update: Don't update an extension if it is an extension and the base is masked

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -32,8 +32,9 @@
  * The version field was added in flatpak 1.2, anything before is 0.
  *
  * Version 1 added appdata-name/summary/version/license
+ * Version 2 added extension-of
  */
-#define FLATPAK_DEPLOY_VERSION_CURRENT 1
+#define FLATPAK_DEPLOY_VERSION_CURRENT 2
 #define FLATPAK_DEPLOY_VERSION_ANY 0
 
 #define FLATPAK_TYPE_DIR flatpak_dir_get_type ()
@@ -362,6 +363,7 @@ const char *        flatpak_deploy_data_get_alt_id (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_eol (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_eol_rebase (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_runtime (GVariant *deploy_data);
+const char *        flatpak_deploy_data_get_extension_of (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_name (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_summary (GVariant *deploy_data);
 const char *        flatpak_deploy_data_get_appdata_version (GVariant *deploy_data);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2369,6 +2369,12 @@ flatpak_deploy_data_get_runtime (GVariant *deploy_data)
 }
 
 const char *
+flatpak_deploy_data_get_extension_of (GVariant *deploy_data)
+{
+  return flatpak_deploy_data_get_string (deploy_data, "extension-of");
+}
+
+const char *
 flatpak_deploy_data_get_appdata_name (GVariant *deploy_data)
 {
   return flatpak_deploy_data_get_localed_string (deploy_data, "appdata-name");
@@ -2510,6 +2516,7 @@ flatpak_dir_new_deploy_data (FlatpakDir         *self,
   char *empty_subpaths[] = {NULL};
   GVariantBuilder metadata_builder;
   g_autofree char *application_runtime = NULL;
+  g_autofree char *extension_of = NULL;
   const char *alt_id = NULL;
   const char *eol = NULL;
   const char *eol_rebase = NULL;
@@ -2521,6 +2528,9 @@ flatpak_dir_new_deploy_data (FlatpakDir         *self,
   application_runtime = g_key_file_get_string (metadata,
                                                FLATPAK_METADATA_GROUP_APPLICATION,
                                                FLATPAK_METADATA_KEY_RUNTIME, NULL);
+  extension_of = g_key_file_get_string (metadata,
+                                        FLATPAK_METADATA_GROUP_EXTENSION_OF,
+                                        FLATPAK_METADATA_KEY_REF, NULL);
 
   g_variant_builder_init (&metadata_builder, G_VARIANT_TYPE ("a{sv}"));
   g_variant_builder_add (&metadata_builder, "{s@v}", "deploy-version",
@@ -2537,6 +2547,9 @@ flatpak_dir_new_deploy_data (FlatpakDir         *self,
   if (application_runtime)
     g_variant_builder_add (&metadata_builder, "{s@v}", "runtime",
                            g_variant_new_variant (g_variant_new_string (application_runtime)));
+  if (extension_of)
+    g_variant_builder_add (&metadata_builder, "{s@v}", "extension-of",
+                           g_variant_new_variant (g_variant_new_string (extension_of)));
 
   if (previous_ids)
     g_variant_builder_add (&metadata_builder, "{s@v}", "previous-ids",

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9079,6 +9079,7 @@ flatpak_dir_needs_update_for_commit_and_subpaths (FlatpakDir  *self,
   g_autofree char *url = NULL;
   const char *installed_commit;
   const char *installed_alt_id;
+  const char *extension_of;
 
   g_assert (target_commit != NULL);
 
@@ -9106,6 +9107,11 @@ flatpak_dir_needs_update_for_commit_and_subpaths (FlatpakDir  *self,
 
   /* If masked, don't update */
   if (flatpak_dir_ref_is_masked (self, ref))
+    return FALSE;
+
+  extension_of = flatpak_deploy_data_get_extension_of (deploy_data);
+  /* If the main ref is masked, don't update extensions of it (like .Locale or .Debug) */
+  if (extension_of && flatpak_dir_ref_is_masked (self, extension_of))
     return FALSE;
 
   installed_commit = flatpak_deploy_data_get_commit (deploy_data);


### PR DESCRIPTION
For example, if org.the.App or org.the.Platform is masked that means we don't want to get any updates to it. Its very likely that we also don't want updates to extensions of this app or runtime. For example, we definately don't want to update the .Locale or .Debug extensions.
