### PR TITLE
Expose /var/usrlocal if "--filesystem=host" is specified.

### DIFF
--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -388,7 +388,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
       /* /usr/local points to ../var/usrlocal on ostree systems,
 	 so bind-mount that too. */
       if (flatpak_exports_stat_in_host (exports, "/var/usrlocal", &buf, 0, NULL) &&
-	  S_ISDIR (buf.st_mode))
+	    S_ISDIR (buf.st_mode))
         flatpak_bwrap_add_args (bwrap,
                                 os_bind_mode, "/var/usrlocal", "/run/host/var/usrlocal", NULL);
 

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -385,6 +385,13 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
         flatpak_bwrap_add_args (bwrap,
                                 os_bind_mode, "/usr", "/run/host/usr", NULL);
 
+      /* /usr/local points to ../var/usrlocal on ostree systems,
+	 so bind-mount that too. */
+      if (flatpak_exports_stat_in_host (exports, "/var/usrlocal", &buf, 0, NULL) &&
+	  S_ISDIR (buf.st_mode))
+        flatpak_bwrap_add_args (bwrap,
+                                os_bind_mode, "/var/usrlocal", "/run/host/var/usrlocal", NULL);
+
       for (i = 0; flatpak_abs_usrmerged_dirs[i] != NULL; i++)
         {
           const char *subdir = flatpak_abs_usrmerged_dirs[i];


### PR DESCRIPTION
 As /usr/local points to ../var/usrlocal on Silverblue,  /run/host/usr/local was previously a broken link inside the
 sandbox. This patch checks if /var/usrlocal exists and bind-mounts it to /run/host/var/usrlocal.
    
 See bug #4010.
