### PR TITLE
Don't install gdm env file by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -153,7 +153,11 @@ profile_DATA = profile/flatpak.sh
 EXTRA_DIST += $(profile_DATA)
 
 envdir = $(datadir)/gdm/env.d
-env_DATA = flatpak.env
+env_DATA =
+if INSTALL_GDM_ENV_FILE
+env_DATA += flatpak.env
+endif
+
 EXTRA_DIST += env.d/flatpak.env.in env.d/60-flatpak
 DISTCLEANFILES += flatpak.env
 

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,11 @@ if test "x$enable_xauth" = "xyes"; then
       [Define if using xauth])
 fi
 
+AC_ARG_ENABLE([gdm-env-file],
+              [AC_HELP_STRING([--enable-gdm-env-file], [Install gdm env.d file (not needed if systemd generators work)])],
+              install_gdm_env_file=$enableval, install_gdm_env_file=no)
+AM_CONDITIONAL(INSTALL_GDM_ENV_FILE, test x$install_gdm_env_file = xyes)
+
 AC_ARG_ENABLE([sandboxed-triggers],
               AC_HELP_STRING([--disable-sandboxed-triggers],
                              [Disable sandboxed triggers]),


### PR DESCRIPTION
As mentioned in https://github.com/flatpak/flatpak/pull/3679 and
https://github.com/flatpak/flatpak/issues/3678 it is causing issues,
and the systemd generators we have should be fine for most uses
anyway.

If a distros need it the gdm file can easily be re-enabled with
--enable-gdm-env-file.