### PR TITLE
Document the flatpak-spawn --watch-bus option

### DIFF
--- a/doc/flatpak-spawn.xml
+++ b/doc/flatpak-spawn.xml
@@ -95,6 +95,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--watch-bus</option></term>
+
+                <listitem><para>
+                    Make the spawned command exit if we do
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--env=VAR=VALUE</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
This was missing from the man page.