### PR TITLE
doc: Point to flatpak-metadata(5) for the meanings of filesystem keywords

### DIFF
--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -232,6 +232,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -226,6 +226,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -209,6 +209,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -349,6 +349,9 @@
                     The optional :ro suffix indicates that the location will be read-only.
                     The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
                     This option can be used multiple times.
+                    See the "[Context] filesystems" list in
+                    <citerefentry><refentrytitle>flatpak-metadata</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                    for details of the meanings of these filesystems.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
Taken from #3373, but useful to merge separately.