### PR TITLE
Properly validate configured collection IDs

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -345,6 +345,21 @@ flatpak_remote_state_unref (FlatpakRemoteState *remote_state)
     }
 }
 
+static gboolean
+_validate_summary_for_collection_id (GVariant    *summary_v,
+                                     const char  *collection_id,
+                                     GError     **error)
+{
+  VarSummaryRef summary;
+  summary = var_summary_from_gvariant (summary_v);
+
+  if (!flatpak_summary_find_ref_map (summary, collection_id, NULL))
+    return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                               _("Configured collection ID ‘%s’ not in summary file"), collection_id);
+
+  return TRUE;
+}
+
 void
 flatpak_remote_state_add_sideload_repo (FlatpakRemoteState *self,
                                         GFile *dir)
@@ -363,14 +378,27 @@ flatpak_remote_state_add_sideload_repo (FlatpakRemoteState *self,
   mfile = g_mapped_file_new (flatpak_file_get_path_cached (summary_path), FALSE, NULL);
   if (mfile != NULL && ostree_repo_open (sideload_repo, NULL, NULL))
     {
+      g_autoptr(GError) local_error = NULL;
       g_autoptr(GBytes) summary_bytes = g_mapped_file_get_bytes (mfile);
       FlatpakSideloadState *ss = g_new0 (FlatpakSideloadState, 1);
 
       ss->repo = g_steal_pointer (&sideload_repo);
       ss->summary = g_variant_ref_sink (g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT, summary_bytes, TRUE));
-      g_ptr_array_add (self->sideload_repos, ss);
 
-      g_debug ("Using sideloaded repo %s for remote %s", flatpak_file_get_path_cached (dir), self->remote_name);
+      if (!_validate_summary_for_collection_id (ss->summary, self->collection_id, &local_error))
+        {
+          /* We expect to hit this code path when the repo is providing things
+           * from other remotes
+           */
+          g_debug ("Sideload repo at path %s not valid for remote %s: %s",
+                   flatpak_file_get_path_cached (dir), self->remote_name, local_error->message);
+          flatpak_sideload_state_free (ss);
+        }
+      else
+        {
+          g_ptr_array_add (self->sideload_repos, ss);
+          g_debug ("Using sideloaded repo %s for remote %s", flatpak_file_get_path_cached (dir), self->remote_name);
+        }
     }
 }
 
@@ -10890,6 +10918,11 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
             }
         }
     }
+
+  if (state->collection_id != NULL &&
+      state->summary != NULL &&
+      !_validate_summary_for_collection_id (state->summary, state->collection_id, error))
+    return NULL;
 
   if (flatpak_dir_get_remote_oci (self, remote_or_uri))
     {

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -167,7 +167,9 @@ gboolean flatpak_summary_lookup_ref (GVariant      *summary,
                                      const char    *ref,
                                      char         **out_checksum,
                                      VarRefInfoRef *out_info);
-
+gboolean flatpak_summary_find_ref_map (VarSummaryRef  summary,
+                                       const char    *collection_id,
+                                       VarRefMapRef  *refs_out);
 gboolean flatpak_name_matches_one_wildcard_prefix (const char         *string,
                                                    const char * const *maybe_wildcard_prefixes,
                                                    gboolean            require_exact_match);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2643,10 +2643,10 @@ flatpak_var_ref_map_lookup_ref (VarRefMapRef   ref_map,
  * If @collection_id is %NULL, the main refs list from the summary will be
  * returned. If @collection_id doesn’t match any collection IDs in the summary
  * file, %FALSE will be returned. */
-static gboolean
-summary_find_ref_map (VarSummaryRef summary,
-                      const char *collection_id,
-                      VarRefMapRef *refs_out)
+gboolean
+flatpak_summary_find_ref_map (VarSummaryRef summary,
+                              const char *collection_id,
+                              VarRefMapRef *refs_out)
 {
   VarMetadataRef metadata = var_summary_get_metadata (summary);
   const char *summary_collection_id;
@@ -2655,7 +2655,8 @@ summary_find_ref_map (VarSummaryRef summary,
 
   if (collection_id == NULL || g_strcmp0 (collection_id, summary_collection_id) == 0)
     {
-      *refs_out = var_summary_get_ref_map (summary);
+      if (refs_out)
+        *refs_out = var_summary_get_ref_map (summary);
       return TRUE;
     }
   else if (collection_id != NULL)
@@ -2689,7 +2690,7 @@ flatpak_summary_match_subrefs (GVariant   *summary_v,
   summary = var_summary_from_gvariant (summary_v);
 
   /* Work out which refs list to use, based on the @collection_id. */
-  if (summary_find_ref_map (summary, collection_id, &ref_map))
+  if (flatpak_summary_find_ref_map (summary, collection_id, &ref_map))
     {
       /* Match against the refs. */
       parts = g_strsplit (ref, "/", 0);
@@ -2747,7 +2748,7 @@ flatpak_summary_lookup_ref (GVariant      *summary_v,
   summary = var_summary_from_gvariant (summary_v);
 
   /* Work out which refs list to use, based on the @collection_id. */
-  if (!summary_find_ref_map (summary, collection_id, &ref_map))
+  if (!flatpak_summary_find_ref_map (summary, collection_id, &ref_map))
     return FALSE;
 
   if (!flatpak_var_ref_map_lookup_ref (ref_map, ref, &info))


### PR DESCRIPTION
This commit is a follow-up for the commit "dir: Validate locally
configured collection IDs". Whereas in that commit we validate the
collection ID in flatpak_remote_state_fetch_commit_object(), here we do
it in _flatpak_dir_get_remote_state(), since fetch_commit_object() is
not called on the code path normally taken for a transaction (only if
try_resolve_op_from_metadata() fails and in other niche scenarios).

This should ensure that if someone erroneously sets a collection ID on a
remote, the error will be caught quickly. It also helps the eos-updater
unit tests pass.