### PR TITLE
run: Always expose host /usr/share/zoneinfo (if possible)

### DIFF
--- a/common/flatpak-utils-base.c
+++ b/common/flatpak-utils-base.c
@@ -34,10 +34,7 @@ flatpak_get_timezone (void)
   g_autofree gchar *symlink = NULL;
   gchar *etc_timezone = NULL;
   const gchar *tzdir;
-
-  tzdir = getenv ("TZDIR");
-  if (tzdir == NULL)
-    tzdir = "/usr/share/zoneinfo";
+  const gchar *default_tzdir = "/usr/share/zoneinfo";
 
   symlink = flatpak_resolve_link ("/etc/localtime", NULL);
   if (symlink != NULL)
@@ -47,9 +44,20 @@ flatpak_get_timezone (void)
       char *canonical_suffix;
 
       /* Strip the prefix and slashes if possible. */
-      if (g_str_has_prefix (canonical, tzdir))
+
+      tzdir = getenv ("TZDIR");
+      if (tzdir != NULL && g_str_has_prefix (canonical, tzdir))
         {
           canonical_suffix = canonical + strlen (tzdir);
+          while (*canonical_suffix == '/')
+            canonical_suffix++;
+
+          return g_strdup (canonical_suffix);
+        }
+
+      if (g_str_has_prefix (canonical, default_tzdir))
+        {
+          canonical_suffix = canonical + strlen (default_tzdir);
           while (*canonical_suffix == '/')
             canonical_suffix++;
 


### PR DESCRIPTION
Instead of relying on the runtime tzdate we now always expose the host
/usr/share/zoneinfo in that location and make /etc/localtime a regular
symlink to it. This means applications that parse the content of the
localtime symlink will work, and additionally it means that we're
guaranteed that the host configure timezone exists (and works with)
the tzdata in the app.

This unfortunately means we no longer make the localtime an indirect
file via the session helper, and thus that localtime configurations
are static over the lifetime of an app sandbox. However, I don't
think there is a workable solution to this.

This fixes https://github.com/flatpak/flatpak/issues/3338