### PR TITLE
update: Restrict --commit to one app/runtime

### DIFF
--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -115,6 +115,10 @@ flatpak_builtin_update (int           argc,
       n_prefs = 1;
     }
 
+  /* It doesn't make sense to use the same commit for more than one thing */
+  if (opt_commit && n_prefs != 1)
+    return usage_error (context, _("With --commit, only one REF may be specified"), error);
+
   transactions = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 
   /* Walk through the array backwards so we can safely remove */


### PR DESCRIPTION
Currently if you run "flatpak update --commit=XYZ", we try to use that
commit for every installed thing, which doesn't make much sense. Make it
an error not to specify a ref with --commit.