### PR TITLE
tests: test search-provider DefaultDisabled logic

### DIFF
--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -76,6 +76,15 @@ MimeType=x-test/Hello;
 X-Flatpak-RenamedFrom=hello-again.desktop;
 EOF
 
+mkdir -p ${DIR}/files/share/gnome-shell/search-providers
+cat > ${DIR}/files/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini <<EOF
+[Shell Search Provider]
+DesktopId=org.test.Hello.desktop
+BusName=org.test.Hello.SearchProvider
+ObjectPath=/org/test/Hello/SearchProvider
+Version=2
+EOF
+
 mkdir -p ${DIR}/files/share/icons/hicolor/64x64/apps
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/${APP_ID}.png
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/hicolor/64x64/apps/dont-export.png

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -46,6 +46,8 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
 # Ensure Exec key is rewritten
 assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
+assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini
+assert_file_has_content $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini "^DefaultDisabled=true$"
 assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png
 assert_not_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/dont-export.png
 assert_has_file $FL_DIR/exports/share/icons/HighContrast/64x64/apps/org.test.Hello.png


### PR DESCRIPTION
2ebf67286660f5111baac379fd44a401f57b40bb introduced special handling to
mark exported GNOME Shell search provider .ini files as disabled by
default. This functionality was not previously tested.