### PR TITLE
Normalize --filesystem arguments

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -82,6 +82,11 @@ extern const char *flatpak_context_devices[];
 extern const char *flatpak_context_features[];
 extern const char *flatpak_context_shares[];
 
+gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                                 char                  **filesystem_out,
+                                                 FlatpakFilesystemMode  *mode_out,
+                                                 GError                **error);
+
 FlatpakContext *flatpak_context_new (void);
 void           flatpak_context_free (FlatpakContext *context);
 void           flatpak_context_merge (FlatpakContext *context,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -752,7 +752,7 @@ parse_filesystem_flags (const char            *filesystem,
   return g_string_free (g_steal_pointer (&s), FALSE);
 }
 
-static gboolean
+gboolean
 flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
                                   char                  **filesystem_out,
                                   FlatpakFilesystemMode  *mode_out,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -826,6 +826,22 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
       return TRUE;
     }
 
+  if (strcmp (filesystem, "~") == 0)
+    {
+      if (filesystem_out != NULL)
+        *filesystem_out = g_strdup ("home");
+
+      return TRUE;
+    }
+
+  if (g_str_has_prefix (filesystem, "home/"))
+    {
+      if (filesystem_out != NULL)
+        *filesystem_out = g_strconcat ("~/", filesystem + 5, NULL);
+
+      return TRUE;
+    }
+
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
                _("Unknown filesystem location %s, valid locations are: host, host-os, host-etc, home, xdg-*[/…], ~/dir, /dir"), filesystem);
   return FALSE;

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -802,6 +802,17 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
           else
             break;
         }
+
+      if (filesystem[0] == '/' && filesystem[1] == '\0')
+        {
+          /* We don't allow --filesystem=/ as equivalent to host, because
+           * it doesn't do what you'd think: --filesystem=host mounts some
+           * host directories in /run/host, not in the root. */
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                       _("--filesystem=/ is not available, "
+                         "use --filesystem=host for a similar result"));
+          return FALSE;
+        }
     }
 
   if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -759,6 +759,50 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
                                   GError                **error)
 {
   g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, mode_out);
+  char *slash;
+
+  slash = strchr (filesystem, '/');
+
+  /* Forbid /../ in paths */
+  if (slash != NULL)
+    {
+      if (g_str_has_prefix (slash + 1, "../") ||
+          g_str_has_suffix (slash + 1, "/..") ||
+          strstr (slash + 1, "/../") != NULL)
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                       _("Filesystem location \"%s\" contains \"..\""),
+                       filesystem);
+          return FALSE;
+        }
+
+      /* Convert "//" and "/./" to "/" */
+      for (; slash != NULL; slash = strchr (slash + 1, '/'))
+        {
+          while (TRUE)
+            {
+              if (slash[1] == '/')
+                memmove (slash + 1, slash + 2, strlen (slash + 2) + 1);
+              else if (slash[1] == '.' && slash[2] == '/')
+                memmove (slash + 1, slash + 3, strlen (slash + 3) + 1);
+              else
+                break;
+            }
+        }
+
+      /* Eliminate trailing "/." or "/". */
+      while (TRUE)
+        {
+          slash = strrchr (filesystem, '/');
+
+          if (slash != NULL &&
+              ((slash != filesystem && slash[1] == '\0') ||
+               (slash[1] == '.' && slash[2] == '\0')))
+            *slash = '\0';
+          else
+            break;
+        }
+    }
 
   if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||
       get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL) ||

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -30,6 +30,7 @@ typedef enum {
   FLATPAK_FILESYSTEM_MODE_READ_ONLY    = 1,
   FLATPAK_FILESYSTEM_MODE_READ_WRITE   = 2,
   FLATPAK_FILESYSTEM_MODE_CREATE       = 3,
+  FLATPAK_FILESYSTEM_MODE_LAST         = FLATPAK_FILESYSTEM_MODE_CREATE
 } FlatpakFilesystemMode;
 
 typedef struct _FlatpakExports FlatpakExports;

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -26,6 +26,7 @@
 
 /* In numerical order of more privs */
 typedef enum {
+  FLATPAK_FILESYSTEM_MODE_NONE         = 0,
   FLATPAK_FILESYSTEM_MODE_READ_ONLY    = 1,
   FLATPAK_FILESYSTEM_MODE_READ_WRITE   = 2,
   FLATPAK_FILESYSTEM_MODE_CREATE       = 3,

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -82,7 +82,7 @@ make_relative (const char *base, const char *path)
 }
 
 #define FAKE_MODE_DIR -1 /* Ensure a dir, either on tmpfs or mapped parent */
-#define FAKE_MODE_TMPFS 0
+#define FAKE_MODE_TMPFS FLATPAK_FILESYSTEM_MODE_NONE
 #define FAKE_MODE_SYMLINK G_MAXINT
 
 typedef struct
@@ -301,7 +301,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
         }
     }
 
-  if (exports->host_os != 0)
+  if (exports->host_os != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       const char *os_bind_mode = "--bind";
       int i;
@@ -355,7 +355,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
             }
         }
 
-      if (exports->host_etc == 0)
+      if (exports->host_etc == FLATPAK_FILESYSTEM_MODE_NONE)
         {
           guint i;
 
@@ -383,7 +383,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
         }
     }
 
-  if (exports->host_etc != 0)
+  if (exports->host_etc != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       const char *etc_bind_mode = "--bind";
 
@@ -404,7 +404,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
     flatpak_bwrap_add_args (bwrap, "--ro-bind", "/usr/lib/os-release", "/run/host/os-release", NULL);
 }
 
-/* Returns 0 if not visible */
+/* Returns FLATPAK_FILESYSTEM_MODE_NONE if not visible */
 FlatpakFilesystemMode
 flatpak_exports_path_get_mode (FlatpakExports *exports,
                                const char     *path)
@@ -449,7 +449,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
                   break;
                 }
 
-              return 0;
+              return FLATPAK_FILESYSTEM_MODE_NONE;
             }
 
           if (S_ISLNK (st.st_mode))
@@ -459,7 +459,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
               int j;
 
               if (resolved == NULL)
-                return 0;
+                return FLATPAK_FILESYSTEM_MODE_NONE;
 
               path2_builder = g_string_new (resolved);
 
@@ -473,7 +473,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
             }
         }
       else if (parts[i + 1] == NULL)
-        return 0; /* Last part was not mapped */
+        return FLATPAK_FILESYSTEM_MODE_NONE; /* Last part was not mapped */
     }
 
   if (is_readonly)
@@ -486,7 +486,7 @@ gboolean
 flatpak_exports_path_is_visible (FlatpakExports *exports,
                                  const char     *path)
 {
-  return flatpak_exports_path_get_mode (exports, path) > 0;
+  return flatpak_exports_path_get_mode (exports, path) > FLATPAK_FILESYSTEM_MODE_NONE;
 }
 
 static gboolean
@@ -727,7 +727,7 @@ flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode,
                                          const char           *path)
 {
-  if (mode == 0)
+  if (mode == FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_path_tmpfs (exports, path);
   else
     flatpak_exports_add_path_expose (exports, mode, path);

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -210,6 +210,14 @@
                                 Available since 0.3.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>home/<replaceable>path</replaceable></option></term><listitem><para>
+                                  Alias for <filename>~/path</filename>
+                                  Available since 1.10.
+                                  For better compatibility with older
+                                  Flatpak versions, prefer to write this
+                                  as <filename>~/path</filename>.
+                            </para></listitem></varlistentry>
+
                             <varlistentry><term><option>host</option></term>
                             <listitem><para>
                                 The entire host file system, except for
@@ -380,6 +388,15 @@
                             </term><listitem><para>
                                 An arbitrary path relative to the home
                                 directory. Available since 0.3.
+                            </para></listitem></varlistentry>
+
+                            <varlistentry><term><option>~</option></term>
+                            <listitem><para>
+                                  The same as <option>home</option>.
+                                  Available since 1.10.
+                                  For better compatibility with older
+                                  Flatpak versions, prefer to write this
+                                  as <option>home</option>.
                             </para></listitem></varlistentry>
 
                             <varlistentry><term>

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -60,6 +60,10 @@ testcommon_LDADD = \
 	$(NULL)
 testcommon_SOURCES = tests/testcommon.c
 
+test_exports_CFLAGS = $(testcommon_CFLAGS)
+test_exports_LDADD = $(testcommon_LDADD)
+test_exports_SOURCES = tests/test-exports.c
+
 tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
 	-DLOCALEDIR=\"$(localedir)\"
@@ -216,7 +220,7 @@ test_scripts = ${TEST_MATRIX}
 dist_test_scripts = ${TEST_MATRIX_DIST}
 dist_installed_test_extra_scripts += ${TEST_MATRIX_EXTRA_DIST}
 
-test_programs = testlibrary testcommon
+test_programs = testlibrary testcommon test-exports
 test_extra_programs = tests/httpcache tests/test-update-portal tests/test-portal-impl tests/test-authenticator
 
 @VALGRIND_CHECK_RULES@

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -271,11 +271,14 @@ typedef struct
 
 static const NotFilesystem not_filesystems[] =
 {
+  { "", G_OPTION_ERROR_FAILED },
   { "homework", G_OPTION_ERROR_FAILED },
   { "xdg-download/foo/bar/..", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-download/../foo/bar", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-download/foo/../bar", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-run", G_OPTION_ERROR_FAILED },
+  { "/", G_OPTION_ERROR_BAD_VALUE },
+  { "/////././././././//////", G_OPTION_ERROR_BAD_VALUE },
 };
 
 typedef struct

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -272,6 +272,9 @@ typedef struct
 static const NotFilesystem not_filesystems[] =
 {
   { "homework", G_OPTION_ERROR_FAILED },
+  { "xdg-download/foo/bar/..", G_OPTION_ERROR_BAD_VALUE },
+  { "xdg-download/../foo/bar", G_OPTION_ERROR_BAD_VALUE },
+  { "xdg-download/foo/../bar", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-run", G_OPTION_ERROR_FAILED },
 };
 
@@ -319,6 +322,8 @@ static const Filesystem filesystems[] =
   { "xdg-cache/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-config", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-config/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config/././///.///././.", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
+  { "xdg-config/////", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
   { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
 };
 

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1,0 +1,481 @@
+/*
+ * Copyright © 2020 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <glib.h>
+#include "flatpak.h"
+#include "flatpak-bwrap-private.h"
+#include "flatpak-context-private.h"
+#include "flatpak-exports-private.h"
+#include "flatpak-run-private.h"
+
+/* This differs from g_file_test (path, G_FILE_TEST_IS_DIR) which
+   returns true if the path is a symlink to a dir */
+static gboolean
+path_is_dir (const char *path)
+{
+  struct stat s;
+
+  if (lstat (path, &s) != 0)
+    return FALSE;
+
+  return S_ISDIR (s.st_mode);
+}
+
+/*
+ * Assert that the next few arguments starting from @i are setting up
+ * /run/host/os-release. Return the next argument that hasn't been used.
+ */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_os_release (FlatpakBwrap *bwrap,
+                           gsize i)
+{
+  if (g_file_test ("/etc/os-release", G_FILE_TEST_EXISTS))
+    {
+      g_assert_cmpuint (i, <, bwrap->argv->len);
+      g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--ro-bind");
+      g_assert_cmpuint (i, <, bwrap->argv->len);
+      g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "/etc/os-release");
+      g_assert_cmpuint (i, <, bwrap->argv->len);
+      g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "/run/host/os-release");
+    }
+  else if (g_file_test ("/usr/lib/os-release", G_FILE_TEST_EXISTS))
+    {
+      g_assert_cmpuint (i, <, bwrap->argv->len);
+      g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--ro-bind");
+      g_assert_cmpuint (i, <, bwrap->argv->len);
+      g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "/usr/lib/os-release");
+      g_assert_cmpuint (i, <, bwrap->argv->len);
+      g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "/run/host/os-release");
+    }
+
+  return i;
+}
+
+/* Assert that arguments starting from @i are --dir @dir.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_dir (FlatpakBwrap *bwrap,
+                    gsize i,
+                    const char *dir)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--dir");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, dir);
+  return i;
+}
+
+/* Assert that arguments starting from @i are --tmpfs @dir.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_tmpfs (FlatpakBwrap *bwrap,
+                      gsize i,
+                      const char *dir)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--tmpfs");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, dir);
+  return i;
+}
+
+/* Assert that arguments starting from @i are @how @path @path.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_bind (FlatpakBwrap *bwrap,
+                     gsize i,
+                     const char *how,
+                     const char *path)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, how);
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  return i;
+}
+
+/* Print the arguments of a call to bwrap. */
+static void
+print_bwrap (FlatpakBwrap *bwrap)
+{
+  guint i;
+
+  for (i = 0; i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL; i++)
+    g_test_message ("%s", (const char *) bwrap->argv->pdata[i]);
+
+  g_test_message ("--");
+}
+
+static void
+test_empty_context (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(FlatpakExports) exports = NULL;
+
+  g_assert_cmpuint (g_hash_table_size (context->env_vars), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->persistent), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->filesystems), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->session_bus_policy), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->system_bus_policy), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->generic_policy), ==, 0);
+  g_assert_cmpuint (context->shares, ==, 0);
+  g_assert_cmpuint (context->shares_valid, ==, 0);
+  g_assert_cmpuint (context->sockets, ==, 0);
+  g_assert_cmpuint (context->sockets_valid, ==, 0);
+  g_assert_cmpuint (context->devices, ==, 0);
+  g_assert_cmpuint (context->devices_valid, ==, 0);
+  g_assert_cmpuint (context->features, ==, 0);
+  g_assert_cmpuint (context->features_valid, ==, 0);
+  g_assert_cmpuint (flatpak_context_get_run_flags (context), ==, 0);
+
+  exports = flatpak_context_get_exports (context, "com.example.App");
+  g_assert_nonnull (exports);
+
+  g_clear_pointer (&exports, flatpak_exports_free);
+  flatpak_context_append_bwrap_filesystem (context, bwrap,
+                                           "com.example.App",
+                                           NULL,
+                                           NULL,
+                                           &exports);
+  print_bwrap (bwrap);
+  g_assert_nonnull (exports);
+}
+
+static void
+test_full_context (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(FlatpakExports) exports = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_SHARED,
+                        "network;ipc;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_SOCKETS,
+                        "x11;wayland;pulseaudio;session-bus;system-bus;"
+                        "fallback-x11;ssh-auth;pcsc;cups;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_DEVICES,
+                        "dri;all;kvm;shm;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_FEATURES,
+                        "devel;multiarch;bluetooth;canbus;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_FILESYSTEMS,
+                        "host;/home;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_PERSISTENT,
+                        ".openarena;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                        "org.example.SessionService",
+                        "own");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                        "net.example.SystemService",
+                        "talk");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_ENVIRONMENT,
+                        "HYPOTHETICAL_PATH", "/foo:/bar");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_PREFIX_POLICY "MyPolicy",
+                        "Colours", "blue;green;");
+
+  flatpak_context_load_metadata (context, keyfile, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpuint (context->shares, ==,
+                    (FLATPAK_CONTEXT_SHARED_NETWORK |
+                     FLATPAK_CONTEXT_SHARED_IPC));
+  g_assert_cmpuint (context->shares_valid, ==, context->shares);
+  g_assert_cmpuint (context->devices, ==,
+                    (FLATPAK_CONTEXT_DEVICE_DRI |
+                     FLATPAK_CONTEXT_DEVICE_ALL |
+                     FLATPAK_CONTEXT_DEVICE_KVM |
+                     FLATPAK_CONTEXT_DEVICE_SHM));
+  g_assert_cmpuint (context->devices_valid, ==, context->devices);
+  g_assert_cmpuint (context->sockets, ==,
+                    (FLATPAK_CONTEXT_SOCKET_X11 |
+                     FLATPAK_CONTEXT_SOCKET_WAYLAND |
+                     FLATPAK_CONTEXT_SOCKET_PULSEAUDIO |
+                     FLATPAK_CONTEXT_SOCKET_SESSION_BUS |
+                     FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS |
+                     FLATPAK_CONTEXT_SOCKET_FALLBACK_X11 |
+                     FLATPAK_CONTEXT_SOCKET_SSH_AUTH |
+                     FLATPAK_CONTEXT_SOCKET_PCSC |
+                     FLATPAK_CONTEXT_SOCKET_CUPS));
+  g_assert_cmpuint (context->sockets_valid, ==, context->sockets);
+  g_assert_cmpuint (context->features, ==,
+                    (FLATPAK_CONTEXT_FEATURE_DEVEL |
+                     FLATPAK_CONTEXT_FEATURE_MULTIARCH |
+                     FLATPAK_CONTEXT_FEATURE_BLUETOOTH |
+                     FLATPAK_CONTEXT_FEATURE_CANBUS));
+  g_assert_cmpuint (context->features_valid, ==, context->features);
+
+  g_assert_cmpuint (flatpak_context_get_run_flags (context), ==,
+                    (FLATPAK_RUN_FLAG_DEVEL |
+                     FLATPAK_RUN_FLAG_MULTIARCH |
+                     FLATPAK_RUN_FLAG_BLUETOOTH |
+                     FLATPAK_RUN_FLAG_CANBUS));
+
+  exports = flatpak_context_get_exports (context, "com.example.App");
+  g_assert_nonnull (exports);
+
+  g_clear_pointer (&exports, flatpak_exports_free);
+  flatpak_context_append_bwrap_filesystem (context, bwrap,
+                                           "com.example.App",
+                                           NULL,
+                                           NULL,
+                                           &exports);
+  print_bwrap (bwrap);
+  g_assert_nonnull (exports);
+}
+
+typedef struct
+{
+  const char *input;
+  GOptionError code;
+} NotFilesystem;
+
+static const NotFilesystem not_filesystems[] =
+{
+  { "homework", G_OPTION_ERROR_FAILED },
+  { "xdg-run", G_OPTION_ERROR_FAILED },
+};
+
+typedef struct
+{
+  const char *input;
+  FlatpakFilesystemMode mode;
+  const char *fs;
+} Filesystem;
+
+static const Filesystem filesystems[] =
+{
+  { "home", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host-etc", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host-os", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host:ro", FLATPAK_FILESYSTEM_MODE_READ_ONLY, "host" },
+  { "home:rw", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~/Music", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "/srv/obs/debian\\:sid\\:main:create", FLATPAK_FILESYSTEM_MODE_CREATE,
+    "/srv/obs/debian:sid:main" },
+  { "/srv/c\\:\\\\Program Files\\\\Steam", FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+    "/srv/c:\\Program Files\\Steam" },
+  { "/srv/escaped\\unnecessarily", FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+    "/srv/escapedunnecessarily" },
+  { "xdg-desktop", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-desktop/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-documents", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-documents/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-download", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-download/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-music", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-music/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-pictures", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-pictures/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-public-share", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-public-share/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-templates", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-templates/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-videos", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-videos/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-data", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-data/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-cache", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-cache/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+};
+
+static void
+test_filesystems (void)
+{
+  gsize i;
+
+  for (i = 0; i < G_N_ELEMENTS (filesystems); i++)
+    {
+      const Filesystem *fs = &filesystems[i];
+      g_autoptr(GError) error = NULL;
+      g_autofree char *normalized;
+      FlatpakFilesystemMode mode;
+      gboolean ret;
+
+      g_test_message ("%s", fs->input);
+      ret = flatpak_context_parse_filesystem (fs->input, &normalized, &mode,
+                                              &error);
+      g_assert_no_error (error);
+      g_assert_true (ret);
+
+      if (fs->fs == NULL)
+        g_assert_cmpstr (normalized, ==, fs->input);
+      else
+        g_assert_cmpstr (normalized, ==, fs->fs);
+
+      g_assert_cmpuint (mode, ==, fs->mode);
+    }
+
+  for (i = 0; i < G_N_ELEMENTS (not_filesystems); i++)
+    {
+      const NotFilesystem *not = &not_filesystems[i];
+      g_autoptr(GError) error = NULL;
+      char *normalized = NULL;
+      FlatpakFilesystemMode mode;
+      gboolean ret;
+
+      g_test_message ("%s", not->input);
+      ret = flatpak_context_parse_filesystem (not->input, &normalized, &mode,
+                                              &error);
+      g_test_message ("-> %s", error ? error->message : "(no error)");
+      g_assert_error (error, G_OPTION_ERROR, not->code);
+      g_assert_false (ret);
+      g_assert_null (normalized);
+    }
+}
+
+static void
+test_empty (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  g_assert_false (flatpak_exports_path_is_visible (exports, "/run"));
+  g_assert_cmpint (flatpak_exports_path_get_mode (exports, "/tmp"), ==,
+                   FLATPAK_FILESYSTEM_MODE_NONE);
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  i = assert_next_is_os_release (bwrap, i);
+
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
+static void
+test_full (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  flatpak_exports_add_host_etc_expose (exports,
+                                       FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  flatpak_exports_add_host_os_expose (exports,
+                                      FLATPAK_FILESYSTEM_MODE_READ_ONLY);
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                   "/tmp");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/var");
+  flatpak_exports_add_path_tmpfs (exports, "/var/tmp");
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_NONE,
+                                           "/home");
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                           "/srv");
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  /* Hiding /home just uses --dir because / is not exposed. */
+  if (path_is_dir ("/home"))
+    i = assert_next_is_dir (bwrap, i, "/home");
+
+  if (path_is_dir ("/srv"))
+    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/srv");
+
+  if (path_is_dir ("/tmp"))
+    i = assert_next_is_bind (bwrap, i, "--bind", "/tmp");
+
+  if (path_is_dir ("/var"))
+    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/var");
+
+  /* We don't create a FAKE_MODE_TMPFS in the container unless there is
+   * a directory on the host to mount it on.
+   * Hiding /var/tmp has to use --tmpfs because /var *is* exposed. */
+  if (path_is_dir ("/var") && path_is_dir ("/var/tmp"))
+    i = assert_next_is_tmpfs (bwrap, i, "/var/tmp");
+
+  while (i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL)
+    {
+      /* An unknown number of --bind, --ro-bind and --symlink,
+       * depending how your /usr and /etc are set up.
+       * About the only thing we can say is that they are in threes. */
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+    }
+
+  g_assert_cmpuint (i, ==, bwrap->argv->len - 1);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
+int
+main (int argc, char *argv[])
+{
+  int res;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/context/empty", test_empty_context);
+  g_test_add_func ("/context/filesystems", test_filesystems);
+  g_test_add_func ("/context/full", test_full_context);
+  g_test_add_func ("/exports/empty", test_empty);
+  g_test_add_func ("/exports/full", test_full);
+
+  res = g_test_run ();
+
+  return res;
+}

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -328,6 +328,12 @@ static const Filesystem filesystems[] =
   { "xdg-config/././///.///././.", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
   { "xdg-config/////", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
   { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "~", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~/.", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~/", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~///././//", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "home/", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "home/Projects", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "~/Projects" },
 };
 
 static void

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -28,17 +28,63 @@
 #include "flatpak-exports-private.h"
 #include "flatpak-run-private.h"
 
-/* This differs from g_file_test (path, G_FILE_TEST_IS_DIR) which
-   returns true if the path is a symlink to a dir */
-static gboolean
-path_is_dir (const char *path)
+static char *testdir;
+
+static void
+global_setup (void)
 {
-  struct stat s;
+  g_autofree char *cachedir = NULL;
+  g_autofree char *configdir = NULL;
+  g_autofree char *datadir = NULL;
+  g_autofree char *homedir = NULL;
+  g_autofree char *runtimedir = NULL;
 
-  if (lstat (path, &s) != 0)
-    return FALSE;
+  testdir = g_strdup ("/tmp/flatpak-test-XXXXXX");
+  g_mkdtemp (testdir);
+  g_test_message ("testdir: %s", testdir);
 
-  return S_ISDIR (s.st_mode);
+  homedir = g_strconcat (testdir, "/home", NULL);
+  g_mkdir_with_parents (homedir, S_IRWXU | S_IRWXG | S_IRWXO);
+
+  g_setenv ("HOME", homedir, TRUE);
+  g_test_message ("setting HOME=%s", homedir);
+
+  cachedir = g_strconcat (testdir, "/home/cache", NULL);
+  g_mkdir_with_parents (cachedir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_CACHE_HOME", cachedir, TRUE);
+  g_test_message ("setting XDG_CACHE_HOME=%s", cachedir);
+
+  configdir = g_strconcat (testdir, "/home/config", NULL);
+  g_mkdir_with_parents (configdir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_CONFIG_HOME", configdir, TRUE);
+  g_test_message ("setting XDG_CONFIG_HOME=%s", configdir);
+
+  datadir = g_strconcat (testdir, "/home/share", NULL);
+  g_mkdir_with_parents (datadir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_DATA_HOME", datadir, TRUE);
+  g_test_message ("setting XDG_DATA_HOME=%s", datadir);
+
+  runtimedir = g_strconcat (testdir, "/runtime", NULL);
+  g_mkdir_with_parents (runtimedir, S_IRWXU);
+  g_setenv ("XDG_RUNTIME_DIR", runtimedir, TRUE);
+  g_test_message ("setting XDG_RUNTIME_DIR=%s", runtimedir);
+
+  g_reload_user_special_dirs_cache ();
+
+  g_assert_cmpstr (g_get_user_cache_dir (), ==, cachedir);
+  g_assert_cmpstr (g_get_user_config_dir (), ==, configdir);
+  g_assert_cmpstr (g_get_user_data_dir (), ==, datadir);
+  g_assert_cmpstr (g_get_user_runtime_dir (), ==, runtimedir);
+}
+
+static void
+global_teardown (void)
+{
+  if (g_getenv ("SKIP_TEARDOWN"))
+    return;
+
+  glnx_shutil_rm_rf_at (-1, testdir, NULL, NULL);
+  g_free (testdir);
 }
 
 /*
@@ -411,9 +457,42 @@ test_empty (void)
 static void
 test_full (void)
 {
+  g_autoptr(GError) error = NULL;
   g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
   g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  g_autofree gchar *subdir = g_build_filename (testdir, "test_full", NULL);
+  g_autofree gchar *expose_rw = g_build_filename (subdir, "expose-rw", NULL);
+  g_autofree gchar *expose_ro = g_build_filename (subdir, "expose-ro", NULL);
+  g_autofree gchar *hide = g_build_filename (subdir, "hide", NULL);
+  g_autofree gchar *dont_hide = g_build_filename (subdir, "dont-hide", NULL);
+  g_autofree gchar *hide_below_expose = g_build_filename (subdir,
+                                                          "expose-ro",
+                                                          "hide-me",
+                                                          NULL);
   gsize i;
+
+  glnx_shutil_rm_rf_at (-1, subdir, NULL, &error);
+
+  if (error != NULL)
+    {
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_clear_error (&error);
+    }
+
+  if (g_mkdir_with_parents (expose_rw, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (expose_ro, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (hide_below_expose, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (hide, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (dont_hide, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
 
   flatpak_exports_add_host_etc_expose (exports,
                                        FLATPAK_FILESYSTEM_MODE_READ_WRITE);
@@ -421,17 +500,17 @@ test_full (void)
                                       FLATPAK_FILESYSTEM_MODE_READ_ONLY);
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_WRITE,
-                                   "/tmp");
+                                   expose_rw);
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
-                                   "/var");
-  flatpak_exports_add_path_tmpfs (exports, "/var/tmp");
+                                   expose_ro);
+  flatpak_exports_add_path_tmpfs (exports, hide_below_expose);
   flatpak_exports_add_path_expose_or_hide (exports,
                                            FLATPAK_FILESYSTEM_MODE_NONE,
-                                           "/home");
+                                           hide);
   flatpak_exports_add_path_expose_or_hide (exports,
                                            FLATPAK_FILESYSTEM_MODE_READ_ONLY,
-                                           "/srv");
+                                           dont_hide);
 
   flatpak_bwrap_add_arg (bwrap, "bwrap");
   flatpak_exports_append_bwrap_args (exports, bwrap);
@@ -442,24 +521,20 @@ test_full (void)
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
 
-  /* Hiding /home just uses --dir because / is not exposed. */
-  if (path_is_dir ("/home"))
-    i = assert_next_is_dir (bwrap, i, "/home");
-
-  if (path_is_dir ("/srv"))
-    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/srv");
-
-  if (path_is_dir ("/tmp"))
-    i = assert_next_is_bind (bwrap, i, "--bind", "/tmp");
-
-  if (path_is_dir ("/var"))
-    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/var");
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", dont_hide);
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", expose_ro);
 
   /* We don't create a FAKE_MODE_TMPFS in the container unless there is
    * a directory on the host to mount it on.
-   * Hiding /var/tmp has to use --tmpfs because /var *is* exposed. */
-  if (path_is_dir ("/var") && path_is_dir ("/var/tmp"))
-    i = assert_next_is_tmpfs (bwrap, i, "/var/tmp");
+   * Hiding $subdir/expose-ro/hide-me has to use --tmpfs because
+   * $subdir/expose-ro *is* exposed. */
+  i = assert_next_is_tmpfs (bwrap, i, hide_below_expose);
+
+  i = assert_next_is_bind (bwrap, i, "--bind", expose_rw);
+
+  /* Hiding $subdir/hide just uses --dir, because $subdir is not
+   * exposed. */
+  i = assert_next_is_dir (bwrap, i, hide);
 
   while (i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL)
     {
@@ -474,12 +549,22 @@ test_full (void)
   g_assert_cmpuint (i, ==, bwrap->argv->len - 1);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
   g_assert_cmpuint (i, ==, bwrap->argv->len);
+
+  glnx_shutil_rm_rf_at (-1, subdir, NULL, &error);
+
+  if (error != NULL)
+    {
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_clear_error (&error);
+    }
 }
 
 int
 main (int argc, char *argv[])
 {
   int res;
+
+  global_setup ();
 
   g_test_init (&argc, &argv, NULL);
 
@@ -490,6 +575,8 @@ main (int argc, char *argv[])
   g_test_add_func ("/exports/full", test_full);
 
   res = g_test_run ();
+
+  global_teardown ();
 
   return res;
 }


### PR DESCRIPTION
* context: Only parse filesystem/mode strings in one place
    
    This gives us the ability for the parse function (the former verify
    function) to carry out a normalization step as well.

* exports: Add assertions to distinguish between mode representations
    
    When we're talking about a "mode", sometimes we mean a
    FlatpakFilesystemMode, sometimes we mean a FlatpakFilesystemMode that
    must be strictly greater than NONE, and sometimes we're willing to
    accept the FAKE_MODE constants too.

* context: Expose flatpak_context_parse_filesystem for testing

* tests: Add basic unit tests for FlatpakExports, FlatpakContext
    
    There's a limit to how many assertions we can make here right now,
    because what we do here is very dependent on the "shape" of the host
    filesystem. This could be extended in future by using a mock home
    directory whose contents we control.
    
* Do some syntactic normalization on filesystems
    
    Paths containing ".." are rejected: they're almost certainly a
    terrible idea.
    
    Paths containing "." or multiple slashes are syntactically normalized.
    
    This assumes that nobody is going to use "--filesystem=/foo/bar/" to
    mean "make /foo/bar available, unless it's a non-directory, in which
    case fail".

* context: Normalize home/path to ~/path, and ~ to home
    
    Historically we didn't accept them, but there's no real reason why not.
    They're normalized to the form in which earlier Flatpak releases would
    want to see them.

---

Mostly solves #3784 (but note that `host`, `host-etc`, `host-os` still can't take a trailing path like `host/opt`).

v2: add the beginnings of some unit tests for this and adjacent functionality; syntactically normalize paths; forbid ".."; actually test it