### PR TITLE
remote-add: Don't make the repo existence optional

### DIFF
--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -287,7 +287,7 @@ flatpak_builtin_remote_add (int argc, char **argv,
   g_option_context_add_main_entries (context, common_options, NULL);
 
   if (!flatpak_option_context_parse (context, add_options, &argc, &argv,
-                                     FLATPAK_BUILTIN_FLAG_ONE_DIR | FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO,
+                                     FLATPAK_BUILTIN_FLAG_ONE_DIR,
                                      &dirs, cancellable, error))
     return FALSE;
 


### PR DESCRIPTION
A repository needs to exist for a remote to be written inside,
otherwise the OstreeRepo instance will be NULL and a crash will
occur once the instance is accessed.

Fixes #3612.