### PR TITLE
Permission set data

### DIFF
--- a/app/flatpak-builtins-permission-list.c
+++ b/app/flatpak-builtins-permission-list.c
@@ -91,7 +91,7 @@ list_table (XdpDbusPermissionStore *store,
       d = g_variant_get_child_value (data, 0);
       txt = g_variant_print (d, FALSE);
 
-      if (g_variant_iter_init (&iter, permissions) == 0 && id != 0)
+      if (g_variant_iter_init (&iter, permissions) == 0)
         {
           flatpak_table_printer_add_column (printer, table);
           flatpak_table_printer_add_column (printer, ids[i]);

--- a/doc/flatpak-permission-set.xml
+++ b/doc/flatpak-permission-set.xml
@@ -70,7 +70,14 @@
                     Show help options and exit.
                 </para></listitem>
             </varlistentry>
+            <varlistentry>
+                <term><option>--data=DATA</option></term>
 
+                <listitem><para>
+                    Associate <arg choice="plain">DATA</arg> with the entry.
+                    The data must be a serialized GVariant.
+                </para></listitem>
+            </varlistentry>
             <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>


### PR DESCRIPTION
Add a way to set data in the permission store via the permission-set command.

While working on this, I ran into the `data wrapping` issue again, and noticed that Set and SetValue treat their data argument differently:

Set:
``` 
data_child = g_variant_get_child_value (data, 0);
new_entry = permission_db_entry_new (data_child);
```
SetValue:
```
new_entry = permission_db_entry_new (data);
```
The permission store interface requires a GVariant of type v for the data argument of both, so i have to add an extra level of wrapping to my argument: `<{'ask':true}>` instead of `{'ask':true}`. But then handle_set_value fails to remove that extra wrapping before stuffing the data into the store :(