### PR TITLE
ps: Allow showing compositor info

### DIFF
--- a/doc/flatpak-ps.xml
+++ b/doc/flatpak-ps.xml
@@ -183,6 +183,22 @@
             </varlistentry>
 
             <varlistentry>
+                <term>active</term>
+
+                <listitem><para>
+                    Show whether the app is active (i.e. has an active window)
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term>background</term>
+
+                <listitem><para>
+                    Show whether the app is in the background (with no open windows)
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term>all</term>
 
                 <listitem><para>


### PR DESCRIPTION
Show active and background state, based on information obtained from the background portal backend about which apps have (active) windows.
    
This currently tries all known portal backends in turn. It might be nicer to have a portal frontend api to query this, or to find out which backend to talk to.
