### PR TITLE
utils: Fix chaining of progress

### DIFF
--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -828,13 +828,17 @@ OstreeAsyncProgress *flatpak_progress_new (FlatpakProgressCallback progress,
 #define FLATPAK_DO_CHAIN_PROGRESS 1
 #endif
 
+#ifdef FLATPAK_DO_CHAIN_PROGRESS
+void flatpak_chained_progress_finish (OstreeAsyncProgress *progress);
+#endif
+
 static inline void
 flatpak_progress_unchain (OstreeAsyncProgress *chained_progress)
 {
 #ifdef FLATPAK_DO_CHAIN_PROGRESS
   if (chained_progress != NULL)
     {
-      ostree_async_progress_finish (chained_progress);
+      flatpak_chained_progress_finish (chained_progress);
       g_object_unref (chained_progress);
     }
 #endif


### PR DESCRIPTION
With the latest ostree that enables the chaining of progress the
testsuite broke because we were not getting changed events. Looking
into this the reason seems to be that when we run the
ostree_async_progress_finish() on the chained progress it is marked
as dead, which causes ostree_async_progress_copy_state() to not copy
any data when called from handle_chained_progress().

The fix is to copy the content manually before calling the finish().

Also, the entire callback chaining system seems wildly
overcomplicated, so I simplified it by relying on the existing change
notification of OstreeAsyncProgress.