### PR TITLE
run: Improve help output for --parent-pid

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -79,7 +79,7 @@ static GOptionEntry options[] = {
   { "runtime-commit", 0, 0, G_OPTION_ARG_STRING, &opt_runtime_commit, N_("Use specified runtime commit"), NULL },
   { "sandbox", 0, 0, G_OPTION_ARG_NONE, &opt_sandbox, N_("Run completely sandboxed"), NULL },
   { "die-with-parent", 'p', 0, G_OPTION_ARG_NONE, &opt_die_with_parent, N_("Kill processes when the parent process dies"), NULL },
-  { "parent-pid", 0, 0, G_OPTION_ARG_INT, &opt_parent_pid, N_("Use this as parent pid for sharing namespaces"), NULL },
+  { "parent-pid", 0, 0, G_OPTION_ARG_INT, &opt_parent_pid, N_("Use PID as parent pid for sharing namespaces"), N_("PID") },
   { "parent-expose-pids", 0, 0, G_OPTION_ARG_NONE, &opt_parent_expose_pids, N_("Make processes visible in parent namespace"), NULL },
   { NULL }
 };

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -550,7 +550,7 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
-                <term><option>--parent-pid</option></term>
+                <term><option>--parent-pid=PID</option></term>
 
                 <listitem><para>
                     Specifies the pid of the "parent" flatpak, used by --parent-expose-pids.


### PR DESCRIPTION
Show a placeholder to indicate that this option
takes an argument. Update docs to match.