### PR TITLE
Install systemd system-environment-generator

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,8 +168,8 @@ flatpak.env: env.d/flatpak.env.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
 		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
 
-envgendir = $(systemduserenvgendir)
-envgen_SCRIPTS = env.d/60-flatpak
+userenvgendir = $(systemduserenvgendir)
+userenvgen_SCRIPTS = env.d/60-flatpak
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = flatpak.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -161,12 +161,15 @@ if INSTALL_GDM_ENV_FILE
 env_DATA += flatpak.env
 endif
 
-EXTRA_DIST += env.d/flatpak.env.in env.d/60-flatpak
+EXTRA_DIST += env.d/flatpak.env.in env.d/60-flatpak env.d/60-flatpak-system-only
 DISTCLEANFILES += flatpak.env
 
 flatpak.env: env.d/flatpak.env.in
 	$(AM_V_GEN) $(SED) -e "s|\@localstatedir\@|$(localstatedir)|" \
 		-e "s|\@sysconfdir\@|$(sysconfdir)|" $< > $@
+
+systemenvgendir = $(systemdsystemenvgendir)
+systemenvgen_SCRIPTS = env.d/60-flatpak-system-only
 
 userenvgendir = $(systemduserenvgendir)
 userenvgen_SCRIPTS = env.d/60-flatpak

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -50,6 +50,8 @@ static gboolean opt_default_arch;
 static gboolean opt_supported_arches;
 static gboolean opt_gl_drivers;
 static gboolean opt_list_installations;
+static gboolean opt_print_updated_env;
+static gboolean opt_print_system_only;
 static gboolean opt_user;
 static gboolean opt_system;
 static char **opt_installations;
@@ -168,6 +170,8 @@ static GOptionEntry empty_entries[] = {
   { "supported-arches", 0, 0, G_OPTION_ARG_NONE, &opt_supported_arches, N_("Print supported arches and exit"), NULL },
   { "gl-drivers", 0, 0, G_OPTION_ARG_NONE, &opt_gl_drivers, N_("Print active gl drivers and exit"), NULL },
   { "installations", 0, 0, G_OPTION_ARG_NONE, &opt_list_installations, N_("Print paths for system installations and exit"), NULL },
+  { "print-updated-env", 0, 0, G_OPTION_ARG_NONE, &opt_print_updated_env, N_("Print the updated environment needed to run flatpaks"), NULL },
+  { "print-system-only", 0, 0, G_OPTION_ARG_NONE, &opt_print_system_only, N_("Only include the system installation with --print-updated-env"), NULL },
   { NULL }
 };
 
@@ -732,6 +736,59 @@ flatpak_run (int      argc,
                         }
                       exit (EXIT_SUCCESS);
                     }
+                }
+
+              /* systemd environment generator for system and user installations.
+               * Intended to be used only from the scripts in env.d/.
+               * See `man systemd.environment-generator`. */
+              if (opt_print_updated_env)
+                {
+                  g_autoptr(GPtrArray) installations = g_ptr_array_new_with_free_func (g_free);  /* (element-type GFile) */
+                  GPtrArray *system_installation_locations;  /* (element-type GFile) */
+                  const gchar * const *xdg_data_dirs = g_get_system_data_dirs ();
+                  g_autoptr(GPtrArray) new_dirs = g_ptr_array_new_with_free_func (g_free);  /* (element-type filename) */
+                  g_autofree gchar *new_dirs_joined = NULL;
+
+                  /* Work out the set of installations we want in the environment. */
+                  if (!opt_print_system_only)
+                    {
+                      g_autoptr(GFile) home_installation_location = flatpak_get_user_base_dir_location ();
+                      g_ptr_array_add (installations, g_file_get_path (home_installation_location));
+                    }
+
+                  system_installation_locations = flatpak_get_system_base_dir_locations (NULL, &local_error);
+                  if (local_error != NULL)
+                    {
+                      g_printerr ("%s\n", local_error->message);
+                      exit (1);
+                    }
+
+                  for (gsize i = 0; i < system_installation_locations->len; i++)
+                    g_ptr_array_add (installations, g_file_get_path (system_installation_locations->pdata[i]));
+
+                  /* Get the export path for each installation, and filter out
+                   * ones which are already listed in @xdg_data_dirs. */
+                  for (gsize i = 0; i < installations->len; i++)
+                    {
+                      g_autofree gchar *share_path = g_build_filename (installations->pdata[i], "exports", "share", NULL);
+                      g_autofree gchar *share_path_with_slash = g_strconcat (share_path, "/", NULL);
+
+                      if (g_strv_contains (xdg_data_dirs, share_path) || g_strv_contains (xdg_data_dirs, share_path_with_slash))
+                        continue;
+
+                      g_ptr_array_add (new_dirs, g_steal_pointer (&share_path));
+                    }
+
+                  /* Add the rest of the existing @xdg_data_dirs to the new list. */
+                  for (gsize i = 0; xdg_data_dirs[i] != NULL; i++)
+                    g_ptr_array_add (new_dirs, g_strdup (xdg_data_dirs[i]));
+                  g_ptr_array_add (new_dirs, NULL);
+
+                  /* Print in a format suitable for a system environment generator. */
+                  new_dirs_joined = g_strjoinv (":", (gchar **) new_dirs->pdata);
+                  g_print ("XDG_DATA_DIRS=%s\n", new_dirs_joined);
+
+                  exit (EXIT_SUCCESS);
                 }
             }
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,15 @@ AC_ARG_WITH([systemdsystemunitdir],
     [with_systemdsystemunitdir='${prefix}/lib/systemd/system'])
 AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 
+AC_ARG_WITH([systemdsystemenvgendir],
+            [AS_HELP_STRING([--with-systemdsystemenvgendir=DIR],
+                            [Directory for systemd system environment generators (default=PREFIX/lib/systemd/system-environment-generators)])],
+    [],
+    dnl This is deliberately not ${libdir}: systemd units always go in
+    dnl .../lib, never .../lib64 or .../lib/x86_64-linux-gnu
+    [with_systemdsystemenvgendir='${prefix}/lib/systemd/system-environment-generators'])
+AC_SUBST([systemdsystemenvgendir], [$with_systemdsystemenvgendir])
+
 AC_ARG_WITH([systemduserenvgendir],
             [AS_HELP_STRING([--with-systemduserenvgendir=DIR],
                             [Directory for systemd user environment generators (default=PREFIX/lib/systemd/user-environment-generators)])],

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -178,6 +178,28 @@
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--print-system-only</option></term>
+
+                <listitem><para>
+                    When the <command>flatpak --print-updated-env</command>
+                    command is run, only print the environment for system
+                    flatpak installations, not including the user’s home
+                    installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--print-updated-env</option></term>
+
+                <listitem><para>
+                    Print the set of environment variables needed to use
+                    flatpaks, amending the current set of environment variables.
+                    This is intended to be used in a systemd environment
+                    generator, and should not need to be run manually.
+                </para></listitem>
+            </varlistentry>
+
         </variablelist>
     </refsect1>
 

--- a/env.d/60-flatpak
+++ b/env.d/60-flatpak
@@ -1,15 +1,2 @@
-#!/bin/bash
-
-new_dirs=
-while read -r install_path
-do
-    share_path=$install_path/exports/share
-    case ":$XDG_DATA_DIRS:" in
-        *":$share_path:"*) :;;
-        *":$share_path/:"*) :;;
-        *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
-    esac
-done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; flatpak  --installations)
-
-XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"
+#!/bin/sh
+exec flatpak --print-updated-env

--- a/env.d/60-flatpak-system-only
+++ b/env.d/60-flatpak-system-only
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec flatpak --print-updated-env --print-system-only

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-echo "1..10"
+echo "1..11"
 
 ${FLATPAK} --version > version_out
 
@@ -46,6 +46,16 @@ ${FLATPAK} --supported-arches > arches
 assert_streq `head -1 arches` `cat arch`
 
 ok "default arch"
+
+${FLATPAK} --print-updated-env > updated_env
+${FLATPAK} --print-updated-env --print-system-only > updated_env_system
+
+assert_file_has_content updated_env "exports/share"
+assert_file_has_content updated_env "^XDG_DATA_DIRS="
+assert_file_has_content updated_env_system "exports/share"
+assert_file_has_content updated_env_system "^XDG_DATA_DIRS="
+
+ok "print updated env"
 
 ${FLATPAK} --gl-drivers > drivers
 

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -69,6 +69,8 @@ ${FLATPAK} complete "flatpak --" 10 "--" | sort > complete_out
 --installation=
 --installations 
 --ostree-verbose 
+--print-system-only 
+--print-updated-env 
 --supported-arches 
 --system 
 --user 


### PR DESCRIPTION
See the commit messages. This installs the existing user-environment-generator as a system-environment-generator too, so that listing flatpaks can work when setting up the parental controls in gnome-initial-setup (which is done outside of a user session).