### PR TITLE
Update documentation for sideload-repos

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -470,9 +470,10 @@ flatpak_transaction_add_dependency_source (FlatpakTransaction  *self,
  * @self: a #FlatpakTransaction
  * @path: a path to a local flatpak repository
  *
- * Adds an extra local ostree repo as source for installation. This is equivalent
- * with setting the xa.sideload-repos global option, but can be done dynamically.
- * If the option is set both sources are used.
+ * Adds an extra local ostree repo as source for installation. This is
+ * equivalent to using the sideload-repos directories (see flatpak(1)), but can
+ * be done dynamically. Any path added here is used in addition to ones in
+ * those directories.
  *
  * Since: 1.7.1
  */

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -262,8 +262,9 @@
 
                 <listitem><para>
                   Adds an extra local ostree repo as source for installation. This is equivalent
-                  with setting the xa.sideload-repos global option, but can be done without modifying the configuration.
-                  If the option is already set both sources are used.
+                  to using the sideload-repos directories (see flatpak(1)), but can be done on a
+                  per-command basis. Any path added here is used in addition to ones in those
+                  directories.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-update.xml
+++ b/doc/flatpak-update.xml
@@ -220,8 +220,9 @@
 
                 <listitem><para>
                   Adds an extra local ostree repo as source for installation. This is equivalent
-                  with setting the xa.sideload-repos global option, but can be done without modifying the configuration.
-                  If the option is already set both sources are used.
+                  to using the sideload-repos directories (see flatpak(1)), but can be done on a
+                  per-command basis. Any path added here is used in addition to ones in those
+                  directories.
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
It is no longer a config option; it was changed to be a directory.