### PR TITLE
utils: Allow chaining OstreeAsyncProgress when pushing GMainContext

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4570,8 +4570,10 @@ repo_pull (OstreeRepo                           *self,
       OstreeCollectionRef *collection_refs_to_fetch[2];
       guint32 update_freq = 0;
       g_autoptr(GMainContextPopDefault) context = NULL;
+      g_autoptr(FlatpakAsyncProgressChained) chained_progress = NULL;
 
       context = flatpak_main_context_new_default ();
+      chained_progress = flatpak_progress_chain (progress);
 
       if (results_to_fetch == NULL)
         {
@@ -4611,7 +4613,8 @@ repo_pull (OstreeRepo                           *self,
 
           ostree_repo_find_remotes_async (self, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                           find_options,
-                                          NULL /* default finders */, progress, cancellable,
+                                          NULL /* default finders */,
+                                          chained_progress, cancellable,
                                           async_result_cb, &find_result);
 
           while (find_result == NULL)
@@ -4646,7 +4649,7 @@ repo_pull (OstreeRepo                           *self,
           pull_options = g_variant_ref_sink (g_variant_builder_end (&pull_builder));
 
           ostree_repo_pull_from_remotes_async (self, results_to_fetch,
-                                               pull_options, progress,
+                                               pull_options, chained_progress,
                                                cancellable, async_result_cb,
                                                &pull_result);
 
@@ -5331,6 +5334,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
           guint update_freq = 0;
           gsize i;
           g_autoptr(GMainContextPopDefault) context = NULL;
+          g_autoptr(FlatpakAsyncProgressChained) chained_progress = NULL;
 
           /* FIXME: It would be nice to break out a helper function from
            * flatpak_dir_do_resolve_p2p_refs() that would resolve refs to
@@ -5361,10 +5365,12 @@ flatpak_dir_pull (FlatpakDir                           *self,
           find_options = g_variant_ref_sink (g_variant_builder_end (&find_builder));
 
           context = flatpak_main_context_new_default ();
+          chained_progress = flatpak_progress_chain (progress);
 
           ostree_repo_find_remotes_async (self->repo, (const OstreeCollectionRef * const *) collection_refs_to_fetch,
                                           find_options,
-                                          NULL /* default finders */, progress, cancellable,
+                                          NULL /* default finders */,
+                                          chained_progress, cancellable,
                                           async_result_cb, &find_result);
 
           while (find_result == NULL)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4761,8 +4761,8 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
                               GError                              **error)
 {
   g_autoptr(GVariant) extra_data_sources = NULL;
-  int i;
-  gsize n_extra_data;
+  guint64 i;
+  guint64 n_extra_data;
   guint64 total_download_size;
 
   /* If @results is set, @rev must be. */
@@ -4818,8 +4818,8 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   if (progress)
     {
       ostree_async_progress_set (progress,
-                                 "outstanding-extra-data", "u", n_extra_data,
-                                 "total-extra-data", "u", n_extra_data,
+                                 "outstanding-extra-data", "t", n_extra_data,
+                                 "total-extra-data", "t", n_extra_data,
                                  "total-extra-data-bytes", "t", total_download_size,
                                  "transferred-extra-data-bytes", "t", (guint64) 0,
                                  "downloading-extra-data", "u", 0,
@@ -4960,7 +4960,7 @@ flatpak_dir_pull_extra_data (FlatpakDir          *self,
 
       extra_data_progress.previous_dl += download_size;
       if (progress)
-        ostree_async_progress_set_uint (progress, "outstanding-extra-data", n_extra_data - i - 1);
+        ostree_async_progress_set_uint64 (progress, "outstanding-extra-data", n_extra_data - i - 1);
 
       sha256 = g_compute_checksum_for_bytes (G_CHECKSUM_SHA256, bytes);
       if (strcmp (sha256, extra_data_sha256) != 0)
@@ -5051,8 +5051,8 @@ oci_pull_init_progress (OstreeAsyncProgress *progress)
                              "start-time", "t", start_time,
                              "outstanding-metadata-fetches", "u", 0,
                              "metadata-fetched", "u", 0,
-                             "outstanding-extra-data", "u", 0,
-                             "total-extra-data", "u", 0,
+                             "outstanding-extra-data", "t", (guint64) 0,
+                             "total-extra-data", "t", (guint64) 0,
                              "total-extra-data-bytes", "t", (guint64) 0,
                              "transferred-extra-data-bytes", "t", (guint64) 0,
                              "downloading-extra-data", "u", 0,

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -812,6 +812,20 @@ typedef void (*FlatpakProgressCallback)(const char *status,
 OstreeAsyncProgress *flatpak_progress_new (FlatpakProgressCallback progress,
                                            gpointer                progress_data);
 
+OstreeAsyncProgress *flatpak_progress_chain (OstreeAsyncProgress *progress);
+
+static inline void
+flatpak_progress_unchain (OstreeAsyncProgress *chained_progress)
+{
+#if OSTREE_CHECK_VERSION (2019, 6)
+  if (chained_progress != NULL)
+    ostree_async_progress_finish (chained_progress);
+#endif
+}
+
+typedef OstreeAsyncProgress FlatpakAsyncProgressChained;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakAsyncProgressChained, flatpak_progress_unchain);
+
 void flatpak_log_dir_access (FlatpakDir *dir);
 
 gboolean flatpak_check_required_version (const char *ref,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6208,11 +6208,13 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
   guint64 total_transferred;
   g_autofree gchar *formatted_bytes_total_transferred = NULL;
   g_autoptr(GVariant) outstanding_fetchesv = NULL;
+  g_autoptr(GVariant) outstanding_extra_datav = NULL;
 
   /* We get some extra calls before we've really started due to the initialization of the
      extra data, so ignore those */
   outstanding_fetchesv = ostree_async_progress_get_variant (progress, "outstanding-fetches");
-  if (outstanding_fetchesv == NULL)
+  outstanding_extra_datav = ostree_async_progress_get_variant (progress, "outstanding-extra-data");
+  if (outstanding_fetchesv == NULL || outstanding_extra_datav == NULL)
     return;
 
   buf = g_string_new ("");

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6187,7 +6187,7 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
   guint64 bytes_transferred;
   guint64 fetched_delta_part_size;
   guint64 total_delta_part_size;
-  guint outstanding_extra_data;
+  guint64 outstanding_extra_data;
   guint64 total_extra_data_bytes;
   guint64 transferred_extra_data_bytes;
   guint64 total = 0;
@@ -6271,7 +6271,7 @@ progress_cb (OstreeAsyncProgress *progress, gpointer user_data)
                              "requested", "u", &requested,
                              "start-time", "t", &start_time,
                              "status", "s", &status,
-                             "outstanding-extra-data", "u", &outstanding_extra_data,
+                             "outstanding-extra-data", "t", &outstanding_extra_data,
                              "total-extra-data-bytes", "t", &total_extra_data_bytes,
                              "transferred-extra-data-bytes", "t", &transferred_extra_data_bytes,
                              "downloading-extra-data", "u", &downloading_extra_data,


### PR DESCRIPTION
It's a common idiom in this codebase to push a temporary GMainContext as
the thread default context in order to run an async operation as if it
were sync. If we are not expecting progress callbacks this isn't a
problem, but it becomes a problem if we pass in an OstreeAsyncProgress
object that was created under a different GMainContext. The reason for
this is that OstreeAsyncProgress creates an idle source and attaches it
to the thread default context, so if we are iterating a temporary
context then the OstreeAsyncProgress's context never gets iterated, and
so no progress signals are fired.

To fix this, we introduce flatpak_progress_chain() and a RAII helper
FlatpakAsyncProgressChained which creates a new OstreeAsyncProgress
under the temporary GMainContext, but forwards all its state and updates
to the previous OstreeAsyncProgress's callbacks.

This is documented in a comment in the code as well.

All known instances of this problem in the existing code are fixed in
this commit.

This requires new API in libostree which is proposed in
https://github.com/ostreedev/ostree/pull/1968. This pull request also
bumps the libostree requirement to 2019.6 in anticipation of that.

This problem was solved conceptually by Philip Withnall, I only wrote
the code.