### PR TITLE
run: Fix double free in the cups config file parser

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -388,7 +388,7 @@ static char *
 flatpak_run_get_cups_server_name (void)
 {
   g_autofree char * cups_server = NULL;
-  g_autofree char * cups_config = NULL;
+  g_autofree char * cups_config_path = NULL;
 
   /* TODO
    * we don't currently support cups servers located on the network, if such
@@ -397,18 +397,18 @@ flatpak_run_get_cups_server_name (void)
    */
   cups_server = g_strdup (g_getenv ("CUPS_SERVER"));
   if (cups_server && flatpak_run_cups_check_server_is_socket (cups_server))
-    return cups_server;
+    return g_steal_pointer (&cups_server);
+  g_clear_pointer (&cups_server, g_free);
 
-  g_free (cups_server);
-  cups_config = g_build_filename (g_get_home_dir (), ".cups/client.conf", NULL);
-  cups_server = flatpak_run_get_cups_server_name_config (cups_config);
+  cups_config_path = g_build_filename (g_get_home_dir (), ".cups/client.conf", NULL);
+  cups_server = flatpak_run_get_cups_server_name_config (cups_config_path);
   if (cups_server && flatpak_run_cups_check_server_is_socket (cups_server))
-    return cups_server;
+    return g_steal_pointer (&cups_server);
+  g_clear_pointer (&cups_server, g_free);
 
-  g_free (cups_server);
   cups_server = flatpak_run_get_cups_server_name_config ("/etc/cups/client.conf");
   if (cups_server && flatpak_run_cups_check_server_is_socket (cups_server))
-    return cups_server;
+    return g_steal_pointer (&cups_server);
 
   // Fallback to default socket
   return g_strdup ("/var/run/cups/cups.sock");
@@ -418,7 +418,7 @@ static void
 flatpak_run_add_cups_args (FlatpakBwrap *bwrap)
 {
   g_autofree char * sandbox_server_name = g_strdup ("/var/run/cups/cups.sock");
-  g_autofree char * cups_server_name = flatpak_run_get_cups_server_name();
+  g_autofree char * cups_server_name = flatpak_run_get_cups_server_name ();
 
   if (!g_file_test (cups_server_name, G_FILE_TEST_EXISTS))
     {


### PR DESCRIPTION
We were returning a g_autofree:d string and it was then also freed
by the parent.