### PR TITLE
cli: Don't use \r in plain output

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -345,7 +345,7 @@ progress_changed_cb (FlatpakTransactionProgress *progress,
         g_print ("\r%s", str->str); /* redraw failed, just update the progress */
     }
   else
-    g_print ("\r%s", str->str);
+    g_print ("\n%s", str->str);
 }
 
 static void


### PR DESCRIPTION
These show up as ^M in test logs, and that is irritating.
Just use \n when producing plain output.

Closes: https://github.com/flatpak/flatpak/issues/3226