### PR TITLE
enter: Correct the help output

### DIFF
--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -84,7 +84,7 @@ flatpak_builtin_enter (int           argc,
   g_autoptr(GPtrArray) instances = NULL;
   int j;
 
-  context = g_option_context_new (_("INSTANCE [COMMAND [ARGUMENT…]] - Run a command inside a running sandbox"));
+  context = g_option_context_new (_("INSTANCE COMMAND [ARGUMENT…] - Run a command inside a running sandbox"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   rest_argc = 0;


### PR DESCRIPTION
The COMMAND is not optional, so don't put it in brackets.

Closes: https://github.com/flatpak/flatpak/issues/2881