### PR TITLE
Fix update detection if authentication is needed and ask for confirmation before auth

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1096,7 +1096,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
 
   related_to_ops = g_hash_table_new_full (g_direct_hash, g_direct_equal, g_object_unref, null_safe_g_ptr_array_unref);
 
-  g_signal_connect (transaction, "ready", G_CALLBACK (transaction_ready), &related_to_ops);
+  g_signal_connect (transaction, "ready-pre-auth", G_CALLBACK (transaction_ready), &related_to_ops);
 
   flatpak_transaction_run (transaction, cancellable, &local_error);
   g_assert (local_error != NULL);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3469,7 +3469,7 @@ request_tokens_for_remote (FlatpakTransaction *self,
       if (g_variant_lookup (results, "error-code", "i", &error_code) && error_code != -1)
         {
           if (error_message)
-            flatpak_fail_error (error, error_code, _("Failed to get tokens for ref: %s"), error_message);
+            return flatpak_fail_error (error, error_code, _("Failed to get tokens for ref: %s"), error_message);
           else
             return flatpak_fail_error (error, error_code, _("Failed to get tokens for ref"));
         }

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -150,7 +150,9 @@ struct _FlatpakTransactionClass
                                    const char         *remote,
                                    const char         *authenticator_ref);
 
-  gpointer padding[4];
+  gboolean (*ready_pre_auth) (FlatpakTransaction *transaction);
+
+  gpointer padding[3];
 };
 
 FLATPAK_EXTERN
@@ -195,6 +197,8 @@ FLATPAK_EXTERN
 GKeyFile *                      flatpak_transaction_operation_get_metadata (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
 GKeyFile *                      flatpak_transaction_operation_get_old_metadata (FlatpakTransactionOperation *self);
+FLATPAK_EXTERN
+gboolean                        flatpak_transaction_operation_get_requires_authentication (FlatpakTransactionOperation *self);
 FLATPAK_EXTERN
 const char *                    flatpak_transaction_operation_type_to_string (FlatpakTransactionOperationType kind);
 


### PR DESCRIPTION
It turns out that out flatpak_installation_list_installed_refs_for_update() implementation using transactions doesn't handle the case where authentication is needed for a particular ref as it doesn't install an auth handler. To avoid this problem we add and use a new ready-pre-auth signal that gets emitted when we're ready with everything except auth.

Once we have this we also make the CLI ask for transaction confirmaion before authentication, as that seems to be a nicer behaviour.