### PR TITLE
Sandbox: Allow share-gpu also if caller has device=all

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -784,7 +784,9 @@ handle_spawn (PortalFlatpak         *object,
         }
       if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_GPU)
         {
-          if (devices != NULL && g_strv_contains ((const char * const *) devices, "dri"))
+          if (devices != NULL &&
+              (g_strv_contains ((const char * const *) devices, "dri") ||
+               g_strv_contains ((const char * const *) devices, "all")))
             g_ptr_array_add (flatpak_argv, g_strdup ("--device=dri"));
         }
       if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS)


### PR DESCRIPTION
This fixes https://github.com/flatpak/flatpak/issues/3330