### PR TITLE
transaction: Update get_operations() docs

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3421,7 +3421,8 @@ sort_ops (FlatpakTransaction *self)
  * flatpak_transaction_get_operations:
  * @self: a #FlatpakTransaction
  *
- * Gets the list of operations. Skipped operations are not included.
+ * Gets the list of operations. Skipped operations are not included. The order
+ * of the list is the order in which the operations are executed.
  *
  * Returns: (transfer full) (element-type FlatpakTransactionOperation): a #GList of operations
  */


### PR DESCRIPTION
Document that operations are executed in the same order they are
returned because gnome-software is depending on that:
https://gitlab.gnome.org/GNOME/gnome-software/-/blob/cf5656031f0d25c9c36e2ad0e6e6cfd4b4f2c718/plugins/flatpak/gs-flatpak-transaction.c#L279