### PR TITLE
transaction: Install extensions before apps

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1619,7 +1619,7 @@ add_related (FlatpakTransaction          *self,
                                                    FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE);
           related_op->non_fatal = TRUE;
           related_op->fail_if_op_fails = op;
-          run_operation_before (op, related_op, 1);
+          run_operation_before (related_op, op, 1);
         }
     }
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -2960,15 +2960,15 @@ check_ready3_abort (FlatpakTransaction *transaction)
   g_assert_cmpint (g_list_length (ops), ==, 3);
   op = ops->data;
   g_assert_cmpint (flatpak_transaction_operation_get_operation_type (op), ==, FLATPAK_TRANSACTION_OPERATION_INSTALL);
-  g_assert_cmpstr (flatpak_transaction_operation_get_ref (op), ==, runtime);
+  g_assert_cmpstr (flatpak_transaction_operation_get_ref (op), ==, locale);
 
   op = ops->next->data;
   g_assert_cmpint (flatpak_transaction_operation_get_operation_type (op), ==, FLATPAK_TRANSACTION_OPERATION_INSTALL);
-  g_assert_cmpstr (flatpak_transaction_operation_get_ref (op), ==, app);
+  g_assert_cmpstr (flatpak_transaction_operation_get_ref (op), ==, runtime);
 
   op = ops->next->next->data;
   g_assert_cmpint (flatpak_transaction_operation_get_operation_type (op), ==, FLATPAK_TRANSACTION_OPERATION_INSTALL);
-  g_assert_cmpstr (flatpak_transaction_operation_get_ref (op), ==, locale);
+  g_assert_cmpstr (flatpak_transaction_operation_get_ref (op), ==, app);
 
   g_list_free_full (ops, g_object_unref);
 


### PR DESCRIPTION
This ensures that when the operation to install the app completes, the
app is ready to run — rather than having to wait for subsequent
operations to install extensions which the app depends on (such as
content, or locales).

This fits in with the current ordering for *un*installing apps, where
the main app is uninstalled first, followed by its extensions.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://github.com/flatpak/flatpak/issues/3017