### PR TITLE
sideload-repos-systemd: Dist service unconditionally

### DIFF
--- a/sideload-repos-systemd/Makefile.am.inc
+++ b/sideload-repos-systemd/Makefile.am.inc
@@ -15,4 +15,4 @@ systemdsystemunit_DATA += sideload-repos-systemd/flatpak-sideload-repos-dir.serv
 
 endif
 
-EXTRA_DIST += sideload-repos-systemd/flatpak-sideload-usb-repo.path.in sideload-repos-systemd/flatpak-sideload-repos-dir.service
+EXTRA_DIST += sideload-repos-systemd/flatpak-sideload-usb-repo.path.in sideload-repos-systemd/flatpak-sideload-usb-repo.service.in sideload-repos-systemd/flatpak-sideload-repos-dir.service


### PR DESCRIPTION
Add flatpak-sideload-usb-repo.service.in to EXTRA_DIST regardless of if
the --enable-auto-sideloading configure option was passed. This allows
building a tarball without that option and then building from the
tarball with the option.

This matches what is done in system-helper/Makefile.am.inc with
flatpak-system-helper.service.in.

Picked from https://github.com/endlessm/flatpak/pull/228