### PR TITLE
session-helper: Correctly annotate use of Unix FDs in D-Bus API

### DIFF
--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -41,6 +41,7 @@
          to do this. For instance for developer tools this lets you
          build flatpaks from inside a flatpak. -->
     <method name="HostCommand">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type='ay' name='cwd_path' direction='in'/>
       <arg type='aay' name='argv' direction='in'/>
       <arg type='a{uh}' name='fds' direction='in'/>

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -201,6 +201,7 @@ child_setup_func (gpointer user_data)
 static gboolean
 handle_host_command (FlatpakDevelopment    *object,
                      GDBusMethodInvocation *invocation,
+                     GUnixFDList           *fd_list,
                      const gchar           *arg_cwd_path,
                      const gchar *const    *arg_argv,
                      GVariant              *arg_fds,
@@ -208,8 +209,6 @@ handle_host_command (FlatpakDevelopment    *object,
                      guint                  flags)
 {
   g_autoptr(GError) error = NULL;
-  GDBusMessage *message = g_dbus_method_invocation_get_message (invocation);
-  GUnixFDList *fd_list = g_dbus_message_get_unix_fd_list (message);
   ChildSetupData child_setup_data = { NULL };
   GPid pid;
   PidData *pid_data;
@@ -362,7 +361,7 @@ handle_host_command (FlatpakDevelopment    *object,
                         pid_data);
 
 
-  flatpak_development_complete_host_command (object, invocation,
+  flatpak_development_complete_host_command (object, invocation, NULL,
                                              pid_data->pid);
   return TRUE;
 }


### PR DESCRIPTION
This fixes compilation with GLib 2.63’s `gdbus-codegen`, which
automatically enables Unix FD support for D-Bus APIs which use the `h`
type, even if the `org.gtk.GDBus.C.UnixFD` annotation is missing.

By adding the annotation, the generated header whether using
`gdbus-codegen` 2.63 or < 2.63.

This is a slight API break in GLib, but it’s questionable about whether
flatpak should have always had the annotation.

Signed-off-by: Philip Withnall <withnall@endlessm.com>