### PR TITLE
common/dir: set MIRROR flag consistently when pulling commits

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4852,8 +4852,6 @@ reset_async_progress_extra_data (OstreeAsyncProgress *progress)
 static gboolean
 flatpak_dir_pull_extra_data (FlatpakDir          *self,
                              OstreeRepo          *repo,
-                             const char          *repository,
-                             const char          *ref,
                              const char          *rev,
                              FlatpakPullFlags     flatpak_flags,
                              OstreeAsyncProgress *progress,
@@ -5504,9 +5502,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
       goto out;
     }
 
-  if (!flatpak_dir_pull_extra_data (self, repo,
-                                    state->remote_name,
-                                    ref, rev,
+  if (!flatpak_dir_pull_extra_data (self, repo, rev,
                                     flatpak_flags,
                                     progress,
                                     cancellable,


### PR DESCRIPTION
The pull to fetch our commit metadata uses the MIRROR flag since
8cea78d, however this is not applied consistently in the other pulls
done in flatpak_dir_setup_extra_data and flatpak_dir_pull. The result
is that two refs are added to the OSTree transaction - one remote ref
and one collection ref, but only one is found in future by
flatpak_repo_resolve_rev so the other is shadowed and ultimately
leaked. Apply the same conditions and pass the MIRROR flag consistently
so that only one ref is created.

Fixes #3215