### PR TITLE
Allow multiarch in the apply_extra for extra-data

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7383,6 +7383,8 @@ apply_extra_data (FlatpakDir   *self,
                           NULL);
 
   if (!flatpak_run_setup_base_argv (bwrap, runtime_files, NULL, runtime_ref_parts[2],
+                                    /* Might need multiarch in apply_extra (see e.g. #3742). Should be pretty safe in this limited context */
+                                    FLATPAK_RUN_FLAG_MULTIARCH |
                                     FLATPAK_RUN_FLAG_NO_SESSION_HELPER | FLATPAK_RUN_FLAG_NO_PROC,
                                     error))
     return FALSE;


### PR DESCRIPTION
Some things could need to run e.g. i386 code in apply_extra (for
example #3742).  In this very limited context (almost everything is
read-only) this seems pretty secure.

We could require the app to specify a multiarch pemission to allow
this, but such permissions only really make sense for an app, and
extra data is often used for other things like runtimes and
extensions, that seems a bit weird.  Lets just enable it always.

Fixes #3742 