### PR TITLE
Add API to allow improved progress reporting in gnome-software

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -696,6 +696,27 @@ flatpak_transaction_operation_get_related_to_op (FlatpakTransactionOperation *se
 }
 
 /**
+ * flatpak_transaction_operation_get_is_skipped:
+ * @self: a #FlatpakTransactionOperation
+ *
+ * Gets whether this operation will be skipped when the transaction is run.
+ * Operations are skipped in some transaction situations, for example when an
+ * app has reached end of life and needs a rebase, or when it would have been
+ * updated but no update is available. By default, skipped
+ * operations are not returned by flatpak_transaction_get_operations() — but
+ * they can be accessed by traversing the operation graph using
+ * flatpak_transaction_operation_get_related_to_op().
+ *
+ * Returns: %TRUE if the operation has been marked as to skip, %FALSE otherwise
+ * Since: 1.7.3
+ */
+gboolean
+flatpak_transaction_operation_get_is_skipped (FlatpakTransactionOperation *self)
+{
+  return self->skip;
+}
+
+/**
  * flatpak_transaction_operation_get_remote:
  * @self: a #FlatpakTransactionOperation
  *

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -802,7 +802,7 @@ flatpak_transaction_operation_get_commit (FlatpakTransactionOperation *self)
  * This information is available when the transaction is resolved,
  * i.e. when #FlatpakTransaction::ready is emitted.
  *
- * Returns: the download size
+ * Returns: the download size, in bytes
  * Since: 1.1.2
  */
 guint64
@@ -826,7 +826,7 @@ flatpak_transaction_operation_get_download_size (FlatpakTransactionOperation *se
  * This information is available when the transaction is resolved,
  * i.e. when #FlatpakTransaction::ready is emitted.
  *
- * Returns: the installed size
+ * Returns: the installed size, in bytes
  * Since: 1.1.2
  */
 guint64

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -685,6 +685,10 @@ flatpak_transaction_operation_get_ref (FlatpakTransactionOperation *self)
  * runtime. In the case of a main app or something added to the transaction by
  * flatpak_transaction_add_ref(), %NULL will be returned.
  *
+ * Note that an op will be returned even if it’s marked as to be skipped when
+ * the transaction is run. Check that using
+ * flatpak_transaction_operation_get_is_skipped().
+ *
  * Returns: (transfer none) (nullable): the #FlatpakTransactionOperation this
  *   one is related to, or %NULL
  * Since: 1.7.3
@@ -875,7 +879,7 @@ flatpak_transaction_operation_get_old_metadata (FlatpakTransactionOperation *sel
  * flatpak_transaction_is_empty:
  * @self: a #FlatpakTransaction
  *
- * Returns whether the transaction contains any operations.
+ * Returns whether the transaction contains any non-skipped operations.
  *
  * Returns: %TRUE if the transaction is empty
  */
@@ -3271,7 +3275,7 @@ sort_ops (FlatpakTransaction *self)
  * flatpak_transaction_get_operations:
  * @self: a #FlatpakTransaction
  *
- * Gets the list of operations.
+ * Gets the list of operations. Skipped operations are not included.
  *
  * Returns: (transfer full) (element-type FlatpakTransactionOperation): a #GList of operations
  */

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -176,6 +176,8 @@ const char *                    flatpak_transaction_operation_get_ref (FlatpakTr
 FLATPAK_EXTERN
 FlatpakTransactionOperation *   flatpak_transaction_operation_get_related_to_op (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
+gboolean                        flatpak_transaction_operation_get_is_skipped (FlatpakTransactionOperation *self);
+FLATPAK_EXTERN
 const char *                    flatpak_transaction_operation_get_remote (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
 GFile *                         flatpak_transaction_operation_get_bundle_path (FlatpakTransactionOperation *self);


### PR DESCRIPTION
I’ve been working on improving the installation progress reporting in gnome-software, using `flatpak_transaction_operation_get_related_to_op()`, and could do with access to the `skip` field to be able to skip related-to ops.

This PR adds that, and contains a few unrelated misc tweaks.