### PR TITLE
Add auth specific errors and allow authenticators to report them

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -564,10 +564,13 @@ basic_auth_start (FlatpakTransaction *transaction,
                   guint               id)
 {
   FlatpakCliTransaction *self = FLATPAK_CLI_TRANSACTION (transaction);
-  char *user, *password;
+  char *user, *password, *previous_error = NULL;
 
   if (self->disable_interaction)
     return FALSE;
+
+  if (g_variant_lookup (options, "previous-error", "&s", &previous_error))
+    g_print ("%s\n", previous_error);
 
   g_print (_("Login required remote %s (realm %s)\n"), remote, realm);
   user = flatpak_prompt (FALSE, _("User"));

--- a/common/flatpak-error.h
+++ b/common/flatpak-error.h
@@ -61,6 +61,11 @@ G_BEGIN_DECLS
  * @FLATPAK_ERROR_PERMISSION_DENIED: An operation was not allowed by the administrative policy.
  *                                   For example, an app is not allowed to be installed due
  *                                   to not complying with the parental controls policy. (Since: 1.5.1)
+ * @FLATPAK_ERROR_AUTHENTICATION_FAILED: An authentication operation failed, for example, no
+ *                                       correct password was supplied. (Since: 1.7.3)
+ * @FLATPAK_ERROR_NOT_AUTHORIZED: An operation tried to access a ref, or information about it that it
+ *                                was not authorized. For example, when succesfully authenticating with a
+ *                                server but the user doesn't have permissions for a private ref. (Since: 1.7.3)
  *
  * Error codes for library functions.
  */
@@ -88,6 +93,8 @@ typedef enum {
   FLATPAK_ERROR_NOT_CACHED,
   FLATPAK_ERROR_REF_NOT_FOUND,
   FLATPAK_ERROR_PERMISSION_DENIED,
+  FLATPAK_ERROR_AUTHENTICATION_FAILED,
+  FLATPAK_ERROR_NOT_AUTHORIZED,
 } FlatpakError;
 
 /**

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -988,7 +988,7 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
 
   if (g_ascii_strncasecmp (www_authenticate, "Bearer ", strlen ("Bearer ")) != 0)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Only Bearer authentication supported");
+      flatpak_fail (error, _("Only Bearer authentication supported"));
       return NULL;
     }
 
@@ -997,14 +997,14 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
   realm = g_hash_table_lookup (params, "realm");
   if (realm == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Only realm in authentication request");
+      flatpak_fail (error, _("Only realm in authentication request"));
       return NULL;
     }
 
   auth_uri = soup_uri_new (realm);
   if (auth_uri == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Invalid realm in authentication request");
+      flatpak_fail (error, _("Invalid realm in authentication request"));
       return NULL;
     }
 
@@ -1043,7 +1043,7 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
   token = object_get_string_member_with_default (json, "token", NULL);
   if (token == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Invalid authentication request response");
+      flatpak_fail (error, _("Invalid authentication request response"));
       return NULL;
     }
 

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -1036,6 +1036,18 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
   if (body == NULL)
     return NULL;
 
+  if (!SOUP_STATUS_IS_SUCCESSFUL (auth_msg->status_code))
+    {
+      if (auth_msg->status_code == SOUP_STATUS_UNAUTHORIZED)
+        {
+          flatpak_fail_error (error, FLATPAK_ERROR_NOT_AUTHORIZED, _("Authorization failed: %s"), (char *)g_bytes_get_data (body, NULL));
+          return NULL;
+        }
+
+      flatpak_fail (error, _("Unexpected response status %d when requesting token: %s"), auth_msg->status_code, (char *)g_bytes_get_data (body, NULL));
+      return NULL;
+    }
+
   json = json_from_string ((char *)g_bytes_get_data (body, NULL), error);
   if (json == NULL)
     return NULL;

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -21,6 +21,7 @@
 #include "config.h"
 #include <locale.h>
 
+#include <glib/gi18n-lib.h>
 #include <json-glib/json-glib.h>
 #include "flatpak-oci-registry-private.h"
 #include "flatpak-utils-http-private.h"
@@ -277,7 +278,7 @@ get_token_for_ref (FlatpakOciRegistry *registry,
 
   if (!g_variant_lookup (data, "summary.xa.oci-repository", "&s", &oci_repository))
     {
-      flatpak_fail (error, "Not a oci remote, missing summary.xa.oci-repository");
+      flatpak_fail (error, _("Not a oci remote, missing summary.xa.oci-repository"));
       return NULL;
     }
 
@@ -462,7 +463,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
     {
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                              G_DBUS_ERROR_INVALID_ARGS,
-                                             "Not a OCI remote");
+                                             _("Not a OCI remote"));
       return TRUE;
     }
   g_variant_lookup (arg_options, "no-interaction", "b", &no_interaction);
@@ -473,7 +474,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
     {
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                              G_DBUS_ERROR_INVALID_ARGS,
-                                             "Invalid token");
+                                             _("Invalid token"));
       return TRUE;
     }
 
@@ -553,7 +554,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
     }
 
   if (!have_auth)
-    return error_request_raw (request, sender, FLATPAK_ERROR_AUTHENTICATION_FAILED, "Authentication failed");
+    return error_request_raw (request, sender, FLATPAK_ERROR_AUTHENTICATION_FAILED, _("Authentication failed"));
 
   g_variant_builder_init (&tokens, G_VARIANT_TYPE ("a{sas}"));
 


### PR DESCRIPTION
This adds `FLATPAK_ERROR_AUTHENTICATION_FAILED` and `FLATPAK_ERROR_NOT_AUTHORIZED` to FlatpakErrors, and extends the authenticator protocol to handle the `error-code` key to pass a FlatpakError code to the client (used instead of G_IO_ERROR_FAILED).

Additionally the oci authenticator is updated to use this (and with some tweaks to its error handling).