### PR TITLE
Document D-Bus APIs

### DIFF
--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -70,14 +70,78 @@
     </method>
   </interface>
 
+  <!--
+      org.freedesktop.Flatpak.Development:
+      @short_description: Flatpak development interface
+
+      The Development interface lets any client, possibly in a sandbox if
+      it has access to the session helper, spawn a process on the host,
+      outside any sandbox.
+
+      Clearly this is not something you typically want a sandboxed app to
+      do: it is a sandbox escape allowing arbitrary code execution,
+      and must not be allowed for applications where sandboxing is
+      intended to be a security boundary.
+
+      However, it is very useful when using Flatpak for distribution and
+      choice of runtime library stack, without intending to create a
+      security boundary. For instance, if an IDE like GNOME Builder is
+      distributed as a trusted Flatpak app and will be used to build other
+      Flatpak apps, it needs to use this facility to launch a Flatpak
+      build operation inside the sandbox, because otherwise recursive
+      calls to flatpak will not work.
+
+      This interface is provided on the D-Bus session bus by the
+      well-known D-Bus name org.freedesktop.Flatpak,
+      at the object path /org/freedesktop/Flatpak/Development.
+
+      This documentation describes version 1 of this interface.
+  -->
   <interface name='org.freedesktop.Flatpak.Development'>
+    <!--
+        version:
+
+        The API version number.
+        This documentation describes version 1 of this interface.
+    -->
     <property name="version" type="u" access="read"/>
 
-    <!-- This methods let you start processes, sandboxed or not on the
-         host, so its not generally safe to allow access to it to any
-         application. However, at times it is very useful to be able
-         to do this. For instance for developer tools this lets you
-         build flatpaks from inside a flatpak. -->
+    <!--
+        HostCommand:
+        @cwd_path: the working directory for the new process
+        @argv: the argv for the new process, starting with the executable to launch
+        @fds: an array of file descriptors to pass to the new process
+        @envs: an array of variable/value pairs for the environment of the new process
+        @flags: flags
+        @pid: the PID of the new process
+
+        This method lets trusted applications (insider or outside a
+        sandbox) run arbitrary commands in the user's session, outside
+        any sandbox.
+
+        The following flags values are supported:
+
+        <variablelist>
+          <varlistentry>
+            <term>1 (FLATPAK_HOST_COMMAND_FLAGS_CLEAR_ENV)</term>
+            <listitem><para>
+              Clear the environment.
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>2 (FLATPAK_HOST_COMMAND_FLAGS_WATCH_BUS)</term>
+            <listitem><para>
+              Kill the sandbox when the caller disappears from the session bus.
+            </para></listitem>
+          </varlistentry>
+        </variablelist>
+
+        Unknown (unsupported) flags are an error and will cause HostCommand()
+        to fail.
+
+        Note that unlike org.freedesktop.portal.Flatpak.Spawn(), there
+        is no options parameter here.
+    -->
     <method name="HostCommand">
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
       <arg type='ay' name='cwd_path' direction='in'/>
@@ -87,11 +151,41 @@
       <arg type='u' name='flags' direction='in'/>
       <arg type='u' name='pid' direction='out'/>
     </method>
+
+    <!--
+        HostCommandSignal:
+        @pid: the process ID on the host system
+        @signal: the signal to send (see <citerefentry><refentrytitle>signal</refentrytitle><manvolnum>7</manvolnum></citerefentry>)
+        @to_process_group: whether to send the signal to the process group
+
+        This method lets you send a Unix signal to a process
+        that was started with org.freedesktop.Flatpak.Development.HostCommand().
+        The @pid argument here must be a PID that was returned by a
+        call to HostCommand() from the same sender: terminating unrelated
+        processes is not allowed.
+    -->
     <method name="HostCommandSignal">
       <arg type='u' name='pid' direction='in'/>
       <arg type='u' name='signal' direction='in'/>
       <arg type='b' name='to_process_group' direction='in'/>
     </method>
+
+    <!--
+        HostCommandExited:
+        @pid: the PID of the process that has ended
+        @exit_status: the wait status (see <citerefentry><refentrytitle>waitpid</refentrytitle><manvolnum>2</manvolnum></citerefentry>)
+
+        Emitted when a process started by
+        org.freedesktop.Flatpak.Development.HostCommand() exits.
+        Use g_spawn_check_exit_status(), or the macros such as
+        WIFEXITED documented in
+        <citerefentry><refentrytitle>waitpid</refentrytitle><manvolnum>2</manvolnum></citerefentry>,
+        to interpret the @exit_status.
+
+        This signal is not emitted for processes that were not launched
+        directly by HostCommand(), for example if a process launched by
+        HostCommand() runs foreground or background child processes.
+    -->
     <signal name="HostCommandExited">
       <arg type='u' name='pid' direction='out'/>
       <arg type='u' name='exit_status' direction='out'/>

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -24,9 +24,47 @@
 -->
 
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <!--
+      org.freedesktop.Flatpak.SessionHelper:
+      @short_description: Flatpak session service
+
+      The Flatpak session service is used by the
+      <command>flatpak run</command> command
+      to bridge various resources from the host system into Flatpak
+      sandboxes. It is not intended to be contacted by third-party
+      applications or libraries.
+
+      This interface is provided on the D-Bus session bus by the
+      well-known D-Bus name org.freedesktop.Flatpak,
+      at the object path /org/freedesktop/Flatpak/SessionHelper.
+
+      Note that the service owning the org.freedesktop.Flatpak
+      well-known name also exports the
+      org.freedesktop.Flatpak.Development interface. As a result,
+      letting a sandboxed application contact that well-known name
+      is a sandbox escape, which must only be allowed for trusted
+      applications where there is not intended to be any security
+      boundary between sandbox and host system.
+
+      This documentation describes version 1 of this interface.
+  -->
   <interface name='org.freedesktop.Flatpak.SessionHelper'>
+    <!--
+        version:
+
+        The API version number.
+        This documentation describes version 1 of this interface.
+    -->
     <property name="version" type="u" access="read"/>
 
+    <!--
+        RequestSession:
+        @data: Information about the new session
+
+        Set up monitoring and resources for a
+        <command>flatpak run</command> session.
+        See the Flatpak source code for details.
+    -->
     <method name="RequestSession">
       <arg type='a{sv}' name='data' direction='out'/>
     </method>

--- a/data/org.freedesktop.Flatpak.xml
+++ b/data/org.freedesktop.Flatpak.xml
@@ -193,6 +193,30 @@
 
   </interface>
 
+  <!--
+      org.freedesktop.Flatpak.SystemHelper:
+      @short_description: Flatpak system service
+
+      The Flatpak system service is used by the libflatpak library
+      to manipulate Flatpak applications and runtimes that are installed
+      system-wide, for example when implementing
+      <command>flatpak install</command>.
+      It is not intended to be contacted by third-party applications
+      or libraries. See the Flatpak source code for more
+      details of this interface's methods.
+
+      This interface is provided on the D-Bus system bus by the
+      well-known D-Bus name org.freedesktop.Flatpak.SystemHelper,
+      at the object path /org/freedesktop/Flatpak/SystemHelper.
+
+      The system helper runs as a privileged user at the system level,
+      and receives method calls from less-privileged users.
+      Authorization for method calls on this interface is mediated by
+      polkit (formerly PolicyKit) using the policy configuration
+      org.freedesktop.Flatpak.policy, and can be configured by
+      system administrators in the same way as for any other system service
+      that uses polkit.
+  -->
   <interface name='org.freedesktop.Flatpak.SystemHelper'>
     <property name="version" type="u" access="read"/>
 

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -47,7 +47,7 @@
          The following flags values are supported:
          <variablelist>
            <varlistentry>
-             <term>1</term>
+             <term>1 (FLATPAK_SPAWN_SUPPORT_FLAGS_EXPOSE_PIDS)</term>
              <listitem><para>
                Supports the expose sandbox pids flag of Spawn.
              </para></listitem>
@@ -74,37 +74,37 @@
          The following flags values are supported:
          <variablelist>
            <varlistentry>
-             <term>1</term>
+             <term>1 (FLATPAK_SPAWN_FLAGS_CLEAR_ENV)</term>
              <listitem><para>
                Clear the environment.
              </para></listitem>
            </varlistentry>
            <varlistentry>
-             <term>2</term>
+             <term>2 (FLATPAK_SPAWN_FLAGS_LATEST_VERSION)</term>
              <listitem><para>
                Spawn the latest version of the app.
              </para></listitem>
            </varlistentry>
            <varlistentry>
-             <term>4</term>
+             <term>4 (FLATPAK_SPAWN_FLAGS_SANDBOX)</term>
              <listitem><para>
                Spawn in a sandbox (equivalent of the sandbox option of flatpak run).
              </para></listitem>
            </varlistentry>
            <varlistentry>
-             <term>8</term>
+             <term>8 (FLATPAK_SPAWN_FLAGS_NO_NETWORK)</term>
              <listitem><para>
                Spawn without network (equivalent of the unshare=network option of flatpak run).
              </para></listitem>
            </varlistentry>
            <varlistentry>
-             <term>16</term>
+             <term>16 (FLATPAK_SPAWN_FLAGS_WATCH_BUS)</term>
              <listitem><para>
                Kill the sandbox when the caller disappears from the session bus.
              </para></listitem>
            </varlistentry>
            <varlistentry>
-             <term>32</term>
+             <term>32 (FLATPAK_SPAWN_FLAGS_EXPOSE_PIDS)</term>
              <listitem><para>
                Expose the sandbox pids in the callers sandbox, only supported if using user namespaces for containers (not setuid), see the support property.
                </para><para>
@@ -112,7 +112,7 @@
              </para></listitem>
            </varlistentry>
            <varlistentry>
-             <term>64</term>
+             <term>64 (FLATPAK_SPAWN_FLAGS_NOTIFY_START)</term>
              <listitem><para>
                Emit a SpawnStarted signal once the sandboxed process has been
                fully started.

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -226,14 +226,15 @@
 
     <!--
         SpawnSignal:
-        @pid: the PID of the process to send the signal to
-        @signal: the signal to send (see signal(7))
+        @pid: the PID inside the container to signal
+        @signal: the signal to send (see <citerefentry><refentrytitle>signal</refentrytitle><manvolnum>7</manvolnum></citerefentry>)
         @to_process_group: whether to send the signal to the process group
 
         This method lets you send a Unix signal to a process
         that was started with org.freedesktop.portal.Flatpak.Spawn().
         The @pid argument here should be the PID that is returned
-        by the Spawn() call.
+        by the Spawn() call: it is not necessarily valid in the caller's
+        PID namespace.
       -->
     <method name="SpawnSignal">
       <arg type='u' name='pid' direction='in'/>
@@ -266,10 +267,18 @@
     <!--
         SpawnExited:
         @pid: the PID of the process that has ended
-        @exit_status: the exit status (see waitpid(2))
+        @exit_status: the wait status (see <citerefentry><refentrytitle>waitpid</refentrytitle><manvolnum>2</manvolnum></citerefentry>)
 
         Emitted when a process started by org.freedesktop.portal.Flatpak.Spawn()
         exits.
+        Use g_spawn_check_exit_status(), or the macros such as
+        WIFEXITED documented in
+        <citerefentry><refentrytitle>waitpid</refentrytitle><manvolnum>2</manvolnum></citerefentry>,
+        to interpret the @exit_status.
+
+        This signal is not emitted for processes that were not launched
+        directly by Spawn(), for example if a process launched by
+        Spawn() runs foreground or background child processes.
     -->
     <signal name="SpawnExited">
       <arg type='u' name='pid' direction='out'/>

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -32,7 +32,7 @@
       host to the sandbox. For example, it allows you to restart the
       applications or start a more sandboxed instance.
 
-      The D-Bus interface for the document portal is available under the
+      This portal is available on the D-Bus session bus under the
       bus name org.freedesktop.portal.Flatpak and the object path
       /org/freedesktop/portal/Flatpak.
 

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -68,7 +68,7 @@
          @options: Vardict with optional further information
          @pid: the PID of the new process
 
-         This methods let you start a new instance of your
+         This method lets you start a new instance of your
          application, optionally enabling a tighter sandbox.
 
          The following flags values are supported:
@@ -226,7 +226,7 @@
         @signal: the signal to send (see signal(7))
         @to_process_group: whether to send the signal to the process group
 
-        This methods let you send a Unix signal to a process
+        This method lets you send a Unix signal to a process
         that was started with org.freedesktop.portal.Flatpak.Spawn().
         The @pid argument here should be the PID that is returned
         by the Spawn() call.

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -122,7 +122,11 @@
            </varlistentry>
          </variablelist>
 
-         The following options are supported:
+        Unknown (unsupported) flags are an error and will cause Spawn()
+        to fail.
+
+        Unknown (unsupported) options are ignored.
+        The following options are supported:
          <variablelist>
            <varlistentry>
              <term>sandbox-expose as</term>

--- a/doc/reference/Makefile.am
+++ b/doc/reference/Makefile.am
@@ -47,7 +47,13 @@ EXTRA_HFILES =
 
 HTML_IMAGES =
 
-content_files =
+content_files = \
+	dbus-org.freedesktop.Flatpak.Authenticator.stamp \
+	dbus-org.freedesktop.Flatpak.stamp \
+	dbus-org.freedesktop.impl.portal.PermissionStore.stamp \
+	dbus-org.freedesktop.portal.Documents.stamp \
+	dbus-org.freedesktop.portal.Flatpak.stamp \
+	$(NULL)
 expand_content_files = 
 
 AM_CPPFLAGS = -I$(top_srcdir)/common -I$(top_builddir)/common $(BASE_CFLAGS)
@@ -67,3 +73,5 @@ endif
 libflatpak-docs.html: libflatpak-docs.xml docs
 	$(AM_V_GEN) $(XMLTO) $(XMLTO_FLAGS) --skip-validation xhtml-nochunks -m $(srcdir)/../xmlto-config.xsl $<
 
+dbus-%.stamp: $(top_srcdir)/data/%.xml
+	$(AM_V_GEN)$(GDBUS_CODEGEN) --generate-docbook=dbus $<

--- a/doc/reference/libflatpak-docs.xml
+++ b/doc/reference/libflatpak-docs.xml
@@ -30,6 +30,18 @@
     <xi:include href="xml/flatpak-version-macros.xml"/>
   </chapter>
 
+  <chapter>
+    <title>D-Bus APIs</title>
+    <xi:include href="dbus-org.freedesktop.Flatpak.Authenticator.xml"/>
+    <xi:include href="dbus-org.freedesktop.Flatpak.Development.xml"/>
+    <xi:include href="dbus-org.freedesktop.Flatpak.SessionHelper.xml"/>
+    <xi:include href="dbus-org.freedesktop.Flatpak.SystemHelper.xml"/>
+    <xi:include href="dbus-org.freedesktop.impl.portal.PermissionStore.xml"/>
+    <xi:include href="dbus-org.freedesktop.portal.Documents.xml"/>
+    <xi:include href="dbus-org.freedesktop.portal.Flatpak.xml"/>
+    <xi:include href="dbus-org.freedesktop.portal.Flatpak.UpdateMonitor.xml"/>
+  </chapter>
+
   <chapter id="object-tree">
     <title>Object Hierarchy</title>
     <xi:include href="xml/tree_index.sgml"/>


### PR DESCRIPTION
* portal: Fix typos in documentation

* portal: This is the flatpak portal, not the documentation portal
    
    Also specify that it's on the session bus, not some other bus.

* portal: Document forwards-compatibility for flags and options
    
    Flags are assumed to be critical, similar to the convention for modern
    Linux syscalls: if an unknown flag is given, the call will fail.
    Callers are expected to guard their use of flags with a version check
    or a fallback.
    
    Conversely, options are assumed to be non-critical "hints", similar
    to org.freedesktop.Notifications: if an unknown option is given, the
    call will succeed as though the option had not been present. Callers
    are expected to carry out an explicit version check if they need to
    know whether an option is going to be respected or not.

* portal: Document the symbolic names of the flags
    
    They aren't currently in any installed header file, but that doesn't
    mean we can't suggest a name for dependent projects to #define.

* portal: Adjust documentation for SpawnSignal, SpawnExited
    
    This is based on documentation that I wrote for Steam's pressure-vessel,
    which has a Launcher interface based on the API and implementation of
    the Flatpak portal.
    
    I haven't renamed exit_status to wait_status like commit 63feb3cc in
    flatpak-xdg-utils, just in case the name is significant in someone's
    code-generation. However, don't be fooled: it's a wait-status, not
    an exit status.

* data: Briefly document the SessionHelper interface

* data: Document the Development interface
    
    This is heavily based on the corresponding documentation for the
    portal.

* data: Very briefly document the SystemHelper interface
    
    I'm not documenting the individual methods here, only the fact that the
    interface exists and is private to the Flatpak source tree (it's the
    communication between libflatpak and the system helper).

* doc: Include D-Bus APIs in the API reference documentation