### PR TITLE
build-commit-from: Fix generation of download-size

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3311,6 +3311,11 @@ flatpak_repo_collect_sizes (OstreeRepo   *repo,
                             GCancellable *cancellable,
                             GError      **error)
 {
+  /* Initialize the sums */
+  if (installed_size)
+    *installed_size = 0;
+  if (download_size)
+    *download_size = 0;
   return _flatpak_repo_collect_sizes (repo, root, NULL, installed_size, download_size, cancellable, error);
 }
 


### PR DESCRIPTION
In flatpak-builtins-build-commit-from.c we call flatpak_repo_collect_sizes()
without initializing the passed in download size to zero, which mean
we sum with sizes with some random value as the start.

This is fixed by having flatpak_repo_collect_sizes() always initialize
the counters to 0 at the start.

Fixes https://github.com/flatpak/flatpak/issues/3362