### PR TITLE
Re-fix progress

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4647,40 +4647,11 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
   /* ostree-metadata and appstreams never have extra data, so ignore those */
   if (g_str_has_prefix (ref, "app/") || g_str_has_prefix (ref, "runtime/"))
     {
-      extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
-      if (extra_data_sources == NULL)
-        {
-          /* This is a gigantic hack where we download the commit in a temporary transaction
-           * which we then abort after having read the result. We do this to avoid creating
-           * a partial commit in the local repo and a ref that points to it, because that
-           * causes ostree to not use static deltas.
-           * See https://github.com/flatpak/flatpak/issues/3412 for details.
-           */
+      g_autoptr(GVariant) commitv = flatpak_remote_state_load_ref_commit (state, self, ref, rev, token, error);
+      if (commitv == NULL)
+        return FALSE;
 
-          if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
-            return FALSE;
-
-          /* Pull the commits (and only the commits) to check for extra data
-           * again. Here we don't pass the progress because we don't want any
-           * reports coming out of it. */
-          if (!repo_pull (repo, state,
-                          NULL,
-                          ref,
-                          rev,
-                          sideload_repo,
-                          token,
-                          flatpak_flags,
-                          OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY,
-                          NULL,
-                          cancellable,
-                          error))
-            return FALSE;
-
-          extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, cancellable, NULL);
-
-          if (!ostree_repo_abort_transaction (repo, cancellable, error))
-            return FALSE;
-        }
+      extra_data_sources = flatpak_commit_get_extra_data_sources (commitv, NULL);
     }
 
   n_extra_data = 0;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5147,7 +5147,6 @@ flatpak_dir_pull (FlatpakDir                           *self,
                                      error))
     goto out;
 
-  /* Note, this has to start after setup_extra_data() because that also uses a transaction */
   if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
     goto out;
 

--- a/common/flatpak-progress.c
+++ b/common/flatpak-progress.c
@@ -118,6 +118,7 @@ struct _FlatpakProgress
   guint estimating             : 1;
   guint last_was_metadata      : 1;
   guint done                   : 1;
+  guint reported_overflow      : 1;
 };
 
 G_DEFINE_TYPE (FlatpakProgress, flatpak_progress, G_TYPE_OBJECT);
@@ -305,6 +306,14 @@ out:
   if (new_progress < self->progress && self->last_total == total)
     new_progress = self->progress;
   self->last_total = total;
+
+  if (new_progress > 100)
+    {
+      if (!self->reported_overflow)
+        g_debug ("Unexpectedly got > 100%% progress, limiting");
+      self->reported_overflow = TRUE;
+      new_progress = 100;
+    }
 
   g_free (self->status);
   self->status = g_string_free (buf, FALSE);


### PR DESCRIPTION
As documented in https://github.com/flatpak/flatpak/pull/3524 the recent change to flatpak_dir_setup_extra_data broke progress reporting and was reverted. This PR reverts the reverts and then fixes the underlying issue, which was a combination of flatpak using partial commit states when it was not needed and a bug in ostree when deltas and partial commits were combined (https://github.com/ostreedev/ostree/issues/2053).

The fix is twofold, first, avoid commitpartials when not needed. Secondly, limit progress to 100% in case we get erroneous behaviour from ostree.