### PR TITLE
Better eol handling in CLI

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -710,19 +710,20 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
   if (action == EOL_UNDECIDED)
     {
       gboolean is_pinned = flatpak_dir_ref_is_pinned (dir, flatpak_decomposed_get_ref (ref));
+      g_autofree char *branch = flatpak_decomposed_dup_branch (ref);
       action = EOL_IGNORE;
 
       if (rebased_to_ref)
         if (is_pinned)
-          g_print (_("Info: (pinned) %s is end-of-life, in favor of %s\n"), name, rebased_to_ref);
+          g_print (_("Info: (pinned) %s//%s is end-of-life, in favor of %s\n"), name, branch, rebased_to_ref);
         else
-          g_print (_("Info: %s is end-of-life, in favor of %s\n"), name, rebased_to_ref);
+          g_print (_("Info: %s//%s is end-of-life, in favor of %s\n"), name, branch, rebased_to_ref);
       else if (reason)
         {
           if (is_pinned)
-            g_print (_("Info: (pinned) %s is end-of-life, with reason:\n"), name);
+            g_print (_("Info: (pinned) %s//%s is end-of-life, with reason:\n"), name, branch);
           else
-            g_print (_("Info: %s is end-of-life, with reason:\n"), name);
+            g_print (_("Info: %s//%s is end-of-life, with reason:\n"), name, branch);
           g_print ("   %s\n", reason);
         }
 

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -39,6 +39,8 @@ struct _FlatpakCliTransaction
   gboolean             non_default_arch;
   GError              *first_operation_error;
 
+  GHashTable          *eol_actions;
+
   int                  rows;
   int                  cols;
   int                  table_width;
@@ -641,49 +643,148 @@ basic_auth_start (FlatpakTransaction *transaction,
 }
 
 
+typedef enum {
+  EOL_UNDECIDED,
+  EOL_IGNORE,        /* Don't do anything, we already printed a warning */
+  EOL_NO_REBASE,     /* Choose to not rebase */
+  EOL_REBASE,        /* Choose to rebase */
+} EolAction;
+
 static gboolean
 end_of_lifed_with_rebase (FlatpakTransaction *transaction,
                           const char         *remote,
-                          const char         *ref,
+                          const char         *ref_str,
                           const char         *reason,
                           const char         *rebased_to_ref,
                           const char        **previous_ids)
 {
   FlatpakCliTransaction *self = FLATPAK_CLI_TRANSACTION (transaction);
-  g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
+  g_autoptr(FlatpakDecomposed) ref = flatpak_decomposed_new_from_ref (ref_str, NULL);
+  g_autofree char *name = NULL;
+  EolAction action = EOL_UNDECIDED;
+  EolAction old_action = EOL_UNDECIDED;
+  gboolean can_rebase = rebased_to_ref != NULL && remote != NULL;
+  FlatpakInstallation *installation = flatpak_transaction_get_installation (transaction);
+  FlatpakDir *dir = flatpak_installation_get_dir (installation, NULL);
+
+  if (ref == NULL)
+    return FALSE; /* Shouldn't happen, the ref should be valid */
+
+  name = flatpak_decomposed_dup_id (ref);
 
   self->did_interaction = TRUE;
 
-  if (rebased_to_ref)
-    g_print (_("Info: %s is end-of-life, in favor of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
-  else if (reason)
-    g_print (_("Info: %s is end-of-life, with reason: %s\n"), flatpak_ref_get_name (rref), reason);
-
-  if (rebased_to_ref && remote)
+  if (flatpak_decomposed_id_is_subref (ref))
     {
-      if (self->disable_interaction ||
-          flatpak_yes_no_prompt (TRUE, _("Replace it with %s?"), rebased_to_ref))
+      GLNX_HASH_TABLE_FOREACH_KV (self->eol_actions, FlatpakDecomposed *, eoled_ref, gpointer, value)
         {
-          g_autoptr(GError) error = NULL;
+          guint old_eol_action = GPOINTER_TO_UINT (value);
 
-          if (self->disable_interaction)
-            g_print (_("Updating to rebased version\n"));
-
-          if (!flatpak_transaction_add_uninstall (transaction, ref, &error) ||
-              !flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error))
-            {
-              g_propagate_prefixed_error (&self->first_operation_error,
-                                          g_error_copy (error),
-                                          _("Failed to rebase %s to %s: "),
-                                          flatpak_ref_get_name (rref), rebased_to_ref);
-              return FALSE;
-            }
-
-          return TRUE;
+          if (flatpak_decomposed_id_is_subref_of (ref, eoled_ref))
+              {
+                old_action = old_eol_action; /* Do the same */
+                break;
+              }
         }
     }
 
-  return FALSE;
+  if (old_action != EOL_UNDECIDED)
+    {
+      switch (old_action)
+        {
+        default:
+        case EOL_IGNORE:
+          if (!can_rebase)
+            action = EOL_IGNORE;
+          /* Else, ask if we want to rebase */
+          break;
+        case EOL_REBASE:
+        case EOL_NO_REBASE:
+          if (can_rebase)
+            action = old_action;
+          else
+            action = EOL_IGNORE;
+        }
+    }
+
+  if (action == EOL_UNDECIDED)
+    {
+      gboolean is_pinned = flatpak_dir_ref_is_pinned (dir, flatpak_decomposed_get_ref (ref));
+      action = EOL_IGNORE;
+
+      if (rebased_to_ref)
+        if (is_pinned)
+          g_print (_("Info: (pinned) %s is end-of-life, in favor of %s\n"), name, rebased_to_ref);
+        else
+          g_print (_("Info: %s is end-of-life, in favor of %s\n"), name, rebased_to_ref);
+      else if (reason)
+        {
+          if (is_pinned)
+            g_print (_("Info: (pinned) %s is end-of-life, with reason:\n"), name);
+          else
+            g_print (_("Info: %s is end-of-life, with reason:\n"), name);
+          g_print ("   %s\n", reason);
+        }
+
+      if (flatpak_decomposed_is_runtime (ref))
+        {
+          g_autoptr(GPtrArray) apps = flatpak_dir_list_app_refs_with_runtime (dir, ref, NULL, NULL);
+          if (apps && apps->len > 0)
+            {
+              g_print (_("Applications using this runtime:\n"));
+              g_print ("   ");
+              for (int i = 0; i < apps->len; i++)
+                {
+                  FlatpakDecomposed *app_ref = g_ptr_array_index (apps, i);
+                  g_autofree char *id = flatpak_decomposed_dup_id (app_ref);
+                  if (i != 0)
+                    g_print (", ");
+                  g_print ("%s", id);
+                }
+              g_print ("\n");
+            }
+        }
+
+      if (rebased_to_ref && remote)
+        {
+          if (self->disable_interaction ||
+              flatpak_yes_no_prompt (TRUE, _("Replace it with %s?"), rebased_to_ref))
+            {
+              if (self->disable_interaction)
+                g_print (_("Updating to rebased version\n"));
+
+              action = EOL_REBASE;
+            }
+          else
+            action = EOL_NO_REBASE;
+        }
+    }
+  else
+    {
+        g_debug ("%s is end-of-life, using action from parent ren", name);
+    }
+
+  /* Cache for later comparison and reuse */
+  g_hash_table_insert (self->eol_actions, flatpak_decomposed_ref (ref), GUINT_TO_POINTER (action));
+
+  if (action == EOL_REBASE)
+    {
+      g_autoptr(GError) error = NULL;
+
+      if (!flatpak_transaction_add_uninstall (transaction, ref_str, &error) ||
+          !flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error))
+        {
+          g_propagate_prefixed_error (&self->first_operation_error,
+                                      g_error_copy (error),
+                                      _("Failed to rebase %s to %s: "),
+                                      name, rebased_to_ref);
+          return FALSE;
+        }
+
+      return TRUE; /* skip update op, in favour of added uninstall */
+    }
+  else /* IGNORE or NO_REBASE */
+    return FALSE;
 }
 
 static int
@@ -1203,6 +1304,8 @@ flatpak_cli_transaction_finalize (GObject *object)
 
   g_free (self->progress_msg);
 
+  g_hash_table_unref (self->eol_actions);
+
   if (self->printer)
     flatpak_table_printer_free (self->printer);
 
@@ -1212,6 +1315,8 @@ flatpak_cli_transaction_finalize (GObject *object)
 static void
 flatpak_cli_transaction_init (FlatpakCliTransaction *self)
 {
+  self->eol_actions = g_hash_table_new_full ((GHashFunc)flatpak_decomposed_hash, (GEqualFunc)flatpak_decomposed_equal,
+                                             (GDestroyNotify)flatpak_decomposed_unref, NULL);
 }
 
 static gboolean flatpak_cli_transaction_run (FlatpakTransaction *transaction,

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -636,6 +636,10 @@ GPtrArray *           flatpak_dir_list_refs                                 (Fla
                                                                              FlatpakKinds                   kinds,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
+GPtrArray *           flatpak_dir_list_app_refs_with_runtime                (FlatpakDir                    *self,
+                                                                             FlatpakDecomposed             *runtime_ref,
+                                                                             GCancellable                  *cancellable,
+                                                                             GError                       **error);
 GVariant *            flatpak_dir_read_latest_commit                        (FlatpakDir                    *self,
                                                                              const char                    *remote,
                                                                              FlatpakDecomposed             *ref,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -15755,7 +15755,7 @@ find_used_refs (FlatpakDir         *self,
           if (runtime)
             {
               g_autoptr(FlatpakDecomposed) runtime_ref = flatpak_decomposed_new_from_pref (FLATPAK_KINDS_RUNTIME, runtime, NULL);
-              if (runtime_ref)
+              if (runtime_ref && !flatpak_decomposed_equal (runtime_ref, ref_to_analyze))
                 queue_ref_for_analysis (runtime_ref, arch, analyzed_refs, refs_to_analyze);
             }
         }
@@ -15765,7 +15765,7 @@ find_used_refs (FlatpakDir         *self,
       if (sdk)
         {
           g_autoptr(FlatpakDecomposed) sdk_ref = flatpak_decomposed_new_from_pref (FLATPAK_KINDS_RUNTIME, sdk, NULL);
-          if (sdk_ref)
+          if (sdk_ref && !flatpak_decomposed_equal (sdk_ref, ref_to_analyze))
             queue_ref_for_analysis (sdk_ref, arch, analyzed_refs, refs_to_analyze);
         }
 

--- a/common/flatpak-ref-utils-private.h
+++ b/common/flatpak-ref-utils-private.h
@@ -113,6 +113,8 @@ gboolean           flatpak_decomposed_id_has_prefix         (FlatpakDecomposed  
 gboolean           flatpak_decomposed_is_id_fuzzy           (FlatpakDecomposed  *ref,
                                                              const char         *id);
 gboolean           flatpak_decomposed_id_is_subref          (FlatpakDecomposed  *ref);
+gboolean           flatpak_decomposed_id_is_subref_of       (FlatpakDecomposed  *ref,
+                                                             FlatpakDecomposed  *parent_ref);
 const char *       flatpak_decomposed_peek_arch             (FlatpakDecomposed  *ref,
                                                              gsize              *out_len);
 char *             flatpak_decomposed_dup_arch              (FlatpakDecomposed  *ref);

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -363,7 +363,8 @@ ${FLATPAK} ${U} remote-ls -d -a test-repo > remote-ls-log
 assert_file_has_content remote-ls-log "app/org\.test\.Hello/.*eol=Reason2"
 
 ${FLATPAK} ${U} update -y org.test.Hello > update-log
-assert_file_has_content update-log "org\.test\.Hello.*Reason2"
+assert_file_has_content update-log "org\.test\.Hello.*end-of-life"
+assert_file_has_content update-log "Reason2"
 
 ${FLATPAK} ${U} info org.test.Hello > info-log
 assert_file_has_content info-log "End-of-life: Reason2"

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -431,6 +431,54 @@ test_decompose (void)
     branch = flatpak_decomposed_dup_branch (pref);
     g_assert_cmpstr (branch, ==, "master");
   }
+
+
+  {
+    g_autoptr(FlatpakDecomposed) a = flatpak_decomposed_new_from_ref ("app/org.app.A/x86_64/master", NULL);
+    g_autoptr(FlatpakDecomposed) a_l = flatpak_decomposed_new_from_ref ("runtime/org.app.A.Locale/x86_64/master", NULL);
+    g_autoptr(FlatpakDecomposed) b = flatpak_decomposed_new_from_ref ("app/org.app.B/x86_64/master", NULL);
+    g_autoptr(FlatpakDecomposed) b_l = flatpak_decomposed_new_from_ref ("runtime/org.app.B.Locale/x86_64/master", NULL);
+    g_autoptr(FlatpakDecomposed) c = flatpak_decomposed_new_from_ref ("app/org.app.A/i386/master", NULL);
+    g_autoptr(FlatpakDecomposed) c_l = flatpak_decomposed_new_from_ref ("runtime/org.app.A.Locale/i386/master", NULL);
+    g_autoptr(FlatpakDecomposed) d = flatpak_decomposed_new_from_ref ("app/org.app.A/x86_64/beta", NULL);
+    g_autoptr(FlatpakDecomposed) d_l = flatpak_decomposed_new_from_ref ("runtime/org.app.A.Locale/x86_64/beta", NULL);
+
+    g_assert (flatpak_decomposed_id_is_subref_of (a_l, a));
+    g_assert (!flatpak_decomposed_id_is_subref_of (b_l, a));
+    g_assert (!flatpak_decomposed_id_is_subref_of (c_l, a));
+    g_assert (!flatpak_decomposed_id_is_subref_of (d_l, a));
+    g_assert (!flatpak_decomposed_id_is_subref_of (a, a));
+    g_assert (!flatpak_decomposed_id_is_subref_of (b, a));
+    g_assert (!flatpak_decomposed_id_is_subref_of (c, a));
+    g_assert (!flatpak_decomposed_id_is_subref_of (d, a));
+
+    g_assert (!flatpak_decomposed_id_is_subref_of (a_l, b));
+    g_assert (flatpak_decomposed_id_is_subref_of (b_l, b));
+    g_assert (!flatpak_decomposed_id_is_subref_of (c_l, b));
+    g_assert (!flatpak_decomposed_id_is_subref_of (d_l, b));
+    g_assert (!flatpak_decomposed_id_is_subref_of (a, b));
+    g_assert (!flatpak_decomposed_id_is_subref_of (b, b));
+    g_assert (!flatpak_decomposed_id_is_subref_of (c, b));
+    g_assert (!flatpak_decomposed_id_is_subref_of (d, b));
+
+    g_assert (!flatpak_decomposed_id_is_subref_of (a_l, c));
+    g_assert (!flatpak_decomposed_id_is_subref_of (b_l, c));
+    g_assert (flatpak_decomposed_id_is_subref_of (c_l, c));
+    g_assert (!flatpak_decomposed_id_is_subref_of (d_l, c));
+    g_assert (!flatpak_decomposed_id_is_subref_of (a, c));
+    g_assert (!flatpak_decomposed_id_is_subref_of (b, c));
+    g_assert (!flatpak_decomposed_id_is_subref_of (c, c));
+    g_assert (!flatpak_decomposed_id_is_subref_of (d, c));
+
+    g_assert (!flatpak_decomposed_id_is_subref_of (a_l, d));
+    g_assert (!flatpak_decomposed_id_is_subref_of (b_l, d));
+    g_assert (!flatpak_decomposed_id_is_subref_of (c_l, d));
+    g_assert (flatpak_decomposed_id_is_subref_of (d_l, d));
+    g_assert (!flatpak_decomposed_id_is_subref_of (a, d));
+    g_assert (!flatpak_decomposed_id_is_subref_of (b, d));
+    g_assert (!flatpak_decomposed_id_is_subref_of (c, d));
+    g_assert (!flatpak_decomposed_id_is_subref_of (d, d));
+  }
 }
 
 


### PR DESCRIPTION
 We remember what action we took for EOLs, and for sub-refs (ie .Locale)  we reuse that.
    
 Also, we show if eol:ed refs are pinned (as that makes them not be auto-uninstalled), and we list the apps that use the eol:ed runtime ref.
    
Example run:
 ```
Looking for updates…
Info: (pinned) org.gnome.Sdk.Compat.i386 is end-of-life, with reason:
   The GNOME 3.34 runtime is no longer supported as of 14th August 2020. Please ask your application developer to migrate to a supported platform.
Info: org.gnome.Platform is end-of-life, with reason:
   The GNOME 3.32 runtime is no longer supported as of 11th March 2020. Please ask your application developer to migrate to a supported platform.
Applications using this runtime:
   org.gnome.HexGL
```
