### PR TITLE
CI: Add a valgrind check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        # Work around github repo bug (see https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/m-p/41163/highlight/true#M4513)
-        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         sudo add-apt-repository ppa:alexlarsson/flatpak
         sudo add-apt-repository ppa:alexlarsson/glib260
         sudo apt-get update
@@ -87,8 +85,6 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        # Work around github repo bug (see https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/m-p/41163/highlight/true#M4513)
-        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         sudo add-apt-repository ppa:alexlarsson/flatpak
         sudo add-apt-repository ppa:alexlarsson/glib260
         sudo apt-get update
@@ -133,3 +129,53 @@ jobs:
         CFLAGS: -Werror=unused-variable
     - name: Build flatpak
       run: make -j $(getconf _NPROCESSORS_ONLN)
+
+  valgrind:
+    name: Run tests in valgrind
+    needs: check # Don't run expensive test if main check fails
+    runs-on: ubuntu-20.04 # Might as well test with a different one too
+    steps:
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
+        libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
+        libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
+        libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
+        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat meson libdbus-1-dev \
+        valgrind
+    - name: Check out flatpak
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Create logs dir
+      run: mkdir test-logs
+    - name: autogen.sh
+      run: NOCONFIGURE=1 ./autogen.sh
+    - name: configure
+      # TODO: Enable gtk-doc builds
+      run: |
+        mkdir _build
+        pushd _build
+        ../configure
+        popd
+      env:
+        CFLAGS: -O2
+    - name: Build flatpak
+      run: make -C _build -j $(getconf _NPROCESSORS_ONLN)
+    - name: Run tests
+      run: make -C _build check
+      env:
+        FLATPAK_TESTS_VALGRIND: true
+    - name: Collect overall test logs on failure
+      if: failure()
+      run: mv _build/test-suite.log test-logs/ || true
+    - name: Collect individual test logs on cancel
+      if: failure() || cancelled()
+      run: mv _build/tests/*.log test-logs/ || true
+    - name: Upload test logs
+      uses: actions/upload-artifact@v1
+      if: failure() || cancelled()
+      with:
+        name: test logs
+        path: test-logs

--- a/tests/flatpak.supp
+++ b/tests/flatpak.supp
@@ -156,6 +156,15 @@
   fun:_check_support_reflink
 }
 
+# Some unsupported ioctl
+{
+   ignore_ostree_write_ioctl
+   Memcheck:Param
+   ioctl(generic)
+   fun:ioctl
+   obj:*/libostree-1.so.1.0.0
+}
+
 # ostree pthread_create issue
 {
    ostree_pthread_create_issue


### PR DESCRIPTION
This takes a long time, but doesn't have to be mandatory.
Additionally the new test uses ubuntu-latest so we get more wider testing.

Also removes some old no-longer needed ci config workaround.