### PR TITLE
extra-data: Resolve runtime from the target installation

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -348,7 +348,7 @@ flatpak_builtin_build_init (int argc, char **argv, GCancellable *cancellable, GE
 
       base_branch = opt_base_version ? opt_base_version : "master";
       base_ref = flatpak_build_app_ref (opt_base, base_branch, opt_arch);
-      base_deploy = flatpak_find_deploy_for_ref (base_ref, NULL, cancellable, error);
+      base_deploy = flatpak_find_deploy_for_ref (base_ref, NULL, NULL, cancellable, error);
       if (base_deploy == NULL)
         return FALSE;
 

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -299,7 +299,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
     }
   else
     {
-      runtime_deploy = flatpak_find_deploy_for_ref (flatpak_decomposed_get_ref (runtime_ref), NULL, cancellable, error);
+      runtime_deploy = flatpak_find_deploy_for_ref (flatpak_decomposed_get_ref (runtime_ref), NULL, NULL, cancellable, error);
       if (runtime_deploy == NULL)
         return FALSE;
 
@@ -341,7 +341,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
       char *x_subdir = NULL;
       g_autofree char *bare_extension_point = NULL;
 
-      extensionof_deploy = flatpak_find_deploy_for_ref (extensionof_ref, NULL, cancellable, error);
+      extensionof_deploy = flatpak_find_deploy_for_ref (extensionof_ref, NULL, NULL, cancellable, error);
       if (extensionof_deploy == NULL)
         return FALSE;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7724,7 +7724,9 @@ apply_extra_data (FlatpakDir   *self,
   if (!g_key_file_get_boolean (metakey, FLATPAK_METADATA_GROUP_EXTRA_DATA,
                                FLATPAK_METADATA_KEY_NO_RUNTIME, NULL))
     {
-      runtime_deploy = flatpak_find_deploy_for_ref (flatpak_decomposed_get_ref (runtime_ref), NULL, cancellable, error);
+      /* We pass in self here so that we ensure that we find the runtime in case it only
+         exists in this installation (which might be custom) */
+      runtime_deploy = flatpak_find_deploy_for_ref (flatpak_decomposed_get_ref (runtime_ref), NULL, self, cancellable, error);
       if (runtime_deploy == NULL)
         return FALSE;
       runtime_files = flatpak_deploy_get_files (runtime_deploy);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3660,7 +3660,7 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
   else
     runtime_ref = flatpak_decomposed_ref (default_runtime);
 
-  runtime_deploy = flatpak_find_deploy_for_ref (flatpak_decomposed_get_ref (runtime_ref), custom_runtime_commit, cancellable, error);
+  runtime_deploy = flatpak_find_deploy_for_ref (flatpak_decomposed_get_ref (runtime_ref), custom_runtime_commit, NULL, cancellable, error);
   if (runtime_deploy == NULL)
     return FALSE;
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -221,6 +221,7 @@ FlatpakDeploy * flatpak_find_deploy_for_ref_in (GPtrArray    *dirs,
                                                 GError      **error);
 FlatpakDeploy * flatpak_find_deploy_for_ref (const char   *ref,
                                              const char   *commit,
+                                             FlatpakDir   *opt_user_dir,
                                              GCancellable *cancellable,
                                              GError      **error);
 char ** flatpak_list_deployed_refs (const char   *type,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -1253,6 +1253,7 @@ flatpak_find_deploy_for_ref_in (GPtrArray    *dirs,
 FlatpakDeploy *
 flatpak_find_deploy_for_ref (const char   *ref,
                              const char   *commit,
+                             FlatpakDir   *opt_user_dir,
                              GCancellable *cancellable,
                              GError      **error)
 {
@@ -1262,7 +1263,15 @@ flatpak_find_deploy_for_ref (const char   *ref,
   if (dirs == NULL)
     return NULL;
 
-  g_ptr_array_insert (dirs, 0, flatpak_dir_get_user ());
+  /* If an custom dir was passed, use that instead of the user dir.
+   * This is used when running apply-extra-data where if the target
+   * is a custom installation location the regular user one may not
+   * have the (possibly just installed in this transaction) runtime.
+   */
+  if (opt_user_dir)
+    g_ptr_array_insert (dirs, 0, g_object_ref (opt_user_dir));
+  else
+    g_ptr_array_insert (dirs, 0, flatpak_dir_get_user ());
 
   return flatpak_find_deploy_for_ref_in (dirs, ref, commit, cancellable, error);
 }


### PR DESCRIPTION
When installing to an installation we need to find the runtime to use
for the apply-extra-data script from the installation we're targeting,
because that is the one that FlatpakTransaction guaranteed has the
required dependencies (although its possible they came from the
default dependency source too, i.e. the system repos).

In particular, we run into this issue if nothing is installed
anywhere, and then we install an extra-data app into a custom
directory. The transaction will download the runtime, and it
will not be anywhere else. Without this change flatpak only
looked for the dependency in the systam an regular user dirs
where it isn't.