### PR TITLE
Fix issues from lack of extension name validation

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -588,6 +588,12 @@ update_metadata (GFile *base, FlatpakContext *arg_context, gboolean is_runtime, 
           goto out;
         }
 
+      if (!flatpak_is_valid_name (elements[0], error))
+        {
+          glnx_prefix_error (error, _("Invalid extension name %s"), elements[0]);
+          goto out;
+        }
+
       groupname = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION,
                                elements[0], NULL);
 

--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -449,6 +449,9 @@ flatpak_builtin_build_init (int argc, char **argv, GCancellable *cancellable, GE
       if (g_strv_length (elements) < 2)
         return flatpak_fail (error, _("Too few elements in --extension argument %s, format should be NAME=VAR[=VALUE]"), opt_extensions[i]);
 
+      if (!flatpak_is_valid_name (elements[0], error))
+        return glnx_prefix_error (error, _("Invalid extension name %s"), elements[0]);
+
       groupname = g_strconcat (FLATPAK_METADATA_GROUP_PREFIX_EXTENSION,
                                elements[0], NULL);
 


### PR DESCRIPTION
This fixes two issues from #3887:

- It's possible to create extensions with invalid ref names.
- Invalid ref names cause the transaction code to segfault.