### PR TITLE
Use oci authenticator by default

### DIFF
--- a/common/flatpak-auth.c
+++ b/common/flatpak-auth.c
@@ -49,6 +49,10 @@ flatpak_auth_new_for_remote (FlatpakDir *dir,
       if (!ostree_repo_get_remote_option (repo, remote, FLATPAK_REMOTE_CONFIG_AUTHENTICATOR_NAME, NULL, &name, error))
         return NULL;
     }
+
+  if (name == NULL && flatpak_dir_get_remote_oci (dir, remote))
+    name = g_strdup ("org.flatpak.Authenticator.Oci");
+
   if (name == NULL || *name == 0 /* or if no repo */)
     {
       flatpak_fail (error, _("No authenticator configured for remote `%s`"), remote);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10683,6 +10683,11 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
         }
     }
 
+  if (flatpak_dir_get_remote_oci (self, remote_or_uri))
+    {
+      state->default_token_type = 1;
+    }
+
   if (state->summary != NULL) /* In the optional case we might not have a summary */
     {
       VarSummaryRef summary = var_summary_from_gvariant (state->summary);

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -1015,6 +1015,9 @@ flatpak_oci_registry_get_token (FlatpakOciRegistry *self,
 
   msg = soup_message_new_from_uri ("HEAD", uri);
 
+  soup_message_headers_replace (msg->request_headers, "Accept",
+                                FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST ", " FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2);
+
   stream = soup_session_send (self->soup_session, msg, NULL, error);
   if (stream == NULL)
     return NULL;

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -493,11 +493,16 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
     {
       g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
 
+      g_debug ("Trying anonymous authentication");
+
       first_token = get_token_for_ref (registry, ref_data, NULL, &error);
       if (first_token != NULL)
         have_auth = TRUE;
       else
-        g_clear_error (&error);
+        {
+          g_debug ("Anonymous authentication failed: %s", error->message);
+          g_clear_error (&error);
+        }
     }
 
   /* Prompt the user for credentials */
@@ -506,6 +511,8 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
       !no_interaction)
     {
       g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
+
+      g_debug ("Trying user/password based authentication");
 
       while (auth == NULL)
         {

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -105,11 +105,15 @@ tests/services/org.flatpak.Authenticator.test.service: tests/org.flatpak.Authent
 	mkdir -p tests/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)/tests|" $< > $@
 
+tests/services/org.flatpak.Authenticator.Oci.service: oci-authenticator/org.flatpak.Authenticator.Oci.service.in
+	mkdir -p tests/services
+	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" $< > $@
+
 tests/share/xdg-desktop-portal/portals/test.portal: tests/test.portal.in
 	mkdir -p tests/share/xdg-desktop-portal/portals
 	$(AM_V_GEN) install -m644 $< $@
 
-tests/libtest.sh: tests/services/org.freedesktop.Flatpak.service tests/services/org.freedesktop.Flatpak.SystemHelper.service tests/services/org.freedesktop.portal.Flatpak.service tests/share/xdg-desktop-portal/portals/test.portal tests/services/org.freedesktop.impl.portal.desktop.test.service tests/services/org.flatpak.Authenticator.test.service
+tests/libtest.sh: tests/services/org.freedesktop.Flatpak.service tests/services/org.freedesktop.Flatpak.SystemHelper.service tests/services/org.freedesktop.portal.Flatpak.service tests/share/xdg-desktop-portal/portals/test.portal tests/services/org.freedesktop.impl.portal.desktop.test.service tests/services/org.flatpak.Authenticator.test.service tests/services/org.flatpak.Authenticator.Oci.service
 
 install-test-data-hook:
 if ENABLE_INSTALLED_TESTS
@@ -223,6 +227,7 @@ DISTCLEANFILES += \
 	tests/services/org.freedesktop.portal.Flatpak.service \
 	tests/services/org.freedesktop.impl.portal.desktop.test.service \
 	tests/services/org.flatpak.Authenticator.test.service \
+	tests/services/org.flatpak.Authenticator.Oci.service \
 	tests/share/xdg-desktop-portal/portals/test.portal \
 	tests/package_version.txt \
 	$(NULL)

--- a/tests/oci-registry-server.py
+++ b/tests/oci-registry-server.py
@@ -135,6 +135,9 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             else:
                 self.wfile.write(response_string.encode('utf-8'))
 
+    def do_HEAD(self):
+        return self.do_GET()
+
     def do_POST(self):
         if self.check_route('/testing/@repo_name/@tag'):
             repo_name = self.matches['repo_name']


### PR DESCRIPTION
Unless otherwise specified use the oci authenticator with default token type 1 for all OCI remotes.

This makes a lot of sense as it allows e.g. use of docker hub (with anonymous login, which we default too if it works).

@owtaylor Opinions?