### PR TITLE
Better `build-init` explanation & fix example

### DIFF
--- a/doc/flatpak-build-init.xml
+++ b/doc/flatpak-build-init.xml
@@ -220,7 +220,7 @@
         <title>Examples</title>
 
         <para>
-            <command>$ flatpak build-init org.example.myapp /build/my-app org.gnome.Sdk org.gnome.Platform 3.36</command>
+            <command>$ flatpak build-init /build/my-app org.example.myapp org.gnome.Sdk org.gnome.Platform 3.36</command>
         </para>
 
     </refsect1>

--- a/doc/flatpak-build-init.xml
+++ b/doc/flatpak-build-init.xml
@@ -56,9 +56,9 @@
         <para>
             Initializes a directory as build directory which can be used as 
             target directory of <command>flatpak build</command>. It
-            create a <filename>metadata</filename> inside the given directory. 
+            creates a <filename>metadata</filename> inside the given directory. 
             Additionally, empty <filename>files</filename> and <filename>var</filename>
-            subdirectoriesa are created.
+            subdirectories are created.
         </para>
         <para>
             It is an error to run build-init on a directory that has already

--- a/doc/flatpak-build-init.xml
+++ b/doc/flatpak-build-init.xml
@@ -44,19 +44,21 @@
         <title>Description</title>
 
         <para>
-            Initializes a directory for building an application.
+            Initializes a separate build directory.
             <arg choice="plain">DIRECTORY</arg> is the name of the directory.
             <arg choice="plain">APPNAME</arg> is the application id of the app
             that will be built.
             <arg choice="plain">SDK</arg> and <arg choice="plain">RUNTIME</arg>
             specify the sdk and runtime that the application should be built
             against and run in.
+            <arg choice="plain">BRANCH</arg> specify the version of sdk and runtime
         </para>
         <para>
-            The result of this command is that a <filename>metadata</filename>
-            file is created inside the given directory. Additionally, empty
-            <filename>files</filename> and <filename>var</filename> subdirectories
-            are created.
+            Initializes a directory as build directory which can be used as 
+            target directory of <command>flatpak build</command>. It
+            create a <filename>metadata</filename> inside the given directory. 
+            Additionally, empty <filename>files</filename> and <filename>var</filename>
+            subdirectoriesa are created.
         </para>
         <para>
             It is an error to run build-init on a directory that has already
@@ -218,7 +220,7 @@
         <title>Examples</title>
 
         <para>
-            <command>$ flatpak build-init /build/my-app org.gnome.Sdk org.gnome.Platform 3.16</command>
+            <command>$ flatpak build-init org.example.myapp /build/my-app org.gnome.Sdk org.gnome.Platform 3.36</command>
         </para>
 
     </refsect1>


### PR DESCRIPTION
New users who jump directly into this command might think this command is to init a project or application dictionary but it actually creates somehow a directory as target of  `flatpak build `

plus, fix the not working example

Sorry for such minor and boring commit.