### PR TITLE
app: fix crash when killing a process without a name

### DIFF
--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -121,7 +121,7 @@ flatpak_builtin_enter (int           argc,
       FlatpakInstance *instance = (FlatpakInstance *) g_ptr_array_index (instances, j);
 
       if (pid == flatpak_instance_get_pid (instance) ||
-          strcmp (pid_s, flatpak_instance_get_app (instance)) == 0 ||
+          g_strcmp0 (pid_s, flatpak_instance_get_app (instance)) == 0 ||
           strcmp (pid_s, flatpak_instance_get_id (instance)) == 0)
         {
           pid = flatpak_instance_get_child_pid (instance);
@@ -315,7 +315,11 @@ flatpak_complete_enter (FlatpakCompletion *completion)
       for (i = 0; i < instances->len; i++)
         {
           FlatpakInstance *instance = (FlatpakInstance *) g_ptr_array_index (instances, i);
-          flatpak_complete_word (completion, "%s ", flatpak_instance_get_app (instance));
+
+          const char *app_name = flatpak_instance_get_app (instance);
+          if (app_name)
+            flatpak_complete_word (completion, "%s ", app_name);
+
           flatpak_complete_word (completion, "%s ", flatpak_instance_get_id (instance));
         }
       break;

--- a/app/flatpak-builtins-kill.c
+++ b/app/flatpak-builtins-kill.c
@@ -53,7 +53,7 @@ kill_instance (const char *id,
   for (j = 0; j < instances->len; j++)
     {
       FlatpakInstance *instance = (FlatpakInstance *) g_ptr_array_index (instances, j);
-      if (strcmp (id, flatpak_instance_get_app (instance)) == 0 ||
+      if (g_strcmp0 (id, flatpak_instance_get_app (instance)) == 0 ||
           strcmp (id, flatpak_instance_get_id (instance)) == 0)
         {
           pid_t pid = flatpak_instance_get_child_pid (instance);

--- a/app/flatpak-builtins-kill.c
+++ b/app/flatpak-builtins-kill.c
@@ -124,7 +124,11 @@ flatpak_complete_kill (FlatpakCompletion *completion)
       for (i = 0; i < instances->len; i++)
         {
           FlatpakInstance *instance = (FlatpakInstance *) g_ptr_array_index (instances, i);
-          flatpak_complete_word (completion, "%s ", flatpak_instance_get_app (instance));
+
+          const char *app_name = flatpak_instance_get_app (instance);
+          if (app_name)
+            flatpak_complete_word (completion, "%s ", app_name);
+
           flatpak_complete_word (completion, "%s ", flatpak_instance_get_id (instance));
         }
       break;

--- a/app/flatpak-builtins-ps.c
+++ b/app/flatpak-builtins-ps.c
@@ -202,9 +202,9 @@ enumerate_instances (Column *columns, GError **error)
           else if (strcmp (columns[i].name, "active") == 0 ||
                    strcmp (columns[i].name, "background") == 0)
            {
-             if (compositor_apps)
+             const char *app = flatpak_instance_get_app (instance);
+             if (compositor_apps && app)
                {
-                 const char *app = flatpak_instance_get_app (instance);
                  guint state;
 
                  if (!g_variant_lookup (compositor_apps, app, "u", &state))

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -130,7 +130,7 @@ flatpak_instance_get_id (FlatpakInstance *self)
  *
  * Note that this may return %NULL for sandboxes that don't have an application.
  *
- * Returns: the application ID
+ * Returns: (nullable): the application ID or %NULL
  *
  * Since: 1.1
  */


### PR DESCRIPTION
This commit fixes the crash that happens when trying to kill a container without a name (which is usually started through `flatpak run --command=sh org.freedesktop.Platform`).