### PR TITLE
portal: Make sure we inherit the passed thought fds in Spawn()

### DIFF
--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -80,7 +80,8 @@ gboolean      flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
                                          GError      **error);
 
 void          flatpak_bwrap_child_setup_cb (gpointer user_data);
-
+void          flatpak_bwrap_child_setup (GArray *fd_array,
+                                         gboolean close_fd_workaround);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakBwrap, flatpak_bwrap_free)
 

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -325,14 +325,14 @@ flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
   return TRUE;
 }
 
-/* Unset FD_CLOEXEC on the array of fds passed in @user_data */
 void
-flatpak_bwrap_child_setup_cb (gpointer user_data)
+flatpak_bwrap_child_setup (GArray *fd_array,
+                           gboolean close_fd_workaround)
 {
-  GArray *fd_array = user_data;
   int i;
 
-  flatpak_close_fds_workaround (3);
+  if (close_fd_workaround)
+    flatpak_close_fds_workaround (3);
 
   /* If no fd_array was specified, don't care. */
   if (fd_array == NULL)
@@ -352,4 +352,13 @@ flatpak_bwrap_child_setup_cb (gpointer user_data)
 
       fcntl (fd, F_SETFD, 0);
     }
+}
+
+/* Unset FD_CLOEXEC on the array of fds passed in @user_data */
+void
+flatpak_bwrap_child_setup_cb (gpointer user_data)
+{
+  GArray *fd_array = user_data;
+
+  flatpak_bwrap_child_setup (fd_array, TRUE);
 }

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3742,8 +3742,11 @@ flatpak_run_app (const char     *app_ref,
       pid_path = g_build_filename (instance_id_host_dir, "pid", NULL);
       g_file_set_contents (pid_path, pid_str, -1, NULL);
 
-      /* Ensure we unset O_CLOEXEC */
-      flatpak_bwrap_child_setup_cb (bwrap->fds);
+      /* Ensure we unset O_CLOEXEC for marked fds and rewind fds as needed.
+       * Note that this does not close fds that are not already marked O_CLOEXEC, because
+       * we do want to allow inheriting fds into flatpak run. */
+      flatpak_bwrap_child_setup (bwrap->fds, FALSE);
+
       if (execvpe (flatpak_get_bwrap (), (char **) bwrap->argv->pdata, bwrap->envp) == -1)
         {
           g_set_error_literal (error, G_IO_ERROR, g_io_error_from_errno (errno),

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -242,6 +242,12 @@ typedef struct
 } ChildSetupData;
 
 static void
+drop_cloexec (int fd)
+{
+  fcntl (fd, F_SETFD, 0);
+}
+
+static void
 child_setup_func (gpointer user_data)
 {
   ChildSetupData *data = (ChildSetupData *) user_data;
@@ -283,6 +289,9 @@ child_setup_func (gpointer user_data)
           dup2 (fd_map[i].to, fd_map[i].final);
           close (fd_map[i].to);
         }
+
+      /* Ensure we inherit the final fd value */
+      drop_cloexec (fd_map[i].final);
     }
 
   /* We become our own session and process group, because it never makes sense


### PR DESCRIPTION
In the start of child_setup_func we set CLOEXEC on everything > 3, so
we need to undo this for the things we actually want to pass in.