### PR TITLE
WIP: build: Bump libmalcontent dependency to 0.5.0 and drop deprecated API

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev
+        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev libaccountsservice-dev
     - name: Check out flatpak
       uses: actions/checkout@v1
       with:
@@ -50,8 +50,8 @@ jobs:
       run: |
         git clone https://gitlab.freedesktop.org/pwithnall/malcontent.git ./malcontent
         pushd ./malcontent
-        git checkout tags/0.4.0
-        meson setup --prefix=/usr _build
+        git checkout tags/0.9.0
+        meson setup --prefix=/usr -Dui=disabled _build
         ninja -C _build
         sudo ninja -C _build install
         popd

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7898,9 +7898,9 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
 
   manager = mct_manager_new (dbus_connection);
   app_filter = mct_manager_get_app_filter (manager, subject_uid,
-                                           MCT_GET_APP_FILTER_FLAGS_INTERACTIVE,
+                                           MCT_MANAGER_GET_VALUE_FLAGS_INTERACTIVE,
                                            cancellable, &local_error);
-  if (g_error_matches (local_error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_DISABLED))
+  if (g_error_matches (local_error, MCT_MANAGER_ERROR, MCT_MANAGER_ERROR_DISABLED))
     {
       g_debug ("Skipping parental controls check for %s since parental "
                "controls are disabled globally", ref);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3413,9 +3413,9 @@ check_parental_controls (FlatpakDecomposed *app_ref,
 
   manager = mct_manager_new (system_bus);
   app_filter = mct_manager_get_app_filter (manager, getuid (),
-                                           MCT_GET_APP_FILTER_FLAGS_INTERACTIVE,
+                                           MCT_MANAGER_GET_VALUE_FLAGS_INTERACTIVE,
                                            cancellable, &local_error);
-  if (g_error_matches (local_error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_DISABLED))
+  if (g_error_matches (local_error, MCT_MANAGER_ERROR, MCT_MANAGER_ERROR_DISABLED))
     {
       g_debug ("Skipping parental controls check for %s since parental "
                "controls are disabled globally", flatpak_decomposed_get_ref (app_ref));

--- a/configure.ac
+++ b/configure.ac
@@ -235,7 +235,7 @@ if test "x$with_systemd" != "xno"; then
 else
   have_libsystemd=no
 fi
-PKG_CHECK_MODULES([MALCONTENT], [malcontent-0 >= 0.4.0], [have_libmalcontent=yes], [have_libmalcontent=no])
+PKG_CHECK_MODULES([MALCONTENT], [malcontent-0 >= 0.5.0], [have_libmalcontent=yes], [have_libmalcontent=no])
 AS_IF([test "$have_libmalcontent" = "yes"],[
   AC_DEFINE([HAVE_LIBMALCONTENT], [1], [Define if libmalcontent is available])
 ])


### PR DESCRIPTION
A few error and flag enums changed with libmalcontent 0.5.0 and while
the old versions are supported for now, they will eventually be dropped
in libmalcontent. So bump flatpak’s libmalcontent dependency from 0.4 to
0.5 and use the new APIs in preparation.

Signed-off-by: Philip Withnall <withnall@endlessm.com>