### PR TITLE
Fix calculation of extra-data total size (1.6.x backport)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
         sudo add-apt-repository ppa:alexlarsson/glib260
         sudo apt-get update
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
-        libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
+        libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat meson libdbus-1-dev
@@ -83,7 +83,7 @@ jobs:
         sudo add-apt-repository ppa:alexlarsson/glib260
         sudo apt-get update
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
-        libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
+        libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang
@@ -109,7 +109,7 @@ jobs:
         sudo add-apt-repository ppa:alexlarsson/flatpak
         sudo apt-get update
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
-        libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
+        libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,40 @@
+# vi: ts=2 sw=2 et:
+
+extraction:
+  cpp:
+    prepare:
+      # package list copied from .github/workflows/check.yml
+      packages:
+        - libglib2.0
+        - attr
+        - automake
+        - gettext
+        - autopoint
+        - bison
+        - dbus
+        - gtk-doc-tools
+        - libfuse-dev
+        - ostree
+        - libostree-dev
+        - libarchive-dev
+        - libcap-dev
+        - libattr1-dev
+        - libdw-dev
+        - libelf-dev
+        - python3-pyparsing
+        - libjson-glib-dev
+        - shared-mime-info
+        - desktop-file-utils
+        - libpolkit-agent-1-dev
+        - libpolkit-gobject-1-dev
+        - libseccomp-dev
+        - libsoup2.4-dev
+        - libsystemd-dev
+        - libxml2-utils
+        - libgpgme11-dev
+        - gobject-introspection
+        - libgirepository1.0-dev
+        - libappstream-glib-dev
+        - libdconf-dev
+        - socat
+        - libdbus-1-dev

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4942,7 +4942,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   g_assert (results == NULL || rev != NULL);
 
   /* ostree-metadata and appstreams never have extra data, so ignore those */
-  if (g_str_has_prefix ("app/", ref) || g_str_has_prefix ("runtime/", ref))
+  if (g_str_has_prefix (ref, "app/") || g_str_has_prefix (ref, "runtime/"))
     {
       extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
       if (extra_data_sources == NULL)


### PR DESCRIPTION
This is a bug introduced in b03916f5bdf878ba42af7ccf569233b839d4b3d2
where we check the extra_data refs against app/ or runtime/ prefix with
arguments in the wrong order.

(cherry picked from commit ed3ba39a06d47d384a50e3a6264d411f3bf20a5d)

This is a backport of the fix noticed in https://github.com/flatpak/flatpak/pull/3482