### PR TITLE
WIP: Mount resolved varlink socket in sandbox if network access is allowed

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -590,6 +590,15 @@ flatpak_run_add_pulseaudio_args (FlatpakBwrap *bwrap)
 }
 
 static void
+flatpak_run_add_resolved_args (FlatpakBwrap *bwrap)
+{
+  const char *resolved_socket = "/run/systemd/resolve/io.systemd.Resolve";
+
+  if (g_file_test (resolved_socket, G_FILE_TEST_EXISTS))
+    flatpak_bwrap_add_args (bwrap, "--bind", resolved_socket, resolved_socket, NULL);
+}
+
+static void
 flatpak_run_add_journal_args (FlatpakBwrap *bwrap)
 {
   g_autofree char *journal_socket_socket = g_strdup ("/run/systemd/journal/socket");
@@ -3872,6 +3881,9 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
                                          app_id, app_context, app_id_dir, previous_app_id_dirs,
                                          &exports, cancellable, error))
     return FALSE;
+
+  if ((app_context->shares & FLATPAK_CONTEXT_SHARED_NETWORK) != 0)
+    flatpak_run_add_resolved_args (bwrap);
 
   flatpak_run_add_journal_args (bwrap);
   add_font_path_args (bwrap);


### PR DESCRIPTION
If network access is allowed, then we should probably allow name
resolution too.

This should be enough to make nss-resolve work inside flatpak. However,
it cannot be tested with GNOME runtimes, because GNOME runtimes do not
contain systemd. It also cannot be tested with the Fedora 33 flatpak
runtime, because this runtime contains systemd 246, where nss-resolve
uses D-Bus rather than varlink to communicate with systemd-resolved. And
there is no rawhide runtime, and will be no Fedora 34 runtime until F34
is branched. So currently it's not possible to actually test this
without building a custom runtime, which I have not attempted to do. I
have built flatpak myself and verified the resolved socket is mounted
properly inside the sandbox, but it would be better to test if it
actually works with a runtime that contains systemd 247.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1912131