### PR TITLE
Rename registered cgroups to have app- prefix

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1666,7 +1666,7 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
   if (!manager)
     goto out;
 
-  name = g_strdup_printf ("flatpak-%s-%d.scope", appid, getpid ());
+  name = g_strdup_printf ("apps-flatpak-%s-%d.scope", appid, getpid ());
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(sv)"));
 


### PR DESCRIPTION
The newly added https://systemd.io/DESKTOP_ENVIRONMENTS/ lists an XDG
defined specification for how cgroups for applications should be named.

This will allow flatpak's to correctly follow any drop-in's set for
applications on the system as well as help next-gen system monitor's
treat flatpaks as applications.

flatpak-session-helper.service is unaffected.