### PR TITLE
OCI: extract appstream data for runtimes

### DIFF
--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -3120,7 +3120,8 @@ add_image_to_appstream (SoupSession               *soup_session,
     return;
 
   ref_parts = g_strsplit (ref, "/", -1);
-  if (g_strv_length (ref_parts) != 4 || strcmp (ref_parts[0], "app") != 0)
+  if (g_strv_length (ref_parts) != 4 ||
+      (strcmp (ref_parts[0], "app") != 0 && strcmp (ref_parts[0], "runtime") != 0))
     return;
 
   id = ref_parts[1];


### PR DESCRIPTION
Runtimes also have appstream data - with description, license information,
and so forth, so we should extract the appstream data from the index
for refs that start with runtime/ as well.