### PR TITLE
Add host-etc, host-os exports

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2085,7 +2085,7 @@ flatpak_context_export (FlatpakContext *context,
           closedir (dir);
         }
       flatpak_exports_add_path_expose (exports, fs_mode, "/run/media");
-      flatpak_exports_add_home_expose (exports, fs_mode);
+      flatpak_exports_add_host_expose (exports, fs_mode);
     }
 
   home_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "home");

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -81,6 +81,12 @@ const char *flatpak_context_features[] = {
   NULL
 };
 
+const char *flatpak_context_special_filesystems[] = {
+  "home",
+  "host",
+  NULL
+};
+
 FlatpakContext *
 flatpak_context_new (void)
 {
@@ -749,9 +755,7 @@ flatpak_context_verify_filesystem (const char *filesystem_and_mode,
 {
   g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, NULL);
 
-  if (strcmp (filesystem, "host") == 0)
-    return TRUE;
-  if (strcmp (filesystem, "home") == 0)
+  if (g_strv_contains (flatpak_context_special_filesystems, filesystem))
     return TRUE;
   if (get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL))
     return TRUE;
@@ -2103,8 +2107,7 @@ flatpak_context_export (FlatpakContext *context,
       const char *filesystem = key;
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-      if (strcmp (filesystem, "host") == 0 ||
-          strcmp (filesystem, "home") == 0)
+      if (g_strv_contains (flatpak_context_special_filesystems, filesystem))
         continue;
 
       if (g_str_has_prefix (filesystem, "xdg-"))

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -37,8 +37,10 @@ void flatpak_exports_free (FlatpakExports *exports);
 FlatpakExports *flatpak_exports_new (void);
 void flatpak_exports_append_bwrap_args (FlatpakExports *exports,
                                         FlatpakBwrap   *bwrap);
-void flatpak_exports_add_host_expose (FlatpakExports       *exports,
-                                      FlatpakFilesystemMode mode);
+void flatpak_exports_add_host_etc_expose (FlatpakExports       *exports,
+                                          FlatpakFilesystemMode mode);
+void flatpak_exports_add_host_os_expose (FlatpakExports       *exports,
+                                         FlatpakFilesystemMode mode);
 void flatpak_exports_add_path_expose (FlatpakExports       *exports,
                                       FlatpakFilesystemMode mode,
                                       const char           *path);

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -37,7 +37,7 @@ void flatpak_exports_free (FlatpakExports *exports);
 FlatpakExports *flatpak_exports_new (void);
 void flatpak_exports_append_bwrap_args (FlatpakExports *exports,
                                         FlatpakBwrap   *bwrap);
-void flatpak_exports_add_home_expose (FlatpakExports       *exports,
+void flatpak_exports_add_host_expose (FlatpakExports       *exports,
                                       FlatpakFilesystemMode mode);
 void flatpak_exports_add_path_expose (FlatpakExports       *exports,
                                       FlatpakFilesystemMode mode,

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -617,7 +617,7 @@ flatpak_exports_add_path_dir (FlatpakExports *exports,
 }
 
 void
-flatpak_exports_add_home_expose (FlatpakExports       *exports,
+flatpak_exports_add_host_expose (FlatpakExports       *exports,
                                  FlatpakFilesystemMode mode)
 {
   exports->host_fs = mode;

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -49,9 +49,11 @@
 #include "flatpak-error.h"
 
 /* We don't want to export paths pointing into these, because they are readonly
-   (so we can't create mountpoints there) and don't match what's on the host anyway */
+   (so we can't create mountpoints there) and don't match what's on the host anyway.
+   flatpak_abs_usrmerged_dirs get the same treatment without having to be listed
+   here. */
 const char *dont_export_in[] = {
-  "/lib", "/lib32", "/lib64", "/bin", "/sbin", "/usr", "/etc", "/app", "/dev", "/proc", NULL
+  "/usr", "/etc", "/app", "/dev", "/proc", NULL
 };
 
 static char *
@@ -541,6 +543,16 @@ _exports_path_expose (FlatpakExports *exports,
          they are not the same as on the host, and we generally can't
          create the parents for them anyway */
       if (flatpak_has_path_prefix (path, dont_export_in[i]))
+        {
+          g_debug ("skipping export for path %s", path);
+          return FALSE;
+        }
+    }
+
+  for (i = 0; flatpak_abs_usrmerged_dirs[i] != NULL; i++)
+    {
+      /* Same as /usr, but for the directories that get merged into /usr */
+      if (flatpak_has_path_prefix (path, flatpak_abs_usrmerged_dirs[i]))
         {
           g_debug ("skipping export for path %s", path);
           return FALSE;

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -279,14 +279,17 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
 
   if (exports->host_fs != 0)
     {
+      const char *host_bind_mode = "--bind";
+
+      if (exports->host_fs == FLATPAK_FILESYSTEM_MODE_READ_ONLY)
+        host_bind_mode = "--ro-bind";
+
       if (g_file_test ("/usr", G_FILE_TEST_IS_DIR))
         flatpak_bwrap_add_args (bwrap,
-                                (exports->host_fs == FLATPAK_FILESYSTEM_MODE_READ_ONLY) ? "--ro-bind" : "--bind",
-                                "/usr", "/run/host/usr", NULL);
+                                host_bind_mode, "/usr", "/run/host/usr", NULL);
       if (g_file_test ("/etc", G_FILE_TEST_IS_DIR))
         flatpak_bwrap_add_args (bwrap,
-                                (exports->host_fs == FLATPAK_FILESYSTEM_MODE_READ_ONLY) ? "--ro-bind" : "--bind",
-                                "/etc", "/run/host/etc", NULL);
+                                host_bind_mode, "/etc", "/run/host/etc", NULL);
     }
 }
 

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -183,4 +183,6 @@ gboolean flatpak_run_app (const char     *app_ref,
                           GCancellable   *cancellable,
                           GError        **error);
 
+extern const char * const *flatpak_abs_usrmerged_dirs;
+
 #endif /* __FLATPAK_RUN_H__ */

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -225,7 +225,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This updates the [Context] group in the metadata.
-                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    FS can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -245,7 +245,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    FILESYSTEM can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -232,6 +232,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -219,7 +219,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -239,7 +239,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -226,6 +226,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -232,6 +232,21 @@
                                 files in /sys available.
                             </para>
                             <para>
+                                Additionally, this keyword provides all of the
+                                same directories in
+                                <filename>/run/host</filename> as the
+                                <option>host-os</option> and
+                                <option>host-etc</option> keywords.
+                                If this keyword is used in conjunction
+                                with one of the <option>host-</option>
+                                keywords, whichever access level is higher
+                                (more permissive) will be used for the
+                                directories in <filename>/run/host</filename>:
+                                for example,
+                                <code>host:rw;host-os:ro;</code> is
+                                equivalent to <code>host:rw;</code>.
+                            </para>
+                            <para>
                                 These other reserved directories are
                                 currently excluded:
                                 <filename>/app</filename>,
@@ -251,6 +266,54 @@
                             </para>
                             <para>
                                 Available since 0.3.
+                            </para></listitem></varlistentry>
+
+                            <varlistentry><term><option>host-os</option></term>
+                            <listitem><para>
+                                The host operating system's libraries,
+                                executables and static data from
+                                <filename>/usr</filename>
+                                and the related directories
+                                <filename>/bin</filename>,
+                                <filename>/lib</filename>,
+                                <filename>/lib32</filename>,
+                                <filename>/lib64</filename>,
+                                <filename>/sbin</filename>.
+                                Additionally, this keyword provides access
+                                to a subset of <filename>/etc</filename> that
+                                is associated with packaged libraries and
+                                executables, even if the
+                                <option>host-etc</option> keyword
+                                was not used:
+                                <filename>/etc/ld.so.cache</filename>,
+                                (used by the dynamic linker) and
+                                <filename>/etc/alternatives</filename>
+                                (on operating systems that use it, such as
+                                Debian).
+                            </para>
+                            <para>
+                                To avoid conflicting with the Flatpak
+                                runtime, these are mounted in the sandbox
+                                at <filename>/run/host/usr</filename>,
+                                <filename>/run/host/etc/ld.so.cache</filename>
+                                and so on.
+                            </para>
+                            <para>
+                                Available since 1.7.
+                            </para></listitem></varlistentry>
+
+                            <varlistentry><term><option>host-etc</option></term>
+                            <listitem><para>
+                                The host operating system's configuration from
+                                <filename>/etc</filename>.
+                            </para>
+                            <para>
+                                To avoid conflicting with the Flatpak
+                                runtime, this is mounted in the sandbox
+                                at <filename>/run/host/etc</filename>.
+                            </para>
+                            <para>
+                                Available since 1.7.
                             </para></listitem></varlistentry>
 
                             <varlistentry><term><option>xdg-desktop</option>,

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -201,7 +201,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths
@@ -222,7 +222,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -209,6 +209,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -341,7 +341,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     xdg-run, xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths
@@ -362,7 +362,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -349,6 +349,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 

--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -136,7 +136,7 @@ rerun_in_sandbox (const char *arg_width,
                   const char *arg_height,
                   const char *filename)
 {
-  const char * const usrmerged_dirs[] = { "bin", "lib64", "lib", "sbin" };
+  const char * const usrmerged_dirs[] = { "bin", "lib32", "lib64", "lib", "sbin" };
   int i;
   g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func (g_free);
   char validate_icon[PATH_MAX + 1];


### PR DESCRIPTION
* exports: Fix a confusingly-named method (#3374)
    
    It was called flatpak_exports_add_home_expose(), but it actually
    exposed the entire host filesystem, to the extent possible.
    Rename it to flatpak_exports_add_host_expose() to reflect that.

* doc: Point to flatpak-metadata(5) for the meanings of filesystem keywords (#3375)

* exports: Only choose bwrap --bind/--ro-bind for host FS once
    
    We can choose this once and use it repeatedly, which will be simpler
    when we add more directories that work this way.

* icon-validator: Add lib32 to usrmerged_dirs, for completeness
    
    This syncs it up with our other lists of /usr-merged directories.
    
    In particular, this could matter on Arch Linux, which uses /usr/lib
    and /usr/lib32 for 64- and 32-bit libraries (respectively), instead
    of the more common /usr/lib64 and /usr/lib.

* common: Unify some lists of /usr-merged directories
    
    In some places we want a list of basenames, and in others we want a list
    of absolute paths. Use the absolute paths, because converting those into
    basenames doesn't require memory allocation.

* exports: If --filesystem=host, provide /run/host/lib etc.
    
    In a host system where the /usr merge has not been implemented, these can
    be necessary to load or inspect libraries or executables from the host
    system. They are conceptually the same as /usr.

* context: Generalize handling of special filesystems a bit
    
    Currently there are only "home" and "host", but I'm going to add one
    that represents /usr and friends (/usr, /lib, ...), and one for /etc.
    These differ from ordinary filesystem mounts because they are redirected
    into /run/host to avoid conflicting with the runtime.

* exports: Add host-etc and host-os keywords
    
    These are subsets of the host keyword, which provide access to operating
    system files but not to users' personal files.
    
    In particular, the experimental support for namespace-based sandboxes
    in the Steam Runtime[1] uses the graphics stack from the host system,
    which requires access to the host /usr/libQUAL, /libQUAL (even if the
    host OS has undergone the /usr merge, the canonical paths of ELF
    interpreters start with /lib), /etc/ld.so.cache, and for some libraries
    on Debian-based systems, /etc/alternatives. It will not be possible to
    do similar things in Flatpak without either allowing full host
    filesystem access (which exposes personal files, and in any case cannot
    be done by the Steam app because it is incompatible with --persist=.),
    or adding the ability to expose /usr and related directories without
    including the rest of the host filesystem.
    
    To the best of my knowledge, host-etc is not necessary for anything;
    I've mainly provided it for symmetry, since it's the other significant
    thing that we mount in /run/host and cannot get via --filesystem=/path.
    
    Some notes on the security/privacy implications of the new keywords:
    
    - Neither new keyword allows anything that was not already allowed
      by "host".
    - Neither new keyword can allow anything that was not already allowed
      to the user outside the sandbox.
    - "host-os" allows enumeration of the installed packages on the host
      system, and often their version numbers too. A malicious app could
      use this to look for exploitable security vulnerabilities on the
      host system. An app could also use this for fingerprinting, although
      this is not a regression, because the systemd/D-Bus machine ID,
      MAC addresses, hostname, kernel boot UUID, DMI product ID and many
      other unique or relatively unique properties are already available
      inside the sandbox.
    - "host-os" allows read access, and possibly write access (if the user
      has it outside the sandbox, for example members of group 'staff' in
      older Debian installations), to /usr/local.
    - "host-etc" allows reading configuration files whose contents might
      be considered sensitive, such as /etc/passwd.
    
    [1] https://steamcommunity.com/app/221410/discussions/0/1638675549018366706/

---

Tested on a host system with unmerged /usr (`/lib`, etc. are real directories), with symlinks like `/lib -> /usr/lib`, and with `/lib -> usr/lib`.

Includes #3374 and #3375.