### PR TITLE
 Avoid authentication of no-op updates for 1.6.x branch

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3979,10 +3979,6 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
   if (!resolve_all_ops (self, cancellable, error))
     return FALSE;
 
-  /* Ensure we have all required tokens */
-  if (!request_required_tokens (self, NULL, cancellable, error))
-    return FALSE;
-
   sort_ops (self);
 
   /* Ensure the operation kind is normalized and not no-op */
@@ -4019,6 +4015,10 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
             op->skip = TRUE;
         }
     }
+
+  /* Ensure we have all required tokens */
+  if (!request_required_tokens (self, NULL, cancellable, error))
+    return FALSE;
 
 
   g_signal_emit (self, signals[READY], 0, &ready_res);


### PR DESCRIPTION
This is a simpler version of https://github.com/flatpak/flatpak/pull/3718 for 1.6