### PR TITLE
Avoid authentication of no-op updates

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2715,6 +2715,7 @@ op_may_need_token (FlatpakTransactionOperation *op)
 {
   return
     !op->skip &&
+    !op->update_only_deploy &&
     (op->kind == FLATPAK_TRANSACTION_OPERATION_INSTALL ||
      op->kind == FLATPAK_TRANSACTION_OPERATION_UPDATE  ||
      op->kind == FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3306,6 +3306,9 @@ request_required_tokens (FlatpakTransaction *self,
   GList *l;
   g_autoptr(GHashTable) need_token_ht = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, (GDestroyNotify) g_list_free); /* remote name -> list of op */
 
+  /* Ensure all ops so far ar normalized so we don't request authentication for no-op updates */
+  flatpak_transaction_normalize_ops (self);
+
   for (l = priv->ops; l != NULL; l = l->next)
     {
       FlatpakTransactionOperation *op = l->data;


### PR DESCRIPTION
If a ref doesn't actually change in an update transaction we need not authenticate it, so avoid that by
moving where we detect the no-op update earlier.