### PR TITLE
update-portal: Limit which filesystem access additions we allow

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1819,22 +1819,25 @@ static gboolean
 adds_filesystem_access (GHashTable *old, GHashTable *new)
 {
   FlatpakFilesystemMode old_host_mode = GPOINTER_TO_INT (g_hash_table_lookup (old, "host"));
-  FlatpakFilesystemMode old_home_mode = GPOINTER_TO_INT (g_hash_table_lookup (old, "home"));
 
   GLNX_HASH_TABLE_FOREACH_KV (new, const char *, location, gpointer, _new_mode)
     {
       FlatpakFilesystemMode new_mode = GPOINTER_TO_INT (_new_mode);
       FlatpakFilesystemMode old_mode = GPOINTER_TO_INT (g_hash_table_lookup (old, location));
 
+      /* Allow more limited access to the same thing */
       if (new_mode <= old_mode)
         continue;
 
-      if (new_mode <= old_host_mode)
+      /* Allow more limited access if we used to have access to everything */
+     if (new_mode <= old_host_mode)
         continue;
 
-      /* All but absolute paths are in homedir */
-      if (!g_path_is_absolute (location) && new_mode <= old_home_mode)
-        continue;
+     /* For the remainder we have to be pessimistic, for instance even
+        if we have home access we can't allow adding access to ~/foo,
+        because foo might be a symlink outside home which didn't work
+        before but would work with an explicit access to that
+        particular file. */
 
       return TRUE;
     }


### PR DESCRIPTION
Don't allow adding access to things like ~/foo xdg-foo/bar or similar
things just because you used to have home access, because such files
may be outside the homedir (for instance, if they are symlinks or configured
via xdg-user-dirs).