### PR TITLE
builtins: hide runtimes with [list|remote-ls] --app-runtime

### DIFF
--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -440,7 +440,7 @@ flatpak_builtin_list (int argc, char **argv, GCancellable *cancellable, GError *
   if (!opt_app && !opt_runtime)
     {
       opt_app = TRUE;
-      opt_runtime = TRUE;
+      opt_runtime = !opt_app_runtime;
     }
 
   /* Default to showing installation if we're listing multiple installations */

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -411,7 +411,10 @@ flatpak_builtin_remote_ls (int argc, char **argv, GCancellable *cancellable, GEr
     return FALSE;
 
   if (!opt_app && !opt_runtime)
-    opt_app = opt_runtime = TRUE;
+    {
+      opt_app = TRUE;
+      opt_runtime = !opt_app_runtime;
+    }
 
   if (argc > 2)
     return usage_error (context, _("Too many arguments"), error);


### PR DESCRIPTION
Currently, if you run:

    flatpak remote-ls flathub --app-runtime=com.endlessm.Platform//eos3.2

you see no apps (correct) but hundreds of runtimes. This is inconsistent
with the documentation for the '--app-runtime' option, which says:

> List applications that use the given runtime

To fix this, default to not showing runtimes if '--app-runtime' is
given. This is consistent with the behaviour if just '--app' is
specified. If you run 'flatpak list --app-runtime=com.example.Foo
--runtime' then you get apps using that runtime, plus all other
runtimes, which seems fair enough to me.