### PR TITLE
Make deprecation warning notice less confusing

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -514,7 +514,7 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
   g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
 
   if (rebased_to_ref)
-    g_print (_("Info: %s is end-of-life, in preference of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
+    g_print (_("Info: %s is end-of-life, in favor of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
   else if (reason)
     g_print (_("Info: %s is end-of-life, with reason: %s\n"), flatpak_ref_get_name (rref), reason);
 


### PR DESCRIPTION
Replace "in preference of" with "in favor of," as the former is not widely used, but the latter is (see https://books.google.com/ngrams/graph?content=in+favor+of%2Cin+preference+of&year_start=1800&year_end=2000&corpus=15&smoothing=3). 
This problem was mentioned in issue #3139.