### PR TITLE
Fix typo in /etc/timezone filename

### DIFF
--- a/common/flatpak-utils-base.c
+++ b/common/flatpak-utils-base.c
@@ -57,7 +57,7 @@ flatpak_get_timezone (void)
         }
     }
 
-  if (g_file_get_contents ("/etc/timezeone", &etc_timezone,
+  if (g_file_get_contents ("/etc/timezone", &etc_timezone,
                            NULL, NULL))
     {
       g_strchomp (etc_timezone);


### PR DESCRIPTION
flatpak_get_timezone () tries to access /etc/timezone if /etc/localtime
isn't a valid symlink, but gets the name wrong. Fix it.

Found by code inspection. Not actually tested.