### PR TITLE
sideload-repo-systemd: Don't require media dir to exist

### DIFF
--- a/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
+++ b/sideload-repos-systemd/flatpak-create-sideload-symlinks.sh
@@ -3,17 +3,13 @@
 # This script is intended to be run by flatpak-sideload-usb-repo.service
 
 shopt -s nullglob
-
-if ! test $# -eq 1 || ! test -d "$1"; then
-  echo "Error: first argument must be a directory"
-  exit 1
-fi
+media_dir=${1:?path to media directory is required}
 
 # Add a link to any newly inserted drives which might have been copied to with
 # "flatpak create-usb". If we were to check for a repo on the drive that would
 # break the case of using it for sideloading directly after copying to it (e.g.
 # for testing).
-for f in "$1"/*; do
+for f in "$media_dir"/*; do
     if ! test -d "$f"; then
         continue
     fi


### PR DESCRIPTION
When launched when the session starts, /run/media/%u may not exist if
the user has never mounted any removable storage devices. This causes
the unit to fail on login.

Relax the check to just validate that the argument has been provided.
Since we use shopt -s nullglob, the "$media_dir"/* glob will expand to
the empty list if $media_dir does not exist.

(The other option is to add a condition check to the .service, but the
script might conceivably want to clean up some stale symlinks.)