### PR TITLE
Backport fix for remote-info command to 1.8.x

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -989,14 +989,14 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
 
   /* First try local availability */
   if (ostree_repo_load_commit (dir->repo, commit, &commit_data, NULL, NULL))
-    return g_steal_pointer (&commit_data);
+    goto out;
 
   for (int i = 0; i < self->sideload_repos->len; i++)
     {
       FlatpakSideloadState *ss = g_ptr_array_index (self->sideload_repos, i);
 
       if (ostree_repo_load_commit (ss->repo, commit, &commit_data, NULL, NULL))
-        return g_steal_pointer (&commit_data);
+        goto out;
     }
 
   if (flatpak_dir_get_remote_oci (dir, self->remote_name))
@@ -1006,6 +1006,7 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
     commit_data = flatpak_remote_state_fetch_commit_object (self, dir, ref, commit, token,
                                                             cancellable, error);
 
+out:
   if (out_commit)
     *out_commit = g_steal_pointer (&commit);
 


### PR DESCRIPTION
Backport the patch from #3854 in response to https://github.com/flatpak/flatpak/pull/3854#issuecomment-722355060