### PR TITLE
profile.d: Disable gvfs plugins when listing flatpak installations

### DIFF
--- a/env.d/60-flatpak
+++ b/env.d/60-flatpak
@@ -1,2 +1,3 @@
 #!/bin/sh
+export GIO_USE_VFS=local
 exec flatpak --print-updated-env

--- a/env.d/60-flatpak-system-only
+++ b/env.d/60-flatpak-system-only
@@ -1,2 +1,3 @@
 #!/bin/sh
+export GIO_USE_VFS=local
 exec flatpak --print-updated-env --print-system-only

--- a/profile/flatpak.csh
+++ b/profile/flatpak.csh
@@ -5,7 +5,7 @@ if ( ${%_flatpak} > 0 ) then
     if ( ! ${?XDG_DATA_DIRS} ) setenv XDG_DATA_DIRS /usr/local/share:/usr/share
     if ( ${%XDG_DATA_DIRS} == 0 ) setenv XDG_DATA_DIRS /usr/local/share:/usr/share
     set _new_dirs=""
-    foreach _line (`(unset G_MESSAGES_DEBUG; echo "${XDG_DATA_HOME}"/flatpak; flatpak --installations)`)
+    foreach _line (`(unset G_MESSAGES_DEBUG; echo "${XDG_DATA_HOME}"/flatpak; setenv GIO_USE_VFS local; flatpak --installations)`)
         set _line=${_line}/exports/share
 	if ( ":${XDG_DATA_DIRS}:" =~ *:${_line}:* ) continue
 	if ( ":${XDG_DATA_DIRS}:" =~ *:${_line}/:* ) continue

--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -5,7 +5,7 @@ if command -v flatpak > /dev/null; then
         (
             unset G_MESSAGES_DEBUG
             echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
-            flatpak --installations
+            GIO_USE_VFS=local flatpak --installations
         ) | (
             new_dirs=
             while read -r install_path


### PR DESCRIPTION
Patch from Mourad De Clerck, via Debian bug <https://bugs.debian.org/975710>.

This avoids gvfs-daemon being started when logging in as root via ssh.