### PR TITLE
Fix argument order of clone() for s390x in seccomp filter

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2667,7 +2667,14 @@ setup_seccomp (FlatpakBwrap   *bwrap,
     {SCMP_SYS (unshare)},
     {SCMP_SYS (mount)},
     {SCMP_SYS (pivot_root)},
+#if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)
+    /* Architectures with CONFIG_CLONE_BACKWARDS2: the child stack
+     * and flags arguments are reversed so the flags come second */
+    {SCMP_SYS (clone), &SCMP_A1 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
+#else
+    /* Normally the flags come first */
     {SCMP_SYS (clone), &SCMP_A0 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
+#endif
 
     /* Don't allow faking input to the controlling tty (CVE-2017-5226) */
     {SCMP_SYS (ioctl), &SCMP_A1 (SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, (int) TIOCSTI)},


### PR DESCRIPTION
From: @julian-klode

clone() is a mad syscall with about 4 different argument orders. While
most of them agree that argument 0 is flags, s390 and s390x have the
flags argument second - A0 is the child stack pointer there.

[smcv: Add an explanatory comment; also test `__CRIS__` for completeness]

Bug-Debian: https://bugs.debian.org/964541  
Bug-Ubuntu: https://launchpad.net/bugs/1886814

---

For reference see clone(2), https://github.com/systemd/systemd/blob/master/src/basic/raw-clone.h and kernel source.

I'm told that this change is necessary and sufficient to make flatpak-builder work on s390x, for everyone who wants to be able to build desktop applications for their non-GUI-capable IBM mainframe (if such users even exist).

This is currently considered to be a release-critical bug in Debian and Ubuntu, because those distributions don't distinguish between architectures where desktop-oriented packages are practically useful and architectures where they are not.