### PR TITLE
CI: Ignore some paths that don't affect build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,15 @@ on:
     - flatpak-1.6.x
     - flatpak-1.8.x
   pull_request:
+    paths-ignore:
+    - README.md
+    - NEWS
+    - INSTALL
+    - COPYING
+    - CODE_OF_CONDUCT.md
+    - .lgtm.yml
+    - uncrustify.cfg
+    - uncrustify.sh
     branches:
     - master
     - flatpak-1.0.x


### PR DESCRIPTION
No need to waste resources running every test after the README
changes.