### PR TITLE
common: Allow skewered to camelcase DConf path conversion both ways

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -7402,12 +7402,21 @@ flatpak_dconf_path_is_similar (const char *path1,
       if (path2[i2] == '\0')
         break;
 
+      if (isupper(path2[i2]) &&
+          (path1[i1] == '-' || path1[i1] == '_'))
+        {
+          i1++;
+          if (path1[i1] == '\0')
+            break;
+        }
+
       if (isupper(path1[i1]) &&
           (path2[i2] == '-' || path2[i2] == '_'))
-        i2++;
-
-      if (path2[i2] == '\0')
-        break;
+        {
+          i2++;
+          if (path2[i2] == '\0')
+            break;
+        }
 
       if (tolower (path1[i1]) == tolower (path2[i2]))
         {

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1153,6 +1153,7 @@ test_dconf_paths (void)
     { "/org/gnome/Sound-Juicer/", "/org/gnome/sound-juicer/", 1 },
     { "/org/gnome/Soundjuicer/", "/org/gnome/sound-juicer/", 0 },
     { "/org/gnome/Soundjuicer/", "/org/gnome/soundjuicer/", 1 },
+    { "/org/gnome/sound-juicer/", "/org/gnome/SoundJuicer/", 1 },
   };
   int i;
 


### PR DESCRIPTION
commit 6b46d9a0ede99dca99737fa3d4e55200cb9336e3 that added DConf path
skewering to camelcase conversion only allowed it in one direction
(skewered path1 and camelcase path2).

That turned out to be not enough to allow /org/gnome/sound-juicer/ to
/org/gnome/SoundJuicer/ conversion as the caller had the
flatpak_dconf_path_is_similar() arguments the other way around.

This commit implements it both ways to avoid confusion which way it
should be called.

F: Ignoring D-Conf migrate-path setting /org/gnome/sound-juicer/