### PR TITLE
tests: Fix gpg signature failure checks

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -166,6 +166,16 @@ assert_file_has_content () {
     fi
 }
 
+assert_log_has_gpg_signature_error () {
+    if ! grep -q -e "GPG signatures found, but none are in trusted keyring" "$1"; then
+        if ! grep -q -e "Can't check signature: public key not found" "$1"; then
+            sed -e 's/^/# /' < "$1" >&2
+            echo 1>&2 "File '$1' doesn't have gpg signature error"
+            exit 1
+        fi
+    fi
+}
+
 assert_symlink_has_content () {
     if ! readlink "$1" | grep -q -e "$2"; then
         readlink "$1" |sed -e 's/^/# /' >&2

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -221,25 +221,24 @@ ${FLATPAK} ${U} uninstall -y org.test.Platform org.test.Hello
 if ${FLATPAK} ${U} install -y test-missing-gpg-repo org.test.Platform 2> install-error-log; then
     assert_not_reached "Should not be able to install with missing gpg key"
 fi
-assert_file_has_content install-error-log "GPG signatures found, but none are in trusted keyring"
-
+assert_log_has_gpg_signature_error install-error-log
 
 if ${FLATPAK} ${U} install test-missing-gpg-repo org.test.Hello 2> install-error-log; then
     assert_not_reached "Should not be able to install with missing gpg key"
 fi
-assert_file_has_content install-error-log "GPG signatures found, but none are in trusted keyring"
+assert_log_has_gpg_signature_error install-error-log
 
 echo "ok fail with missing gpg key"
 
 if ${FLATPAK} ${U} install test-wrong-gpg-repo org.test.Platform 2> install-error-log; then
     assert_not_reached "Should not be able to install with wrong gpg key"
 fi
-assert_file_has_content install-error-log "GPG signatures found, but none are in trusted keyring"
+assert_log_has_gpg_signature_error install-error-log
 
 if ${FLATPAK} ${U} install test-wrong-gpg-repo org.test.Hello 2> install-error-log; then
     assert_not_reached "Should not be able to install with wrong gpg key"
 fi
-assert_file_has_content install-error-log "GPG signatures found, but none are in trusted keyring"
+assert_log_has_gpg_signature_error install-error-log
 
 echo "ok fail with wrong gpg key"
 


### PR DESCRIPTION
It seems recent ostree reports a different error string for signature
check failures.