### PR TITLE
permission-set: Auto-apply wrapping for data

### DIFF
--- a/app/flatpak-builtins-permission-set.c
+++ b/app/flatpak-builtins-permission-set.c
@@ -153,7 +153,7 @@ flatpak_builtin_permission_set (int argc, char **argv,
   if (data)
     {
       if (!xdp_dbus_permission_store_call_set_value_sync (store, table, FALSE,
-                                                          id, data, NULL, error))
+                                                          id, g_variant_new_variant (data), NULL, error))
         return FALSE;
     }
 


### PR DESCRIPTION
It is confusing if we explicitly have to specify
the <> GVariant wrapping with --data, but
flatpak permissions strips it when displaying the
result.

Make it transparent by auto-applying the wrapping,
so what you need to pass to --data is the same
as what flatpak permissions shows you.