### PR TITLE
Add back the ostree.commit.timestamp per-ref metadata for summary

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -67,8 +67,6 @@
 #include <systemd/sd-journal.h>
 #endif
 
-#define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
-
 #define NO_SYSTEM_HELPER ((FlatpakSystemHelper *) (gpointer) 1)
 
 #define SUMMARY_CACHE_TIMEOUT_SEC (60 * 5)

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -54,13 +54,18 @@
 #define FLATPAK_ANSI_ROW_N "\x1b[%d;1H"
 #define FLATPAK_ANSI_CLEAR "\x1b[0J"
 
-#define FLATPAK_XA_CACHE_VERSION 1
+#define FLATPAK_XA_CACHE_VERSION 2
 /* version 1 added extra data download size */
+/* version 2 added ot.ts timestamps (to new format) */
 
 #define FLATPAK_XA_SUMMARY_VERSION 1
 /* version 0/missing is standard ostree summary,
  * version 1 is compact format with inline cache and no deltas
  */
+
+/* Thse are key names in the per-ref metadata in the summary */
+#define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
+#define OSTREE_COMMIT_TIMESTAMP2 "ot.ts" /* Shorter version of the above */
 
 #define FLATPAK_SUMMARY_DIFF_HEADER "xadf"
 


### PR DESCRIPTION
The old summary had a ostree.commit.timestamp in the per-ref metadata
dict. However, since this was not used anymore by flatpak I removed it.
However, it turns out that flathub has infra that depends on this,
so I'm adding it back.

We reuse the data in the old summary for unchanged refs when
rebuilding the summary, to avoid having to read all the commits. In
the new world the new format summaries are used for this, which means
we have to keep the timestamp in that too. However, to not be
unnecessary large its now using a shorter key name, as this is
duplicated for each ref in the summary.