### PR TITLE
http-utils: Stop exporting an internal error quark

### DIFF
--- a/common/flatpak-utils-http-private.h
+++ b/common/flatpak-utils-http-private.h
@@ -32,7 +32,7 @@ typedef enum {
 
 #define FLATPAK_HTTP_ERROR flatpak_http_error_quark ()
 
-FLATPAK_EXTERN GQuark  flatpak_http_error_quark (void);
+GQuark flatpak_http_error_quark (void);
 
 
 SoupSession * flatpak_create_soup_session (const char *user_agent);


### PR DESCRIPTION
This made its way into the Debian symbols file, but looks like it was
never supposed to be exported.

Signed-off-by: Philip Withnall <withnall@endlessm.com>