### PR TITLE
Add test coverage for FlatpakExports implementation of host-os, host-etc

### DIFF
--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -61,5 +61,8 @@ FlatpakFilesystemMode flatpak_exports_path_get_mode (FlatpakExports *exports,
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakExports, flatpak_exports_free);
 
+void flatpak_exports_take_host_fd (FlatpakExports *exports,
+                                   int             fd);
+
 
 #endif /* __FLATPAK_EXPORTS_H__ */

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -151,14 +151,15 @@ G_GNUC_WARN_UNUSED_RESULT static gsize
 assert_next_is_bind (FlatpakBwrap *bwrap,
                      gsize i,
                      const char *how,
-                     const char *path)
+                     const char *path,
+                     const char *dest)
 {
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, how);
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
   g_assert_cmpuint (i, <, bwrap->argv->len);
-  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, dest);
   return i;
 }
 
@@ -804,8 +805,8 @@ test_full (void)
 
   i = assert_next_is_symlink (bwrap, i, abs_target, abs_link);
   i = assert_next_is_symlink (bwrap, i, "../2/target", rel_link);
-  i = assert_next_is_bind (bwrap, i, "--bind", abs_target);
-  i = assert_next_is_bind (bwrap, i, "--bind", target);
+  i = assert_next_is_bind (bwrap, i, "--bind", abs_target, abs_target);
+  i = assert_next_is_bind (bwrap, i, "--bind", target, target);
   i = assert_next_is_dir (bwrap, i, create_dir);
 
   /* create_dir2 is not currently created with --dir inside the container
@@ -816,8 +817,8 @@ test_full (void)
       g_strcmp0 (bwrap->argv->pdata[i + 1], create_dir2) == 0)
     i += 2;
 
-  i = assert_next_is_bind (bwrap, i, "--ro-bind", dont_hide);
-  i = assert_next_is_bind (bwrap, i, "--ro-bind", expose_ro);
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", dont_hide, dont_hide);
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", expose_ro, expose_ro);
 
   /* We don't create a FAKE_MODE_TMPFS in the container unless there is
    * a directory on the host to mount it on.
@@ -825,7 +826,7 @@ test_full (void)
    * $subdir/expose-ro *is* exposed. */
   i = assert_next_is_tmpfs (bwrap, i, hide_below_expose);
 
-  i = assert_next_is_bind (bwrap, i, "--bind", expose_rw);
+  i = assert_next_is_bind (bwrap, i, "--bind", expose_rw, expose_rw);
 
   /* Hiding $subdir/hide just uses --dir, because $subdir is not
    * exposed. */


### PR DESCRIPTION
Follow-up from #3283.

* exports: Allow redirecting /etc, /usr from the host to an alternative
    
    This is primarily for test coverage ("design for test"): it will let us
    pretend a temporary directory is the host for the purposes of testing
    --filesystem=host-etc, --filesystem=host-os, and the os-release handling
    from #3733.
    
    It can also be used to build a bwrap command-line that will be used on
    the host, while already inside a container, which will be useful for
    Steam's pressure-vessel tool (which copies some of the Flatpak code).

* tests: Allow asserting that a bind-mount has a different target

* tests: Assert that symlinks point to the right place
    
    The previous implementation was rather simplistic, and assumed that
    all symlinks that get exported are in /tmp/something/test_full/.
    Tighten up the assertions, while also coping with symlinks that are
    created at top level, such as /bin -> usr/bin.

* tests: Exercise host-os, host-etc and os-release in fake system roots
    
    Now that FlatpakExports can be told to look for /etc and /usr in a
    fake directory hierarchy, we can assert that systems resembling
    particular OSs' layouts still work, even if we are not running on that
    OS right now. In particular, this provides unit tests for commits
    12e3dc05, 08d65c54, 7872935e and fe2536b8.