### PR TITLE
sideload-repo-systemd: Various fixes

### DIFF
--- a/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
+++ b/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
@@ -26,6 +26,10 @@ done
 
 # Remove any broken symlinks e.g. from drives that were removed
 for f in /run/flatpak/sideload-repos/automount*; do
+    OWNER=$(stat -c '%u' "$f")
+    if [ "$UID" != "$OWNER" ]; then
+        continue
+    fi
     if ! test -e "$f"; then
         rm "$f"
     fi

--- a/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
+++ b/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # This script is intended to be run by flatpak-sideload-usb-repo.service
+
 shopt -s nullglob
 
 if ! test $# -eq 1 || ! test -d "$1"; then

--- a/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
+++ b/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
@@ -17,7 +17,7 @@ for f in "$1"/*; do
     if ! test -d "$f"; then
         continue
     fi
-    unique_name=automount-$(echo "$f" | sha256sum | cut -f 1 -d ' ')
+    unique_name=automount$(systemd-escape "$f")
     if test -e "/run/flatpak/sideload-repos/$unique_name"; then
         continue
     fi
@@ -25,7 +25,7 @@ for f in "$1"/*; do
 done
 
 # Remove any broken symlinks e.g. from drives that were removed
-for f in /run/flatpak/sideload-repos/automount-*; do
+for f in /run/flatpak/sideload-repos/automount*; do
     if ! test -e "$f"; then
         rm "$f"
     fi

--- a/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
+++ b/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # This script is intended to be run by flatpak-sideload-usb-repo.service
+shopt -s nullglob
 
 if ! test $# -eq 1 || ! test -d "$1"; then
   echo "Error: first argument must be a directory"

--- a/sideload-repos-systemd/flatpak-sideload-usb-repo.path.in
+++ b/sideload-repos-systemd/flatpak-sideload-usb-repo.path.in
@@ -1,6 +1,6 @@
 # This unit is intended to be installed in the systemd user instance, and
-# depends on flatpak-sideload-repos-dir.service being in the system instance
-# and running first. The idea here is that we add any USB drive mounts to the
+# depends on /run/flatpak/sideload-repos having been created via
+# systemd-tmpfiles. The idea here is that we add any USB drive mounts to the
 # appropriate directory so Flatpak can find and pull from them in case they
 # have flatpaks on them, both when a new drive is inserted and at the start of
 # the user session.

--- a/sideload-repos-systemd/flatpak-sideload-usb-repo.path.in
+++ b/sideload-repos-systemd/flatpak-sideload-usb-repo.path.in
@@ -5,7 +5,6 @@
 # have flatpaks on them, both when a new drive is inserted and at the start of
 # the user session.
 [Path]
-PathExists=@media_dir@/%u
 PathChanged=@media_dir@/%u
 
 [Install]

--- a/sideload-repos-systemd/flatpak-sideload-usb-repo.service.in
+++ b/sideload-repos-systemd/flatpak-sideload-usb-repo.service.in
@@ -3,3 +3,6 @@
 [Service]
 Type=oneshot
 ExecStart=@libexecdir@/flatpak-create-sideload-symlinks.sh @media_dir@/%u
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Previously, if there were no existing symlinks, this script would fail:

    wjt@camille:~$ LANG=en_GB.utf8 bash -x /usr/libexec/flatpak-create-sideload-symlinks.sh /run/media/wjt
    + test 1 -eq 1
    + test -d /run/media/wjt
    + for f in "$1"/*
    + test -d '/run/media/wjt/*'
    + continue
    + for f in /run/flatpak/sideload-repos/automount-*
    + test -e '/run/flatpak/sideload-repos/automount-*'
    + rm '/run/flatpak/sideload-repos/automount-*'
    rm: cannot remove '/run/flatpak/sideload-repos/automount-*': No such file or directory

This is due to the surprising POSIX shell behaviour that a glob that
matches no files expands to itself, rather than to the empty list.

http://mywiki.wooledge.org/BashFAQ/004

The POSIX solution is to add 'test -L $f' inside the loop to check if
the variable actually exists.  The first loop in this script uses this
technique: it has a 'test -d "$f"', seen in the trace above.

Bash implements a 'nullglob' feature which gives globs the behaviour you
might hope for. Set it in this script.