### PR TITLE
OCI: Also look for the docker media type when looking manifests

### DIFF
--- a/common/flatpak-json-oci.c
+++ b/common/flatpak-json-oci.c
@@ -502,7 +502,8 @@ const char *
 flatpak_oci_manifest_descriptor_get_ref (FlatpakOciManifestDescriptor *m)
 {
   if (m->parent.mediatype == NULL ||
-      strcmp (m->parent.mediatype, FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST) != 0)
+      (strcmp (m->parent.mediatype, FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST) != 0 &&
+       strcmp (m->parent.mediatype, FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2) != 0))
     return NULL;
 
   if (m->parent.annotations == NULL)


### PR DESCRIPTION
We handle both types, so look for both.