### PR TITLE
Revert "CI: Run make check in parallel (-j NCPU)"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,7 +64,8 @@ jobs:
     - name: Build flatpak
       run: make -C _build -j $(getconf _NPROCESSORS_ONLN)
     - name: Run tests
-      run: make -C _build check -j $(getconf _NPROCESSORS_ONLN)
+      # TODO: Build with -j (currently ends up with hangs in the tests)
+      run: make -C _build check
       env:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
     - name: Collect overall test logs on failure


### PR DESCRIPTION
Reverts flatpak/flatpak#3811

This seems to make CI hang, like https://github.com/flatpak/flatpak/pull/3809/checks?check_run_id=1012991662