### PR TITLE
common: Allow version numbers in app-id for DConf migration

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -7515,27 +7515,58 @@ gboolean
 flatpak_dconf_path_is_similar (const char *path1,
                                const char *path2)
 {
-  int i;
+  int i, i1, i2;
+  int num_components = -1;
 
-  for (i = 0; path1[i]; i++)
+  for (i = 0; path1[i] != '\0'; i++)
     {
       if (path2[i] == '\0')
-        return FALSE;
+        break;
 
       if (tolower (path1[i]) == tolower (path2[i]))
-        continue;
+        {
+          if (path1[i] == '/')
+            num_components++;
+          continue;
+        }
 
       if ((path1[i] == '-' || path1[i] == '_') &&
           (path2[i] == '-' || path2[i] == '_'))
         continue;
 
-      return FALSE;
+      break;
     }
 
-  if (path2[i] != '\0')
+  /* Skip over any versioning if we have at least a TLD and
+   * domain name, so 2 components */
+  /* We need at least TLD, and domain name, so 2 components */
+  i1 = i2 = i;
+  if (num_components >= 2)
+    {
+      while (isdigit (path1[i1]))
+        i1++;
+      while (isdigit (path2[i2]))
+        i2++;
+    }
+
+  if (path1[i1] != path2[i2])
     return FALSE;
 
-  return TRUE;
+  /* Both strings finished? */
+  if (path1[i1] == '\0')
+    return TRUE;
+
+  /* Maybe a trailing slash in both strings */
+  if (path1[i1] == '/')
+    {
+      i1++;
+      i2++;
+    }
+
+  if (path1[i1] != path2[i2])
+    return FALSE;
+
+  return (path1[i1] == '\0');
 }
 
 

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1152,7 +1152,12 @@ test_dconf_paths (void)
       gboolean result;
 
       result = flatpak_dconf_path_is_similar (tests[i].path1, tests[i].path2);
-      g_assert_cmpint (result, ==, tests[i].result);
+      if (result != tests[i].result)
+        g_error ("Unexpected %s: flatpak_dconf_path_is_similar (%s, %s) = %d",
+                 result ? "success" : "failure",
+                 tests[i].path1,
+                 tests[i].path2,
+                 result);
     }
 }
 

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1144,6 +1144,11 @@ test_dconf_paths (void)
     { "/org/gnome/Builder-2/", "/org/gnome/Builder_2/", 1 },
     { "/org/gnome/Builder/", "/org/gnome/Builder", 0 },
     { "/org/gnome/Builder/", "/org/gnome/Buildex/", 0 },
+    { "/org/gnome/Rhythmbox3/", "/org/gnome/rhythmbox/", 1 },
+    { "/org/gnome/Rhythmbox3/", "/org/gnome/rhythmbox", 0 },
+    { "/org/gnome1/Rhythmbox/", "/org/gnome/rhythmbox", 0 },
+    { "/org/gnome1/Rhythmbox", "/org/gnome/rhythmbox/", 0 },
+    { "/org/gnome/Rhythmbox3plus/", "/org/gnome/rhythmbox/", 0 },
   };
   int i;
 


### PR DESCRIPTION
Allow the app-id or the DConf path to finish with a digit and still be
considered similar enough for DConf migration purposes.

This allows the org.gnome.Rhythmbox3 app-id to migrate its
/org/gnome/rhythmbox DConf path.

See https://github.com/flathub/org.gnome.Rhythmbox3/pull/26