### PR TITLE
tests: install org.flatpak.Authenticator.Oci.service

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -123,6 +123,7 @@ if ENABLE_INSTALLED_TESTS
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" -e "s|\@extraargs\@| --session --no-idle-exit|" $(top_srcdir)/system-helper/org.freedesktop.Flatpak.SystemHelper.service.in > $(DESTDIR)$(installed_testdir)/services/org.freedesktop.Flatpak.SystemHelper.service
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(installed_testdir)|" $(top_srcdir)/tests/org.freedesktop.impl.portal.desktop.test.service.in > $(DESTDIR)$(installed_testdir)/services/org.freedesktop.impl.portal.desktop.test.service
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(installed_testdir)|" $(top_srcdir)/tests/org.flatpak.Authenticator.test.service.in > $(DESTDIR)$(installed_testdir)/services/org.flatpak.Authenticator.test.service.service
+	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" $(top_srcdir)/oci-authenticator/org.flatpak.Authenticator.Oci.service.in > $(DESTDIR)$(installed_testdir)/services/org.flatpak.Authenticator.Oci.service
 	mkdir -p $(DESTDIR)$(installed_testdir)/share/xdg-desktop-portal/portals
 	install -m644 $(top_srcdir)/tests/test.portal.in $(DESTDIR)$(installed_testdir)/share/xdg-desktop-portal/portals/test.portal
 endif


### PR DESCRIPTION
Otherwise the installed tests will fail:

	SUMMARY: total=32; passed=30; skipped=0; failed=2; user=820.8s; system=589.3s; maxrss=445132
	FAIL: flatpak/test-oci-registry@user.wrap.test (Child process exited with code 1)
	FAIL: flatpak/test-oci-registry@system.wrap.test (Child process exited with code 1)

due to:

	error: The name org.flatpak.Authenticator.Oci was not provided by any .service files


- [x] Verified that the tests pass with this patch applied.
