### PR TITLE
Fix (and test) out-of-tree builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,24 +46,30 @@ jobs:
         popd
     - name: Create logs dir
       run: mkdir test-logs
+    - name: autogen.sh
+      run: NOCONFIGURE=1 ./autogen.sh
     - name: configure
       # TODO: Enable gtk-doc builds
-      run: ./autogen.sh
+      run: |
+        mkdir _build
+        pushd _build
+        ../configure
+        popd
       env:
         CFLAGS: -fsanitize=undefined -fsanitize-undefined-trap-on-error -fsanitize=address -O2 -Wp,-D_FORTIFY_SOURCE=2
     - name: Build flatpak
-      run: make -j $(getconf _NPROCESSORS_ONLN)
+      run: make -C _build -j $(getconf _NPROCESSORS_ONLN)
     - name: Run tests
       # TODO: Build with -j (currently ends up with hangs in the tests)
-      run: make check
+      run: make -C _build check
       env:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
     - name: Collect overall test logs on failure
       if: failure()
-      run: mv test-suite.log test-logs/ || true
+      run: mv _build/test-suite.log test-logs/ || true
     - name: Collect individual test logs on cancel
       if: failure() || cancelled()
-      run: mv tests/*.log test-logs/ || true
+      run: mv _build/tests/*.log test-logs/ || true
     - name: Upload test logs
       uses: actions/upload-artifact@v1
       if: failure() || cancelled()

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -76,7 +76,7 @@ BUILT_SOURCES += $(nodist_libflatpak_common_base_la_SOURCES)
 CLEANFILES += $(nodist_libflatpak_common_base_la_SOURCES)
 
 common/flatpak-variant-private.h common/flatpak-variant-impl-private.h: variant-schema-compiler/variant-schema-compiler  data/flatpak-variants.gv
-	$(AM_V_GEN) variant-schema-compiler/variant-schema-compiler --outfile-header common/flatpak-variant-private.h  --outfile common/flatpak-variant-impl-private.h --prefix var data/flatpak-variants.gv
+	$(AM_V_GEN) $(srcdir)/variant-schema-compiler/variant-schema-compiler --outfile-header common/flatpak-variant-private.h  --outfile common/flatpak-variant-impl-private.h --prefix var $(srcdir)/data/flatpak-variants.gv
 
 BUILT_SOURCES += common/flatpak-variant-private.h common/flatpak-variant-impl-private.h
 CLEANFILES += common/flatpak-variant-private.h common/flatpak-variant-impl-private.h


### PR DESCRIPTION
* build: Fix out-of-tree build with variant-schema-compiler
    
    The variant-schema-compiler and its input are in the $(srcdir).

* CI: Do one build out-of-tree
    
    With the gcc build out-of-tree and the clang build in-tree, we're
    testing both ways.