### PR TITLE
Gpg agent support

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -43,6 +43,7 @@ typedef enum {
   FLATPAK_CONTEXT_SOCKET_SSH_AUTH    = 1 << 6,
   FLATPAK_CONTEXT_SOCKET_PCSC        = 1 << 7,
   FLATPAK_CONTEXT_SOCKET_CUPS        = 1 << 8,
+  FLATPAK_CONTEXT_SOCKET_GPG_AGENT   = 1 << 9,
 } FlatpakContextSockets;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -62,6 +62,7 @@ const char *flatpak_context_sockets[] = {
   "ssh-auth",
   "pcsc",
   "cups",
+  "gpg-agent",
   NULL
 };
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -429,6 +429,47 @@ flatpak_run_add_cups_args (FlatpakBwrap *bwrap)
                           NULL);
 }
 
+static void
+flatpak_run_add_gpg_args (FlatpakBwrap *bwrap)
+{
+  const char * agent_socket;
+  g_autofree char * agent_dirs = NULL;
+  g_autofree char * sandbox_agent_socket = NULL;
+  g_autoptr(GError) gpgconf_error = NULL;
+  g_autoptr(GSubprocess) process = NULL;
+  g_autoptr(GInputStream) base_stream = NULL;
+  g_autoptr(GDataInputStream) data_stream = NULL;
+
+  process = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE,
+                    &gpgconf_error,
+                    "gpgconf", "--list-dirs", "|",
+                    "grep", "agent-socket", NULL);
+
+  if (gpgconf_error)
+    {
+      g_debug ("GPG-Agent directories: %s", gpgconf_error->message);
+      return;
+    }
+
+  base_stream = g_subprocess_get_stdout_pipe (process);
+  data_stream = g_data_input_stream_new (base_stream);
+
+  agent_socket = g_data_input_stream_read_line (data_stream,
+                                                NULL, NULL,
+                                                &gpgconf_error);
+  if (!agent_socket || gpgconf_error)
+    {
+      g_debug ("GPG-Agent directories: %s", gpgconf_error->message);
+      return;
+    }
+
+  sandbox_agent_socket = g_strdup_printf ("/run/user/%d/gnupg/S.gpg-agent", getuid ());
+
+  flatpak_bwrap_add_args (bwrap,
+                          "--ro-bind", agent_socket, sandbox_agent_socket,
+                          NULL);
+}
+
 /* Try to find a default server from a pulseaudio confguration file */
 static char *
 flatpak_run_get_pulseaudio_server_user_config (const char *path)
@@ -1303,6 +1344,11 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
   if (context->sockets & FLATPAK_CONTEXT_SOCKET_SSH_AUTH)
     {
       flatpak_run_add_ssh_args (bwrap);
+    }
+
+  if(context->sockets & FLATPAK_CONTEXT_SOCKET_GPG_AGENT)
+    {
+      flatpak_run_add_gpg_args (bwrap);
     }
 
   if (context->sockets & FLATPAK_CONTEXT_SOCKET_PULSEAUDIO)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -442,8 +442,7 @@ flatpak_run_add_gpg_args (FlatpakBwrap *bwrap)
 
   process = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE,
                     &gpgconf_error,
-                    "gpgconf", "--list-dirs", "|",
-                    "grep", "agent-socket", NULL);
+                    "gpgconf", "--list-dir", "agent-extra-socket", NULL);
 
   if (gpgconf_error)
     {


### PR DESCRIPTION
I've looked into adding gpg-agent access, but this will require some work still.

This patch mounts the gpg-agent-extra socket (https://jlk.fjfi.cvut.cz/arch/manpages/man/gpg-agent.1 see the --extra-socket option) with has a reduced command set (so arguably more secure), but still allows for encryption & signing as a proof of concept. We may want to add two flags for gpg-agent and gpg-agent-extra (I think being able to do key-management from a flatpak'd app is a valid usecase as well.)

For gpg to work as expected inside the container it is still required to "chmod 700 /run/user/1000/gnupg", which I have failed to do from flatpak so far (doesn't look like bubblewrap has the necessary options?)

I'd like to get some feedback on whether this approach has potential to be accepted, and if yes some guidance with the chmod part above. I would then also add both the gpg-agent and gpg-agent-extra flags (if you agree)

For the usecase: I have an email application that uses gpgme. Currently I'm starting a gpg-agent inside the container, which means the agent has to be unlocked every time I open the application.
By using the system gpg-agent this can be avoided and the agent only needs to be unlocked once.