### PR TITLE
run: implement sandbox host os-release interface

### DIFF
--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -395,6 +395,14 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
         flatpak_bwrap_add_args (bwrap,
                                 etc_bind_mode, "/etc", "/run/host/etc", NULL);
     }
+
+  /* As per the os-release specification https://www.freedesktop.org/software/systemd/man/os-release.html
+   * always read-only bind-mount /etc/os-release if it exists, or /usr/lib/os-release as a fallback from
+   * the host into the application's /run/host */
+  if (g_file_test ("/etc/os-release", G_FILE_TEST_EXISTS))
+    flatpak_bwrap_add_args (bwrap, "--ro-bind", "/etc/os-release", "/run/host/os-release", NULL);
+  else if (g_file_test ("/usr/lib/os-release", G_FILE_TEST_EXISTS))
+    flatpak_bwrap_add_args (bwrap, "--ro-bind", "/usr/lib/os-release", "/run/host/os-release", NULL);
 }
 
 /* Returns 0 if not visible */

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -113,6 +113,13 @@
             ID of the running app.
         </para>
         <para>
+            Flatpak also bind-mounts as read-only the host's <filename>/etc/os-release</filename>
+            (if available, or <filename>/usr/lib/os-release</filename> as a fallback) to
+            <filename>/run/host/os-release</filename> in accordance with the
+            <ulink url="https://www.freedesktop.org/software/systemd/man/os-release.html">
+            os-release specification</ulink>.
+        </para>
+        <para>
             If parental controls support is enabled, flatpak will check the
             current user’s parental controls settings, and will refuse to
             run an app if it is blocklisted for the current user.


### PR DESCRIPTION
If available, always read-only bind-mount /etc/os-release as
/run/host/os-release (or /usr/lib/os-release as fallback)
as suggested by the os-release specification:

https://www.freedesktop.org/software/systemd/man/os-release.html