### PR TITLE
info: Add an example to the man page

### DIFF
--- a/doc/flatpak-info.xml
+++ b/doc/flatpak-info.xml
@@ -220,6 +220,9 @@
         <para>
             <command>$ flatpak info org.gnome.Builder//master</command>
         </para>
+        <para>
+            <command>$ tree `flatpak info -l org.gnome.Builder//master`/files</command>
+        </para>
 
     </refsect1>
 


### PR DESCRIPTION
Show an example for how to list the files that are
part of an installed app.

Related: https://github.com/flatpak/flatpak/issues/3079