### PR TITLE
common: Allow skewering when converting in app-id for DConf migration

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -7540,6 +7540,13 @@ flatpak_dconf_path_is_similar (const char *path1,
       if (path2[i2] == '\0')
         break;
 
+      if (isupper(path1[i1]) &&
+          (path2[i2] == '-' || path2[i2] == '_'))
+        i2++;
+
+      if (path2[i2] == '\0')
+        break;
+
       if (tolower (path1[i1]) == tolower (path2[i2]))
         {
           if (path1[i1] == '/')

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -7532,23 +7532,23 @@ gboolean
 flatpak_dconf_path_is_similar (const char *path1,
                                const char *path2)
 {
-  int i, i1, i2;
+  int i1, i2;
   int num_components = -1;
 
-  for (i = 0; path1[i] != '\0'; i++)
+  for (i1 = i2 = 0; path1[i1] != '\0'; i1++, i2++)
     {
-      if (path2[i] == '\0')
+      if (path2[i2] == '\0')
         break;
 
-      if (tolower (path1[i]) == tolower (path2[i]))
+      if (tolower (path1[i1]) == tolower (path2[i2]))
         {
-          if (path1[i] == '/')
+          if (path1[i1] == '/')
             num_components++;
           continue;
         }
 
-      if ((path1[i] == '-' || path1[i] == '_') &&
-          (path2[i] == '-' || path2[i] == '_'))
+      if ((path1[i1] == '-' || path1[i1] == '_') &&
+          (path2[i2] == '-' || path2[i2] == '_'))
         continue;
 
       break;
@@ -7557,7 +7557,6 @@ flatpak_dconf_path_is_similar (const char *path1,
   /* Skip over any versioning if we have at least a TLD and
    * domain name, so 2 components */
   /* We need at least TLD, and domain name, so 2 components */
-  i1 = i2 = i;
   if (num_components >= 2)
     {
       while (isdigit (path1[i1]))

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1149,6 +1149,10 @@ test_dconf_paths (void)
     { "/org/gnome1/Rhythmbox/", "/org/gnome/rhythmbox", 0 },
     { "/org/gnome1/Rhythmbox", "/org/gnome/rhythmbox/", 0 },
     { "/org/gnome/Rhythmbox3plus/", "/org/gnome/rhythmbox/", 0 },
+    { "/org/gnome/SoundJuicer/", "/org/gnome/sound-juicer/", 1 },
+    { "/org/gnome/Sound-Juicer/", "/org/gnome/sound-juicer/", 1 },
+    { "/org/gnome/Soundjuicer/", "/org/gnome/sound-juicer/", 0 },
+    { "/org/gnome/Soundjuicer/", "/org/gnome/soundjuicer/", 1 },
   };
   int i;
 


### PR DESCRIPTION
Allow a snake-case in the app-id to convert to a '-' or '_' in the
DConf path to be considered similar enough for DConf migration purposes.

This allows the org.gnome.SoundJuicer app-id to migrate its
/org/gnome/sound-juicer DConf path.

`F: Ignoring D-Conf migrate-path setting /org/gnome/sound-juicer/`