### PR TITLE
Auto install authenticator

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -959,8 +959,8 @@ gboolean flatpak_dir_find_latest_rev (FlatpakDir               *self,
                                       GFile                   **out_sideload_path,
                                       GCancellable             *cancellable,
                                       GError                  **error);
-GPtrArray * flatpak_dir_find_remote_auto_install_refs (FlatpakDir         *self,
-                                                       const char         *remote_name);
+char * flatpak_dir_get_remote_auto_install_authenticator_ref (FlatpakDir         *self,
+                                                              const char         *remote_name);
 
 typedef struct
 {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13860,22 +13860,17 @@ flatpak_dir_find_local_related (FlatpakDir   *self,
   return g_steal_pointer (&related);
 }
 
-GPtrArray *
-flatpak_dir_find_remote_auto_install_refs (FlatpakDir         *self,
-                                           const char         *remote_name)
+char *
+flatpak_dir_get_remote_auto_install_authenticator_ref (FlatpakDir         *self,
+                                                        const char         *remote_name)
 {
-  GPtrArray *auto_install_refs = g_ptr_array_new_with_free_func ((GDestroyNotify) g_free);
   g_autofree char *authenticator_name = NULL;
-  g_autofree char *authenticator_ref = NULL;
 
   authenticator_name = flatpak_dir_get_remote_install_authenticator_name (self, remote_name);
   if (authenticator_name != NULL)
-    authenticator_ref = g_strdup_printf ("app/%s/%s/autoinstall", authenticator_name, flatpak_get_arch ());
+    return g_strdup_printf ("app/%s/%s/autoinstall", authenticator_name, flatpak_get_arch ());
 
-  if (authenticator_ref)
-    g_ptr_array_add (auto_install_refs, g_steal_pointer (&authenticator_ref));
-
-  return auto_install_refs;
+  return NULL;
 }
 
 

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -146,7 +146,11 @@ struct _FlatpakTransactionClass
                                 const char         *realm,
                                 GVariant           *options,
                                 guint               id);
-  gpointer padding[5];
+  void (*install_authenticator)   (FlatpakTransaction *transaction,
+                                   const char         *remote,
+                                   const char         *authenticator_ref);
+
+  gpointer padding[4];
 };
 
 FLATPAK_EXTERN

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -371,8 +371,11 @@ make_updated_app () {
         COLLECTION_ID=""
     fi
     BRANCH=${3:-master}
+    TEXT=${4:-UPDATED}
+    APP_ID=${5:-""}
+    RUNTIME_BRANCH=${6:-$BRANCH}
 
-    GPGARGS="${GPGARGS:-${FL_GPGARGS}}" $(dirname $0)/make-test-app.sh repos/${REPONAME} "" "${BRANCH}" "${COLLECTION_ID}" ${4:-UPDATED} > /dev/null
+    RUNTIME_BRANCH=$RUNTIME_BRANCH GPGARGS="${GPGARGS:-${FL_GPGARGS}}" $(dirname $0)/make-test-app.sh repos/${REPONAME} "${APP_ID}" "${BRANCH}" "${COLLECTION_ID}" "${TEXT}" > /dev/null
     update_repo $REPONAME "${COLLECTION_ID}"
 }
 

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -20,6 +20,8 @@ if [ x$APP_ID = x ]; then
     APP_ID=org.test.Hello
 fi
 
+RUNTIME_BRANCH=${RUNTIME_BRANCH:-$BRANCH}
+
 EXTRA="${1-}"
 
 ARCH=`flatpak --default-arch`
@@ -28,8 +30,8 @@ ARCH=`flatpak --default-arch`
 cat > ${DIR}/metadata <<EOF
 [Application]
 name=$APP_ID
-runtime=org.test.Platform/$ARCH/$BRANCH
-sdk=org.test.Platform/$ARCH/$BRANCH
+runtime=org.test.Platform/$ARCH/$RUNTIME_BRANCH
+sdk=org.test.Platform/$ARCH/$RUNTIME_BRANCH
 EOF
 
 if [ x${REQUIRED_VERSION-} != x ]; then


### PR DESCRIPTION
This is an alternative version of https://github.com/flatpak/flatpak/pull/3510
It has a different API as mentioned there. Instead of changing how FlatpakTransaction works it adds a single transaction signal which you need to connect to and install the authenticator via a separate transaction.