### PR TITLE
Added flatpak remote-modify reference

### DIFF
--- a/doc/flatpak-create-usb.xml
+++ b/doc/flatpak-create-usb.xml
@@ -202,6 +202,7 @@
 
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpak remote-modify</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-install</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>ostree-create-usb</refentrytitle><manvolnum>1</manvolnum></citerefentry>


### PR DESCRIPTION
`flatpak remote-modify --collection-id= ` can be use to set the collection ID of the remote server.
I spent quite a while trying to find how to set it, until I found this blog post:
https://blogs.gnome.org/mclasen/2018/08/26/about-flatpak-installations/