### PR TITLE
Enforce little endian for token-type

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -604,7 +604,7 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
 
       if (opt_token_type >= 0)
         g_variant_builder_add (&metadata_builder, "{sv}", "xa.token-type",
-                               g_variant_new_int32 (opt_token_type));
+                               g_variant_new_int32 (GINT32_TO_LE (opt_token_type)));
 
       timestamp = ostree_commit_get_timestamp (src_commitv);
       if (opt_timestamp)

--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -1035,7 +1035,7 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
 
   if (opt_token_type >= 0)
     g_variant_dict_insert_value (&metadata_dict, "xa.token-type",
-                                 g_variant_new_int32 (opt_token_type));
+                                 g_variant_new_int32 (GINT32_TO_LE (opt_token_type)));
 
   metadata_dict_v = g_variant_ref_sink (g_variant_dict_end (&metadata_dict));
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3801,7 +3801,7 @@ flatpak_dir_resolve_maybe_resolve_from_metadata (FlatpakDirResolve *resolve,
     {
       resolve->eol = g_strdup (var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE, NULL));
       resolve->eol_rebase = g_strdup (var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE_REBASE, NULL));
-      resolve->token_type = var_metadata_lookup_int32 (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, 0);
+      resolve->token_type = GINT32_FROM_LE(var_metadata_lookup_int32 (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, 0));
     }
 
   return TRUE; /* Resolved */
@@ -3833,7 +3833,8 @@ resolve_p2p_update_from_commit (FlatpakDirResolve *resolve,
   g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE, "s", &resolve->eol);
   g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, "s", &resolve->eol_rebase);
   /* NOTE: The transaction code already default or stored token_type from ostree-metadata here, but fix it up from the commit anyway */
-  g_variant_lookup (commit_metadata, "xa.token-type", "i", &resolve->token_type);
+  if (g_variant_lookup (commit_metadata, "xa.token-type", "i", &resolve->token_type))
+    resolve->token_type = GINT32_FROM_LE (resolve->token_type);
 }
 
 struct _FlatpakDirP2PState {
@@ -11282,7 +11283,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
     {
       gint32 token_type;
       if (g_variant_lookup (state->metadata, "xa.default-token-type", "i", &token_type))
-        state->default_token_type = token_type;
+        state->default_token_type = GINT32_FROM_LE (token_type);
     }
 
   return g_steal_pointer (&state);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2527,7 +2527,7 @@ resolve_op_from_metadata (FlatpakTransaction *self,
     {
       op->eol = g_strdup (var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE, NULL));
       op->eol_rebase = g_strdup (var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE_REBASE, NULL));
-      op->token_type = var_metadata_lookup_int32 (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, op->token_type);
+      op->token_type = GINT32_FROM_LE (var_metadata_lookup_int32 (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, op->token_type));
     }
 
   resolve_op_end (self, op, checksum, metadata_bytes);
@@ -2624,7 +2624,7 @@ resolve_p2p_ops (FlatpakTransaction *self,
           token_type = state->default_token_type;
 
           if (flatpak_remote_state_lookup_sparse_cache (state, op->ref, &sparse_cache, NULL))
-            token_type = var_metadata_lookup_int32 (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, token_type);
+            token_type = GINT32_FROM_LE (var_metadata_lookup_int32 (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, token_type));
 
           if (token_type > 0)
             {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3738,7 +3738,8 @@ flatpak_repo_update (OstreeRepo   *repo,
 
       g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE, "&s", &eol);
       g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, "&s", &eol_rebase);
-      g_variant_lookup (commit_metadata, "xa.token-type", "i", &token_type);
+      if (g_variant_lookup (commit_metadata, "xa.token-type", "i", &token_type))
+        token_type = GINT32_FROM_LE(token_type);
       if (eol || eol_rebase || token_type >= 0)
         {
           g_auto(GVariantBuilder) sparse_builder = FLATPAK_VARIANT_BUILDER_INITIALIZER;
@@ -3748,7 +3749,7 @@ flatpak_repo_update (OstreeRepo   *repo,
           if (eol_rebase)
             g_variant_builder_add (&sparse_builder, "{sv}", FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE_REBASE, g_variant_new_string (eol_rebase));
           if (token_type >= 0)
-            g_variant_builder_add (&sparse_builder, "{sv}", FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, g_variant_new_int32 (token_type));
+            g_variant_builder_add (&sparse_builder, "{sv}", FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE, g_variant_new_int32 (GINT32_TO_LE(token_type)));
 
           rev_data->sparse_data = g_variant_ref_sink (g_variant_builder_end (&sparse_builder));
         }


### PR DESCRIPTION
When storing the token-type in the commit and the summary cache we
hardcode it to little-endian.

In theory this breaks the "ABI", but in practice this change is a
no-op on little-endian systems which is what most are. Additionally as most
servers are little-endian this also fixes using big-endian clients with
such servers.

This fixes:
https://github.com/flatpak/flatpak/issues/3434