### PR TITLE
Avoid critical error in remote-info command

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -991,14 +991,14 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
 
   /* First try local availability */
   if (ostree_repo_load_commit (dir->repo, commit, &commit_data, NULL, NULL))
-    return g_steal_pointer (&commit_data);
+    goto out;
 
   for (int i = 0; i < self->sideload_repos->len; i++)
     {
       FlatpakSideloadState *ss = g_ptr_array_index (self->sideload_repos, i);
 
       if (ostree_repo_load_commit (ss->repo, commit, &commit_data, NULL, NULL))
-        return g_steal_pointer (&commit_data);
+        goto out;
     }
 
   if (flatpak_dir_get_remote_oci (dir, self->remote_name))
@@ -1008,6 +1008,7 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
     commit_data = flatpak_remote_state_fetch_commit_object (self, dir, ref, commit, token,
                                                             cancellable, error);
 
+out:
   if (out_commit)
     *out_commit = g_steal_pointer (&commit);
 


### PR DESCRIPTION
Without this patch, the remote-info command will sometimes emit a
critical error "g_utf8_strlen: assertion 'p != NULL || max == 0' failed"
and print (null) for the "Commit:" field, since the commit doesn't get
initialized properly.