### PR TITLE
[RFC] run: implement container host os-release interface

### DIFF
--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -113,6 +113,11 @@
             ID of the running app.
         </para>
         <para>
+            Flatpak also parses <filename>os-release</filename> on the host, and for
+            each key-value pair sets an environment variable prefixed with service_host_.
+            Example: <envar>service_host_ID=debian</envar>
+        </para>
+        <para>
             If parental controls support is enabled, flatpak will check the
             current user’s parental controls settings, and will refuse to
             run an app if it is blacklisted for the current user.

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -63,7 +63,7 @@ add_bin() {
     fi
 }
 
-for i in $@ bash ls cat echo readlink socat; do
+for i in $@ bash ls cat echo env grep readlink socat; do
     I=`which $i`
     add_bin $I
 done

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..16"
+echo "1..17"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -79,6 +79,13 @@ assert_file_has_content runtime-fpi "[Runtime]"
 assert_file_has_content runtime-fpi "^runtime=runtime/org\.test\.Platform/$ARCH/stable$"
 
 ok "run a runtime"
+
+run_sh org.test.Platform env | grep service_host_ >runtime-os-release
+while read -r line; do
+assert_file_has_content runtime-os-release "service_host_$(eval "echo ${line}")"
+done < /etc/os-release
+
+ok "host os-release"
 
 if run org.test.Nonexistent 2> run-error-log; then
     assert_not_reached "Unexpectedly able to run non-existent runtime"


### PR DESCRIPTION
Parse the host's os-release file, and for each key-value set an
environment variable prefixed by service_host_.
Allows applications that need to know what is running on the host
to do so.

References:

https://lists.freedesktop.org/archives/systemd-devel/2020-April/044378.html
https://github.com/systemd/systemd/issues/15878
https://github.com/systemd/systemd/pull/15891


The desired goal is to establish a common interface to provide this information, so that applications can rely on it without having to infer what runtime manager they are spawned by.

There are many ways to implement this, the discussion for the nspawn/portabled cases gravitated toward using prefixed environment variables - the advantage being that it's the most convenient way for applications, since they can trivially have both sets of information at the same time (eg: source /etc/os-release and then VERSION_ID is the runtime's version, service_host_VERSION_ID is the host's version).

Paging @smcv