### PR TITLE
Fix extra-data progress reporting

### DIFF
--- a/common/flatpak-progress.c
+++ b/common/flatpak-progress.c
@@ -370,6 +370,8 @@ flatpak_progress_update_extra_data (FlatpakProgress *self,
 
   self->transferred_extra_data_bytes = self->extra_data_previous_dl + downloaded_bytes;
   update_status_progress_and_estimating (self);
+
+  self->callback (self->status, self->progress, self->estimating, self->user_data);
 }
 
 void


### PR DESCRIPTION
We were never calling the progress callback for extra-data downloaded
bytes.