### PR TITLE
tokens: Request tokens during resolve if we get 401 status

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4295,7 +4295,7 @@ flatpak_dir_update_oci_index (FlatpakDir   *self,
                                         index_cache, index_uri_out,
                                         cancellable, &local_error))
     {
-      if (!g_error_matches (local_error, FLATPAK_OCI_ERROR, FLATPAK_OCI_ERROR_NOT_CHANGED))
+      if (!g_error_matches (local_error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_NOT_CHANGED))
         {
           g_propagate_error (error, g_steal_pointer (&local_error));
           return NULL;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -800,7 +800,7 @@ flatpak_remote_state_fetch_commit_object_oci (FlatpakRemoteState *self,
                                      metadata_builder);
 
 
-  if (strcmp (manifest_ref, ref) != 0)
+  if (g_strcmp0 (manifest_ref, ref) != 0)
     {
       flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Commit has no requested ref ‘%s’ in ref binding metadata"),  ref);
       return NULL;

--- a/common/flatpak-oci-registry-private.h
+++ b/common/flatpak-oci-registry-private.h
@@ -43,14 +43,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakOciRegistry, g_object_unref)
 
 GType flatpak_oci_layer_writer_get_type (void);
 
-typedef enum {
-  FLATPAK_OCI_ERROR_NOT_CHANGED = 0,
-} FlatpakOciErrorEnum;
-
-#define FLATPAK_OCI_ERROR flatpak_oci_error_quark ()
-
-FLATPAK_EXTERN GQuark  flatpak_oci_error_quark (void);
-
 typedef struct FlatpakOciLayerWriter FlatpakOciLayerWriter;
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakOciLayerWriter, g_object_unref)

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -32,8 +32,6 @@
 #include "flatpak-utils-private.h"
 #include "flatpak-dir-private.h"
 
-G_DEFINE_QUARK (flatpak_oci_error, flatpak_oci_error)
-
 #define MAX_JSON_SIZE (1024 * 1024)
 
 typedef struct archive FlatpakAutoArchiveWrite;
@@ -2212,7 +2210,7 @@ flatpak_oci_index_ensure_cached (SoupSession  *soup_session,
                                     cancellable, &local_error);
 
   if (success ||
-      g_error_matches (local_error, FLATPAK_OCI_ERROR, FLATPAK_OCI_ERROR_NOT_CHANGED))
+      g_error_matches (local_error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_NOT_CHANGED))
     {
       if (index_uri_out)
         *index_uri_out = soup_uri_to_string (base_uri, FALSE);
@@ -2488,7 +2486,7 @@ add_icon_image (SoupSession  *soup_session,
                                    icons_dfd, icon_path,
                                    NULL, NULL,
                                    cancellable, &local_error) &&
-          !g_error_matches (local_error, FLATPAK_OCI_ERROR, FLATPAK_OCI_ERROR_NOT_CHANGED))
+          !g_error_matches (local_error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_NOT_CHANGED))
         {
           g_propagate_error (error, g_steal_pointer (&local_error));
           return FALSE;

--- a/common/flatpak-utils-http-private.h
+++ b/common/flatpak-utils-http-private.h
@@ -27,6 +27,7 @@
 
 typedef enum {
   FLATPAK_HTTP_ERROR_NOT_CHANGED = 0,
+  FLATPAK_HTTP_ERROR_UNAUTHORIZED = 1,
 } FlatpakHttpErrorEnum;
 
 #define FLATPAK_HTTP_ERROR flatpak_http_error_quark ()

--- a/common/flatpak-utils-http-private.h
+++ b/common/flatpak-utils-http-private.h
@@ -25,6 +25,15 @@
 
 #include <libsoup/soup.h>
 
+typedef enum {
+  FLATPAK_HTTP_ERROR_NOT_CHANGED = 0,
+} FlatpakHttpErrorEnum;
+
+#define FLATPAK_HTTP_ERROR flatpak_http_error_quark ()
+
+FLATPAK_EXTERN GQuark  flatpak_http_error_quark (void);
+
+
 SoupSession * flatpak_create_soup_session (const char *user_agent);
 
 typedef enum {

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -437,6 +437,11 @@ load_uri_callback (GObject      *source_object,
           code = FLATPAK_HTTP_ERROR_NOT_CHANGED;
           break;
 
+        case 401:
+          domain = FLATPAK_HTTP_ERROR;
+          code = FLATPAK_HTTP_ERROR_UNAUTHORIZED;
+          break;
+
         case 403:
         case 404:
         case 410:

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -31,6 +31,8 @@
 /* copied from libostree */
 #define DEFAULT_N_NETWORK_RETRIES 5
 
+G_DEFINE_QUARK (flatpak_http_error, flatpak_http_error)
+
 typedef struct
 {
   char  *uri;
@@ -431,8 +433,8 @@ load_uri_callback (GObject      *source_object,
           if (data->cache_data)
             set_cache_http_data_from_headers (data->cache_data, msg);
 
-          domain = FLATPAK_OCI_ERROR;
-          code = FLATPAK_OCI_ERROR_NOT_CHANGED;
+          domain = FLATPAK_HTTP_ERROR;
+          code = FLATPAK_HTTP_ERROR_NOT_CHANGED;
           break;
 
         case 403:
@@ -887,8 +889,8 @@ flatpak_cache_http_uri_once (SoupSession           *soup_session,
       if (cache_data->expires > now.tv_sec)
         {
           if (error)
-            *error = g_error_new (FLATPAK_OCI_ERROR,
-                                  FLATPAK_OCI_ERROR_NOT_CHANGED,
+            *error = g_error_new (FLATPAK_HTTP_ERROR,
+                                  FLATPAK_HTTP_ERROR_NOT_CHANGED,
                                   "Reusing cached value");
           return FALSE;
         }
@@ -949,8 +951,8 @@ flatpak_cache_http_uri_once (SoupSession           *soup_session,
 
   if (data.error)
     {
-      if (data.error->domain == FLATPAK_OCI_ERROR &&
-          data.error->code == FLATPAK_OCI_ERROR_NOT_CHANGED)
+      if (data.error->domain == FLATPAK_HTTP_ERROR &&
+          data.error->code == FLATPAK_HTTP_ERROR_NOT_CHANGED)
         {
           GError *tmp_error = NULL;
 


### PR DESCRIPTION
If downloading a specific commit (or oci manifest) we may get a 401 back.
If so, request a token and try again. In this case we don't yet know the
token type, so pass MAXINT32 for "don't know".
