### PR TITLE
Add and use per-transaction no-interaction option

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1161,8 +1161,6 @@ flatpak_cli_transaction_new (FlatpakDir *dir,
   g_autoptr(FlatpakInstallation) installation = NULL;
   g_autoptr(FlatpakCliTransaction) self = NULL;
 
-  flatpak_dir_set_no_interaction (dir, disable_interaction);
-
   installation = flatpak_installation_new_for_dir (dir, NULL, error);
   if (installation == NULL)
     return NULL;
@@ -1178,6 +1176,7 @@ flatpak_cli_transaction_new (FlatpakDir *dir,
   self->stop_on_first_error = stop_on_first_error;
   self->non_default_arch = non_default_arch;
 
+  flatpak_transaction_set_no_interaction (FLATPAK_TRANSACTION (self), disable_interaction);
   flatpak_transaction_add_default_dependency_sources (FLATPAK_TRANSACTION (self));
 
   return (FlatpakTransaction *) g_steal_pointer (&self);

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -34,7 +34,6 @@ struct _FlatpakQuietTransaction
 {
   FlatpakTransaction parent;
   gboolean got_error;
-  gboolean no_interaction_oldvalue;
 };
 
 struct _FlatpakQuietTransactionClass
@@ -226,7 +225,6 @@ flatpak_quiet_transaction_finalize (GObject *object)
   g_autoptr(FlatpakInstallation) installation = NULL;
 
   installation = flatpak_transaction_get_installation (FLATPAK_TRANSACTION (self));
-  flatpak_installation_set_no_interaction (installation, self->no_interaction_oldvalue);
 
   G_OBJECT_CLASS (flatpak_quiet_transaction_parent_class)->finalize (object);
 }
@@ -257,14 +255,10 @@ flatpak_quiet_transaction_new (FlatpakDir *dir,
 {
   g_autoptr(FlatpakQuietTransaction) self = NULL;
   g_autoptr(FlatpakInstallation) installation = NULL;
-  gboolean no_interaction_oldvalue;
 
   installation = flatpak_installation_new_for_dir (dir, NULL, error);
   if (installation == NULL)
     return NULL;
-
-  no_interaction_oldvalue = flatpak_installation_get_no_interaction (installation);
-  flatpak_installation_set_no_interaction (installation, TRUE);
 
   self = g_initable_new (FLATPAK_TYPE_QUIET_TRANSACTION,
                          NULL, error,
@@ -274,8 +268,7 @@ flatpak_quiet_transaction_new (FlatpakDir *dir,
   if (self == NULL)
     return NULL;
 
-  self->no_interaction_oldvalue = no_interaction_oldvalue;
-
+  flatpak_transaction_set_no_interaction (FLATPAK_TRANSACTION (self), TRUE);
   flatpak_transaction_add_default_dependency_sources (FLATPAK_TRANSACTION (self));
 
   return FLATPAK_TRANSACTION (g_steal_pointer (&self));

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1577,6 +1577,28 @@ flatpak_transaction_set_reinstall (FlatpakTransaction *self,
 }
 
 /**
+ * flatpak_transaction_set_no_interaction:
+ * @self: a #FlatpakTransaction
+ * @no_interaction: Whether to disallow interactive authorization for operations
+ *
+ * This method can be used to prevent interactive authorization dialogs to appear
+ * for operations on @self. This is useful for background operations that are not
+ * directly triggered by a user action.
+ *
+ * By default, the setting from the parent #FlatpakInstallation is used.
+ *
+ * Since: 1.7.3
+ */
+void
+flatpak_transaction_set_no_interaction (FlatpakTransaction *self,
+                                        gboolean            no_interaction)
+{
+  FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
+
+  flatpak_dir_set_no_interaction (priv->dir, no_interaction);
+}
+
+/**
  * flatpak_transaction_set_force_uninstall:
  * @self: a #FlatpakTransaction
  * @force_uninstall: whether to force-uninstall refs

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -220,6 +220,9 @@ FLATPAK_EXTERN
 void                flatpak_transaction_set_reinstall (FlatpakTransaction *self,
                                                        gboolean            reinstall);
 FLATPAK_EXTERN
+void                flatpak_transaction_set_no_interaction (FlatpakTransaction *self,
+                                                            gboolean            no_interaction);
+FLATPAK_EXTERN
 void                flatpak_transaction_set_force_uninstall (FlatpakTransaction *self,
                                                              gboolean            force_uninstall);
 FLATPAK_EXTERN


### PR DESCRIPTION
This is useful if to avoid changing the no-interaction of the whole
FlatpakInstallation. Also, having this per transaction lets us
clean up the code in FlatpakQuietTransaction a bit.

Replaces https://github.com/flatpak/flatpak/pull/3571