### PR TITLE
gitignore: Add built units in sideload-repos-systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ oci-authenticator/*.service
 portal/*.service
 session-helper/*.service
 system-helper/*.service
+sideload-repos-systemd/flatpak-sideload-usb-repo.service
+sideload-repos-systemd/flatpak-sideload-usb-repo.path
 tests/*.service
 flatpak.conf
 flatpak.env


### PR DESCRIPTION
I mistakenly omitted these in 9caf664fabc911419cc483125bf543c4550604c7