### PR TITLE
Add the SpawnStarted signal

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -537,7 +537,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                       runtime_ref,
                                       app_id_dir, app_context, NULL,
                                       FALSE, TRUE, TRUE,
-                                      &app_info_path,
+                                      &app_info_path, 0,
                                       &instance_id_host_dir,
                                       error))
     return FALSE;

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -537,7 +537,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                       runtime_ref,
                                       app_id_dir, app_context, NULL,
                                       FALSE, TRUE, TRUE,
-                                      &app_info_path, 0,
+                                      &app_info_path, -1,
                                       &instance_id_host_dir,
                                       error))
     return FALSE;

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -57,6 +57,7 @@ static char *opt_commit;
 static char *opt_runtime_commit;
 static int opt_parent_pid;
 static gboolean opt_parent_expose_pids;
+static int opt_instance_id_fd = -1;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to use"), N_("ARCH") },
@@ -81,6 +82,7 @@ static GOptionEntry options[] = {
   { "die-with-parent", 'p', 0, G_OPTION_ARG_NONE, &opt_die_with_parent, N_("Kill processes when the parent process dies"), NULL },
   { "parent-pid", 0, 0, G_OPTION_ARG_INT, &opt_parent_pid, N_("Use PID as parent pid for sharing namespaces"), N_("PID") },
   { "parent-expose-pids", 0, 0, G_OPTION_ARG_NONE, &opt_parent_expose_pids, N_("Make processes visible in parent namespace"), NULL },
+  { "instance-id-fd", 0, 0, G_OPTION_ARG_INT, &opt_instance_id_fd, N_("Write the instance ID to the given file descriptor"), NULL },
   { NULL }
 };
 
@@ -310,6 +312,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
                         opt_command,
                         &argv[rest_argv_start + 1],
                         rest_argc - 1,
+                        opt_instance_id_fd,
                         NULL,
                         cancellable,
                         error))

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -705,7 +705,7 @@ flatpak_installation_launch_full (FlatpakInstallation *self,
                         run_flags,
                         NULL,
                         NULL,
-                        NULL, 0, 0,
+                        NULL, 0, -1,
                         &instance_dir,
                         cancellable, error))
     return FALSE;

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -705,7 +705,7 @@ flatpak_installation_launch_full (FlatpakInstallation *self,
                         run_flags,
                         NULL,
                         NULL,
-                        NULL, 0,
+                        NULL, 0, 0,
                         &instance_dir,
                         cancellable, error))
     return FALSE;

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -164,6 +164,7 @@ gboolean flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
                                         gboolean        build,
                                         gboolean        devel,
                                         char          **app_info_path_out,
+                                        int             instance_id_fd,
                                         char          **host_instance_id_host_dir_out,
                                         GError        **error);
 
@@ -179,6 +180,7 @@ gboolean flatpak_run_app (const char     *app_ref,
                           const char     *custom_command,
                           char           *args[],
                           int             n_args,
+                          int             instance_id_fd,
                           char          **instance_dir_out,
                           GCancellable   *cancellable,
                           GError        **error);

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -36,7 +36,7 @@
       bus name org.freedesktop.portal.Flatpak and the object path
       /org/freedesktop/portal/Flatpak.
 
-      This documentation describes version 3 of this interface.
+      This documentation describes version 4 of this interface.
   -->
   <interface name='org.freedesktop.portal.Flatpak'>
     <property name="version" type="u" access="read"/>
@@ -109,6 +109,15 @@
                Expose the sandbox pids in the callers sandbox, only supported if using user namespaces for containers (not setuid), see the support property.
                </para><para>
                This was added in version 3 of this interface (available from flatpak 1.6.0 and later).
+             </para></listitem>
+           </varlistentry>
+           <varlistentry>
+             <term>64</term>
+             <listitem><para>
+               Emit a SpawnStarted signal once the sandboxed process has been
+               fully started.
+               </para><para>
+               This was added in version 4 of this interface (available from flatpak 1.8.0 and later).
              </para></listitem>
            </varlistentry>
          </variablelist>
@@ -227,6 +236,28 @@
       <arg type='u' name='signal' direction='in'/>
       <arg type='b' name='to_process_group' direction='in'/>
     </method>
+
+    <!--
+        SpawnStarted:
+        @pid: the PID of the process that has been started
+        @relpid: the PID of the process relative to the current namespace.
+        This is only non-zero if the expose PIDs flag (32) was passed to
+        org.freedesktop.portal.Flatpak.Spawn(), and it may still be zero if
+        the process exits before its relative PID could be read.
+
+        Emitted when a process started by org.freedesktop.portal.Flatpak.Spawn()
+        has fully started. In other words, org.freedesktop.portal.Flatpak.Spawn() returns once the sandbox
+        has been started, and this signal is emitted once the process inside
+        itself is started.
+
+        Only emitted by version 4 of this interface (available from flatpak
+        1.8.0 and later) and if the notify start flag (64) was passed to
+        org.freedesktop.portal.Flatpak.Spawn().
+    -->
+    <signal name="SpawnStarted">
+      <arg type='u' name='pid' direction='out'/>
+      <arg type='u' name='relpid' direction='out'/>
+    </signal>
 
     <!--
         SpawnExited:

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -570,6 +570,14 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
+                <term><option>--instance-id-fd</option></term>
+
+                <listitem><para>
+                    Write the instance ID string to the given file descriptor.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--file-forwarding</option></term>
 
                 <listitem><para>

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -424,7 +424,7 @@ instance_id_read_finish (GObject      *source,
     {
       /* 0 means EOF, so the process could never have been started. */
       if (bytes_read == -1)
-        g_error ("Failed to read instance id: %s", error->message);
+        g_warning ("Failed to read instance id: %s", error->message);
 
       return;
     }
@@ -463,7 +463,7 @@ child_setup_func (gpointer user_data)
   sigemptyset (&set);
   if (pthread_sigmask (SIG_SETMASK, &set, NULL) == -1)
     {
-      g_error ("Failed to unblock signals when starting child");
+      g_warning ("Failed to unblock signals when starting child");
       return;
     }
 

--- a/portal/flatpak-portal.h
+++ b/portal/flatpak-portal.h
@@ -28,6 +28,7 @@ typedef enum {
   FLATPAK_SPAWN_FLAGS_NO_NETWORK = 1 << 3,
   FLATPAK_SPAWN_FLAGS_WATCH_BUS = 1 << 4,
   FLATPAK_SPAWN_FLAGS_EXPOSE_PIDS = 1 << 5,
+  FLATPAK_SPAWN_FLAGS_NOTIFY_START = 1 << 6,
 } FlatpakSpawnFlags;
 
 typedef enum {
@@ -48,7 +49,8 @@ typedef enum {
                                  FLATPAK_SPAWN_FLAGS_SANDBOX | \
                                  FLATPAK_SPAWN_FLAGS_NO_NETWORK | \
                                  FLATPAK_SPAWN_FLAGS_WATCH_BUS | \
-                                 FLATPAK_SPAWN_FLAGS_EXPOSE_PIDS)
+                                 FLATPAK_SPAWN_FLAGS_EXPOSE_PIDS | \
+                                 FLATPAK_SPAWN_FLAGS_NOTIFY_START)
 
 #define FLATPAK_SPAWN_SANDBOX_FLAGS_ALL (FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_DISPLAY | \
                                          FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SOUND | \


### PR DESCRIPTION
Now we can see PIDs of spawned processes...but there's no way to actually know what spawned processes they correspond to. This adds the ability to see that.