### PR TITLE
Support --device=snd, for audio on ALSA-only systems.

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -50,6 +50,7 @@ typedef enum {
   FLATPAK_CONTEXT_DEVICE_ALL         = 1 << 1,
   FLATPAK_CONTEXT_DEVICE_KVM         = 1 << 2,
   FLATPAK_CONTEXT_DEVICE_SHM         = 1 << 3,
+  FLATPAK_CONTEXT_DEVICE_SND         = 1 << 4,
 } FlatpakContextDevices;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -70,6 +70,7 @@ const char *flatpak_context_devices[] = {
   "all",
   "kvm",
   "shm",
+  "snd",
   NULL
 };
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1272,6 +1272,13 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
           if (real_dev_shm != NULL)
               flatpak_bwrap_add_args (bwrap, "--bind", real_dev_shm, "/dev/shm", NULL);
         }
+
+      if (context->devices & FLATPAK_CONTEXT_DEVICE_SND)
+        {
+          g_debug ("Allowing snd access");
+          if (g_file_test ("/dev/snd", G_FILE_TEST_IS_DIR))
+            flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/snd", "/dev/snd", NULL);
+        }
     }
 
   flatpak_context_append_bwrap_filesystem (context, bwrap, app_id, app_id_dir, previous_app_id_dirs, &exports);

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -162,7 +162,7 @@
                 <listitem><para>
                     Expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, shm, all.
+                    DEVICE must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -173,7 +173,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, shm, all.
+                    DEVICE must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -172,7 +172,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -183,7 +183,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -180,6 +180,13 @@
                                 Available since 0.6.12.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>snd</option></term>
+                            <listitem><para>
+                                Sound
+                                (<filename>/dev/snd</filename>).
+                                Available since 1.6.2.
+                            </para></listitem></varlistentry>
+
                             <varlistentry><term><option>all</option></term>
                             <listitem><para>
                                 All device nodes in <filename>/dev</filename>, but not /dev/shm (which is separately specified).

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -154,7 +154,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -165,7 +165,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -294,7 +294,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -305,7 +305,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, snd, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This allows sound on non-PulseAudio systems, without requiring --device=all.

Fixes #3390