### PR TITLE
po: Add some translations for parental controls strings

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -4889,6 +4889,14 @@ msgstr "Mutakhirkan metadata"
 msgid "Authentication is required to update metadata"
 msgstr "Autentikasi diperlukan untuk memutakhirkan metadata"
 
+#. Translators: The placeholder is for an app ref.
+#: common/flatpak-dir.c:7773
+#, c-format
+msgid "Installing %s is not allowed by the policy set by your administrator"
+msgstr ""
+"Instalasi %s tidak diizinkan oleh kebijakan yang ditetapkan oleh "
+"administrator Anda"
+
 #~ msgid "Default system installation"
 #~ msgstr "Pemasangan sistem bawaan"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4894,6 +4894,12 @@ msgstr "Atualizar metadados"
 msgid "Authentication is required to update metadata"
 msgstr "Autenticação é necessária para atualizar metadados"
 
+#. Translators: The placeholder is for an app ref.
+#: common/flatpak-dir.c:7773
+#, c-format
+msgid "Installing %s is not allowed by the policy set by your administrator"
+msgstr "Instalar %s não é permitido pela política definida pelo administrador"
+
 #~ msgid "Default system installation"
 #~ msgstr "Instalação padrão do sistema"
 


### PR DESCRIPTION
These are from paid-for translations from Endless’ downstream copy of
flatpak. I don’t know the original authors, and don’t know if the
translations are correct. (They should be though.)

Probably better than having no translations for these strings in
upstream flatpak, for the moment.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

cc @cho2, @rffontenelle 