### PR TITLE
run: Avoid hanging if xdg-dbus-proxy startup fails

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -987,6 +987,10 @@ start_dbus_proxy (FlatpakBwrap *app_bwrap,
                       NULL, error))
     return FALSE;
 
+  /* The write end can be closed now, otherwise the read below will hang of xdg-dbus-proxy
+     fails to start. */
+  g_clear_pointer (&proxy_bwrap, flatpak_bwrap_free);
+
   /* Sync with proxy, i.e. wait until its listening on the sockets */
   if (read (sync_fds[0], &x, 1) != 1)
     {


### PR DESCRIPTION
Discovered this by accident, in particular it meshes badly with the new `SpawnStarted` system because if the portal fails to start, but flatpak hangs, the portal will forever be waiting for the process and running a timer every 100ms.