### PR TITLE
OCI: Only use labels, never annotations

### DIFF
--- a/app/flatpak-builtins-build-bundle.c
+++ b/app/flatpak-builtins-build-bundle.c
@@ -48,7 +48,7 @@ static char *opt_runtime_repo;
 static gboolean opt_runtime = FALSE;
 static char **opt_gpg_file;
 static gboolean opt_oci = FALSE;
-static gboolean opt_oci_use_labels = FALSE;
+static gboolean opt_oci_use_labels = TRUE; // Unused now
 static char **opt_gpg_key_ids;
 static char *opt_gpg_homedir;
 static char *opt_from_commit;
@@ -63,7 +63,8 @@ static GOptionEntry options[] = {
   { "gpg-homedir", 0, 0, G_OPTION_ARG_STRING, &opt_gpg_homedir, N_("GPG Homedir to use when looking for keyrings"), N_("HOMEDIR") },
   { "from-commit", 0, 0, G_OPTION_ARG_STRING, &opt_from_commit, N_("OSTree commit to create a delta bundle from"), N_("COMMIT") },
   { "oci", 0, 0, G_OPTION_ARG_NONE, &opt_oci, N_("Export oci image instead of flatpak bundle"), NULL },
-  { "oci-use-labels", 0, 0, G_OPTION_ARG_NONE, &opt_oci_use_labels, N_("Use OCI labels instead of annotations"), NULL },
+  // This is not used anymore as it is the default, but accept it if old code uses it
+  { "oci-use-labels", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_oci_use_labels, NULL, NULL },
   { NULL }
 };
 
@@ -366,39 +367,39 @@ export_commit_to_archive (OstreeRepo *repo,
 }
 
 static void
-add_icon_to_annotations (const char *icon_size_name,
-                         GBytes     *png_data,
-                         gpointer    user_data)
+add_icon_to_labels (const char *icon_size_name,
+                    GBytes     *png_data,
+                    gpointer    user_data)
 {
-  GHashTable *annotations = user_data;
+  GHashTable *labels = user_data;
   g_autofree char *encoded = g_base64_encode (g_bytes_get_data (png_data, NULL),
                                               g_bytes_get_size (png_data));
 
-  g_hash_table_replace (annotations,
+  g_hash_table_replace (labels,
                         g_strconcat ("org.freedesktop.appstream.", icon_size_name, NULL),
                         g_strconcat ("data:image/png;base64,", encoded, NULL));
 }
 
 static GHashTable *
-generate_annotations (FlatpakOciDescriptor *layer_desc,
-                      OstreeRepo *repo,
-                      GFile *root,
-                      const char *name,
-                      const char *ref,
-                      const char *commit_checksum,
-                      GVariant   *commit_data,
-                      GCancellable *cancellable,
-                      GError **error)
+generate_labels (FlatpakOciDescriptor *layer_desc,
+                 OstreeRepo *repo,
+                 GFile *root,
+                 const char *name,
+                 const char *ref,
+                 const char *commit_checksum,
+                 GVariant   *commit_data,
+                 GCancellable *cancellable,
+                 GError **error)
 {
   g_autoptr(GFile) metadata_file = NULL;
   gsize metadata_size;
   g_autofree char *metadata_contents = NULL;
-  g_autoptr(GHashTable) annotations = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  g_autoptr(GHashTable) labels = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autoptr(GBytes) xml_data = NULL;
   guint64 installed_size = 0;
 
-  flatpak_oci_add_annotations_for_commit (annotations, ref, commit_checksum, commit_data);
+  flatpak_oci_add_labels_for_commit (labels, ref, commit_checksum, commit_data);
 
   metadata_file = g_file_get_child (root, "metadata");
   if (g_file_load_contents (metadata_file, cancellable, &metadata_contents, &metadata_size, NULL, NULL) &&
@@ -412,7 +413,7 @@ generate_annotations (FlatpakOciDescriptor *layer_desc,
                                       G_KEY_FILE_NONE, error))
         return NULL;
 
-      g_hash_table_replace (annotations,
+      g_hash_table_replace (labels,
                             g_strdup ("org.flatpak.metadata"),
                             g_steal_pointer (&metadata_contents));
     }
@@ -420,11 +421,11 @@ generate_annotations (FlatpakOciDescriptor *layer_desc,
   if (!flatpak_repo_collect_sizes (repo, root, &installed_size, NULL, NULL, error))
     return NULL;
 
-  g_hash_table_replace (annotations,
+  g_hash_table_replace (labels,
                         g_strdup ("org.flatpak.installed-size"),
                         g_strdup_printf ("%" G_GUINT64_FORMAT, installed_size));
 
-  g_hash_table_replace (annotations,
+  g_hash_table_replace (labels,
                         g_strdup ("org.flatpak.download-size"),
                         g_strdup_printf ("%" G_GUINT64_FORMAT, layer_desc->size));
 
@@ -437,16 +438,16 @@ generate_annotations (FlatpakOciDescriptor *layer_desc,
     {
       gsize xml_data_len;
 
-      g_hash_table_replace (annotations,
+      g_hash_table_replace (labels,
                             g_strdup ("org.freedesktop.appstream.appdata"),
                             g_bytes_unref_to_data (g_steal_pointer (&xml_data), &xml_data_len));
 
-      if (!iterate_bundle_icons (root, name, add_icon_to_annotations,
-                                 annotations, cancellable, error))
+      if (!iterate_bundle_icons (root, name, add_icon_to_labels,
+                                 labels, cancellable, error))
         return FALSE;
     }
 
-  return g_steal_pointer (&annotations);
+  return g_steal_pointer (&labels);
 }
 
 
@@ -471,7 +472,7 @@ build_oci (OstreeRepo *repo, const char *commit_checksum, GFile *dir,
   g_autoptr(FlatpakOciDescriptor) manifest_desc = NULL;
   g_autoptr(FlatpakOciManifest) manifest = NULL;
   g_autoptr(FlatpakOciIndex) index = NULL;
-  g_autoptr(GHashTable) flatpak_annotations = NULL;
+  g_autoptr(GHashTable) flatpak_labels = NULL;
   g_auto(GStrv) ref_parts = NULL;
   int history_index;
   GTimeVal tv;
@@ -511,8 +512,8 @@ build_oci (OstreeRepo *repo, const char *commit_checksum, GFile *dir,
                                        error))
     return FALSE;
 
-  flatpak_annotations = generate_annotations (layer_desc, repo, root, name, ref, commit_checksum, commit_data, cancellable, error);
-  if (flatpak_annotations == NULL)
+  flatpak_labels = generate_labels (layer_desc, repo, root, name, ref, commit_checksum, commit_data, cancellable, error);
+  if (flatpak_labels == NULL)
     return FALSE;
 
   image = flatpak_oci_image_new ();
@@ -524,9 +525,8 @@ build_oci (OstreeRepo *repo, const char *commit_checksum, GFile *dir,
   image->history[history_index]->created = g_time_val_to_iso8601 (&tv);
   image->history[history_index]->created_by = g_strdup ("flatpak build-bundle");
 
-  if (opt_oci_use_labels)
-    flatpak_oci_copy_annotations (flatpak_annotations,
-                                  flatpak_oci_image_get_labels (image));
+  flatpak_oci_copy_labels (flatpak_labels,
+                           flatpak_oci_image_get_labels (image));
 
   timestamp = timestamp_to_iso8601 (ostree_commit_get_timestamp (commit_data));
   flatpak_oci_image_set_created (image, timestamp);
@@ -539,15 +539,9 @@ build_oci (OstreeRepo *repo, const char *commit_checksum, GFile *dir,
   flatpak_oci_manifest_set_config (manifest, image_desc);
   flatpak_oci_manifest_set_layer (manifest, layer_desc);
 
-  if (!opt_oci_use_labels)
-    flatpak_oci_copy_annotations (flatpak_annotations,
-                                  flatpak_oci_manifest_get_annotations (manifest));
-
   manifest_desc = flatpak_oci_registry_store_json (registry, FLATPAK_JSON (manifest), cancellable, error);
   if (manifest_desc == NULL)
     return FALSE;
-
-  flatpak_oci_export_annotations (manifest->annotations, manifest_desc->annotations);
 
   index = flatpak_oci_registry_load_index (registry, NULL, NULL);
   if (index == NULL)

--- a/app/flatpak-builtins-build-import-bundle.c
+++ b/app/flatpak-builtins-build-import-bundle.c
@@ -64,7 +64,7 @@ import_oci (OstreeRepo *repo, GFile *file,
   FlatpakOciManifest *manifest = NULL;
   g_autoptr(FlatpakOciIndex) index = NULL;
   const FlatpakOciManifestDescriptor *desc;
-  GHashTable *annotations, *labels;
+  GHashTable *labels;
 
   dir_uri = g_file_get_uri (file);
   registry = flatpak_oci_registry_new (dir_uri, FALSE, -1, cancellable, error);
@@ -110,18 +110,10 @@ import_oci (OstreeRepo *repo, GFile *file,
   if (image_config == NULL)
     return FALSE;
 
-  annotations = flatpak_oci_manifest_get_annotations (manifest);
-  if (annotations)
-    flatpak_oci_parse_commit_annotations (annotations, NULL, NULL, NULL,
-                                          &target_ref, NULL, NULL, NULL);
-  if (target_ref == NULL)
-    {
-      labels = flatpak_oci_image_get_labels (image_config);
-      if (labels)
-        flatpak_oci_parse_commit_annotations (labels, NULL, NULL, NULL,
-                                              &target_ref, NULL, NULL, NULL);
-    }
-
+  labels = flatpak_oci_image_get_labels (image_config);
+  if (labels)
+    flatpak_oci_parse_commit_labels (labels, NULL, NULL, NULL,
+                                     &target_ref, NULL, NULL, NULL);
   if (target_ref == NULL)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,

--- a/common/flatpak-json-oci-private.h
+++ b/common/flatpak-json-oci-private.h
@@ -37,10 +37,10 @@ G_BEGIN_DECLS
 #define FLATPAK_OCI_SIGNATURE_TYPE_FLATPAK "flatpak oci image signature"
 
 const char * flatpak_arch_to_oci_arch (const char *flatpak_arch);
-void flatpak_oci_export_annotations (GHashTable *source,
-                                     GHashTable *dest);
-void flatpak_oci_copy_annotations (GHashTable *source,
-                                   GHashTable *dest);
+void flatpak_oci_export_labels (GHashTable *source,
+                                GHashTable *dest);
+void flatpak_oci_copy_labels (GHashTable *source,
+                              GHashTable *dest);
 
 typedef struct
 {
@@ -229,18 +229,18 @@ int              flatpak_oci_image_add_history (FlatpakOciImage *image);
 FlatpakOciImage * flatpak_oci_image_from_json (GBytes *bytes,
                                                GError **error);
 
-void flatpak_oci_add_annotations_for_commit (GHashTable *annotations,
-                                             const char *ref,
-                                             const char *commit,
-                                             GVariant   *commit_data);
-void flatpak_oci_parse_commit_annotations (GHashTable      *annotations,
-                                           guint64         *out_timestamp,
-                                           char           **out_subject,
-                                           char           **out_body,
-                                           char           **out_ref,
-                                           char           **out_commit,
-                                           char           **out_parent_commit,
-                                           GVariantBuilder *metadata_builder);
+void flatpak_oci_add_labels_for_commit (GHashTable *labels,
+                                        const char *ref,
+                                        const char *commit,
+                                        GVariant   *commit_data);
+void flatpak_oci_parse_commit_labels (GHashTable      *labels,
+                                      guint64         *out_timestamp,
+                                      char           **out_subject,
+                                      char           **out_body,
+                                      char           **out_ref,
+                                      char           **out_commit,
+                                      char           **out_parent_commit,
+                                      GVariantBuilder *metadata_builder);
 
 #define FLATPAK_TYPE_OCI_SIGNATURE flatpak_oci_signature_get_type ()
 G_DECLARE_FINAL_TYPE (FlatpakOciSignature, flatpak_oci_signature, FLATPAK, OCI_SIGNATURE, FlatpakJson)

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5508,8 +5508,6 @@ flatpak_mirror_image_from_oci (FlatpakOciRegistry    *dst_registry,
 
   manifest_desc = flatpak_oci_descriptor_new (versioned->mediatype, digest, versioned_size);
 
-  flatpak_oci_export_annotations (manifest->annotations, manifest_desc->annotations);
-
   flatpak_oci_index_add_manifest (index, ref, manifest_desc);
 
   if (!flatpak_oci_registry_save_index (dst_registry, index, cancellable, error))
@@ -5545,27 +5543,18 @@ flatpak_pull_from_oci (OstreeRepo            *repo,
   FlatpakOciPullProgressData progress_data = { progress_cb, progress_user_data };
   g_autoptr(GVariantBuilder) metadata_builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
   g_autoptr(GVariant) metadata = NULL;
-  GHashTable *annotations, *labels;
+  GHashTable *labels;
   int i;
 
   g_assert (ref != NULL);
   g_assert (g_str_has_prefix (digest, "sha256:"));
 
-  annotations = flatpak_oci_manifest_get_annotations (manifest);
-  if (annotations)
-    flatpak_oci_parse_commit_annotations (annotations, &timestamp,
-                                          &subject, &body,
-                                          &manifest_ref, NULL, NULL,
-                                          metadata_builder);
-  if (manifest_ref == NULL)
-    {
-      labels = flatpak_oci_image_get_labels (image_config);
-      if (labels)
-        flatpak_oci_parse_commit_annotations (labels, &timestamp,
-                                              &subject, &body,
-                                              &manifest_ref, NULL, NULL,
-                                              metadata_builder);
-    }
+  labels = flatpak_oci_image_get_labels (image_config);
+  if (labels)
+    flatpak_oci_parse_commit_labels (labels, &timestamp,
+                                     &subject, &body,
+                                     &manifest_ref, NULL, NULL,
+                                     metadata_builder);
 
   if (manifest_ref == NULL)
     {

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -43,8 +43,15 @@ digest=$(grep sha256: oci/image/index.json | sed s'@.*sha256:\([a-fA-F0-9]\+\).*
 manifest=oci/image/blobs/sha256/$digest
 
 assert_has_file $manifest
-assert_file_has_content $manifest "org\.freedesktop\.appstream\.appdata.*<summary>Print a greeting</summary>"
-assert_file_has_content $manifest "org\.freedesktop\.appstream\.icon-64"
+
+DIGEST=$(grep -C2 application/vnd.oci.image.config.v1+json $manifest | grep digest  | sed s/.*\"sha256:\\\(.*\\\)\".*/\\1/)
+echo DIGEST: $DIGEST
+image=oci/image/blobs/sha256/$DIGEST
+
+assert_has_file $image
+assert_file_has_content $image "org\.freedesktop\.appstream\.appdata.*<summary>Print a greeting</summary>"
+assert_file_has_content $image "org\.freedesktop\.appstream\.icon-64"
+assert_file_has_content $image org.flatpak.ref.*app/org.test.Hello/x86_64/master
 
 echo "ok export oci"
 


### PR DESCRIPTION
This is a slightly incompatible change, as we now only support
oci images generated with (what was before) build-export --oci-use-labels.
However, there are not a lot of OCI implementations in the wild, and
we can modify the ones in use to ensure there are labels (and
annotations if needed for older flatpak clients).

This also removes the --oci-use-label option from build-bundle --oci as
this is now the default.