### PR TITLE
Add flag for non-interaction to authenticator request

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3034,6 +3034,9 @@ request_tokens_for_remote (FlatpakTransaction *self,
   if (state->collection_id)
     g_variant_builder_add (extra_builder, "{sv}", "collection-id", g_variant_new_string (state->collection_id));
 
+  if (flatpak_dir_get_no_interaction (priv->dir))
+    g_variant_builder_add (extra_builder, "{sv}", "no-interaction", g_variant_new_boolean (TRUE));
+
   context = flatpak_main_context_new_default ();
 
   authenticator = flatpak_auth_new_for_remote (priv->dir, remote, cancellable, error);

--- a/data/org.freedesktop.Flatpak.Authenticator.xml
+++ b/data/org.freedesktop.Flatpak.Authenticator.xml
@@ -133,6 +133,13 @@
               contains the images.
             </para></listitem>
           </varlistentry>
+          <varlistentry>
+            <term>no-interation b</term>
+            <listitem><para>
+              If true, the authenticator should not do any interaction (and fail instead if it needs to). This can be enabled by
+              clients that want to run in the background.
+            </para></listitem>
+          </varlistentry>
         </variablelist>
     -->
     <method name="RequestRefTokens">

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -427,6 +427,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *authenticator,
   const char *auth = NULL;
   const char *oci_registry_uri = NULL;
   gsize n_refs, i;
+  gboolean no_interaction = FALSE;
   g_autoptr(FlatpakOciRegistry) registry = NULL;
   GVariantBuilder tokens;
   GVariantBuilder results;
@@ -443,6 +444,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *authenticator,
                                              "Not a OCI remote");
       return TRUE;
     }
+  g_variant_lookup (arg_options, "no-interaction", "b", &no_interaction);
 
   request_path = flatpak_auth_create_request_path (g_dbus_method_invocation_get_sender (invocation),
                                                    arg_handle_token, NULL);
@@ -478,7 +480,8 @@ handle_request_ref_tokens (FlatpakAuthenticator *authenticator,
     }
 
   n_refs = g_variant_n_children (arg_refs);
-  if (auth == NULL && n_refs > 0)
+  if (auth == NULL && n_refs > 0 &&
+      !no_interaction)
     {
       g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
       g_autofree char *token = NULL;


### PR DESCRIPTION
This is primary useful to disable the authenticator doing native windows for apps that run in the background, however it can also avoid doing unnecessary webflow or basic auth flows.

As requested by @pwithnall on the list.