### PR TITLE
[1.2.x] Fix tests when installed tests are not enabled

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -108,8 +108,13 @@ tests_libpreload_la_LDFLAGS = \
 	-avoid-version \
 	-module \
 	-no-undefined \
-	-rpath $(installed_testdir) \
 	$(NULL)
+
+if ENABLE_INSTALLED_TESTS
+tests_libpreload_la_LDFLAGS += -rpath $(installed_testdir)
+else
+tests_libpreload_la_LDFLAGS += -rpath  ${abs_builddir}
+endif
 
 installed_test_keyringdir = $(installed_testdir)/test-keyring
 installed_test_keyring2dir = $(installed_testdir)/test-keyring2


### PR DESCRIPTION
From: Alexander Larsson

We need a different rpath for libpreload in this case, because
installed_testdir is not set.