### PR TITLE
oci-auth: Don't ask for authentication if anon auth fails with weird …

### DIFF
--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -525,8 +525,21 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
         have_auth = TRUE;
       else
         {
-          g_debug ("Anonymous authentication failed: %s", error->message);
-          g_clear_error (&error);
+          if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_AUTHORIZED))
+            {
+              g_debug ("Anonymous authentication failed: %s", error->message);
+              g_clear_error (&error);
+
+              /* Continue trying with authentication below */
+            }
+          else
+            {
+              /* We failed with some weird reason (network issue maybe?) and it is unlikely
+               * that adding some authentication will fix it. It will just cause a bad UX like
+               * described in #3753, so just return the error early.
+               */
+              return error_request (request, sender, error);
+            }
         }
     }
 


### PR DESCRIPTION
…error

If the initial anonymous fails for any other reason than "not authorized"
we immediately fail the operation instead of asking for user/password.
The later is creating a very bad UX in case of e.g. networking or
infrastructure issues, as described in #3753.