### PR TITLE
Don't loop authentincating if updating to the current version

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2765,6 +2765,18 @@ resolve_ops (FlatpakTransaction *self,
       if (op->resolved)
         continue;
 
+      if (op->skip)
+        {
+          /* We're not yet resolved, but marked skip anyway, this can happen if during
+           * request_required_tokens() we were normalized away even though not fully resolved.
+           * For example we got the checksum but need to auth to get the commit, but the
+           * checksum we got was the version already installed.
+           */
+          g_assert (op->resolved_commit != NULL);
+          mark_op_resolved (op, op->resolved_commit, NULL, NULL, NULL);
+          continue;
+        }
+
       if (op->kind == FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
         {
           /* We resolve to the deployed metadata, because we need it to uninstall related ops */


### PR DESCRIPTION
In case we need to authenticate for updates (in my test case i was
doing an OCI downgrade) we might need to download a commit object (or
in the OCI case a manifest json), so it did a request_required_tokens(),
but that noticed during the flatpak_transaction_normalize_ops() call
that the partial resolve to a particular commit actually was the
same as the local installed commit and marked op->skip = TRUE.

However, when we got back to resolving the op again we didn't actually
look at the skip, so it kept looping wanting (but never doing) auth.

The fix is to just directly resolve ops marked as skipped.