### PR TITLE
docs: Fix typo in flatpak-search usage

### DIFF
--- a/doc/flatpak-search.xml
+++ b/doc/flatpak-search.xml
@@ -159,7 +159,7 @@
             </varlistentry>
 
             <varlistentry>
-                <term>version</term>
+                <term>branch</term>
 
                 <listitem><para>
                     Show the branch


### PR DESCRIPTION
The title for the `branch` column description says `version`.