### PR TITLE
Make listing refs work for sideload repos

### DIFF
--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -152,8 +152,9 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
       g_autoptr(AsStore) store = NULL;
       g_autoptr(GHashTable) names = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
-      GLNX_HASH_TABLE_FOREACH (refs, char *, ref)
+      GLNX_HASH_TABLE_FOREACH (refs, FlatpakCollectionRef *, coll_ref)
         {
+          char *ref = coll_ref->ref_name;
           char *partial_ref;
           const char *slash = strchr (ref, '/');
 
@@ -167,8 +168,9 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
           g_hash_table_insert (pref_hash, partial_ref, ref);
         }
 
-      GLNX_HASH_TABLE_FOREACH_KV (refs, const char *, ref, const char *, checksum)
+      GLNX_HASH_TABLE_FOREACH_KV (refs, FlatpakCollectionRef *, coll_ref, const char *, checksum)
         {
+          const char *ref = coll_ref->ref_name;
           g_auto(GStrv) parts = NULL;
 
           parts = flatpak_decompose_ref (ref, NULL);
@@ -221,7 +223,8 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
               strcmp (arches[0], parts[2]) != 0)
             {
               g_autofree char *alt_arch_ref = g_strconcat (parts[0], "/", parts[1], "/", arches[0], "/", parts[3], NULL);
-              if (g_hash_table_lookup (refs, alt_arch_ref))
+              g_autoptr(FlatpakCollectionRef) alt_arch_coll_ref = flatpak_collection_ref_new (coll_ref->collection_id, alt_arch_ref);
+              if (g_hash_table_lookup (refs, alt_arch_coll_ref))
                 continue;
             }
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -182,6 +182,21 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDeploy, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRelated, flatpak_related_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRemoteState, flatpak_remote_state_unref)
 
+typedef struct
+{
+  char *collection_id;
+  char *ref_name;
+} FlatpakCollectionRef;
+
+FlatpakCollectionRef *    flatpak_collection_ref_new (const char *collection_id,
+                                                      const char *ref_name);
+void                      flatpak_collection_ref_free (FlatpakCollectionRef *ref);
+guint                     flatpak_collection_ref_hash (gconstpointer ref);
+gboolean                  flatpak_collection_ref_equal (gconstpointer ref1,
+                                                        gconstpointer ref2);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakCollectionRef, flatpak_collection_ref_free)
+
 typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_NONE = 0,
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE = 1 << 0,

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -2408,11 +2408,13 @@ flatpak_installation_list_remote_refs_sync_full (FlatpakInstallation *self,
   g_hash_table_iter_init (&iter, ht);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
-      const char *ref_name = key;
+      FlatpakCollectionRef *collection_ref = key;
       const gchar *ref_commit = value;
       FlatpakRemoteRef *ref;
 
-      ref = flatpak_remote_ref_new (ref_name, ref_commit, remote_or_uri, state->collection_id, state);
+      ref = flatpak_remote_ref_new (collection_ref->ref_name, ref_commit,
+                                    remote_or_uri, collection_ref->collection_id,
+                                    state);
 
       if (ref)
         g_ptr_array_add (refs, ref);
@@ -2485,6 +2487,7 @@ flatpak_installation_fetch_remote_ref_sync_full (FlatpakInstallation *self,
   g_autoptr(FlatpakRemoteState) state = NULL;
   g_autofree char *ref = NULL;
   const char *checksum;
+  FlatpakCollectionRef coll_ref;
 
   if (branch == NULL)
     branch = "master";
@@ -2513,7 +2516,9 @@ flatpak_installation_fetch_remote_ref_sync_full (FlatpakInstallation *self,
                                      branch,
                                      arch);
 
-  checksum = g_hash_table_lookup (ht, ref);
+  coll_ref.collection_id = state->collection_id;
+  coll_ref.ref_name = ref;
+  checksum = g_hash_table_lookup (ht, &coll_ref);
 
   if (checksum != NULL)
     return flatpak_remote_ref_new (ref, checksum, remote_name, state->collection_id, state);

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -511,6 +511,7 @@ handle_deploy (FlatpakSystemHelper   *object,
       g_autoptr(FlatpakOciImage) image_config = NULL;
       g_autoptr(FlatpakRemoteState) state = NULL;
       g_autoptr(GHashTable) remote_refs = NULL;
+      FlatpakCollectionRef collection_ref;
       g_autofree char *checksum = NULL;
       const char *verified_digest;
       g_autofree char *upstream_url = NULL;
@@ -589,7 +590,10 @@ handle_deploy (FlatpakSystemHelper   *object,
           return TRUE;
         }
 
-      verified_digest = g_hash_table_lookup (remote_refs, arg_ref);
+      collection_ref.collection_id = state->collection_id;
+      collection_ref.ref_name = (char *) arg_ref;
+
+      verified_digest = g_hash_table_lookup (remote_refs, &collection_ref);
       if (!verified_digest)
         {
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,


### PR DESCRIPTION
This commit makes
flatpak_installation_list_remote_refs_sync() work for local URIs
pointing at sideload repos, e.g.
"file:///media/mwleeds/flatpaks/.ostree/repo" where a command "flatpak
create-usb /media/mwleeds/flatpaks ..." was previously run. This is
important because the Endless fork of gnome-software uses that API to
list apps on a USB drive. The API worked before Flatpak 1.7.1 so making
it work again basically involves reverting parts of
336a127f5515f69c7d5c6aa7943076035c59bf84.

This commit also makes the remote-ls command work for file:// URIs to
sideload repos, which is useful behavior for debugging, and is also the
behavior mentioned in this blog post:
https://blogs.gnome.org/mclasen/2018/08/26/about-flatpak-installations/