### PR TITLE
build: Distribute autogen.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -181,6 +181,8 @@ EXTRA_DIST += scripts/flatpak-bisect scripts/flatpak-coredumpctl
 
 EXTRA_DIST += variant-schema-compiler/variant-schema-compiler
 
+EXTRA_DIST += autogen.sh
+
 EXTRA_DIST += README.md
 
 EXTRA_DIST += flatpak.png


### PR DESCRIPTION
So that we can use the same sequence of commands for building flatpak out of the repository and the tarball.

- [x] Verified that the tarball produced with `make dist` contains the `autogen.sh` file and can be used for build.