### PR TITLE
Improve summary/summary.sig caching to reduce unnecessary network requests

### DIFF
--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -680,7 +680,7 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
 
     /* Try to update the repo metadata by creating a FlatpakRemoteState object,
      * but don't fail on error because we want this to work offline. */
-    state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, &local_error);
+    state = flatpak_dir_get_remote_state_optional (dir, remote_name, FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, &local_error);
     if (state == NULL)
       {
         g_printerr (_("Warning: Couldn't update repo metadata for remote ‘%s’: %s\n"),

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1351,11 +1351,11 @@ get_remote_state (FlatpakDir   *dir,
     }
   else
     {
-      state = flatpak_dir_get_remote_state (dir, remote, cached, cancellable, &local_error);
+      state = flatpak_dir_get_remote_state (dir, remote, cached ? FLATPAK_CACHE_ONLY : FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, &local_error);
       if (state == NULL && g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_CACHED))
         {
           g_clear_error (&local_error);
-          state = flatpak_dir_get_remote_state (dir, remote, FALSE, cancellable, &local_error);
+          state = flatpak_dir_get_remote_state (dir, remote, FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, &local_error);
         }
 
       if (state == NULL)

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -336,6 +336,23 @@ typedef enum {
   FIND_MATCHING_REFS_FLAGS_FUZZY = (1 << 1),
 } FindMatchingRefsFlags;
 
+/**
+ * FlatpakCachePolicy:
+ * @FLATPAK_CACHE_ALWAYS_REFRESH: Always do a small amount of network I/O to
+ *    check the cache freshness against the server (and update it if necessary).
+ * @FLATPAK_CACHE_ONLY: Use the cache if available, and error otherwise.
+ *
+ * Cache query policy, determining how a function will interact with the cache
+ * and the network. Typically this is used for caching of the repository’s
+ * `summary` file.
+ *
+ * Since: 1.9.1
+ */
+typedef enum {
+  FLATPAK_CACHE_ALWAYS_REFRESH = 0,
+  FLATPAK_CACHE_ONLY = 1,
+} FlatpakCachePolicy;
+
 GQuark       flatpak_dir_error_quark (void);
 
 /**
@@ -915,7 +932,7 @@ gboolean flatpak_dir_update_remote_configuration_for_state (FlatpakDir         *
                                                             GError            **error);
 FlatpakRemoteState * flatpak_dir_get_remote_state (FlatpakDir   *self,
                                                    const char   *remote,
-                                                   gboolean      only_cached,
+                                                   FlatpakCachePolicy cache_policy,
                                                    GCancellable *cancellable,
                                                    GError      **error);
 FlatpakRemoteState * flatpak_dir_get_remote_state_for_summary (FlatpakDir   *self,
@@ -930,13 +947,13 @@ gboolean flatpak_dir_migrate_config (FlatpakDir   *self,
                                      GError      **error);
 gboolean flatpak_dir_remote_make_oci_summary (FlatpakDir   *self,
                                               const char   *remote,
-                                              gboolean      only_cached,
+                                              FlatpakCachePolicy cache_policy,
                                               GBytes      **out_summary,
                                               GCancellable *cancellable,
                                               GError      **error);
 FlatpakRemoteState * flatpak_dir_get_remote_state_optional (FlatpakDir   *self,
                                                             const char   *remote,
-                                                            gboolean      only_cached,
+                                                            FlatpakCachePolicy cache_policy,
                                                             GCancellable *cancellable,
                                                             GError      **error);
 FlatpakRemoteState * flatpak_dir_get_remote_state_local_only (FlatpakDir   *self,

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1870,7 +1870,7 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
       return NULL;
     }
 
-  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, error);
   if (state == NULL)
     return NULL;
 
@@ -2030,7 +2030,7 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
   if (remote_name == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, error);
   if (state == NULL)
     return NULL;
 
@@ -2272,7 +2272,7 @@ flatpak_installation_fetch_remote_size_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return FALSE;
 
-  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, error);
   if (state == NULL)
     return FALSE;
 
@@ -2314,7 +2314,7 @@ flatpak_installation_fetch_remote_metadata_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, error);
   if (state == NULL)
     return FALSE;
 
@@ -2386,7 +2386,7 @@ flatpak_installation_list_remote_refs_sync_full (FlatpakInstallation *self,
   if (flags & FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED)
     state = flatpak_dir_get_remote_state_local_only (dir, remote_or_uri, cancellable, error);
   else
-    state = flatpak_dir_get_remote_state (dir, remote_or_uri, (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) != 0, cancellable, error);
+    state = flatpak_dir_get_remote_state (dir, remote_or_uri, (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) ? FLATPAK_CACHE_ONLY : FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, error);
   if (state == NULL)
     return NULL;
 
@@ -2496,7 +2496,7 @@ flatpak_installation_fetch_remote_ref_sync_full (FlatpakInstallation *self,
   if (flags & FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED)
     state = flatpak_dir_get_remote_state_local_only (dir, remote_name, cancellable, error);
   else
-    state = flatpak_dir_get_remote_state (dir, remote_name, (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) != 0, cancellable, error);
+    state = flatpak_dir_get_remote_state (dir, remote_name, (flags & FLATPAK_QUERY_FLAGS_ONLY_CACHED) ? FLATPAK_CACHE_ONLY : FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, error);
   if (state == NULL)
     return NULL;
 
@@ -2673,7 +2673,7 @@ flatpak_installation_list_remote_related_refs_sync (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FALSE, cancellable, error);
+  state = flatpak_dir_get_remote_state_optional (dir, remote_name, FLATPAK_CACHE_ALWAYS_REFRESH, cancellable, error);
   if (state == NULL)
     return NULL;
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1751,7 +1751,7 @@ flatpak_transaction_ensure_remote_state (FlatpakTransaction             *self,
   if (state)
     return flatpak_remote_state_ref (state);
 
-  state = flatpak_dir_get_remote_state_optional (priv->dir, remote, FALSE, NULL, error);
+  state = flatpak_dir_get_remote_state_optional (priv->dir, remote, FLATPAK_CACHE_ALWAYS_REFRESH, NULL, error);
 
   if (state)
     {

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -571,7 +571,7 @@ handle_deploy (FlatpakSystemHelper   *object,
           return TRUE;
         }
 
-      state = flatpak_dir_get_remote_state (system, arg_origin, FALSE, NULL, &error);
+      state = flatpak_dir_get_remote_state (system, arg_origin, FLATPAK_CACHE_ALWAYS_REFRESH, NULL, &error);
       if (state == NULL)
         {
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
@@ -645,7 +645,7 @@ handle_deploy (FlatpakSystemHelper   *object,
           return TRUE;
         }
 
-      state = flatpak_dir_get_remote_state_optional (system, arg_origin, FALSE, NULL, &error);
+      state = flatpak_dir_get_remote_state_optional (system, arg_origin, FLATPAK_CACHE_ALWAYS_REFRESH, NULL, &error);
       if (state == NULL)
         {
           flatpak_invocation_return_error (invocation, error, "Error getting remote state");
@@ -868,7 +868,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
           return TRUE;
         }
 
-      state = flatpak_dir_get_remote_state_optional (system, arg_origin, FALSE, NULL, &error);
+      state = flatpak_dir_get_remote_state_optional (system, arg_origin, FLATPAK_CACHE_ALWAYS_REFRESH, NULL, &error);
       if (state == NULL)
         {
           flatpak_invocation_return_error (invocation, error, "Error getting remote state");
@@ -1794,7 +1794,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
 {
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
-  gboolean only_cached;
+  FlatpakCachePolicy cache_policy;
   gboolean is_oci;
 
   g_debug ("GenerateOciSummary %u %s %s", arg_flags, arg_origin, arg_installation);
@@ -1813,7 +1813,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
       return TRUE;
     }
 
-  only_cached = (arg_flags & FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_ONLY_CACHED) != 0;
+  cache_policy = (arg_flags & FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_ONLY_CACHED) ? FLATPAK_CACHE_ONLY : FLATPAK_CACHE_ALWAYS_REFRESH;
 
   if (!flatpak_dir_ensure_repo (system, NULL, &error))
     {
@@ -1830,7 +1830,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
       return TRUE;
     }
 
-  if (!flatpak_dir_remote_make_oci_summary (system, arg_origin, only_cached, NULL, NULL, &error))
+  if (!flatpak_dir_remote_make_oci_summary (system, arg_origin, cache_policy, NULL, NULL, &error))
     {
       flatpak_invocation_return_error (invocation, error, "Failed to update OCI summary");
       return TRUE;


### PR DESCRIPTION
Previously, transactions were downloading `summary.sig` multiple times (once per OSTree pull operation). This isn’t a problem on fast, low-latency connections, but on high-latency or lossy connections the extra blocking round trips can cause quite a slowdown.

This has a soft dependency on https://github.com/ostreedev/ostree/pull/2166. If the right OSTree version isn’t available, then older OSTree versions will continue to re-download the `summary.sig` file (which is correct, but slow).