### PR TITLE
build-init: Print required branch version in error message on missing extension

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -111,7 +111,7 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_branch,
 
                   subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
                   if (subpaths[0] != NULL)
-                    return flatpak_fail (error, _("Requested extension %s is only partially installed"), ext->installed_id);
+                    return flatpak_fail (error, _("Requested extension %s//%s is only partially installed"), ext->installed_id, default_branch);
                 }
 
               if (top_dir)
@@ -140,7 +140,7 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_branch,
       if (!found)
         {
           g_list_free_full (extensions, (GDestroyNotify) flatpak_extension_free);
-          return flatpak_fail (error, _("Requested extension %s not installed"), requested_extension_name);
+          return flatpak_fail (error, _("Requested extension %s//%s not installed"), requested_extension_name, default_branch);
         }
     }
 


### PR DESCRIPTION
This adresses the issue #3774.

build-init printed an error message but did not mention the required branch of
the extension. This resulted in a lot of confusion and wasted time (at least for me).
This fix appends the required branch to the name in the message.

### Example
Before:
`error: Requested extension org.freedesktop.Sdk.Extension.texlive not installed`
After:
`error: Requested extension org.freedesktop.Sdk.Extension.texlive//5.12 not installed`