### PR TITLE
Fix a doc typo

### DIFF
--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -60,7 +60,7 @@
 
        <para>
             System-wide remotes can be statically preconfigured by dropping
-            flatpakref files into <filename>/etc/flatpak/remotes.d/</filename>.
+            flatpakrepo files into <filename>/etc/flatpak/remotes.d/</filename>.
        </para>
 
         <para>


### PR DESCRIPTION
The docs refer to flatpakref files in /etc/flatpak/remotes.d,
but the code is looking for flatpakrepo files there.