### PR TITLE
flatpak-oci-authenticator: try getting a token without credentials

### DIFF
--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -949,8 +949,11 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
 
   auth_msg = soup_message_new_from_uri ("GET", auth_uri);
 
-  g_autofree char *basic_auth = g_strdup_printf ("Basic %s", auth);
-  soup_message_headers_replace (auth_msg->request_headers, "Authorization", basic_auth);
+  if (auth)
+    {
+      g_autofree char *basic_auth = g_strdup_printf ("Basic %s", auth);
+      soup_message_headers_replace (auth_msg->request_headers, "Authorization", basic_auth);
+    }
 
   auth_stream = soup_session_send (self->soup_session, auth_msg, NULL, error);
   if (auth_stream == NULL)


### PR DESCRIPTION
Some registries require getting a token even to download an image
anonymously. So, if no auth has been configured, before prompting
the user for username/password, try without a BasicAuth header.

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>

<hr>

Another approach would be to handle this without going to the authenticator at all - if we get UNAUTHORIZED response with a WWW-Authenticate and don't have a token, try to get one anonymously. This patch posits that maybe we'll change things so that OCI remotes always have the OCI authenticator configured by default, and always try to get a token for every image.