### PR TITLE
Clean up duplicated instance collection code

### DIFF
--- a/common/flatpak-instance-private.h
+++ b/common/flatpak-instance-private.h
@@ -26,4 +26,6 @@
 FlatpakInstance *flatpak_instance_new (const char *dir);
 FlatpakInstance *flatpak_instance_new_for_id (const char *id);
 
+void flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances);
+
 #endif /* __FLATPAK_INSTANCE_PRIVATE_H__ */

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -58,6 +58,7 @@
 #include "flatpak-proxy.h"
 #include "flatpak-utils-base-private.h"
 #include "flatpak-dir-private.h"
+#include "flatpak-instance-private.h"
 #include "flatpak-systemd-dbus-generated.h"
 #include "flatpak-document-dbus-generated.h"
 #include "flatpak-error.h"
@@ -1885,46 +1886,7 @@ flatpak_app_compute_permissions (GKeyFile *app_metadata,
 static void
 flatpak_run_gc_ids (void)
 {
-  g_autofree char *base_dir = g_build_filename (g_get_user_runtime_dir (), ".flatpak", NULL);
-  g_auto(GLnxDirFdIterator) iter = { 0 };
-  struct dirent *dent;
-
-  /* Clean up unused instances */
-  if (!glnx_dirfd_iterator_init_at (AT_FDCWD, base_dir, FALSE, &iter, NULL))
-    return;
-
-  while (TRUE)
-    {
-      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&iter, &dent, NULL, NULL))
-        break;
-
-      if (dent == NULL)
-        break;
-
-      if (dent->d_type == DT_DIR)
-        {
-          g_autofree char *ref_file = g_strconcat (dent->d_name, "/.ref", NULL);
-          struct stat statbuf;
-          struct flock l = {
-            .l_type = F_WRLCK,
-            .l_whence = SEEK_SET,
-            .l_start = 0,
-            .l_len = 0
-          };
-          glnx_autofd int lock_fd = openat (iter.fd, ref_file, O_RDWR | O_CLOEXEC);
-          if (lock_fd != -1 &&
-              fstat (lock_fd, &statbuf) == 0 &&
-              /* Only gc if created at least 3 secs ago, to work around race mentioned in flatpak_run_allocate_id() */
-              statbuf.st_mtime + 3 < time (NULL) &&
-              fcntl (lock_fd, F_GETLK, &l) == 0 &&
-              l.l_type == F_UNLCK)
-            {
-              /* The instance is not used, remove it */
-              g_debug ("Cleaning up unused container id %s", dent->d_name);
-              glnx_shutil_rm_rf_at (iter.fd, dent->d_name, NULL, NULL);
-            }
-        }
-    }
+  flatpak_instance_iterate_all_and_gc (NULL);
 }
 
 static char *


### PR DESCRIPTION
It was completely identical in flatpak-run.c and flatpak-instance.c.

This is something I noticed while working on #3617 and figured I might as well clean it up a bit...