### PR TITLE
Re-implement list_installed_refs_for_update() again

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -706,11 +706,6 @@ gboolean flatpak_dir_needs_update_for_commit_and_subpaths (FlatpakDir  *self,
                                                            const char  *ref,
                                                            const char  *target_commit,
                                                            const char **opt_subpaths);
-gboolean flatpak_dir_check_if_installed_ref_needs_update (FlatpakDir               *self,
-                                                          FlatpakRemoteState       *state,
-                                                          const char               *ref,
-                                                          GBytes                   *deploy_data,
-                                                          GCancellable             *cancellable);
 char * flatpak_dir_check_for_update (FlatpakDir               *self,
                                      FlatpakRemoteState       *state,
                                      const char               *ref,
@@ -943,10 +938,6 @@ GPtrArray * flatpak_dir_find_remote_related_for_metadata (FlatpakDir         *se
                                                           GKeyFile           *metakey,
                                                           GCancellable       *cancellable,
                                                           GError            **error);
-gboolean    flatpak_dir_check_installed_ref_missing_related_ref (FlatpakDir          *self,
-                                                                 FlatpakRemoteState  *state,
-                                                                 const gchar         *full_ref,
-                                                                 GCancellable        *cancellable);
 GPtrArray * flatpak_dir_find_remote_related (FlatpakDir         *dir,
                                              FlatpakRemoteState *state,
                                              const char         *ref,

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1070,7 +1070,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
         const char *ref = refs_app[i];
         if (ref_check_for_update (dir, ref, remote_states, cancellable))
           {
-            g_printerr ("adding update %s\n", ref);
+            g_debug ("%s: Installed ref %s needs update", G_STRFUNC, ref);
             FlatpakInstalledRef *installed_ref = get_ref (dir, ref, cancellable, NULL);
             if (installed_ref)
               g_ptr_array_add (updates, g_object_ref (installed_ref));
@@ -1085,7 +1085,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
         const char *ref = refs_runtime[i];
         if (ref_check_for_update (dir, ref, remote_states, cancellable))
           {
-            g_printerr ("adding update %s\n", ref);
+            g_debug ("%s: Installed ref %s needs update", G_STRFUNC, ref);
             FlatpakInstalledRef *installed_ref = get_ref (dir, ref, cancellable, NULL);
             if (installed_ref)
               g_ptr_array_add (updates, g_object_ref (installed_ref));

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3194,7 +3194,7 @@ sort_ops (FlatpakTransaction *self)
   priv->ops = NULL;
 
   /* First mark runnable all jobs that depend on nothing.
-     Note that this seesntially reverses the original list, so these
+     Note that this essentially reverses the original list, so these
      are in the same order as specified */
   for (l = remaining; l != NULL; l = next)
     {

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -174,6 +174,8 @@ FlatpakTransactionOperationType flatpak_transaction_operation_get_operation_type
 FLATPAK_EXTERN
 const char *                    flatpak_transaction_operation_get_ref (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
+FlatpakTransactionOperation *   flatpak_transaction_operation_get_related_to_op (FlatpakTransactionOperation *self);
+FLATPAK_EXTERN
 const char *                    flatpak_transaction_operation_get_remote (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
 GFile *                         flatpak_transaction_operation_get_bundle_path (FlatpakTransactionOperation *self);

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -872,6 +872,12 @@ gboolean flatpak_repo_resolve_rev (OstreeRepo    *repo,
                                    GCancellable  *cancellable,
                                    GError       **error);
 
+static inline void
+null_safe_g_object_unref (gpointer data)
+{
+  g_clear_object (&data);
+}
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 #endif /* __FLATPAK_UTILS_H__ */

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -198,7 +198,7 @@ tests/test-%.wrap:
 
 tests/runtime-repo: tests/make-test-runtime.sh flatpak
 	rm -rf tests/runtime-repo
-	PATH=$(abs_top_builddir):$${PATH} $(top_srcdir)/tests/make-test-runtime.sh tests/runtime-repo org.test.Platform master ""
+	PATH=$(abs_top_builddir):$${PATH} $(top_srcdir)/tests/make-test-runtime.sh tests/runtime-repo org.test.Platform master "" ""
 
 check_DATA += tests/runtime-repo
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -280,7 +280,7 @@ make_runtime () {
         (
             flock -s 200
             if [ ! -d ${RUNTIME_REPO} ]; then
-                $(dirname $0)/make-test-runtime.sh ${RUNTIME_REPO} org.test.Platform ${BRANCH} "" > /dev/null
+                $(dirname $0)/make-test-runtime.sh ${RUNTIME_REPO} org.test.Platform ${BRANCH} "" "" > /dev/null
             fi
         ) 200>${TEST_DATA_DIR}/runtime-repo-lock
     fi
@@ -385,7 +385,7 @@ setup_sdk_repo () {
     fi
     BRANCH=${3:-master}
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Sdk "${BRANCH}" "${COLLECTION_ID}" make mkdir cp touch > /dev/null
+    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" . $(dirname $0)/make-test-runtime.sh repos/${REPONAME} org.test.Sdk "${BRANCH}" "${COLLECTION_ID}" "" make mkdir cp touch > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -16,6 +16,9 @@ shift
 COLLECTION_ID=$1
 shift
 
+EXTRA="${1-}"
+shift
+
 mkdir ${DIR}/files
 mkdir ${DIR}/usr
 cat > ${DIR}/metadata <<EOF
@@ -73,6 +76,13 @@ for i in `cat $LIBS`; do
     cp "$i" ${DIR}/usr/lib/
 done
 ln -s bash ${DIR}/usr/bin/sh
+
+# This only exists so we can update the runtime
+cat > ${DIR}/usr/bin/runtime_hello.sh <<EOF
+#!/bin/sh
+echo "Hello world, from a runtime$EXTRA"
+EOF
+chmod a+x ${DIR}/usr/bin/runtime_hello.sh
 
 # We copy the C.UTF8 locale and call it en_US. Its a bit of a lie, but
 # the real en_US locale is often not available, because its in the

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -95,7 +95,7 @@ EOF
 
 mkdir -p repos
 ostree init --repo=repos/test --mode=archive-z2
-$(dirname $0)/make-test-runtime.sh repos/test org.test.Platform master "" bash ls cat echo readlink > /dev/null
+$(dirname $0)/make-test-runtime.sh repos/test org.test.Platform master "" "" bash ls cat echo readlink > /dev/null
 $(dirname $0)/make-test-app.sh repos/test "" master "" > /dev/null
 
 # Modify platform metadata

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1185,7 +1185,7 @@ test_update_related_refs (void)
                                        FLATPAK_REF_KIND_APP,
                                        "org.test.Hello",
                                        NULL, "master", NULL, NULL, NULL,
-				                               &error);
+                                       &error);
   G_GNUC_END_IGNORE_DEPRECATIONS
   g_assert_no_error (error);
   g_assert (FLATPAK_IS_INSTALLED_REF (iref));

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1906,21 +1906,7 @@ test_list_updates (void)
                       "hello-again.desktop;net.example.Goodbye.Again.desktop;");
 
   /* Uninstall the runtime and app */
-  transaction = flatpak_transaction_new_for_installation (inst, NULL, &error);
-  g_assert_no_error (error);
-  g_assert_nonnull (transaction);
-
-  res = flatpak_transaction_add_uninstall (transaction, app, &error);
-  g_assert_no_error (error);
-  g_assert_true (res);
-
-  res = flatpak_transaction_add_uninstall (transaction, runtime, &error);
-  g_assert_no_error (error);
-  g_assert_true (res);
-
-  res = flatpak_transaction_run (transaction, NULL, &error);
-  g_assert_no_error (error);
-  g_assert_true (res);
+  empty_installation (inst);
 }
 
 static void


### PR DESCRIPTION
This re-implements flatpak_installation_list_installed_refs_for_update() using FlatpakTransaction, which ensures it behaves consistently with the CLI. The impetus is that gnome-software uses this API, and tends to not show the same updates as `flatpak update`.