### PR TITLE
flatpak.pc: Move ostree-1 from Requires.private to Requires

### DIFF
--- a/flatpak.pc.in
+++ b/flatpak.pc.in
@@ -10,7 +10,7 @@ interfaces_dir=${datadir}/dbus-1/interfaces/
 Name: flatpak
 Description: Application sandboxing framework
 Version: @VERSION@
-Requires: glib-2.0 gio-2.0
-Requires.private: gio-unix-2.0 ostree-1
+Requires: glib-2.0 gio-2.0 ostree-1
+Requires.private: gio-unix-2.0
 Libs: -L${libdir} -lflatpak
 Cflags: -I${includedir}/flatpak


### PR DESCRIPTION
While flatpak carefully doesn’t expose any OSTree symbols in its C API,
it does sometimes return GErrors with the domain `OSTREE_GPG_ERROR`.
Applications can happily link against flatpak and receive such errors,
but won’t be able to understand them without also linking against
OSTree.

OSTree is a hard dependency of flatpak, so we might as well move it to
`Requires` rather than `Requires.private` to ensure that clients link
against it.

See https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/336/diffs#note_650999

Signed-off-by: Philip Withnall <withnall@endlessm.com>