### PR TITLE
eol: Use the right ref in the confirmation message

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -521,7 +521,7 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
   if (rebased_to_ref && remote)
     {
       if (self->disable_interaction ||
-          flatpak_yes_no_prompt (TRUE, _("Replace it with %s?"), flatpak_ref_get_name (rref)))
+          flatpak_yes_no_prompt (TRUE, _("Replace it with %s?"), rebased_to_ref))
         {
           g_autoptr(GError) error = NULL;
 


### PR DESCRIPTION
We were using the old ref here, instead of the new
one, when asking whether to go ahead.

Closes: https://github.com/flatpak/flatpak/issues/3139