### PR TITLE
flatpak-transaction: Change related_to_op to related_to_ops

### DIFF
--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -174,7 +174,7 @@ FlatpakTransactionOperationType flatpak_transaction_operation_get_operation_type
 FLATPAK_EXTERN
 const char *                    flatpak_transaction_operation_get_ref (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
-FlatpakTransactionOperation *   flatpak_transaction_operation_get_related_to_op (FlatpakTransactionOperation *self);
+GPtrArray *                     flatpak_transaction_operation_get_related_to_ops (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
 gboolean                        flatpak_transaction_operation_get_is_skipped (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -873,9 +873,9 @@ gboolean flatpak_repo_resolve_rev (OstreeRepo    *repo,
                                    GError       **error);
 
 static inline void
-null_safe_g_object_unref (gpointer data)
+null_safe_g_ptr_array_unref (gpointer data)
 {
-  g_clear_object (&data);
+  g_clear_pointer (&data, g_ptr_array_unref);
 }
 
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"


### PR DESCRIPTION
Since a single runtime (for example) can be related-to several apps,
that needs to be representable in the data format.

This is an API break, but only of API which has not been released yet.

See https://github.com/flatpak/flatpak/pull/3568#issuecomment-618251958

Signed-off-by: Philip Withnall <withnall@endlessm.com>