### PR TITLE
common: Don't potentially write outside allocation

### DIFF
--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -295,7 +295,6 @@ flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
     data_len +=  strlen (bwrap->argv->pdata[i]) + 1;
 
   data = g_new (gchar, data_len);
-  *data = 0;
   ptr = data;
   for (i = start; i < end; i++)
     ptr = g_stpcpy (ptr, bwrap->argv->pdata[i]) + 1;


### PR DESCRIPTION
flatpak_bwrap_bundle_args() for some reasons does:

data = g_new (gchar, data_len);
*data = 0;

And then it starts copying in the data into the allocation, overwriting
the initial 0. If data_len is 0 this causes a write past end of
allocation, so just drop the second line above.