### PR TITLE
portal: Fix unset GError issue

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1527,11 +1527,10 @@ lookup_installation_for_path (GFile *path, GError **error)
   installation = g_hash_table_lookup (installation_cache, path);
   if (installation == NULL)
     {
-      g_autoptr(GError) error = NULL;
       g_autoptr(FlatpakDir) dir = NULL;
 
       dir = flatpak_dir_get_by_path (path);
-      installation = flatpak_installation_new_for_dir (dir, NULL, &error);
+      installation = flatpak_installation_new_for_dir (dir, NULL, error);
       if (installation == NULL)
         return NULL;
 


### PR DESCRIPTION
Fix lookup_installation_for_path() to not leave the GError pointer unset
on its error code path. This error is only used by the caller for a
debug message, and shouldn't be hit normally, but it could mean a NULL
pointer dereference when we try to print error->message.