### PR TITLE
context: do not use a cast to convert a pointer to an integer

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2140,7 +2140,7 @@ flatpak_context_export (FlatpakContext *context,
   GHashTableIter iter;
   gpointer key, value;
 
-  fs_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host");
+  fs_mode = GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "host"));
   if (fs_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       DIR *dir;
@@ -2168,19 +2168,19 @@ flatpak_context_export (FlatpakContext *context,
       flatpak_exports_add_path_expose (exports, fs_mode, "/run/media");
     }
 
-  os_mode = MAX ((FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host-os"),
+  os_mode = MAX (GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "host-os")),
                    fs_mode);
 
   if (os_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_host_os_expose (exports, os_mode);
 
-  etc_mode = MAX ((FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host-etc"),
+  etc_mode = MAX (GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "host-etc")),
                    fs_mode);
 
   if (etc_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_host_etc_expose (exports, etc_mode);
 
-  home_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "home");
+  home_mode = GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "home"));
   if (home_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       g_debug ("Allowing homedir access");


### PR DESCRIPTION
Building with Clang 11 shows a warning for the cast of the 'gpointer' to
'FlatpakFilesystemMode'.
This is due to '-Wpointer-to-int-cast' being now enabled by default.

```
common/flatpak-context.c:2144:13: warning: cast to smaller integer type
'FlatpakFilesystemMode' from 'gpointer' (aka 'void *')
[-Wvoid-pointer-to-enum-cast]
fs_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host");
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
