### PR TITLE
README: Link to Flathub discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ desktop applications on Linux.
 
 See https://flatpak.org/ for more information.
 
-Community discussion happens in [#flatpak on Freenode](ircs://chat.freenode.net/flatpak) and on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak).
+Community discussion happens in [#flatpak on Freenode](ircs://chat.freenode.net/flatpak), on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak), and on [the Flathub Discourse](https://discourse.flathub.org/).
 
 Read documentation for [Flatpak](http://docs.flatpak.org/en/latest/introduction.html), its [commandline tools](http://docs.flatpak.org/en/latest/flatpak-command-reference.html), and for the libflatpak [library API](http://flatpak.github.io/flatpak/reference/html/index.html).
 


### PR DESCRIPTION
We don't have a separate discourse for Flatpak; it seems fine to link to
the Flathub one.

Fixes https://github.com/flatpak/flatpak/issues/3602