### PR TITLE
parental controls: Fail open if accountsservice is missing

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7658,6 +7658,13 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
                "controls are disabled globally", ref);
       return TRUE;
     }
+  else if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
+           g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER))
+    {
+      g_debug ("Skipping parental controls check for %s since a required "
+               "service was not found", ref);
+      return TRUE;
+    }
   else if (local_error != NULL)
     {
       g_propagate_error (error, g_steal_pointer (&local_error));

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3432,6 +3432,13 @@ check_parental_controls (const char     *app_ref,
                "controls are disabled globally", app_ref);
       return TRUE;
     }
+  else if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
+           g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER))
+    {
+      g_debug ("Skipping parental controls check for %s since a required "
+               "service was not found", app_ref);
+      return TRUE;
+    }
   else if (local_error != NULL)
     {
       g_propagate_error (error, g_steal_pointer (&local_error));


### PR DESCRIPTION
* Skip parental controls checks on ServiceUnknown or NameHasNoOwner
    
    If accountsservice isn't available on the system bus, then we can't
    ask it for the user's parental controls settings, and we also can't
    ask it whether it even has the malcontent extension. Since this is
    not a real security boundary, fail open.
    
    This can be dropped if we depend on a version of libmalcontent that maps
    these errors to MCT_APP_FILTER_ERROR_DISABLED
    (https://gitlab.freedesktop.org/pwithnall/malcontent/-/merge_requests/89).

Resolves: #3902 (aka Debian bug https://bugs.debian.org/972138)

cc @pwithnall, @bigon 