### PR TITLE
Add --device=shm permission

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -49,6 +49,7 @@ typedef enum {
   FLATPAK_CONTEXT_DEVICE_DRI         = 1 << 0,
   FLATPAK_CONTEXT_DEVICE_ALL         = 1 << 1,
   FLATPAK_CONTEXT_DEVICE_KVM         = 1 << 2,
+  FLATPAK_CONTEXT_DEVICE_SHM         = 1 << 3,
 } FlatpakContextDevices;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -69,6 +69,7 @@ const char *flatpak_context_devices[] = {
   "dri",
   "all",
   "kvm",
+  "shm",
   NULL
 };
 

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -162,7 +162,7 @@
                 <listitem><para>
                     Expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    DEVICE must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -173,7 +173,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, all.
+                    DEVICE must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -172,7 +172,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -183,7 +183,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -189,7 +189,7 @@
                             <varlistentry><term><option>shm</option></term>
                             <listitem><para>
                                 Access to the host /dev/shm
-                                (<filename>/dev/kvm</filename>).
+                                (<filename>/dev/shm</filename>).
                                 Available since 1.6.1.
                             </para></listitem></varlistentry>
 

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -182,8 +182,15 @@
 
                             <varlistentry><term><option>all</option></term>
                             <listitem><para>
-                                All device nodes in <filename>/dev</filename>.
+                                All device nodes in <filename>/dev</filename>, but not /dev/shm (which is separately specified).
                                 Available since 0.6.6.
+                            </para></listitem></varlistentry>
+
+                            <varlistentry><term><option>shm</option></term>
+                            <listitem><para>
+                                Access to the host /dev/shm
+                                (<filename>/dev/kvm</filename>).
+                                Available since 1.6.1.
                             </para></listitem></varlistentry>
 
                         </variablelist>

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -154,7 +154,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -165,7 +165,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -294,7 +294,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -305,7 +305,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This new permission exposes the host /dev, which is normally not visible
even with --device=all, as it is not really a device node but rather
a bunch of shared memory blocks available on the host.

This access is needed by jack, as explained at:
https://github.com/flatpak/flatpak/issues/1509

Long term I think a better solution for pro audio (like pipewire) is
a better solution, but for now we should at least allow jack apps to work.