### PR TITLE
Add support for repo subsets

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -642,10 +642,7 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
 
       /* Skip "" subsets as they mean everything. This way --subsets= causes old subsets to be stripped from the original commit */
       if (get_subsets (opt_subsets, &subsets_v))
-        {
-          g_print ("subsets: %s\n", g_variant_print (subsets_v, FALSE));
-          g_variant_builder_add (&metadata_builder, "{sv}", "xa.subsets", subsets_v);
-        }
+        g_variant_builder_add (&metadata_builder, "{sv}", "xa.subsets", subsets_v);
 
       timestamp = ostree_commit_get_timestamp (src_commitv);
       if (opt_timestamp)

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -48,6 +48,7 @@ static char *opt_comment;
 static char *opt_description;
 static char *opt_homepage;
 static char *opt_icon;
+static char *opt_subset;
 static char *opt_default_branch;
 static char *opt_url;
 static char *opt_collection_id = NULL;
@@ -69,6 +70,7 @@ static GOptionEntry common_options[] = {
   { "no-enumerate", 0, 0, G_OPTION_ARG_NONE, &opt_no_enumerate, N_("Mark the remote as don't enumerate"), NULL },
   { "no-use-for-deps", 0, 0, G_OPTION_ARG_NONE, &opt_no_deps, N_("Mark the remote as don't use for deps"), NULL },
   { "prio", 0, 0, G_OPTION_ARG_INT, &opt_prio, N_("Set priority (default 1, higher is more prioritized)"), N_("PRIORITY") },
+  { "subset", 0, 0, G_OPTION_ARG_STRING, &opt_subset, N_("The named subset to use for this remote"), N_("SUBSET") },
   { "title", 0, 0, G_OPTION_ARG_STRING, &opt_title, N_("A nice name to use for this remote"), N_("TITLE") },
   { "comment", 0, 0, G_OPTION_ARG_STRING, &opt_comment, N_("A one-line comment for this remote"), N_("COMMENT") },
   { "description", 0, 0, G_OPTION_ARG_STRING, &opt_description, N_("A full-paragraph description for this remote"), N_("DESCRIPTION") },
@@ -118,6 +120,12 @@ get_config_from_opts (GKeyFile *config,
 
   if (opt_collection_id)
     g_key_file_set_string (config, group, "collection-id", opt_collection_id);
+
+  if (opt_subset)
+    {
+      g_key_file_set_string (config, group, "xa.subset", opt_subset);
+      g_key_file_set_boolean (config, group, "xa.subset-is-set", TRUE);
+    }
 
   if (opt_title)
     {

--- a/app/flatpak-builtins-remote-list.c
+++ b/app/flatpak-builtins-remote-list.c
@@ -50,6 +50,7 @@ static Column all_columns[] = {
   { "title",      N_("Title"),         N_("Show the title"),         0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "url",        N_("URL"),           N_("Show the URL"),           0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "collection", N_("Collection ID"), N_("Show the collection ID"), 0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
+  { "subset",     N_("Subset"),        N_("Show the subset"),        0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "filter",     N_("Filter"),        N_("Show filter file"),       0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "priority",   N_("Priority"),      N_("Show the priority"),      0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 0 },
   { "options",    N_("Options"),       N_("Show options"),           0, FLATPAK_ELLIPSIZE_MODE_NONE, 1, 1 },
@@ -100,6 +101,14 @@ list_remotes (GPtrArray *dirs, Column *columns, GCancellable *cancellable, GErro
                   g_autofree char *title = flatpak_dir_get_remote_title (dir, remote_name);
                   if (title)
                     flatpak_table_printer_add_column (printer, title);
+                  else
+                    flatpak_table_printer_add_column (printer, "-");
+                }
+              else if (strcmp (columns[k].name, "subset") == 0)
+                {
+                  g_autofree char *subset = flatpak_dir_get_remote_subset (dir, remote_name);
+                  if (subset)
+                    flatpak_table_printer_add_column (printer, subset);
                   else
                     flatpak_table_printer_add_column (printer, "-");
                 }

--- a/app/flatpak-builtins-remote-modify.c
+++ b/app/flatpak-builtins-remote-modify.c
@@ -52,6 +52,7 @@ static char *opt_comment;
 static char *opt_description;
 static char *opt_homepage;
 static char *opt_icon;
+static char *opt_subset;
 static char *opt_default_branch;
 static char *opt_url;
 static char *opt_collection_id = NULL;
@@ -66,6 +67,7 @@ static GOptionEntry modify_options[] = {
   { "enumerate", 0, 0, G_OPTION_ARG_NONE, &opt_do_enumerate, N_("Mark the remote as enumerate"), NULL },
   { "use-for-deps", 0, 0, G_OPTION_ARG_NONE, &opt_do_deps, N_("Mark the remote as used for dependencies"), NULL },
   { "url", 0, 0, G_OPTION_ARG_STRING, &opt_url, N_("Set a new url"), N_("URL") },
+  { "subset", 0, 0, G_OPTION_ARG_STRING, &opt_subset, N_("Set a new subset to use"), N_("SUBSET") },
   { "enable", 0, 0, G_OPTION_ARG_NONE, &opt_enable, N_("Enable the remote"), NULL },
   { "update-metadata", 0, 0, G_OPTION_ARG_NONE, &opt_update_metadata, N_("Update extra metadata from the summary file"), NULL },
   { NULL }
@@ -138,6 +140,13 @@ get_config_from_opts (FlatpakDir *dir, const char *remote_name, gboolean *change
   if (opt_collection_id)
     {
       g_key_file_set_string (config, group, "collection-id", opt_collection_id);
+      *changed = TRUE;
+    }
+
+  if (opt_subset)
+    {
+      g_key_file_set_string (config, group, "xa.subset", opt_subset);
+      g_key_file_set_boolean (config, group, "xa.subset-is-set", TRUE);
       *changed = TRUE;
     }
 

--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -189,11 +189,20 @@ print_branches_for_subsummary (FlatpakTablePrinter *printer,
 {
   g_autoptr(GVariant) meta = NULL;
   guint summary_version = 0;
+  g_autofree char *subset = NULL;
 
-  if (subsummary != NULL && opt_subset != NULL)
+  if (subsummary != NULL)
     {
-      if (!g_str_has_prefix (subsummary, opt_subset))
-        return;
+      const char *dash = strrchr (subsummary, '-');
+      if (dash)
+        subset = g_strndup (subsummary, dash - subsummary);
+    }
+
+  if (opt_subset != NULL)
+    {
+      if (subset == NULL ||
+          strcmp (subset, opt_subset) != 0)
+        return; /* Not the requested subset, ignore */
     }
 
   meta = g_variant_get_child_value (summary, 1);
@@ -224,8 +233,8 @@ print_branches_for_subsummary (FlatpakTablePrinter *printer,
           int old_row = flatpak_table_printer_lookup_row (printer, ref);
           if (old_row >= 0)
             {
-              if (subsummary)
-                flatpak_table_printer_append_cell_with_comma (printer, old_row, 4, subsummary);
+              if (subset)
+                flatpak_table_printer_append_cell_with_comma_unique (printer, old_row, 4, subset);
               continue;
             }
 
@@ -246,8 +255,8 @@ print_branches_for_subsummary (FlatpakTablePrinter *printer,
           if (g_variant_lookup (ref_meta, FLATPAK_SPARSE_CACHE_KEY_ENDOFLINE_REBASE, "&s", &eol))
             flatpak_table_printer_append_with_comma_printf (printer, "eol-rebase=%s", eol);
 
-          if (subsummary)
-            flatpak_table_printer_add_column (printer, subsummary);
+          if (subset)
+            flatpak_table_printer_add_column (printer, subset);
           else
             flatpak_table_printer_add_column (printer, "");
 
@@ -280,8 +289,8 @@ print_branches_for_subsummary (FlatpakTablePrinter *printer,
               int old_row = flatpak_table_printer_lookup_row (printer, ref);
               if (old_row >= 0)
                 {
-                  if (subsummary)
-                    flatpak_table_printer_append_cell_with_comma (printer, old_row, 4, subsummary);
+                  if (subset)
+                    flatpak_table_printer_append_cell_with_comma_unique (printer, old_row, 4, subset);
                   continue;
                 }
 
@@ -305,8 +314,8 @@ print_branches_for_subsummary (FlatpakTablePrinter *printer,
                     }
                 }
 
-              if (subsummary)
-                flatpak_table_printer_add_column (printer, subsummary);
+              if (subset)
+                flatpak_table_printer_add_column (printer, subset);
               else
                 flatpak_table_printer_add_column (printer, "");
 

--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -788,6 +788,37 @@ flatpak_table_printer_append_cell_with_comma (FlatpakTablePrinter *printer,
 }
 
 void
+flatpak_table_printer_append_cell_with_comma_unique (FlatpakTablePrinter *printer,
+                                                     int                  r,
+                                                     int                  c,
+                                                     const char          *text)
+{
+  Row *row;
+  Cell *cell;
+
+  row = (Row *) g_ptr_array_index (printer->rows, r);
+  g_assert (row);
+  cell = (Cell *) g_ptr_array_index (row->cells, c);
+  g_assert (cell);
+
+  /* Look for existing text in comma separated text */
+  if (cell->text != NULL && *text != 0)
+    {
+      gsize len = strlen (text);
+      const char *match = cell->text;
+      while ((match = strstr (match, text)) != NULL)
+        {
+          if (match[len] == 0 || match[len] == ',' )
+            return; /* Already in string, do nothing */
+          /* Look for next match */
+          match = match + len;
+        }
+    }
+
+  set_cell (printer, r, c, text, -1, 2);
+}
+
+void
 flatpak_table_printer_set_decimal_cell (FlatpakTablePrinter *printer,
                                         int                  r,
                                         int                  c,

--- a/app/flatpak-table-printer.h
+++ b/app/flatpak-table-printer.h
@@ -79,6 +79,10 @@ void                flatpak_table_printer_append_cell_with_comma (FlatpakTablePr
                                                                   int                  row,
                                                                   int                  col,
                                                                   const char          *cell);
+void                flatpak_table_printer_append_cell_with_comma_unique (FlatpakTablePrinter *printer,
+                                                                         int                  row,
+                                                                         int                  col,
+                                                                         const char          *cell);
 void                flatpak_table_printer_set_decimal_cell (FlatpakTablePrinter *printer,
                                                             int                  row,
                                                             int                  col,

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -72,6 +72,7 @@ GType flatpak_deploy_get_type (void);
 #define FLATPAK_REPO_GROUP "Flatpak Repo"
 #define FLATPAK_REPO_VERSION_KEY "Version"
 #define FLATPAK_REPO_URL_KEY "Url"
+#define FLATPAK_REPO_SUBSET_KEY "Subset"
 #define FLATPAK_REPO_TITLE_KEY "Title"
 #define FLATPAK_REPO_DEFAULT_BRANCH_KEY "DefaultBranch"
 #define FLATPAK_REPO_GPGKEY_KEY "GPGKey"

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2192,6 +2192,7 @@ flatpak_parse_repofile (const char   *remote_name,
   g_autofree char *icon = NULL;
   g_autofree char *homepage = NULL;
   g_autofree char *filter = NULL;
+  g_autofree char *subset = NULL;
   g_autofree char *authenticator_name = NULL;
   gboolean nodeps;
   const char *source_group;
@@ -2231,6 +2232,11 @@ flatpak_parse_repofile (const char   *remote_name,
     }
 
   g_key_file_set_string (config, group, "url", uri);
+
+  subset = g_key_file_get_locale_string (keyfile, source_group,
+                                         FLATPAK_REPO_SUBSET_KEY, NULL, NULL);
+  if (subset != NULL)
+    g_key_file_set_string (config, group, "xa.subset", subset);
 
   title = g_key_file_get_locale_string (keyfile, source_group,
                                         FLATPAK_REPO_TITLE_KEY, NULL, NULL);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3198,7 +3198,7 @@ populate_commit_data_cache (OstreeRepo *repo,
         }
       digest = ostree_checksum_from_bytes (checksum_bytes);
 
-      s = strchr (name, '-');
+      s = strrchr (name, '-');
       if (s != NULL)
         subset = g_strndup (name, s - name);
       else

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5357,6 +5357,255 @@ flatpak_repo_list_flatpak_refs (OstreeRepo   *repo,
   return g_steal_pointer (&refs);
 }
 
+static gboolean
+_flatpak_repo_generate_appstream (OstreeRepo   *repo,
+                                  const char  **gpg_key_ids,
+                                  const char   *gpg_homedir,
+                                  FlatpakDecomposed **all_refs_keys,
+                                  guint         n_keys,
+                                  GHashTable   *all_commits,
+                                  const char   *arch,
+                                  const char   *subset,
+                                  guint64       timestamp,
+                                  GCancellable *cancellable,
+                                  GError      **error)
+{
+  g_autoptr(FlatpakXml) appstream_root = NULL;
+  g_autoptr(GBytes) xml_data = NULL;
+  g_autoptr(GBytes) xml_gz_data = NULL;
+  g_autoptr(OstreeMutableTree) mtree = ostree_mutable_tree_new ();
+  g_autoptr(OstreeMutableTree) icons_mtree = NULL;
+  g_autoptr(OstreeMutableTree) icons_flatpak_mtree = NULL;
+  g_autoptr(OstreeMutableTree) size1_mtree = NULL;
+  g_autoptr(OstreeMutableTree) size2_mtree = NULL;
+  const char *compat_arch;
+  compat_arch = flatpak_get_compat_arch (arch);
+  const char *branch_names[] = { "appstream", "appstream2" };
+  const char *collection_id;
+
+  if (subset != NULL && *subset != 0)
+    g_debug ("Generating appstream for %s, subset %s", arch, subset);
+  else
+    g_debug ("Generating appstream for %s", arch);
+
+  collection_id = ostree_repo_get_collection_id (repo);
+
+  if (!flatpak_mtree_ensure_dir_metadata (repo, mtree, cancellable, error))
+    return FALSE;
+
+  if (!flatpak_mtree_create_dir (repo, mtree, "icons", &icons_mtree, error))
+    return FALSE;
+
+  if (!flatpak_mtree_create_dir (repo, icons_mtree, "64x64", &size1_mtree, error))
+    return FALSE;
+
+  if (!flatpak_mtree_create_dir (repo, icons_mtree, "128x128", &size2_mtree, error))
+    return FALSE;
+
+  /* For compatibility with libappstream we create a $origin ("flatpak") subdirectory with symlinks
+   * to the size directories thus matching the standard merged appstream layout if we assume the
+   * appstream has origin=flatpak, which flatpak-builder creates.
+   *
+   * See https://github.com/ximion/appstream/pull/224 for details.
+   */
+  if (!flatpak_mtree_create_dir (repo, icons_mtree, "flatpak", &icons_flatpak_mtree, error))
+    return FALSE;
+  if (!flatpak_mtree_create_symlink (repo, icons_flatpak_mtree, "64x64", "../64x64", error))
+    return FALSE;
+  if (!flatpak_mtree_create_symlink (repo, icons_flatpak_mtree, "128x128", "../128x128", error))
+    return FALSE;
+
+  appstream_root = flatpak_appstream_xml_new ();
+
+  for (int i = 0; i < n_keys; i++)
+    {
+      FlatpakDecomposed *ref = all_refs_keys[i];
+      GVariant *commit_v = NULL;
+      VarMetadataRef commit_metadata;
+      g_autoptr(GError) my_error = NULL;
+      g_autofree char *id = NULL;
+
+      if (!flatpak_decomposed_is_arch (ref, arch))
+        {
+          g_autoptr(FlatpakDecomposed) main_ref = NULL;
+
+          /* Include refs that don't match the main arch (e.g. x86_64), if they match
+             the compat arch (e.g. i386) and the main arch version is not in the repo */
+          if (compat_arch != NULL && flatpak_decomposed_is_arch (ref, compat_arch))
+            main_ref = flatpak_decomposed_new_from_decomposed (ref, 0, NULL, compat_arch, NULL, NULL);
+
+          if (main_ref == NULL ||
+              g_hash_table_lookup (all_commits, main_ref))
+            continue;
+        }
+
+      commit_v = g_hash_table_lookup (all_commits, ref);
+      g_assert (commit_v != NULL);
+
+      commit_metadata = var_commit_get_metadata (var_commit_from_gvariant (commit_v));
+      if (var_metadata_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE, NULL, NULL) ||
+          var_metadata_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, NULL, NULL))
+        {
+          g_debug (_("%s is end-of-life, ignoring for appstream"), flatpak_decomposed_get_ref (ref));
+          continue;
+        }
+
+      if (*subset != 0)
+        {
+          VarVariantRef xa_subsets_v;
+          gboolean in_subset = FALSE;
+
+          if (var_metadata_lookup (commit_metadata, "xa.subsets", NULL, &xa_subsets_v))
+            {
+              VarArrayofstringRef xa_subsets = var_arrayofstring_from_variant (xa_subsets_v);
+              gsize len = var_arrayofstring_get_length (xa_subsets);
+
+              for (gsize j = 0; j < len; j++)
+                {
+                  const char *xa_subset = var_arrayofstring_get_at (xa_subsets, j);
+                  if (strcmp (subset, xa_subset) == 0)
+                    {
+                      in_subset = TRUE;
+                      break;
+                    }
+                }
+            }
+
+          if (!in_subset)
+            continue;
+        }
+
+      id = flatpak_decomposed_dup_id (ref);
+      if (!extract_appstream (repo, appstream_root,
+                              ref, id, size1_mtree, size2_mtree,
+                              cancellable, &my_error))
+        {
+          if (flatpak_decomposed_is_app (ref))
+            g_print (_("No appstream data for %s: %s\n"), flatpak_decomposed_get_ref (ref), my_error->message);
+          continue;
+        }
+    }
+
+  if (!flatpak_appstream_xml_root_to_data (appstream_root, &xml_data, &xml_gz_data, error))
+    return FALSE;
+
+  for (int i = 0; i < G_N_ELEMENTS (branch_names); i++)
+    {
+      gboolean skip_commit = FALSE;
+      const char *branch_prefix = branch_names[i];
+      g_autoptr(GFile) root = NULL;
+      g_autofree char *branch = NULL;
+      g_autofree char *parent = NULL;
+      g_autofree char *commit_checksum = NULL;
+
+      if (*subset != 0 && i == 0)
+        continue; /* No old-style branch for subsets */
+
+      if (*subset != 0)
+        branch = g_strdup_printf ("%s/%s-%s", branch_prefix, subset, arch);
+      else
+        branch = g_strdup_printf ("%s/%s", branch_prefix, arch);
+
+      if (!flatpak_repo_resolve_rev (repo, collection_id, NULL, branch, TRUE,
+                                     &parent, cancellable, error))
+        return FALSE;
+
+      if (i == 0)
+        {
+          if (!flatpak_mtree_add_file_from_bytes (repo, xml_gz_data, mtree, "appstream.xml.gz", cancellable, error))
+            return FALSE;
+        }
+      else
+        {
+          if (!ostree_mutable_tree_remove (mtree, "appstream.xml.gz", TRUE, error))
+            return FALSE;
+
+          if (!flatpak_mtree_add_file_from_bytes (repo, xml_data, mtree, "appstream.xml", cancellable, error))
+            return FALSE;
+        }
+
+      if (!ostree_repo_write_mtree (repo, mtree, &root, cancellable, error))
+        return FALSE;
+
+      /* No need to commit if nothing changed */
+      if (parent)
+        {
+          g_autoptr(GFile) parent_root = NULL;
+
+          if (!ostree_repo_read_commit (repo, parent, &parent_root, NULL, cancellable, error))
+            return FALSE;
+
+          if (g_file_equal (root, parent_root))
+            {
+              skip_commit = TRUE;
+              g_debug ("Not updating %s, no change", branch);
+            }
+        }
+
+      if (!skip_commit)
+        {
+          g_autoptr(GVariantDict) metadata_dict = NULL;
+          g_autoptr(GVariant) metadata = NULL;
+
+          /* Add bindings to the metadata. Do this even if P2P support is not
+           * enabled, as it might be enable for other flatpak builds. */
+          metadata_dict = g_variant_dict_new (NULL);
+          g_variant_dict_insert (metadata_dict, "ostree.collection-binding",
+                                 "s", (collection_id != NULL) ? collection_id : "");
+          g_variant_dict_insert_value (metadata_dict, "ostree.ref-binding",
+                                       g_variant_new_strv ((const gchar * const *) &branch, 1));
+          metadata = g_variant_ref_sink (g_variant_dict_end (metadata_dict));
+
+          if (timestamp > 0)
+            {
+              if (!ostree_repo_write_commit_with_time (repo, parent, "Update", NULL, metadata,
+                                                       OSTREE_REPO_FILE (root),
+                                                       timestamp,
+                                                       &commit_checksum,
+                                                       cancellable, error))
+                return FALSE;
+            }
+          else
+            {
+              if (!ostree_repo_write_commit (repo, parent, "Update", NULL, metadata,
+                                             OSTREE_REPO_FILE (root),
+                                             &commit_checksum, cancellable, error))
+                return FALSE;
+            }
+
+          if (gpg_key_ids)
+            {
+              for (int j = 0; gpg_key_ids[j] != NULL; j++)
+                {
+                  const char *keyid = gpg_key_ids[j];
+
+                  if (!ostree_repo_sign_commit (repo,
+                                                commit_checksum,
+                                                keyid,
+                                                gpg_homedir,
+                                                cancellable,
+                                                error))
+                    return FALSE;
+                }
+            }
+
+          g_debug ("Creating appstream branch %s", branch);
+          if (collection_id != NULL)
+            {
+              const OstreeCollectionRef collection_ref = { (char *) collection_id, branch };
+              ostree_repo_transaction_set_collection_ref (repo, &collection_ref, commit_checksum);
+            }
+          else
+            {
+              ostree_repo_transaction_set_ref (repo, NULL, branch, commit_checksum);
+            }
+        }
+    }
+
+  return TRUE;
+}
+
+
 gboolean
 flatpak_repo_generate_appstream (OstreeRepo   *repo,
                                  const char  **gpg_key_ids,
@@ -5366,259 +5615,107 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
                                  GError      **error)
 {
   g_autoptr(GHashTable) all_refs = NULL;
+  g_autoptr(GHashTable) all_commits = NULL;
   g_autofree FlatpakDecomposed **all_refs_keys = NULL;
   guint n_keys;
   g_autoptr(GPtrArray) arches = NULL;  /* (element-type utf8 utf8) */
-  const char *collection_id;
+  g_autoptr(GPtrArray) subsets = NULL;  /* (element-type utf8 utf8) */
+  g_autoptr(FlatpakRepoTransaction) transaction = NULL;
+  OstreeRepoTransactionStats stats;
 
   arches = g_ptr_array_new_with_free_func (g_free);
+  subsets = g_ptr_array_new_with_free_func (g_free);
 
-  collection_id = ostree_repo_get_collection_id (repo);
+  g_ptr_array_add (subsets, g_strdup (""));
 
   all_refs = flatpak_repo_list_flatpak_refs (repo, cancellable, error);
   if (all_refs == NULL)
     return FALSE;
+
+  all_commits = g_hash_table_new_full ((GHashFunc)flatpak_decomposed_hash, (GEqualFunc)flatpak_decomposed_equal, (GDestroyNotify)flatpak_decomposed_unref, (GDestroyNotify)g_variant_unref);
+
+  GLNX_HASH_TABLE_FOREACH_KV (all_refs, FlatpakDecomposed *, ref, const char *, commit)
+    {
+      VarMetadataRef commit_metadata;
+      VarVariantRef xa_subsets_v;
+      const char *reverse_compat_arch;
+      char *new_arch = NULL;
+      g_autoptr(GVariant) commit_v = NULL;
+
+      if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT, commit, &commit_v, NULL))
+        {
+          g_warning ("Couldn't load commit %s (ref %s)", commit, flatpak_decomposed_get_ref (ref));
+          continue;
+        }
+
+      g_hash_table_insert (all_commits, flatpak_decomposed_ref (ref), g_variant_ref (commit_v));
+
+      /* Compute list of subsets */
+      commit_metadata = var_commit_get_metadata (var_commit_from_gvariant (commit_v));
+      if (var_metadata_lookup (commit_metadata, "xa.subsets", NULL, &xa_subsets_v))
+        {
+          VarArrayofstringRef xa_subsets = var_arrayofstring_from_variant (xa_subsets_v);
+          gsize len = var_arrayofstring_get_length (xa_subsets);
+          for (gsize j = 0; j < len; j++)
+            {
+              const char *subset = var_arrayofstring_get_at (xa_subsets, j);
+
+              if (!flatpak_g_ptr_array_contains_string (subsets, subset))
+                g_ptr_array_add (subsets, g_strdup (subset));
+            }
+        }
+
+      /* Compute list of arches */
+      if (!flatpak_decomposed_is_arches (ref, arches->len, (const char **) arches->pdata))
+        {
+          new_arch = flatpak_decomposed_dup_arch (ref);
+          g_ptr_array_add (arches, new_arch);
+
+          /* If repo contains e.g. i386, also generated x86-64 appdata */
+          reverse_compat_arch = flatpak_get_compat_arch_reverse (new_arch);
+          if (reverse_compat_arch != NULL &&
+              !flatpak_g_ptr_array_contains_string (arches, reverse_compat_arch))
+            g_ptr_array_add (arches, g_strdup (reverse_compat_arch));
+        }
+    }
+
+  g_ptr_array_sort (subsets, flatpak_strcmp0_ptr);
+  g_ptr_array_sort (arches, flatpak_strcmp0_ptr);
 
   all_refs_keys = (FlatpakDecomposed **) g_hash_table_get_keys_as_array (all_refs, &n_keys);
 
   /* Sort refs so that appdata order is stable for e.g. deltas */
   g_qsort_with_data (all_refs_keys, n_keys, sizeof (FlatpakDecomposed *), (GCompareDataFunc) flatpak_decomposed_strcmp_p, NULL);
 
-  for (int i = 0; i < n_keys; i++)
+  transaction = flatpak_repo_transaction_start (repo, cancellable, error);
+  if (transaction == NULL)
+    return FALSE;
+
+  for (int l = 0; l < subsets->len; l++)
     {
-      FlatpakDecomposed *ref = all_refs_keys[i];
-      const char *reverse_compat_arch;
-      char *new_arch = NULL;
+      const char *subset = g_ptr_array_index (subsets, l);
 
-      if (flatpak_decomposed_is_arches (ref, arches->len, (const char **) arches->pdata))
-        continue;
+      for (int k = 0; k < arches->len; k++)
+        {
+          const char *arch = g_ptr_array_index (arches, k);
 
-      new_arch = flatpak_decomposed_dup_arch (ref);
-      g_ptr_array_add (arches, new_arch);
-
-      /* If repo contains e.g. i386, also generated x86-64 appdata */
-      reverse_compat_arch = flatpak_get_compat_arch_reverse (new_arch);
-      if (reverse_compat_arch != NULL &&
-          !flatpak_g_ptr_array_contains_string (arches, reverse_compat_arch))
-        g_ptr_array_add (arches, g_strdup (reverse_compat_arch));
+          if (!_flatpak_repo_generate_appstream (repo,
+                                                 gpg_key_ids,
+                                                 gpg_homedir,
+                                                 all_refs_keys,
+                                                 n_keys,
+                                                 all_commits,
+                                                 arch,
+                                                 subset,
+                                                 timestamp,
+                                                 cancellable,
+                                                 error))
+            return FALSE;
+        }
     }
 
-  g_ptr_array_sort (arches, flatpak_strcmp0_ptr);
-
-  for (int k = 0; k < arches->len; k++)
-    {
-      const char *arch = g_ptr_array_index (arches, k);
-      OstreeRepoTransactionStats stats;
-      g_autoptr(FlatpakXml) appstream_root = NULL;
-      g_autoptr(GBytes) xml_data = NULL;
-      g_autoptr(GBytes) xml_gz_data = NULL;
-      g_autoptr(OstreeMutableTree) mtree = ostree_mutable_tree_new ();
-      g_autoptr(OstreeMutableTree) icons_mtree = NULL;
-      g_autoptr(OstreeMutableTree) icons_flatpak_mtree = NULL;
-      g_autoptr(OstreeMutableTree) size1_mtree = NULL;
-      g_autoptr(OstreeMutableTree) size2_mtree = NULL;
-      const char *compat_arch;
-      g_autoptr(FlatpakRepoTransaction) transaction = NULL;
-      compat_arch = flatpak_get_compat_arch (arch);
-      const char *branch_names[] = { "appstream", "appstream2" };
-
-      if (!flatpak_mtree_ensure_dir_metadata (repo, mtree, cancellable, error))
-        return FALSE;
-
-      if (!flatpak_mtree_create_dir (repo, mtree, "icons", &icons_mtree, error))
-        return FALSE;
-
-      if (!flatpak_mtree_create_dir (repo, icons_mtree, "64x64", &size1_mtree, error))
-        return FALSE;
-
-      if (!flatpak_mtree_create_dir (repo, icons_mtree, "128x128", &size2_mtree, error))
-        return FALSE;
-
-      /* For compatibility with libappstream we create a $origin ("flatpak") subdirectory with symlinks
-       * to the size directories thus matching the standard merged appstream layout if we assume the
-       * appstream has origin=flatpak, which flatpak-builder creates.
-       *
-       * See https://github.com/ximion/appstream/pull/224 for details.
-       */
-      if (!flatpak_mtree_create_dir (repo, icons_mtree, "flatpak", &icons_flatpak_mtree, error))
-        return FALSE;
-      if (!flatpak_mtree_create_symlink (repo, icons_flatpak_mtree, "64x64", "../64x64", error))
-        return FALSE;
-      if (!flatpak_mtree_create_symlink (repo, icons_flatpak_mtree, "128x128", "../128x128", error))
-        return FALSE;
-
-      appstream_root = flatpak_appstream_xml_new ();
-
-      for (int i = 0; i < n_keys; i++)
-        {
-          FlatpakDecomposed *ref = all_refs_keys[i];
-          const char *commit;
-          g_autoptr(GVariant) commit_v = NULL;
-          g_autoptr(GVariant) commit_metadata = NULL;
-          g_autoptr(GError) my_error = NULL;
-          g_autofree char *id = NULL;
-          const char *eol = NULL;
-          const char *eol_rebase = NULL;
-
-          if (!flatpak_decomposed_is_arch (ref, arch))
-            {
-              g_autoptr(FlatpakDecomposed) main_ref = NULL;
-
-              /* Include refs that don't match the main arch (e.g. x86_64), if they match
-                 the compat arch (e.g. i386) and the main arch version is not in the repo */
-              if (compat_arch != NULL && flatpak_decomposed_is_arch (ref, compat_arch))
-                main_ref = flatpak_decomposed_new_from_decomposed (ref, 0, NULL, compat_arch, NULL, NULL);
-
-              if (main_ref == NULL ||
-                  g_hash_table_lookup (all_refs, main_ref))
-                continue;
-            }
-
-          commit = g_hash_table_lookup (all_refs, ref);
-          g_assert (commit != NULL);
-
-          if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT, commit,
-                                         &commit_v, NULL))
-            {
-              g_warning ("Couldn't load commit %s (ref %s)", commit, flatpak_decomposed_get_ref (ref));
-              continue;
-            }
-
-          commit_metadata = g_variant_get_child_value (commit_v, 0);
-          g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE, "&s", &eol);
-          g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, "&s", &eol_rebase);
-          if (eol || eol_rebase)
-            {
-              g_debug (_("%s is end-of-life, ignoring for appstream\n"), flatpak_decomposed_get_ref (ref));
-              continue;
-            }
-
-          id = flatpak_decomposed_dup_id (ref);
-          if (!extract_appstream (repo, appstream_root,
-                                  ref, id, size1_mtree, size2_mtree,
-                                  cancellable, &my_error))
-            {
-              if (flatpak_decomposed_is_app (ref))
-                g_print (_("No appstream data for %s: %s\n"), flatpak_decomposed_get_ref (ref), my_error->message);
-              continue;
-            }
-        }
-
-      if (!flatpak_appstream_xml_root_to_data (appstream_root, &xml_data, &xml_gz_data, error))
-        return FALSE;
-
-      transaction = flatpak_repo_transaction_start (repo, cancellable, error);
-      if (transaction == NULL)
-        return FALSE;
-
-      for (int i = 0; i < G_N_ELEMENTS (branch_names); i++)
-        {
-          gboolean skip_commit = FALSE;
-          const char *branch_prefix = branch_names[i];
-          g_autoptr(GFile) root = NULL;
-          g_autofree char *branch = NULL;
-          g_autofree char *parent = NULL;
-          g_autofree char *commit_checksum = NULL;
-
-          branch = g_strdup_printf ("%s/%s", branch_prefix, arch);
-          if (!flatpak_repo_resolve_rev (repo, collection_id, NULL, branch, TRUE,
-                                         &parent, cancellable, error))
-            return FALSE;
-
-          if (i == 0)
-            {
-              if (!flatpak_mtree_add_file_from_bytes (repo, xml_gz_data, mtree, "appstream.xml.gz", cancellable, error))
-                return FALSE;
-            }
-          else
-            {
-              if (!ostree_mutable_tree_remove (mtree, "appstream.xml.gz", TRUE, error))
-                return FALSE;
-
-              if (!flatpak_mtree_add_file_from_bytes (repo, xml_data, mtree, "appstream.xml", cancellable, error))
-                return FALSE;
-            }
-
-          if (!ostree_repo_write_mtree (repo, mtree, &root, cancellable, error))
-            return FALSE;
-
-          /* No need to commit if nothing changed */
-          if (parent)
-            {
-              g_autoptr(GFile) parent_root = NULL;
-
-              if (!ostree_repo_read_commit (repo, parent, &parent_root, NULL, cancellable, error))
-                return FALSE;
-
-              if (g_file_equal (root, parent_root))
-                {
-                  skip_commit = TRUE;
-                  g_debug ("Not updating %s, no change", branch);
-                }
-            }
-
-          if (!skip_commit)
-            {
-              g_autoptr(GVariantDict) metadata_dict = NULL;
-              g_autoptr(GVariant) metadata = NULL;
-
-              /* Add bindings to the metadata. Do this even if P2P support is not
-               * enabled, as it might be enable for other flatpak builds. */
-              metadata_dict = g_variant_dict_new (NULL);
-              g_variant_dict_insert (metadata_dict, "ostree.collection-binding",
-                                     "s", (collection_id != NULL) ? collection_id : "");
-              g_variant_dict_insert_value (metadata_dict, "ostree.ref-binding",
-                                           g_variant_new_strv ((const gchar * const *) &branch, 1));
-              metadata = g_variant_ref_sink (g_variant_dict_end (metadata_dict));
-
-              if (timestamp > 0)
-                {
-                  if (!ostree_repo_write_commit_with_time (repo, parent, "Update", NULL, metadata,
-                                                           OSTREE_REPO_FILE (root),
-                                                           timestamp,
-                                                           &commit_checksum,
-                                                           cancellable, error))
-                    return FALSE;
-                }
-              else
-                {
-                  if (!ostree_repo_write_commit (repo, parent, "Update", NULL, metadata,
-                                                 OSTREE_REPO_FILE (root),
-                                                 &commit_checksum, cancellable, error))
-                    return FALSE;
-                }
-
-              if (gpg_key_ids)
-                {
-                  for (int j = 0; gpg_key_ids[j] != NULL; j++)
-                    {
-                      const char *keyid = gpg_key_ids[j];
-
-                      if (!ostree_repo_sign_commit (repo,
-                                                    commit_checksum,
-                                                    keyid,
-                                                    gpg_homedir,
-                                                    cancellable,
-                                                    error))
-                        return FALSE;
-                    }
-                }
-
-              if (collection_id != NULL)
-                {
-                  const OstreeCollectionRef collection_ref = { (char *) collection_id, branch };
-                  ostree_repo_transaction_set_collection_ref (repo, &collection_ref, commit_checksum);
-                }
-              else
-                {
-                  ostree_repo_transaction_set_ref (repo, NULL, branch, commit_checksum);
-                }
-            }
-        }
-
-    if (!ostree_repo_commit_transaction (repo, &stats, cancellable, error))
-      return FALSE;
-  }
+  if (!ostree_repo_commit_transaction (repo, &stats, cancellable, error))
+    return FALSE;
 
   return TRUE;
 }

--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -113,6 +113,16 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--subset=SUBSET</option></term>
+
+                <listitem><para>
+                    Mark the commit to be included in the named subset. This will cause the commit
+                    to be put in the named subset summary (in addition to the main one), allowing
+                    users to see only this subset instead of the whole repo.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--untrusted</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-build-export.xml
+++ b/doc/flatpak-build-export.xml
@@ -124,6 +124,16 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--subset=SUBSET</option></term>
+
+                <listitem><para>
+                    Mark the commit to be included in the named subset. This will cause the commit
+                    to be put in the named subset summary (in addition to the main one), allowing
+                    users to see only this subset instead of the whole repo.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--arch=ARCH</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-flatpakrepo.xml
+++ b/doc/flatpak-flatpakrepo.xml
@@ -84,6 +84,10 @@
                     <listitem><para>The default branch to use for this remote.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>Subset</option> (string)</term>
+                    <listitem><para>Limit the remote to the named subset of refs.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>Title</option> (string)</term>
                     <listitem><para>The title of the remote. This should be a user-friendly name that can be displayed e.g. in an app store.</para></listitem>
                 </varlistentry>

--- a/doc/flatpak-remote-add.xml
+++ b/doc/flatpak-remote-add.xml
@@ -127,6 +127,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--subset=SUBSET</option></term>
+
+                <listitem><para>
+                  Limit the refs available from the remote to those that are part of the named subset.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--no-enumerate</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -120,6 +120,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--subset=SUBSET</option></term>
+
+                <listitem><para>
+                  Limit the refs available from the remote to those that are part of the named subset.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--no-enumerate</option></term>
 
                 <listitem><para>

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -767,6 +767,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
   g_autoptr(GError) error = NULL;
   g_autofree char *new_branch = NULL;
   g_autofree char *old_branch = NULL;
+  g_autofree char *subset = NULL;
   gboolean is_oci;
 
   g_debug ("DeployAppstream %s %u %s %s %s", arg_repo_path, arg_flags, arg_origin, arg_arch, arg_installation);
@@ -798,8 +799,18 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
 
   is_oci = flatpak_dir_get_remote_oci (system, arg_origin);
 
-  new_branch = g_strdup_printf ("appstream2/%s", arg_arch);
-  old_branch = g_strdup_printf ("appstream/%s", arg_arch);
+  subset = flatpak_dir_get_remote_subset (system, arg_origin);
+
+  if (subset)
+    {
+      new_branch = g_strdup_printf ("appstream2/%s-%s", subset, arg_arch);
+      old_branch = g_strdup_printf ("appstream/%s-%s", subset, arg_arch);
+    }
+  else
+    {
+      new_branch = g_strdup_printf ("appstream2/%s", arg_arch);
+      old_branch = g_strdup_printf ("appstream/%s", arg_arch);
+    }
 
   if (is_oci)
     {

--- a/tests/Makefile-test-matrix.am.inc
+++ b/tests/Makefile-test-matrix.am.inc
@@ -26,6 +26,8 @@ TEST_MATRIX= \
 	tests/test-update-portal@system.wrap \
 	tests/test-summaries@user.wrap \
 	tests/test-summaries@system.wrap \
+	tests/test-subset@user.wrap \
+	tests/test-subset@system.wrap \
 	$(NULL)
 TEST_MATRIX_DIST= \
 	tests/test-basic.sh \
@@ -50,4 +52,5 @@ TEST_MATRIX_EXTRA_DIST= \
 	tests/test-update-remote-configuration.sh \
 	tests/test-update-portal.sh \
 	tests/test-summaries.sh \
+	tests/test-subset.sh \
 	$(NULL)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -205,6 +205,7 @@ TEST_MATRIX_SOURCE = \
 	tests/test-auth.sh \
 	tests/test-unused.sh \
 	tests/test-summaries.sh{user+system} \
+	tests/test-subset.sh{user+system} \
 	$(NULL)
 
 update-test-matrix:

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -303,7 +303,7 @@ make_runtime () {
         ostree --repo=repos/${REPONAME} init --mode=archive-z2 ${collection_args}
     fi
 
-    flatpak build-commit-from --disable-fsync --src-repo=${RUNTIME_REPO} --force ${GPGARGS} repos/${REPONAME}  ${RUNTIME_REF}
+    flatpak build-commit-from --disable-fsync --src-repo=${RUNTIME_REPO} --force ${GPGARGS} ${EXPORT_ARGS-}  repos/${REPONAME}  ${RUNTIME_REF}
 }
 
 httpd () {

--- a/tests/test-subset.sh
+++ b/tests/test-subset.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Alexander Larsson <alexl@redhat.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+skip_revokefs_without_fuse
+
+echo "1..3"
+
+EXPORT_ARGS="--subset=subset1 --subset=subset2" setup_repo
+
+$FLATPAK repo repos/test > repo-info.txt
+assert_file_has_content repo-info.txt "Subsummaries: .*subset1-$ARCH.*"
+assert_file_has_content repo-info.txt "Subsummaries: .*subset2-$ARCH.*"
+
+$FLATPAK repo --branches repos/test > repo-all.txt
+assert_file_has_content repo-all.txt "app/org.test.Hello/$ARCH/master"
+assert_file_has_content repo-all.txt "runtime/org.test.Platform/$ARCH/master"
+
+EXPORT_ARGS="--subset=subset1 " GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test org.test.SubsetOne master ""
+EXPORT_ARGS="--subset=subset2 " GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test org.test.SubsetTwo master ""
+EXPORT_ARGS="" GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test org.test.NoSubset master ""
+${FLATPAK} build-update-repo ${BUILD_UPDATE_REPO_FLAGS-} ${FL_GPGARGS} repos/test
+
+$FLATPAK repo repos/test > repo-info.txt
+assert_file_has_content repo-info.txt "Subsummaries: .*subset1-$ARCH.*"
+assert_file_has_content repo-info.txt "Subsummaries: .*subset2-$ARCH.*"
+
+$FLATPAK repo --branches repos/test > repo-all.txt
+assert_file_has_content repo-all.txt "app/org.test.Hello/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org.test.SubsetOne/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org.test.SubsetTwo/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org.test.NoSubset/$ARCH/master"
+assert_file_has_content repo-all.txt "runtime/org.test.Platform/$ARCH/master"
+
+$FLATPAK repo --branches repos/test --subset=subset1 > repo-subset1.txt
+assert_file_has_content repo-subset1.txt "app/org.test.Hello/$ARCH/master"
+assert_file_has_content repo-subset1.txt "app/org.test.SubsetOne/$ARCH/master"
+assert_not_file_has_content repo-subset1.txt "app/org.test.SubsetTwo/$ARCH/master"
+assert_not_file_has_content repo-subset1.txt "app/org.test.NoSubset/$ARCH/master"
+assert_file_has_content repo-subset1.txt "runtime/org.test.Platform/$ARCH/master"
+
+$FLATPAK repo --branches repos/test --subset=subset2 > repo-subset2.txt
+assert_file_has_content repo-subset2.txt "app/org.test.Hello/$ARCH/master"
+assert_not_file_has_content repo-subset2.txt "app/org.test.SubsetOne/$ARCH/master"
+assert_file_has_content repo-subset2.txt "app/org.test.SubsetTwo/$ARCH/master"
+assert_not_file_has_content repo-subset2.txt "app/org.test.NoSubset/$ARCH/master"
+assert_file_has_content repo-subset2.txt "runtime/org.test.Platform/$ARCH/master"
+
+ok "repo has right refs in right subset"
+
+${FLATPAK} ${U} remote-modify --subset=subset1 test-repo
+
+${FLATPAK} ${U} remote-ls test-repo > remote-subset1.txt
+assert_file_has_content remote-subset1.txt "org.test.Hello"
+assert_file_has_content remote-subset1.txt "org.test.SubsetOne"
+assert_not_file_has_content remote-subset1.txt "org.test.SubsetTwo"
+assert_not_file_has_content remote-subset1.txt "org.test.NoSubset"
+assert_file_has_content remote-subset1.txt "org.test.Platform"
+
+${FLATPAK} ${U} install -y org.test.Hello &> /dev/null
+${FLATPAK} ${U} install -y org.test.SubsetOne &> /dev/null
+
+if ${FLATPAK} ${U} install -y org.test.SubsetTwo &> /dev/null; then
+    assert_not_reached "Subset2 should not be visible"
+fi
+
+${FLATPAK} ${U} update --appstream
+assert_has_file $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml
+assert_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.Hello.desktop
+assert_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.SubsetOne.desktop
+assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.SubsetTwo.desktop
+assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.NoSubset.desktop
+
+ok "remote subset handling works"
+
+${FLATPAK} ${U} remote-modify --subset=subset2 test-repo
+
+${FLATPAK} ${U} remote-ls test-repo > remote-subset2.txt
+assert_file_has_content remote-subset2.txt "org.test.Hello"
+assert_not_file_has_content remote-subset2.txt "org.test.SubsetOne"
+assert_file_has_content remote-subset2.txt "org.test.SubsetTwo"
+assert_not_file_has_content remote-subset1.txt "org.test.NoSubset"
+assert_file_has_content remote-subset2.txt "org.test.Platform"
+
+${FLATPAK} ${U} install -y org.test.SubsetTwo &> /dev/null
+
+${FLATPAK} ${U} update --appstream
+assert_has_file $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml
+assert_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.Hello.desktop
+assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.SubsetOne.desktop
+assert_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.SubsetTwo.desktop
+assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.NoSubset.desktop
+
+ok "remote subset switching works"


### PR DESCRIPTION
When you create a commit (i.e. `build-export` or `build-commit-from`) you can add `--subset=foobar`, which will mark that commit as part of the subset named "foobar".  When we generate summaries we create an extra set of subsummaries (one per arch) that only contains the refs marked with that subset, and we also generate a subset of the appstream data (named `appstream2/foobar-x86_64` etc). 

On the client you can `remote-add` or `remote-modify` with `--subset=foobar`, or have a flatpakrepo file with `Summary=foobar`. This sets the `xa.subset` config option on the remote, and if this is set, then flatpak will only use the summaries with that subset, and will use the per-subset appstream branch. 

The goal here is to allow for instance flathub to have a "free" subset which only contains fully foss software, while still just storing and serving a single repo.