### PR TITLE
oci-authenticator: fix failures to clear GError

### DIFF
--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -496,6 +496,8 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
       token = get_token_for_ref (registry, ref_data, NULL, &error);
       if (token != NULL)
         have_auth = TRUE;
+      else
+        g_clear_error (&error);
     }
 
   /* Prompt the user for credentials */
@@ -520,6 +522,11 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
             {
               auth = g_steal_pointer (&test_auth);
               have_auth = TRUE;
+            }
+          else
+            {
+              g_debug ("Failed to get token: %s", error->message);
+              g_clear_error (&error);
             }
         }
     }


### PR DESCRIPTION
Fix problems overwriting a GError when we retry multiple times.
One of these was introduced with the recent change
e3f17a89a flatpak-oci-authenticator: try getting a token without credentials
but the other was existing.

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>

<hr>

I added a g_debug in the prompted-auth-retry-loop to add debugging information in the "something else is going wrong" case, but decided to skip it for the initial try-without-credentials attempt, since a failure there is expected.