### PR TITLE
app: Improve "remote not found" error message

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -357,8 +357,19 @@ flatpak_resolve_duplicate_remotes (GPtrArray    *dirs,
   if (out_dir)
     {
       if (dirs_with_remote->len == 0)
-        return flatpak_fail_error (error, FLATPAK_ERROR_REMOTE_NOT_FOUND,
-                                   "Remote \"%s\" not found", remote_name);
+        {
+          if (dirs->len > 1 || dirs->len == 0)
+            return flatpak_fail_error (error, FLATPAK_ERROR_REMOTE_NOT_FOUND,
+                                       _("Remote \"%s\" not found\nHint: Use flatpak remote-add to add a remote"),
+                                       remote_name);
+          else
+            {
+              FlatpakDir *dir = g_ptr_array_index (dirs, 0);
+              return flatpak_fail_error (error, FLATPAK_ERROR_REMOTE_NOT_FOUND,
+                                         _("Remote \"%s\" not found in the %s installation"),
+                                         remote_name, flatpak_dir_get_name_cached (dir));
+            }
+        }
       else
         *out_dir = g_object_ref (g_ptr_array_index (dirs_with_remote, chosen - 1));
     }


### PR DESCRIPTION
It often happens that people use --user or --system or --installation
and get a "Remote not found" error message, because they don't
understand that remotes have to be defined separately in each
installation. Make the error message more helpful by pointing out when
one of those options was used.

Fixes https://github.com/flatpak/flatpak/issues/3296