### PR TITLE
exports: Fix a confusingly-named method

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2085,7 +2085,7 @@ flatpak_context_export (FlatpakContext *context,
           closedir (dir);
         }
       flatpak_exports_add_path_expose (exports, fs_mode, "/run/media");
-      flatpak_exports_add_home_expose (exports, fs_mode);
+      flatpak_exports_add_host_expose (exports, fs_mode);
     }
 
   home_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "home");

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -37,7 +37,7 @@ void flatpak_exports_free (FlatpakExports *exports);
 FlatpakExports *flatpak_exports_new (void);
 void flatpak_exports_append_bwrap_args (FlatpakExports *exports,
                                         FlatpakBwrap   *bwrap);
-void flatpak_exports_add_home_expose (FlatpakExports       *exports,
+void flatpak_exports_add_host_expose (FlatpakExports       *exports,
                                       FlatpakFilesystemMode mode);
 void flatpak_exports_add_path_expose (FlatpakExports       *exports,
                                       FlatpakFilesystemMode mode,

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -617,7 +617,7 @@ flatpak_exports_add_path_dir (FlatpakExports *exports,
 }
 
 void
-flatpak_exports_add_home_expose (FlatpakExports       *exports,
+flatpak_exports_add_host_expose (FlatpakExports       *exports,
                                  FlatpakFilesystemMode mode)
 {
   exports->host_fs = mode;


### PR DESCRIPTION
It was called flatpak_exports_add_home_expose(), but it actually
exposed the entire host filesystem, to the extent possible.
Rename it to flatpak_exports_add_host_expose() to reflect that.

---

Taken from #3373, but mergeable separately (and fairly trivial tbh).