### PR TITLE
flatpak-transaction: Mark commit param on operation_done nullable

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1175,7 +1175,7 @@ flatpak_transaction_class_init (FlatpakTransactionClass *klass)
    * FlatpakTransaction::operation-done:
    * @object: A #FlatpakTransaction
    * @operation: The #FlatpakTransactionOperation which finished
-   * @commit: The commit
+   * @commit: (nullable): The commit
    * @result: (type FlatpakTransactionResult): A #FlatpakTransactionResult giving details about the result
    *
    * The ::operation-done signal gets emitted during the execution of


### PR DESCRIPTION
It seems it's possible for `commit` to be null in the case of uninstallations as the signal is emitted after the ref has been uninstalled and hence it's not possible to get the deploy data and commit:

https://github.com/flatpak/flatpak/blob/09b470c0fd8a5392173b16009c90c51e4582cb4b/common/flatpak-transaction.c#L2890-L2901

If this is supposed to be the case, we need to ensure that this is marked as nullable in the introspection data as the Vala compiler generates null checks that throw assertions if things aren't ever supposed to be null.