### PR TITLE
Fix a case of signed/unsigned confusion

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -352,7 +352,7 @@ load_uri_read_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 {
   LoadUriData *data = user_data;
   GInputStream *stream = G_INPUT_STREAM (source);
-  gsize nread;
+  gssize nread;
 
   nread = g_input_stream_read_finish (stream, res, &data->error);
   if (nread == -1 || nread == 0)


### PR DESCRIPTION
G_input_stream_read_finish returns a gssize,
which we must not store in a gsize, since it
may be -1.

Closes: https://github.com/flatpak/flatpak/issues/2885