### PR TITLE
Skip a test-case if /etc/mtab doesn't exist

### DIFF
--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -4459,6 +4459,12 @@ test_installation_unused_refs_across_installations (void)
   FlatpakInstalledRef *unused_ref;
   gboolean res;
 
+  if (!g_file_test ("/etc/mtab", G_FILE_TEST_EXISTS))
+    {
+      g_test_skip ("fusermount won't work without /etc/mtab");
+      return;
+    }
+
   runtime = g_strdup_printf ("runtime/org.test.Platform/%s/master",
                              flatpak_get_default_arch ());
   app = g_strdup_printf ("app/org.test.Hello/%s/master",


### PR DESCRIPTION
fusermount requires /etc/mtab, but not all Debian buildd chroots
have that file, either as a regular file or as a symlink to
/proc/self/mounts.

(This is similar to commit b07b48e2, but for C code.)