### PR TITLE
Revert "extra-data: Simplify extra-data progress setup"

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4647,11 +4647,40 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   /* ostree-metadata and appstreams never have extra data, so ignore those */
   if (g_str_has_prefix (ref, "app/") || g_str_has_prefix (ref, "runtime/"))
     {
-      g_autoptr(GVariant) commitv = flatpak_remote_state_load_ref_commit (state, self, ref, rev, token, error);
-      if (commitv == NULL)
-        return FALSE;
+      extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
+      if (extra_data_sources == NULL)
+        {
+          /* This is a gigantic hack where we download the commit in a temporary transaction
+           * which we then abort after having read the result. We do this to avoid creating
+           * a partial commit in the local repo and a ref that points to it, because that
+           * causes ostree to not use static deltas.
+           * See https://github.com/flatpak/flatpak/issues/3412 for details.
+           */
 
-      extra_data_sources = flatpak_commit_get_extra_data_sources (commitv, NULL);
+          if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
+            return FALSE;
+
+          /* Pull the commits (and only the commits) to check for extra data
+           * again. Here we don't pass the progress because we don't want any
+           * reports coming out of it. */
+          if (!repo_pull (repo, state,
+                          NULL,
+                          ref,
+                          rev,
+                          sideload_repo,
+                          token,
+                          flatpak_flags,
+                          OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY,
+                          NULL,
+                          cancellable,
+                          error))
+            return FALSE;
+
+          extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
+
+          if (!ostree_repo_abort_transaction (repo, cancellable, error))
+            return FALSE;
+        }
     }
 
   n_extra_data = 0;


### PR DESCRIPTION
This reverts commit 6deb23a32231e1d88d45532130f4ffeb7d71cd54.

This commit has two unintended side effects:
1. It breaks progress bars
(https://github.com/flatpak/flatpak/issues/3448)
2. It causes us not to use static deltas