### PR TITLE
app: Swap order of rebase/uninstall calls

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -772,8 +772,8 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
     {
       g_autoptr(GError) error = NULL;
 
-      if (!flatpak_transaction_add_uninstall (transaction, ref_str, &error) ||
-          !flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error))
+      if (!flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error) ||
+          !flatpak_transaction_add_uninstall (transaction, ref_str, &error))
         {
           g_propagate_prefixed_error (&self->first_operation_error,
                                       g_error_copy (error),

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -222,8 +222,8 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
 
       g_print (_("Updating to rebased version\n"));
 
-      if (!flatpak_transaction_add_uninstall (transaction, ref, &error) ||
-          !flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error))
+      if (!flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error) ||
+          !flatpak_transaction_add_uninstall (transaction, ref, &error))
         {
           g_printerr (_("Failed to rebase %s to %s: %s\n"),
                       flatpak_ref_get_name (rref), rebased_to_ref, error->message);


### PR DESCRIPTION
In case the second of these two fails, the first will still have been
added to the transaction. And since it's better to install the renamed
app but not uninstall the old one, than to uninstall the old one but not
install the new one, swap the order.

See also https://github.com/flatpak/flatpak/issues/3991