### PR TITLE
Backport oci changes to 1.6.x

### DIFF
--- a/common/flatpak-auth.c
+++ b/common/flatpak-auth.c
@@ -49,6 +49,10 @@ flatpak_auth_new_for_remote (FlatpakDir *dir,
       if (!ostree_repo_get_remote_option (repo, remote, FLATPAK_REMOTE_CONFIG_AUTHENTICATOR_NAME, NULL, &name, error))
         return NULL;
     }
+
+  if (name == NULL && flatpak_dir_get_remote_oci (dir, remote))
+    name = g_strdup ("org.flatpak.Authenticator.Oci");
+
   if (name == NULL || *name == 0 /* or if no repo */)
     {
       flatpak_fail (error, _("No authenticator configured for remote `%s`"), remote);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11233,6 +11233,11 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
         }
     }
 
+  if (flatpak_dir_get_remote_oci (self, remote_or_uri))
+    {
+      state->default_token_type = 1;
+    }
+
   if (state->collection_id == NULL)
     {
       if (state->summary != NULL) /* In the optional case we might not have a summary */

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -92,6 +92,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitSubject, g_object_unref)
 
 static FlatpakOciRegistry *flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
                                                                          GLnxLockFile *file_lock,
+                                                                         const char   *token,
                                                                          GError      **error);
 
 static OstreeRepo * flatpak_dir_create_child_repo (FlatpakDir   *self,
@@ -8602,6 +8603,7 @@ flatpak_dir_deploy_update (FlatpakDir   *self,
 static FlatpakOciRegistry *
 flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
                                               GLnxLockFile *file_lock,
+                                              const char   *token,
                                               GError      **error)
 {
   g_autoptr(GFile) cache_dir = NULL;
@@ -8635,6 +8637,8 @@ flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
                                            NULL, error);
   if (new_registry == NULL)
     return NULL;
+
+  flatpak_oci_registry_set_token (new_registry, token);
 
   return g_steal_pointer (&new_registry);
 }
@@ -8952,7 +8956,7 @@ flatpak_dir_install (FlatpakDir          *self,
           g_autoptr(FlatpakOciRegistry) registry = NULL;
           g_autoptr(GFile) registry_file = NULL;
 
-          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, error);
+          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token, error);
           if (registry == NULL)
             return FALSE;
 
@@ -9662,7 +9666,7 @@ flatpak_dir_update (FlatpakDir                           *self,
           g_autoptr(FlatpakOciRegistry) registry = NULL;
           g_autoptr(GFile) registry_file = NULL;
 
-          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, error);
+          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token, error);
           if (registry == NULL)
             return FALSE;
 

--- a/common/flatpak-json-oci.c
+++ b/common/flatpak-json-oci.c
@@ -469,7 +469,8 @@ const char *
 flatpak_oci_manifest_descriptor_get_ref (FlatpakOciManifestDescriptor *m)
 {
   if (m->parent.mediatype == NULL ||
-      strcmp (m->parent.mediatype, FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST) != 0)
+      (strcmp (m->parent.mediatype, FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST) != 0 &&
+       strcmp (m->parent.mediatype, FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2) != 0))
     return NULL;
 
   if (m->parent.annotations == NULL)

--- a/common/flatpak-oci-registry-private.h
+++ b/common/flatpak-oci-registry-private.h
@@ -62,6 +62,7 @@ FlatpakOciRegistry  *  flatpak_oci_registry_new (const char           *uri,
                                                  GError              **error);
 void                   flatpak_oci_registry_set_token (FlatpakOciRegistry *self,
                                                        const char *token);
+gboolean               flatpak_oci_registry_is_local (FlatpakOciRegistry *self);
 const char          *  flatpak_oci_registry_get_uri (FlatpakOciRegistry *self);
 FlatpakOciIndex     *  flatpak_oci_registry_load_index (FlatpakOciRegistry *self,
                                                         GCancellable       *cancellable,

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -205,6 +205,12 @@ flatpak_oci_registry_init (FlatpakOciRegistry *self)
   self->tmp_dfd = -1;
 }
 
+gboolean
+flatpak_oci_registry_is_local (FlatpakOciRegistry *self)
+{
+  return self->dfd != -1;
+}
+
 const char *
 flatpak_oci_registry_get_uri (FlatpakOciRegistry *self)
 {

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -1015,6 +1015,9 @@ flatpak_oci_registry_get_token (FlatpakOciRegistry *self,
 
   msg = soup_message_new_from_uri ("HEAD", uri);
 
+  soup_message_headers_replace (msg->request_headers, "Accept",
+                                FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST ", " FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2);
+
   stream = soup_session_send (self->soup_session, msg, NULL, error);
   if (stream == NULL)
     return NULL;

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -105,11 +105,15 @@ tests/services/org.flatpak.Authenticator.test.service: tests/org.flatpak.Authent
 	mkdir -p tests/services
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)/tests|" $< > $@
 
+tests/services/org.flatpak.Authenticator.Oci.service: oci-authenticator/org.flatpak.Authenticator.Oci.service.in
+	mkdir -p tests/services
+	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(abs_top_builddir)|" $< > $@
+
 tests/share/xdg-desktop-portal/portals/test.portal: tests/test.portal.in
 	mkdir -p tests/share/xdg-desktop-portal/portals
 	$(AM_V_GEN) install -m644 $< $@
 
-tests/libtest.sh: tests/services/org.freedesktop.Flatpak.service tests/services/org.freedesktop.Flatpak.SystemHelper.service tests/services/org.freedesktop.portal.Flatpak.service tests/share/xdg-desktop-portal/portals/test.portal tests/services/org.freedesktop.impl.portal.desktop.test.service tests/services/org.flatpak.Authenticator.test.service
+tests/libtest.sh: tests/services/org.freedesktop.Flatpak.service tests/services/org.freedesktop.Flatpak.SystemHelper.service tests/services/org.freedesktop.portal.Flatpak.service tests/share/xdg-desktop-portal/portals/test.portal tests/services/org.freedesktop.impl.portal.desktop.test.service tests/services/org.flatpak.Authenticator.test.service tests/services/org.flatpak.Authenticator.Oci.service
 
 install-test-data-hook:
 if ENABLE_INSTALLED_TESTS
@@ -223,6 +227,7 @@ DISTCLEANFILES += \
 	tests/services/org.freedesktop.portal.Flatpak.service \
 	tests/services/org.freedesktop.impl.portal.desktop.test.service \
 	tests/services/org.flatpak.Authenticator.test.service \
+	tests/services/org.flatpak.Authenticator.Oci.service \
 	tests/share/xdg-desktop-portal/portals/test.portal \
 	tests/package_version.txt \
 	$(NULL)

--- a/tests/oci-registry-server.py
+++ b/tests/oci-registry-server.py
@@ -135,6 +135,9 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             else:
                 self.wfile.write(response_string.encode('utf-8'))
 
+    def do_HEAD(self):
+        return self.do_GET()
+
     def do_POST(self):
         if self.check_route('/testing/@repo_name/@tag'):
             repo_name = self.matches['repo_name']


### PR DESCRIPTION
This backports:
 * Always use authenticator for OCI
 * Also use token when pulling oci in system-helper
 * Handle docker media types

This should be enough to make e.g. docker hub and redhat infra work.

@owtaylor wanna check this?