### PR TITLE
transaction: Add more details to the ABORTED error

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -4791,7 +4791,7 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
                   break;
                 }
 
-              flatpak_fail_error (error, FLATPAK_ERROR_ABORTED, _("Aborted due to failure"));
+              flatpak_fail_error (error, FLATPAK_ERROR_ABORTED, _("Aborted due to failure (%s)"), local_error->message);
               succeeded = FALSE;
               break;
             }


### PR DESCRIPTION
This is reported when we reported an error to the user via
::operation-error signal and the app told us to not continue.

If this happens in some weird case and we see the results its nice
to have access to the original error message.