### PR TITLE
Ensure deploy files have complete metadata

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -36,8 +36,10 @@
  * Version 1 added appdata-name/summary/version/license
  * Version 2 added extension-of/appdata-content-rating
  * Version 3 added timestamp
+ * Version 4 guarantees that alt-id/eol/eolr/runtime/extension-of/appdata-content-rating
+ *           are present if in the commit metadata or metadata file or appdata
  */
-#define FLATPAK_DEPLOY_VERSION_CURRENT 3
+#define FLATPAK_DEPLOY_VERSION_CURRENT 4
 #define FLATPAK_DEPLOY_VERSION_ANY 0
 
 #define FLATPAK_TYPE_DIR flatpak_dir_get_type ()
@@ -427,6 +429,7 @@ const char **flatpak_deploy_data_get_previous_ids                (GBytes *deploy
 GFile *         flatpak_deploy_get_dir         (FlatpakDeploy      *deploy);
 GBytes *        flatpak_load_deploy_data       (GFile              *deploy_dir,
                                                 FlatpakDecomposed  *ref,
+                                                OstreeRepo         *repo,
                                                 int                 required_version,
                                                 GCancellable       *cancellable,
                                                 GError            **error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3448,7 +3448,7 @@ upgrade_deploy_data (GBytes             *deploy_data,
       g_variant_get_child (metadata, i, "{&s@v}", &key, &value);
       if (strcmp (key, "deploy-version") == 0)
         continue;
-      g_variant_dict_insert_value (&metadata_dict, key, g_steal_pointer (&value));
+      g_variant_dict_insert_value (&metadata_dict, key, value);
     }
 
   old_version = flatpak_deploy_data_get_version (deploy_data);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6424,7 +6424,8 @@ flatpak_dir_list_app_refs_with_runtime (FlatpakDir        *self,
   for (int i = 0; app_refs != NULL && i < app_refs->len; i++)
     {
       FlatpakDecomposed *app_ref = g_ptr_array_index (app_refs, i);
-      g_autoptr(GBytes) app_deploy_data = flatpak_dir_get_deploy_data (self, app_ref, FLATPAK_DEPLOY_VERSION_ANY, NULL, NULL);
+      /* deploy v4 guarantees runtime info */
+      g_autoptr(GBytes) app_deploy_data = flatpak_dir_get_deploy_data (self, app_ref, 4, NULL, NULL);
 
       if (app_deploy_data)
         {
@@ -9569,7 +9570,8 @@ flatpak_dir_needs_update_for_commit_and_subpaths (FlatpakDir        *self,
   if (*url == 0)
     return FALSE;
 
-  deploy_data = flatpak_dir_get_deploy_data (self, ref, FLATPAK_DEPLOY_VERSION_ANY, NULL, NULL);
+  /* deploy v4 guarantees alt-id/extension-of info */
+  deploy_data = flatpak_dir_get_deploy_data (self, ref, 4, NULL, NULL);
   if (deploy_data != NULL)
     old_subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
   else
@@ -15971,8 +15973,9 @@ flatpak_dir_list_unused_refs (FlatpakDir         *self,
             {
               g_autoptr(GBytes) deploy_data = NULL;
 
-              deploy_data = flatpak_dir_get_deploy_data (self, ref,
-                                                         FLATPAK_DEPLOY_VERSION_ANY, cancellable, NULL);
+              /* deploy v4 guarantees eol/eolr info */
+              deploy_data = flatpak_dir_get_deploy_data (self, ref, 4,
+                                                         cancellable, NULL);
               is_eol = deploy_data != NULL &&
                 (flatpak_deploy_data_get_eol (deploy_data) != NULL ||
                  flatpak_deploy_data_get_eol_rebase (deploy_data));

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -4757,8 +4757,8 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
       if (res)
         {
           g_autoptr(GBytes) deploy_data = NULL;
-          deploy_data = flatpak_dir_get_deploy_data (priv->dir, op->ref,
-                                                     FLATPAK_DEPLOY_VERSION_ANY, NULL, NULL);
+          /* deploy v4 guarantees eol/eolr info */
+          deploy_data = flatpak_dir_get_deploy_data (priv->dir, op->ref, 4, NULL, NULL);
 
           if (deploy_data)
             {

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2917,7 +2917,9 @@ load_deployed_metadata (FlatpakTransaction *self, FlatpakDecomposed *ref, char *
   if (out_commit || out_remote)
     {
       g_autoptr(GBytes) deploy_data = NULL;
-      deploy_data = flatpak_load_deploy_data (deploy_dir, ref, FLATPAK_DEPLOY_VERSION_ANY, NULL, NULL);
+      deploy_data = flatpak_load_deploy_data (deploy_dir, ref,
+                                              flatpak_dir_get_repo (priv->dir),
+                                              FLATPAK_DEPLOY_VERSION_ANY, NULL, NULL);
       if (deploy_data == NULL)
         return NULL;
 


### PR DESCRIPTION
Currently we use the deploy data to decide if a runtime is end-of-life,
when calculating which refs are unused and should therefore be removed.
In most cases this works fine. However, it is possible for the
end-of-life metadata to be set on the commit without it being set in the
deploy data. You can diagnose this scenario by comparing "ostree show
--print-metadata-key=ostree.endoflife ...", "ostree show
--print-metadata-key=ostree.endoflife-rebase ...", and "flatpak info
..." since the info command normally prints EOL info from the deploy
data.

I am testing the unused runtimes removal code using an installation of
Endless OS 3.3.16 that has been upgraded, and that OS version included
Flatpak 0.10.1, which was before we started including EOL info in the
deploy data. So I believe that's why the legacy runtime
com.endlessm.Platform//eos3.2 isn't being removed despite being unused.

So, check commit metadata rather than deploy data to determine if a
runtime is end-of-life.

I checked that unused EOL runtimes are still removed with this patch.