### PR TITLE
check: Limit clone depth for clones done as part of CI builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,9 +56,8 @@ jobs:
         popd
     - name: Build ostree dependency
       run: |
-        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch v2020.8 --depth 1 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
-        git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
         make -j $(getconf _NPROCESSORS_ONLN)
         sudo make install
@@ -112,9 +111,8 @@ jobs:
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang e2fslibs-dev
     - name: Build ostree dependency
       run: |
-        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch v2020.8 --depth 1 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
-        git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
         make -j $(getconf _NPROCESSORS_ONLN)
         sudo make install
@@ -150,9 +148,8 @@ jobs:
         submodules: true
     - name: Build ostree dependency
       run: |
-        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch v2020.8 --depth 1 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
-        git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
         make -j $(getconf _NPROCESSORS_ONLN)
         sudo make install
@@ -185,9 +182,8 @@ jobs:
         submodules: true
     - name: Build ostree dependency
       run: |
-        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch v2020.8 --depth 1 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
-        git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
         make -j $(getconf _NPROCESSORS_ONLN)
         sudo make install

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,16 +48,15 @@ jobs:
         submodules: true
     - name: Build malcontent dependency
       run: |
-        git clone https://gitlab.freedesktop.org/pwithnall/malcontent.git ./malcontent
+        git clone --branch 0.4.0 --depth 1 --no-tags https://gitlab.freedesktop.org/pwithnall/malcontent.git ./malcontent
         pushd ./malcontent
-        git checkout tags/0.4.0
         meson setup --prefix=/usr _build
         ninja -C _build
         sudo ninja -C _build install
         popd
     - name: Build ostree dependency
       run: |
-        git clone https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
         git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
@@ -113,7 +112,7 @@ jobs:
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang e2fslibs-dev
     - name: Build ostree dependency
       run: |
-        git clone https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
         git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
@@ -151,7 +150,7 @@ jobs:
         submodules: true
     - name: Build ostree dependency
       run: |
-        git clone https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
         git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
@@ -186,7 +185,7 @@ jobs:
         submodules: true
     - name: Build ostree dependency
       run: |
-        git clone https://github.com/ostreedev/ostree.git ./ostree
+        git clone --branch master --shallow-since 2020-10-27 --no-tags https://github.com/ostreedev/ostree.git ./ostree
         pushd ./ostree
         git checkout 7bc53f006351fcf5d32d9427e61a4f842f57f67b
         ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var


### PR DESCRIPTION
There’s no need to fetch the entire git history for OSTree or malcontent
for each CI job. Do shallow clones and don’t fetch tags. This should
reduce the bandwidth requirement for clones in a CI job by potentially a
factor of 10
(https://tecnocode.co.uk/2020/07/09/easily-speed-up-ci-by-reducing-download-size/).

This is slightly complicated by the fact that OSTree is currently being
built from a relatively-recent git commit. Once the flatpak CI can
depend on a tagged OSTree release (say, 2020.8),
```
--branch master --shallow-since 2020-10-27
```
can be changed to
```
--branch v2020.8 --depth 1
```

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>