### PR TITLE
flatpak-dir: Allow root to bypass parental controls

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7855,6 +7855,11 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   g_autoptr(AutoPolkitAuthorizationResult) result = NULL;
   gboolean authorized;
   gboolean repo_installation_allowed, app_is_appropriate;
+  
+  /* Assume that root is allowed to install any ref and shouldn't have any
+   * parental controls restrictions applied to them */
+  if (getuid () == 0)
+    return TRUE;
 
   /* The ostree-metadata and appstream/ branches should not have any parental
    * controls restrictions. Similarly, for the moment, there is no point in


### PR DESCRIPTION
In elementary OS, we're building our images with some flatpaks pre-installed. To do this, we run noninteractive `flatpak install` commands in the chroot as part of the build scripts. We've bumped into some build failures recently after switching to a version of flatpak with malcontent support built in.

After some debugging, it turns out installations are failing the parental controls checks with errors like `Failed to install org.gnome.Epiphany: Could not connect: No such file or directory` message. I'm assuming this is a failure to connect to the system bus in this method (since there isn't one in the chroot).

Is it reasonable to assume that UID 0 should be allowed to install whatever they want regardless of parental controls? I believe this would fix our issue too.