### PR TITLE
app: Change xa.extra-languages to accept locales

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -955,7 +955,9 @@ gboolean           flatpak_dir_resolve_p2p_refs (FlatpakDir         *self,
                                                  GError            **error);
 
 
+char ** flatpak_dir_get_default_locales (FlatpakDir *self);
 char ** flatpak_dir_get_default_locale_languages (FlatpakDir *self);
+char ** flatpak_dir_get_locales (FlatpakDir *self);
 char ** flatpak_dir_get_locale_languages (FlatpakDir *self);
 char ** flatpak_dir_get_locale_subpaths (FlatpakDir *self);
 

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1683,6 +1683,32 @@ flatpak_installation_get_default_languages (FlatpakInstallation  *self,
 }
 
 /**
+ * flatpak_installation_get_default_locales:
+ * @self: a #FlatpakInstallation
+ * @error: return location for a #GError
+ *
+ * Like flatpak_installation_get_default_languages() but includes region 
+ * information (e.g. en_US rather than en) which may be included in the 
+ * xa.extra-languages configuration.
+ *
+ * Returns: (array zero-terminated=1) (element-type utf8) (transfer full):
+ *   A possibly empty array of language and locale strings, or %NULL on error.
+ * Since: 1.5.1
+ */
+char **
+flatpak_installation_get_default_locales (FlatpakInstallation  *self,
+                                          GError              **error)
+{
+  g_autoptr(FlatpakDir) dir = NULL;
+
+  dir = flatpak_installation_get_dir (self, error);
+  if (dir == NULL)
+    return NULL;
+
+  return flatpak_dir_get_locales (dir);
+}
+
+/**
  * flatpak_installation_get_min_free_space_bytes:
  * @self: a #FlatpakInstallation
  * @out_bytes: (out): Location to store the result

--- a/common/flatpak-installation.h
+++ b/common/flatpak-installation.h
@@ -298,6 +298,8 @@ FLATPAK_EXTERN char *                flatpak_installation_get_config (FlatpakIns
                                                                       GError             **error);
 FLATPAK_EXTERN char **               flatpak_installation_get_default_languages (FlatpakInstallation  *self,
                                                                                  GError              **error);
+FLATPAK_EXTERN char **               flatpak_installation_get_default_locales (FlatpakInstallation  *self,
+                                                                               GError              **error);
 FLATPAK_EXTERN char *              flatpak_installation_load_app_overrides (FlatpakInstallation *self,
                                                                             const char          *app_id,
                                                                             GCancellable        *cancellable,

--- a/doc/flatpak-config.xml
+++ b/doc/flatpak-config.xml
@@ -70,7 +70,8 @@
                 <listitem><para>
                    This key is used when languages is not set, and it defines extra locale
                    extensions on top of the system configured languages. The value is a
-                   semicolon-separated list of two-letter language codes.
+                   semicolon-separated list of two-letter language codes or locale identifiers
+                   (eg. en;en_DK;az_Latn_AZ).
                 </para></listitem>
             </varlistentry>
         </variablelist>


### PR DESCRIPTION
Make the languages key more relevant for different regions than just
the language code adopting full locales to the core keys.