### PR TITLE
Fix for XDG_DATA_DIRS override

### DIFF
--- a/env.d/flatpak.env.in
+++ b/env.d/flatpak.env.in
@@ -1,1 +1,1 @@
-XDG_DATA_DIRS=$HOME/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/
+XDG_DATA_DIRS=$XDG_DATA_DIRS:$HOME/.local/share/flatpak/exports/share/:@localstatedir@/lib/flatpak/exports/share/:/usr/local/share/:/usr/share/


### PR DESCRIPTION
This avoids all snaps to disappear when flatpak is installed in ubuntu 20.04. Related to issue #3678.