### PR TITLE
app/flatpak-quiet-transaction: Use "in favor of" phrasing

### DIFF
--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -171,7 +171,7 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
   g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
 
   if (rebased_to_ref)
-    g_print (_("Info: %s is end-of-life, in preference of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
+    g_print (_("Info: %s is end-of-life, in favor of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
   else if (reason)
     g_print (_("Info: %s is end-of-life, with reason: %s\n"), flatpak_ref_get_name (rref), reason);
 


### PR DESCRIPTION
In commit 0772ab6c9 we changed "in preference of" to "in favor of" in an
informational message produced by FlatpakCliTransaction for clarity. Do
the same for FlatpakQuietTransaction.