### PR TITLE
Systemd unit name

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1623,17 +1623,20 @@ job_removed_cb (SystemdManager *manager,
 }
 
 static gchar *
-systemd_unit_name_escape (const gchar *in) {
+systemd_unit_name_escape (const gchar *in)
+{
   /* Adapted from systemd source */
   gchar * const ret = g_new (gchar, strlen (in) * 4 + 1);
   gchar *out = ret;
 
-  for (; *in; in++) {
-    if (g_ascii_isalnum (*in) || *in == ':' || *in == '_' || *in == '.')
-      *(out++) = *in;
-    else
-      out += g_snprintf (out, 4, "\\x%02x", *in);;
-  }
+  for (; *in; in++)
+    {
+      if (g_ascii_isalnum (*in) || *in == ':' || *in == '_' || *in == '.')
+        *(out++) = *in;
+      else
+        out += g_snprintf (out, 4, "\\x%02x", *in);
+      ;
+    }
 
   *out = 0;
   return ret;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1626,7 +1626,7 @@ static GString *
 systemd_unit_name_escape (const gchar *in)
 {
   /* Adapted from systemd source */
-  GString * const ret = g_string_sized_new (strlen (in) * 4 + 1);
+  GString * const ret = g_string_sized_new (strlen (in) * 4);
 
   for (; *in; in++)
     {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1622,20 +1622,20 @@ job_removed_cb (SystemdManager *manager,
     g_main_loop_quit (data->main_loop);
 }
 
-static GString *
+static gchar *
 systemd_unit_name_escape (const gchar *in)
 {
   /* Adapted from systemd source */
-  GString * const ret = g_string_sized_new (strlen (in));
+  GString * const str = g_string_sized_new (strlen (in));
 
   for (; *in; in++)
     {
       if (g_ascii_isalnum (*in) || *in == ':' || *in == '_' || *in == '.')
-        g_string_append_c (ret, *in);
+        g_string_append_c (str, *in);
       else
-        g_string_append_printf (ret, "\\x%02x", *in);
+        g_string_append_printf (str, "\\x%02x", *in);
     }
-  return ret;
+  return g_string_free (str, FALSE);
 }
 
 gboolean
@@ -1645,7 +1645,7 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
   g_autofree char *path = NULL;
   g_autofree char *address = NULL;
   g_autofree char *name = NULL;
-  g_autoptr(GString) appid_escaped = NULL;
+  g_autofree char *appid_escaped = NULL;
   g_autofree char *job = NULL;
   SystemdManager *manager = NULL;
   GVariantBuilder builder;
@@ -1684,7 +1684,7 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
     goto out;
 
   appid_escaped = systemd_unit_name_escape (appid);
-  name = g_strdup_printf ("app-flatpak-%s-%d.scope", appid_escaped->str, getpid ());
+  name = g_strdup_printf ("app-flatpak-%s-%d.scope", appid_escaped, getpid ());
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(sv)"));
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1626,7 +1626,7 @@ static GString *
 systemd_unit_name_escape (const gchar *in)
 {
   /* Adapted from systemd source */
-  GString * const ret = g_string_sized_new (strlen (in) * 4);
+  GString * const ret = g_string_sized_new (strlen (in));
 
   for (; *in; in++)
     {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1666,7 +1666,7 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
   if (!manager)
     goto out;
 
-  name = g_strdup_printf ("apps-flatpak-%s-%d.scope", appid, getpid ());
+  name = g_strdup_printf ("app-flatpak-%s-%d.scope", appid, getpid ());
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(sv)"));
 


### PR DESCRIPTION
The systemd app prefix has changed from `apps-` to `app-` (https://github.com/systemd/systemd/pull/15647) (following https://github.com/flatpak/flatpak/pull/3589)

Also, special characters need to be escaped in systemd unit names, especially `-` which has a special meaning.