### PR TITLE
extra-data: Simplify extra-data progress setup

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -212,7 +212,7 @@ install_from (FlatpakDir *dir,
     {
       g_autoptr(SoupSession) soup_session = NULL;
       soup_session = flatpak_create_soup_session (PACKAGE_STRING);
-      file_data = flatpak_load_http_uri (soup_session, filename, 0, NULL, NULL, NULL, cancellable, error);
+      file_data = flatpak_load_uri (soup_session, filename, 0, NULL, NULL, NULL, cancellable, error);
       if (file_data == NULL)
         {
           g_prefix_error (error, "Can't load uri %s: ", filename);

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -226,14 +226,15 @@ load_options (const char *remote_name,
   g_autoptr(GBytes) bytes = NULL;
 
   if (g_str_has_prefix (filename, "http:") ||
-      g_str_has_prefix (filename, "https:"))
+      g_str_has_prefix (filename, "https:") ||
+      g_str_has_prefix (filename, "file:"))
     {
       const char *options_data;
       gsize options_size;
       g_autoptr(SoupSession) soup_session = NULL;
 
       soup_session = flatpak_create_soup_session (PACKAGE_STRING);
-      bytes = flatpak_load_http_uri (soup_session, filename, 0, NULL, NULL, NULL, NULL, &local_error);
+      bytes = flatpak_load_uri (soup_session, filename, 0, NULL, NULL, NULL, NULL, &local_error);
 
       if (bytes == NULL)
         {

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -165,7 +165,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
     }
   else
     {
-      commit_v = flatpak_dir_fetch_remote_commit (preferred_dir, remote, ref, opt_commit, &commit, cancellable, error);
+      commit_v = flatpak_dir_fetch_remote_commit (preferred_dir, remote, ref, opt_commit, NULL, &commit, cancellable, error);
       if (commit_v == NULL)
         return FALSE;
     }
@@ -344,7 +344,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
               g_autoptr(GVariant) p_commit_v = NULL;
               VarCommitRef p_commit;
 
-              p_commit_v = flatpak_dir_fetch_remote_commit (preferred_dir, remote, ref, p, NULL, cancellable, NULL);
+              p_commit_v = flatpak_dir_fetch_remote_commit (preferred_dir, remote, ref, p, NULL, NULL, cancellable, NULL);
               if (p_commit_v == NULL)
                 break;
 
@@ -465,7 +465,7 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
           c_v = NULL;
 
           if (c && opt_log)
-            c_v = flatpak_dir_fetch_remote_commit (preferred_dir, remote, ref, c, NULL, cancellable, NULL);
+            c_v = flatpak_dir_fetch_remote_commit (preferred_dir, remote, ref, c, NULL, NULL, cancellable, NULL);
         }
       while (c_v != NULL);
     }

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -167,6 +167,7 @@ GVariant *flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
                                                 FlatpakDir         *dir,
                                                 const char         *ref,
                                                 const char         *commit,
+                                                const char         *token,
                                                 GError            **error);
 void flatpak_remote_state_add_sideload_repo (FlatpakRemoteState *self,
                                              const char          *path);
@@ -887,6 +888,7 @@ GVariant * flatpak_dir_fetch_remote_commit (FlatpakDir   *self,
                                             const char   *remote_name,
                                             const char   *ref,
                                             const char   *opt_commit,
+                                            const char   *token,
                                             char        **out_commit,
                                             GCancellable *cancellable,
                                             GError      **error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -142,6 +142,7 @@ static GBytes * flatpak_dir_fetch_remote_object (FlatpakDir   *self,
                                                  const char   *remote_name,
                                                  const char   *checksum,
                                                  const char   *type,
+                                                 const char   *token,
                                                  GCancellable *cancellable,
                                                  GError      **error);
 
@@ -671,6 +672,7 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
                                       FlatpakDir         *dir,
                                       const char         *ref,
                                       const char         *commit,
+                                      const char         *token,
                                       GError            **error)
 {
   g_autoptr(GBytes) commit_bytes = NULL;
@@ -690,7 +692,7 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
     }
 
   commit_bytes = flatpak_dir_fetch_remote_object (dir, self->remote_name,
-                                                  commit, "commit",
+                                                  commit, "commit", token,
                                                   NULL, error);
   if (commit_bytes == NULL)
     return NULL;
@@ -4611,7 +4613,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   /* ostree-metadata and appstreams never have extra data, so ignore those */
   if (g_str_has_prefix (ref, "app/") || g_str_has_prefix (ref, "runtime/"))
     {
-      g_autoptr(GVariant) commitv = flatpak_remote_state_load_ref_commit (state, self, ref, rev, error);
+      g_autoptr(GVariant) commitv = flatpak_remote_state_load_ref_commit (state, self, ref, rev, token, error);
       if (commitv == NULL)
         return FALSE;
 
@@ -13080,6 +13082,7 @@ flatpak_dir_fetch_remote_object (FlatpakDir   *self,
                                  const char   *remote_name,
                                  const char   *checksum,
                                  const char   *type,
+                                 const char   *token,
                                  GCancellable *cancellable,
                                  GError      **error)
 {
@@ -13099,7 +13102,7 @@ flatpak_dir_fetch_remote_object (FlatpakDir   *self,
 
   object_url = g_build_filename (base_url, "objects", part1, part2, NULL);
 
-  bytes = flatpak_load_uri (self->soup_session, object_url, 0, NULL,
+  bytes = flatpak_load_uri (self->soup_session, object_url, 0, token,
                             NULL, NULL,
                             cancellable, error);
   if (bytes == NULL)
@@ -13113,6 +13116,7 @@ flatpak_dir_fetch_remote_commit (FlatpakDir   *self,
                                  const char   *remote_name,
                                  const char   *ref,
                                  const char   *opt_commit,
+                                 const char   *token,
                                  char        **out_commit,
                                  GCancellable *cancellable,
                                  GError      **error)
@@ -13143,7 +13147,7 @@ flatpak_dir_fetch_remote_commit (FlatpakDir   *self,
     }
 
   commit_bytes = flatpak_dir_fetch_remote_object (self, remote_name,
-                                                  opt_commit, "commit",
+                                                  opt_commit, "commit", token,
                                                   cancellable, error);
   if (commit_bytes == NULL)
     return NULL;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4744,9 +4744,9 @@ flatpak_dir_pull_extra_data (FlatpakDir          *self,
       else
         {
           ensure_soup_session (self);
-          bytes = flatpak_load_http_uri (self->soup_session, extra_data_uri, 0, NULL,
-                                         extra_data_progress_report, progress,
-                                         cancellable, error);
+          bytes = flatpak_load_uri (self->soup_session, extra_data_uri, 0, NULL,
+                                    extra_data_progress_report, progress,
+                                    cancellable, error);
         }
 
       if (bytes == NULL)
@@ -13099,9 +13099,9 @@ flatpak_dir_fetch_remote_object (FlatpakDir   *self,
 
   object_url = g_build_filename (base_url, "objects", part1, part2, NULL);
 
-  bytes = flatpak_load_http_uri (self->soup_session, object_url, 0, NULL,
-                                 NULL, NULL,
-                                 cancellable, error);
+  bytes = flatpak_load_uri (self->soup_session, object_url, 0, NULL,
+                            NULL, NULL,
+                            cancellable, error);
   if (bytes == NULL)
     return NULL;
 

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -318,11 +318,11 @@ remote_load_file (SoupSession  *soup_session,
     }
 
   uri_s = soup_uri_to_string (uri, FALSE);
-  bytes = flatpak_load_http_uri (soup_session,
-                                 uri_s, FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
-                                 token,
-                                 NULL, NULL,
-                                 cancellable, error);
+  bytes = flatpak_load_uri (soup_session,
+                            uri_s, FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
+                            token,
+                            NULL, NULL,
+                            cancellable, error);
   if (bytes == NULL)
     return NULL;
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2696,11 +2696,14 @@ resolve_ops (FlatpakTransaction *self,
           /* First try to resolve via metadata (if remote is available and its metadata matches the commit version) */
           if (!try_resolve_op_from_metadata (self, op, checksum, sideload_path, state))
             {
-              /* Else try to load the commit object */
+              /* Else try to load the commit object.
+               * Note, we don't have a token here, so this will not work for authenticated apps.
+               * However they still work when in summary metadata or sideloaded. */
               g_autoptr(GVariant) commit_data = NULL;
 
               commit_data = flatpak_remote_state_load_ref_commit (state, priv->dir,
-                                                                  op->ref, checksum, error);
+                                                                  op->ref, checksum, /* token: */ NULL,
+                                                                  error);
               if (commit_data == NULL)
                 return FALSE;
 

--- a/common/flatpak-utils-http-private.h
+++ b/common/flatpak-utils-http-private.h
@@ -36,14 +36,14 @@ typedef enum {
 typedef void (*FlatpakLoadUriProgress) (guint64  downloaded_bytes,
                                         gpointer user_data);
 
-GBytes * flatpak_load_http_uri (SoupSession           *soup_session,
-                                const char            *uri,
-                                FlatpakHTTPFlags       flags,
-                                const char            *token,
-                                FlatpakLoadUriProgress progress,
-                                gpointer               user_data,
-                                GCancellable          *cancellable,
-                                GError               **error);
+GBytes * flatpak_load_uri (SoupSession           *soup_session,
+                           const char            *uri,
+                           FlatpakHTTPFlags       flags,
+                           const char            *token,
+                           FlatpakLoadUriProgress progress,
+                           gpointer               user_data,
+                           GCancellable          *cancellable,
+                           GError               **error);
 gboolean flatpak_download_http_uri (SoupSession           *soup_session,
                                     const char            *uri,
                                     FlatpakHTTPFlags       flags,

--- a/tests/test-auth.sh
+++ b/tests/test-auth.sh
@@ -41,10 +41,7 @@ mark_need_token () {
 
 assert_failed_with_401 () {
     LOGFILE=${1:-install-error-log}
-    # Unfortunately we don't properly return the 401 error in the p2p case...
-    if [ x${USE_COLLECTIONS_IN_CLIENT-} != xyes ] ; then
-        assert_file_has_content $LOGFILE "401"
-    fi
+    assert_file_has_content $LOGFILE "401"
 }
 
 # Mark as need token, even though the app doesn't have token-type set


### PR DESCRIPTION
We need to get the commit object to setup the extra-data progress information,
and this is currently done using a complex pull operation to a temporary
repo. According to https://github.com/flatpak/flatpak/issues/3515 it
even causes an unecessary download of the summary in some cases.

Now that we don't need to support p2p we can instead directly download
the commit object using a simple http operation (or from the sideload
repos), as we know the commit id at this point anyway.