### PR TITLE
Add unconfined_domain(flatpak_helper_t) to optional_policy block

### DIFF
--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -12,8 +12,6 @@ type flatpak_helper_t;
 type flatpak_helper_exec_t;
 init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
-unconfined_domain(flatpak_helper_t)
-
 optional_policy(`
     dbus_stub()
     dbus_system_domain(flatpak_helper_t, flatpak_helper_exec_t)
@@ -24,4 +22,8 @@ optional_policy(`
 
 optional_policy(`
    policykit_dbus_chat(flatpak_helper_t)
+')
+
+optional_policy(`                   
+    unconfined_domain(flatpak_helper_t)
 ')


### PR DESCRIPTION
Hi,
I am part of SELinux team and I fixed bug where disabling unconfined module fails:

`# semodule -d unconfined`
`Failed to resolve typeattributeset statement at /var/lib/selinux/targeted/tmp/modules/200/flatpak/cil:29`
`semodule : Failed !`

It was because macro unconfined_domain(flatpak_helper_t) wasn't in optional_policy block, so I added it.