### PR TITLE
Implement more of systemd's container interface

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2365,6 +2365,17 @@ flatpak_run_add_app_info_args (FlatpakBwrap   *bwrap,
                           "--symlink", "../../../.flatpak-info", old_dest,
                           NULL);
 
+  /* Tell the application that it's running under Flatpak in a generic way. */
+  flatpak_bwrap_add_args (bwrap,
+                          "--setenv", "container", "flatpak",
+                          NULL);
+  if (!flatpak_bwrap_add_args_data (bwrap,
+                                    "container-manager",
+                                    "flatpak\n", -1,
+                                    "/run/host/container-manager",
+                                    error))
+    return FALSE;
+
   bwrapinfo_path = g_build_filename (instance_id_host_dir, "bwrapinfo.json", NULL);
   fd3 = open (bwrapinfo_path, O_RDWR | O_CREAT, 0644);
   if (fd3 == -1)

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..17"
+echo "1..18"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -101,6 +101,14 @@ elif [ -f /usr/lib/os-release ]; then
 fi
 
 ok "host os-release"
+
+run_sh org.test.Platform 'cat /run/host/container-manager' > container-manager
+echo flatpak > expected
+diff -u expected container-manager
+run_sh org.test.Platform 'echo "${container}"' > container-manager
+diff -u expected container-manager
+
+ok "host container-manager"
 
 if run org.test.Nonexistent 2> run-error-log; then
     assert_not_reached "Unexpectedly able to run non-existent runtime"


### PR DESCRIPTION
* run: Tell processes in container that the container manager is Flatpak
    
    https://systemd.io/CONTAINER_INTERFACE/ describes a generic way to tell
    programs and libraries that they are running in a container: set
    pid 1's ${container} to the name of the container manager in lower case,
    and populate /run/host/container-manager with the same string followed
    by a newline. Let's be nice to application code by doing that, instead
    of requiring it to look at /.flatpak-info.

* tests: Test container-manager interface