### PR TITLE
Fix out-of-tree build error

### DIFF
--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -7,7 +7,7 @@ EXTRA_DIST += app/parse-datetime.y
 flatpak_dbus_built_sources = app/flatpak-permission-dbus-generated.c app/flatpak-permission-dbus-generated.h
 
 app/flatpak-permission-dbus-generated.c: data/org.freedesktop.impl.portal.PermissionStore.xml Makefile
-	mkdir -p $(builddir)/common
+	mkdir -p $(builddir)/app
 	$(AM_V_GEN) $(GDBUS_CODEGEN)                            \
 		--interface-prefix org.freedesktop.impl.portal  \
 		--c-namespace XdpDbus                           \


### PR DESCRIPTION
Fixes the missing 'app' directory:

```
Traceback (most recent call last):
  File "/data/dwrobel1/rdkv/rpi-flutter-3/build-raspberrypirdkhybrefapp/tmp/sysroots/x86_64-linux/usr/bin/gdbus-codegen", line 39, in <module>
      sys.exit(codegen_main.codegen_main())
        File "/data/dwrobel1/rdkv/rpi-flutter-3/build-raspberrypirdkhybrefapp/tmp/sysroots/x86_64-linux/usr/share/glib-2.0/codegen/codegen_main.py", line 186, in codegen_main
            h = open(c_code + '.h', 'w')
            FileNotFoundError: [Errno 2] No such file or directory: './app/flatpak-permission-dbus-generated.h'
            make: *** [app/flatpak-permission-dbus-generated.c] Error 1
            make: *** Waiting for unfinished jobs....
```