### PR TITLE
repair: Don't crash if no remotes are configured

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -15140,7 +15140,7 @@ flatpak_dir_delete_mirror_refs (FlatpakDir    *self,
    * OS updates which Flatpak shouldn't touch.
    */
   remotes = ostree_repo_remote_list (repo, NULL);
-  for (i = 0; remotes[i] != NULL; i++)
+  for (i = 0; remotes != NULL && remotes[i] != NULL; i++)
     {
       g_autofree char *remote_collection_id = NULL;
 


### PR DESCRIPTION
If no remotes are configured, ostree_repo_remote_list returns NULL
so don't dereference it.

Fixes: https://github.com/flatpak/flatpak/issues/3436