### PR TITLE
Allow ALSA device access if app has pulseaudio access

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -579,6 +579,14 @@ flatpak_run_add_pulseaudio_args (FlatpakBwrap *bwrap)
     }
   else
     g_debug ("Could not find pulseaudio socket");
+
+  /* Also allow ALSA access. This was added in 1.8, and is not ideally named. However,
+   * since the practical permission of ALSA and PulseAudio are essentially the same, and
+   * since we don't want to add more permissions for something we plan to replace with
+   * portals/pipewire going forward we reinterpret pulseaudio to also mean ALSA.
+   */
+  if (g_file_test ("/dev/snd", G_FILE_TEST_IS_DIR))
+    flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/snd", "/dev/snd", NULL);
 }
 
 static void


### PR DESCRIPTION
Alternative fix to https://github.com/flatpak/flatpak/pull/3389

If an app has PulseAudio access, also allow direct ALSA device access.

The practical permissions of ALSA and PulseAudio access are
essentially the same (in fact, its possibly less damaging to have
direct device access as bugs in pulseaudio could allow sandbox
breakout that wouldn't be possible with deivce access).

We could add a separate option for this, but since they are
essentially the same, and since both are not the end goal (which is
using portals and PipeWire for audio), seems like unnecessary churn in
apps and code.