### PR TITLE
Actually use from-scratch deltas

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -195,7 +195,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
       g_autoptr(FlatpakDeploy) runtime_deploy = NULL;
       g_autoptr(GError) local_error2 = NULL;
       g_autoptr(GPtrArray) ref_dir_pairs = NULL;
-      RefDirPair *chosen_pair;
+      RefDirPair *chosen_pair = NULL;
 
       /* Whereas for apps we want to default to using the "current" one (see
        * flatpak-make-current(1)) runtimes don't have a concept of currentness.

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4941,39 +4941,43 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   /* If @results is set, @rev must be. */
   g_assert (results == NULL || rev != NULL);
 
-  extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
-  if (extra_data_sources == NULL)
+  /* ostree-metadata and appstreams never have extra data, so ignore those */
+  if (g_str_has_prefix ("app/", ref) || g_str_has_prefix ("runtime/", ref))
     {
-      /* This is a gigantic hack where we download the commit in a temporary transaction
-       * which we then abort after having read the result. We do this to avoid creating
-       * a partial commit in the local repo and a ref that points to it, because that
-       * causes ostree to not use static deltas.
-       * See https://github.com/flatpak/flatpak/issues/3412 for details.
-       */
-
-      if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
-        return FALSE;
-
-      /* Pull the commits (and only the commits) to check for extra data
-       * again. Here we don't pass the progress because we don't want any
-       * reports coming out of it. */
-      if (!repo_pull (repo, repository,
-                      NULL,
-                      ref,
-                      rev,
-                      token,
-                      results,
-                      flatpak_flags,
-                      OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY,
-                      NULL,
-                      cancellable,
-                      error))
-        return FALSE;
-
       extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
+      if (extra_data_sources == NULL)
+        {
+          /* This is a gigantic hack where we download the commit in a temporary transaction
+           * which we then abort after having read the result. We do this to avoid creating
+           * a partial commit in the local repo and a ref that points to it, because that
+           * causes ostree to not use static deltas.
+           * See https://github.com/flatpak/flatpak/issues/3412 for details.
+           */
 
-      if (!ostree_repo_abort_transaction (repo, cancellable, error))
-        return FALSE;
+          if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
+            return FALSE;
+
+          /* Pull the commits (and only the commits) to check for extra data
+           * again. Here we don't pass the progress because we don't want any
+           * reports coming out of it. */
+          if (!repo_pull (repo, repository,
+                          NULL,
+                          ref,
+                          rev,
+                          token,
+                          results,
+                          flatpak_flags,
+                          OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY,
+                          NULL,
+                          cancellable,
+                          error))
+            return FALSE;
+
+          extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
+
+          if (!ostree_repo_abort_transaction (repo, cancellable, error))
+            return FALSE;
+        }
     }
 
   n_extra_data = 0;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13617,7 +13617,7 @@ _flatpak_dir_fetch_remote_state_metadata_branch (FlatpakDir         *self,
           if (!flatpak_dir_pull (self, state, OSTREE_REPO_METADATA_REF, NULL, NULL, NULL, NULL,
                                  child_repo,
                                  flatpak_flags,
-                                 OSTREE_REPO_PULL_FLAGS_MIRROR,
+                                 0,
                                  progress, cancellable, error))
             return FALSE;
 

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -2213,7 +2213,7 @@ message_handler (const gchar   *log_domain,
 {
   /* Make this look like normal console output */
   if (log_level & G_LOG_LEVEL_DEBUG)
-    g_printerr ("F: %s\n", message);
+    g_printerr ("FH: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
 }


### PR DESCRIPTION
As noticed in https://github.com/flatpak/flatpak/issues/3412 we
regressed at some point and are no longer using from-scratch deltas.
This is caused by an optimization in ostree where it decides to not
use a from-scratch deltas if theres is *some* version of the ref
locally available.

This conflicts with some code in flatpak that pulls *only* the commit
object in order to look for extra data size information so that we can
get the progress reporting right. Unfortunately the existance of
just the object triggers the above causing us to *never* use from-scratch
deltas.

We fix this by throwing away the partial pull in an aborted ostree
transaction.