### PR TITLE
docs: Add flatpak permissions-set to command list

### DIFF
--- a/doc/flatpak-permission-remove.xml
+++ b/doc/flatpak-permission-remove.xml
@@ -97,7 +97,8 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-set</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permission-reset.xml
+++ b/doc/flatpak-permission-reset.xml
@@ -107,7 +107,8 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-set</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permission-set.xml
+++ b/doc/flatpak-permission-set.xml
@@ -97,7 +97,8 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permission-set.xml
+++ b/doc/flatpak-permission-set.xml
@@ -96,7 +96,8 @@
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-add</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permission-show.xml
+++ b/doc/flatpak-permission-show.xml
@@ -25,7 +25,7 @@
 
     <refnamediv>
         <refname>flatpak-permission-show</refname>
-        <refpurpose>List permissions</refpurpose>
+        <refpurpose>Show permissions</refpurpose>
     </refnamediv>
 
     <refsynopsisdiv>

--- a/doc/flatpak-permission-show.xml
+++ b/doc/flatpak-permission-show.xml
@@ -102,7 +102,8 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permissions</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-set</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-permissions.xml
+++ b/doc/flatpak-permissions.xml
@@ -103,7 +103,8 @@
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-show</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-permission-remove</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpak-permission-reset</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak-permission-set</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/flatpak-ps.xml
+++ b/doc/flatpak-ps.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
     "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
 
-<refentry id="flatpak-enter">
+<refentry id="flatpak-ps">
 
     <refentryinfo>
-        <title>flatpak enter</title>
+        <title>flatpak ps</title>
         <productname>flatpak</productname>
 
         <authorgroup>

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -363,6 +363,13 @@
                     Reset app permissions.
                 </para></listitem>
             </varlistentry>
+            <varlistentry>
+                <term><citerefentry><refentrytitle>flatpak-permission-set</refentrytitle><manvolnum>1</manvolnum></citerefentry></term>
+
+                <listitem><para>
+                    Set app permissions.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
 
         <para>Commands for managing remote repositories:</para>


### PR DESCRIPTION
This new command was missing from flatpak(1) and
from the references in other permission commands.