### PR TITLE
Extra data size in summary

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -91,6 +91,7 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE "eol"
 #define FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE_REBASE "eolr"
 #define FLATPAK_SPARSE_CACHE_KEY_TOKEN_TYPE "tokt"
+#define FLATPAK_SPARSE_CACHE_KEY_EXTRA_DATA_SIZE "eds"
 
 typedef struct
 {

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -53,6 +53,9 @@
 #define FLATPAK_ANSI_ROW_N "\x1b[%d;1H"
 #define FLATPAK_ANSI_CLEAR "\x1b[0J"
 
+#define FLATPAK_XA_CACHE_VERSION 1
+/* version 1 added extra data download size */
+
 gboolean flatpak_set_tty_echo (gboolean echo);
 void flatpak_get_window_size (int *rows,
                               int *cols);

--- a/data/flatpak-variants.gv
+++ b/data/flatpak-variants.gv
@@ -57,3 +57,8 @@ type ContentRating {
  rating_type: string;
  ratings: 'Ratings [string] string;
 };
+
+type ExtraDataSize {
+ n_extra_data: littleendian uint32;
+ total_size: littleendian uint64;
+};


### PR DESCRIPTION
Avoid the extra commit download by storing the extra-data download size in the summary.