### PR TITLE
app: Don't print "< 0 bytes"

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -499,7 +499,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
               size = flatpak_deploy_data_get_installed_size (ext_deploy_data);
               formatted = g_format_size (size);
               subpaths = flatpak_deploy_data_get_subpaths (ext_deploy_data);
-              if (subpaths && subpaths[0])
+              if (subpaths && subpaths[0] && size > 0)
                 formatted_size = g_strconcat ("<", formatted, NULL);
               else
                 formatted_size = g_steal_pointer (&formatted);

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1018,15 +1018,21 @@ transaction_ready (FlatpakTransaction *transaction)
           guint64 download_size;
           g_autofree char *formatted = NULL;
           g_autofree char *text = NULL;
+          const char *prefix;
 
           download_size = flatpak_transaction_operation_get_download_size (op);
           formatted = g_format_size (download_size);
 
+          if (download_size > 0)
+            prefix = "< ";
+          else
+            prefix = "";
+
           flatpak_table_printer_add_column (printer, remote);
           if (g_str_has_suffix (flatpak_ref_get_name (rref), ".Locale"))
-            text = g_strdup_printf ("< %s (%s)", formatted, _("partial"));
+            text = g_strdup_printf ("%s%s (%s)", prefix, formatted, _("partial"));
           else
-            text = g_strdup_printf ("< %s", formatted);
+            text = g_strdup_printf ("%s%s", prefix, formatted);
           flatpak_table_printer_add_decimal_column (printer, text);
         }
 


### PR DESCRIPTION
Don't imply a download or install uses a negative number of bytes.