### PR TITLE
Fix libseccomp Google Groups link

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2620,7 +2620,7 @@ setup_seccomp (FlatpakBwrap   *bwrap,
    * If you make any changes here, I suggest sending the changes along
    * to other sandbox maintainers.  Using the libseccomp list is also
    * an appropriate venue:
-   * https://groups.google.com/forum/#!topic/libseccomp
+   * https://groups.google.com/forum/#!forum/libseccomp
    *
    * A non-exhaustive list of links to container tooling that might
    * want to share this blocklist:


### PR DESCRIPTION
Otherwise it just bounces you to the Google Groups home page.

(Side note: As a Sandstorm.io contributor, it was exciting to hear that we share code with something!)