### PR TITLE
Fix a gnome-software crash 

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14348,7 +14348,7 @@ flatpak_dir_find_remote_related (FlatpakDir         *self,
   const char *metadata = NULL;
   g_autoptr(GKeyFile) metakey = g_key_file_new ();
   g_auto(GStrv) parts = NULL;
-  g_autoptr(GPtrArray) related = NULL;
+  g_autoptr(GPtrArray) related = g_ptr_array_new_with_free_func ((GDestroyNotify) flatpak_related_free);
   g_autofree char *url = NULL;
 
   parts = flatpak_decompose_ref (ref, error);
@@ -14368,9 +14368,10 @@ flatpak_dir_find_remote_related (FlatpakDir         *self,
                                          NULL, NULL, &metadata,
                                          NULL, NULL) &&
       g_key_file_load_from_data (metakey, metadata, -1, 0, NULL))
-    related = flatpak_dir_find_remote_related_for_metadata (self, state, ref, metakey, cancellable, error);
-  else
-    related = g_ptr_array_new_with_free_func ((GDestroyNotify) flatpak_related_free);
+    {
+      g_ptr_array_unref (related);
+      related = flatpak_dir_find_remote_related_for_metadata (self, state, ref, metakey, cancellable, error);
+    }
 
   return g_steal_pointer (&related);
 }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14198,7 +14198,7 @@ flatpak_dir_find_remote_related_for_metadata (FlatpakDir         *self,
                                    state->remote_name,
                                    &url,
                                    error))
-    return FALSE;
+    return NULL;
 
   if (*url == 0)
     return g_steal_pointer (&related);  /* Empty url, silently disables updates */
@@ -14359,7 +14359,7 @@ flatpak_dir_find_remote_related (FlatpakDir         *self,
                                    state->remote_name,
                                    &url,
                                    error))
-    return FALSE;
+    return NULL;
 
   if (*url == 0)
     return g_steal_pointer (&related);  /* Empty url, silently disables updates */


### PR DESCRIPTION
After installing a locally built bundle, gnome-software started to crash due the changes introduced in https://github.com/flatpak/flatpak/pull/3204

