### PR TITLE
transaction: Install authenticators before operations that require them

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -512,6 +512,10 @@ webflow_start (FlatpakTransaction *transaction,
   const char *browser;
   g_autoptr(GError) local_error = NULL;
   const char *args[3] = { NULL, url, NULL };
+  gboolean raw_enabled = flatpak_is_raw_mode_enabled ();
+
+  if (raw_enabled)
+    flatpak_disable_raw_mode ();
 
   if (!self->disable_interaction)
     {
@@ -543,6 +547,9 @@ webflow_start (FlatpakTransaction *transaction,
 
   g_print ("Waiting for browser...\n");
 
+  if (raw_enabled)
+    flatpak_enable_raw_mode ();
+
   return TRUE;
 }
 
@@ -563,9 +570,13 @@ basic_auth_start (FlatpakTransaction *transaction,
 {
   FlatpakCliTransaction *self = FLATPAK_CLI_TRANSACTION (transaction);
   char *user, *password;
+  gboolean raw_enabled = flatpak_is_raw_mode_enabled ();
 
   if (self->disable_interaction)
     return FALSE;
+
+  if (raw_enabled)
+    flatpak_disable_raw_mode ();
 
   g_print (_("Login required remote %s (realm %s)\n"), remote, realm);
   user = flatpak_prompt (FALSE, _("User"));
@@ -575,6 +586,9 @@ basic_auth_start (FlatpakTransaction *transaction,
   password = flatpak_password_prompt (_("Password"));
   if (password == NULL)
     return FALSE;
+
+  if (raw_enabled)
+    flatpak_enable_raw_mode ();
 
   flatpak_transaction_complete_basic_auth (transaction, id, user, password, NULL);
   return TRUE;

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -969,8 +969,8 @@ gboolean flatpak_dir_find_latest_rev (FlatpakDir               *self,
                                       GFile                   **out_sideload_path,
                                       GCancellable             *cancellable,
                                       GError                  **error);
-GPtrArray * flatpak_dir_find_remote_auto_install_refs (FlatpakDir         *self,
-                                                       const char         *remote_name);
+char * flatpak_dir_find_remote_auto_install_authenticator_ref (FlatpakDir         *self,
+                                                               const char         *remote_name);
 
 typedef struct
 {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13792,22 +13792,23 @@ flatpak_dir_find_local_related (FlatpakDir   *self,
   return g_steal_pointer (&related);
 }
 
-GPtrArray *
-flatpak_dir_find_remote_auto_install_refs (FlatpakDir         *self,
-                                           const char         *remote_name)
+char *
+flatpak_dir_find_remote_auto_install_authenticator_ref (FlatpakDir         *self,
+                                                        const char         *remote_name)
 {
-  GPtrArray *auto_install_refs = g_ptr_array_new_with_free_func ((GDestroyNotify) g_free);
   g_autofree char *authenticator_name = NULL;
   g_autofree char *authenticator_ref = NULL;
 
   authenticator_name = flatpak_dir_get_remote_install_authenticator_name (self, remote_name);
-  if (authenticator_name != NULL)
-    authenticator_ref = g_strdup_printf ("app/%s/%s/autoinstall", authenticator_name, flatpak_get_arch ());
+  if (authenticator_name == NULL)
+    return NULL;
+
+  authenticator_ref = g_strdup_printf ("app/%s/%s/autoinstall", authenticator_name, flatpak_get_arch ());
 
   if (authenticator_ref)
-    g_ptr_array_add (auto_install_refs, g_steal_pointer (&authenticator_ref));
+    return g_steal_pointer (&authenticator_ref);
 
-  return auto_install_refs;
+  return NULL;
 }
 
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -63,6 +63,7 @@ void flatpak_show_cursor (void);
 
 void flatpak_enable_raw_mode (void);
 void flatpak_disable_raw_mode (void);
+gboolean flatpak_is_raw_mode_enabled (void);
 
 /* https://bugzilla.gnome.org/show_bug.cgi?id=766370 */
 #if !GLIB_CHECK_VERSION (2, 49, 3)

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6727,6 +6727,16 @@ flatpak_disable_raw_mode (void)
   tcsetattr (STDIN_FILENO, TCSAFLUSH, &raw);
 }
 
+gboolean
+flatpak_is_raw_mode_enabled (void)
+{
+  struct termios raw;
+
+  tcgetattr (STDIN_FILENO, &raw);
+
+  return (raw.c_lflag & (ECHO | ICANON)) == 0;
+}
+
 /* Wrapper that uses ostree_repo_resolve_collection_ref() and on failure falls
  * back to using ostree_repo_resolve_rev() for backwards compatibility. This
  * means we support refs/heads/, refs/remotes/, and refs/mirrors/. */


### PR DESCRIPTION
Resolves #3497 

Instead of checking if we have all of the required tokens before starting the transaction (and failing because the authenticator may not be installed yet), ensure that downloads that require tokens are sorted after any relevant authenticator installs, and then check for tokens right before downloading the ref that requires it.

Due to the fact that any webflows or auth now happen during the transaction, rather than before, this required some minor modifications to the `flatpak` CLI tool to disable raw mode before asking for any user input.

Additionally, I renamed `flatpak_dir_find_remote_auto_install_refs` as this was currently only being used for the authenticator autoinstall and I feel as though authenticators need some special handling due to this issue.

I appreciate that this PR may not be great as I'm not highly familiar with the inner workings of flatpak and I don't often write code in C, but I wanted to provide a starting point towards solving the linked issue I opened and I'm very open to feedback and constructive criticism.

Thanks!