### PR TITLE
Make xa.redirect-url handling configurable

### DIFF
--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -56,6 +56,7 @@ static char **opt_gpg_import;
 static char *opt_authenticator_name = NULL;
 static char **opt_authenticator_options = NULL;
 static gboolean opt_authenticator_install = -1;
+static gboolean opt_no_follow_redirect;
 
 static GOptionEntry add_options[] = {
   { "if-not-exists", 0, 0, G_OPTION_ARG_NONE, &opt_if_not_exists, N_("Do nothing if the provided remote exists"), NULL },
@@ -82,6 +83,7 @@ static GOptionEntry common_options[] = {
   { "authenticator-option", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_authenticator_options, N_("Authenticator option"), N_("KEY=VALUE") },
   { "authenticator-install", 0, 0, G_OPTION_ARG_NONE, &opt_authenticator_install, N_("Autoinstall authenticator"), NULL },
   { "no-authenticator-install", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_authenticator_install, N_("Don't autoinstall authenticator"), NULL },
+  { "no-follow_redirect", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_no_follow_redirect, N_("Don't follow the redirect set in the summary file"), NULL },
   { NULL }
 };
 
@@ -210,6 +212,9 @@ get_config_from_opts (GKeyFile *config,
             g_key_file_set_string (config, group, key, split[1]);
         }
     }
+
+  if (opt_no_follow_redirect)
+    g_key_file_set_boolean (config, group, "url-is-set", TRUE);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-remote-modify.c
+++ b/app/flatpak-builtins-remote-modify.c
@@ -124,7 +124,10 @@ get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *change
       if (g_str_has_prefix (opt_url, "metalink="))
         g_key_file_set_string (config, group, "metalink", opt_url + strlen ("metalink="));
       else
-        g_key_file_set_string (config, group, "url", opt_url);
+        {
+          g_key_file_set_string (config, group, "url", opt_url);
+          g_key_file_set_boolean (config, group, "url-is-set", TRUE);
+        }
       *changed = TRUE;
     }
 

--- a/app/flatpak-builtins-remote-modify.c
+++ b/app/flatpak-builtins-remote-modify.c
@@ -43,6 +43,8 @@ static gboolean opt_enable;
 static gboolean opt_update_metadata;
 static gboolean opt_disable;
 static gboolean opt_no_filter;
+static gboolean opt_do_follow_redirect;
+static gboolean opt_no_follow_redirect;
 static int opt_prio = -1;
 static char *opt_filter;
 static char *opt_title;
@@ -89,6 +91,8 @@ static GOptionEntry common_options[] = {
   { "authenticator-option", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_authenticator_options, N_("Authenticator options"), N_("KEY=VALUE") },
   { "authenticator-install", 0, 0, G_OPTION_ARG_NONE, &opt_authenticator_install, N_("Autoinstall authenticator"), NULL },
   { "no-authenticator-install", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_authenticator_install, N_("Don't autoinstall authenticator"), NULL },
+  { "follow-redirect", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_do_follow_redirect, N_("Follow the redirect set in the summary file"), NULL },
+  { "no-follow-redirect", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_no_follow_redirect, N_("Don't follow the redirect set in the summary file"), NULL },
   { NULL }
 };
 
@@ -253,6 +257,18 @@ get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *change
           else
             g_key_file_set_string (config, group, key, split[1]);
         }
+      *changed = TRUE;
+    }
+
+  if (opt_do_follow_redirect)
+    {
+      g_key_file_set_boolean (config, group, "url-is-set", FALSE);
+      *changed = TRUE;
+    }
+
+  if (opt_no_follow_redirect)
+    {
+      g_key_file_set_boolean (config, group, "url-is-set", TRUE);
       *changed = TRUE;
     }
 

--- a/doc/flatpak-remote-add.xml
+++ b/doc/flatpak-remote-add.xml
@@ -280,6 +280,14 @@ allow org.signal.Signal.*/*/stable
             </varlistentry>
 
             <varlistentry>
+                <term><option>--no-follow-redirect</option></term>
+
+                <listitem><para>
+                    Do not follow xa.redirect-url defined in the summary file.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -302,6 +302,22 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--follow-redirect</option></term>
+
+                <listitem><para>
+                    Follow xa.redirect-url defined in the summary file.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--no-follow-redirect</option></term>
+
+                <listitem><para>
+                    Do not follow xa.redirect-url defined in the summary file.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 


### PR DESCRIPTION
Assume that if user explicitly modifies the URL, they want to keep
using that URL instead of having it overwritten by xa.redirect-url.

Add switches to remote-add and remote-modify for uniformity.