### PR TITLE
Fix "Can't pull from untrusted non-gpg verified remote" error

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3146,7 +3146,7 @@ flatpak_dir_migrate_config (FlatpakDir   *self,
         }
 
       if (changed != NULL)
-        *changed = FALSE;
+        *changed = TRUE;
     }
 
   return TRUE;

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2874,8 +2874,6 @@ flatpak_parse_repofile (const char   *remote_name,
       g_key_file_set_string (config, group, "collection-id", collection_id);
     }
 
-  /* If a collection ID is set, refs are verified from commit metadata rather
-   * than the summary file. */
   g_key_file_set_boolean (config, group, "gpg-verify-summary",
                           (gpg_key != NULL));
 


### PR DESCRIPTION
A fix for https://github.com/flatpak/flatpak/issues/3496