### PR TITLE
Fix mtime issues

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -194,7 +194,7 @@ typedef struct
 {
   GBytes *bytes;
   GBytes *bytes_sig;
-  char   *remote;
+  char   *name;
   char   *url;
   guint64 time;
 } CachedSummary;
@@ -10827,7 +10827,7 @@ cached_summary_free (CachedSummary *summary)
   g_bytes_unref (summary->bytes);
   if (summary->bytes_sig)
     g_bytes_unref (summary->bytes_sig);
-  g_free (summary->remote);
+  g_free (summary->name);
   g_free (summary->url);
   g_free (summary);
 }
@@ -10835,7 +10835,7 @@ cached_summary_free (CachedSummary *summary)
 static CachedSummary *
 cached_summary_new (GBytes     *bytes,
                     GBytes     *bytes_sig,
-                    const char *remote,
+                    const char *name,
                     const char *url)
 {
   CachedSummary *summary = g_new0 (CachedSummary, 1);
@@ -10844,7 +10844,7 @@ cached_summary_new (GBytes     *bytes,
   if (bytes_sig)
     summary->bytes_sig = g_bytes_ref (bytes_sig);
   summary->url = g_strdup (url);
-  summary->remote = g_strdup (remote);
+  summary->name = g_strdup (name);
   summary->time = g_get_monotonic_time ();
   return summary;
 }
@@ -10917,7 +10917,7 @@ flatpak_dir_cache_summary (FlatpakDir *self,
   g_assert (self->summary_cache != NULL);
 
   summary = cached_summary_new (bytes, bytes_sig, name, url);
-  g_hash_table_replace (self->summary_cache, summary->remote, summary);
+  g_hash_table_replace (self->summary_cache, summary->name, summary);
 
   G_UNLOCK (cache);
 }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14129,6 +14129,10 @@ flatpak_dir_modify_remote (FlatpakDir   *self,
                                                             cancellable, error))
         return FALSE;
 
+      /* If we e.g. changed url or gpg config the cached summary may be invalid */
+      if (!flatpak_dir_remote_clear_cached_summary (self, remote_name, cancellable, error))
+        return FALSE;
+
       return TRUE;
     }
 
@@ -14198,6 +14202,10 @@ flatpak_dir_modify_remote (FlatpakDir   *self,
           g_debug ("Failed to read filter %s file while making a backup copy: %s\n", filter_path, local_error->message);
         }
     }
+
+  /* If we e.g. changed url or gpg config the cached summary may be invalid */
+  if (!flatpak_dir_remote_clear_cached_summary (self, remote_name, cancellable, error))
+    return FALSE;
 
   if (!flatpak_dir_mark_changed (self, error))
     return FALSE;

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -563,14 +563,6 @@ static gboolean
 flatpak_http_should_retry_request (const GError *error,
                                    guint         n_retries_remaining)
 {
-  if (error == NULL)
-    g_debug ("%s: error: unset, n_retries_remaining: %u",
-             G_STRFUNC, n_retries_remaining);
-  else
-    g_debug ("%s: error: %u:%u %s, n_retries_remaining: %u",
-             G_STRFUNC, error->domain, error->code, error->message,
-             n_retries_remaining);
-
   if (error == NULL || n_retries_remaining == 0)
     return FALSE;
 


### PR DESCRIPTION
This fixes various issues I had with using ostree master that relies on the mtime of the summary cache to be up-to date.

Note: I didn't get it fully working without https://github.com/ostreedev/ostree/pull/2230