### PR TITLE
More consistently convert bwrap->envp into --setenv arguments

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -571,6 +571,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                               NULL);
     }
 
+  flatpak_bwrap_envp_to_args (bwrap);
+
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return FALSE;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7847,6 +7847,8 @@ apply_extra_data (FlatpakDir   *self,
                                          app_context, NULL, NULL, NULL, cancellable, error))
     return FALSE;
 
+  flatpak_bwrap_envp_to_args (bwrap);
+
   flatpak_bwrap_add_arg (bwrap, "/app/bin/apply_extra");
 
   flatpak_bwrap_finish (bwrap);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1067,9 +1067,7 @@ start_dbus_proxy (FlatpakBwrap *app_bwrap,
   g_autoptr(FlatpakBwrap) proxy_bwrap = NULL;
   int sync_fds[2] = {-1, -1};
   int proxy_start_index;
-  g_auto(GStrv) minimal_envp = NULL;
 
-  minimal_envp = flatpak_run_get_minimal_env (FALSE, FALSE);
   proxy_bwrap = flatpak_bwrap_new (NULL);
 
   if (!add_bwrap_wrapper (proxy_bwrap, app_info_path, error))

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3437,6 +3437,7 @@ regenerate_ld_cache (GPtrArray    *base_argv_array,
                           "--dev", "/dev",
                           "--bind", flatpak_file_get_path_cached (ld_so_dir), "/run/ld-so-cache-dir",
                           NULL);
+  flatpak_bwrap_envp_to_args (bwrap);
 
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return -1;


### PR DESCRIPTION
This is one of two possible approaches to solving #4080, a regression caused by my fixes for CVE-2021-21261. The other option is #4082, but I think I prefer this one.

Of the uses of bwrap listed in https://github.com/flatpak/flatpak/issues/4080#issuecomment-762400524, this fixes `app/flatpak-builtins-build.c` (tested and confirmed to work), `apply_extra_data()` (untested), and `regenerate_ld_cache()` (untested). If this approach is the preferred one, then I would suggest only backporting the first two commits to older branches.

---

* build: Convert environment into a sequence of bwrap arguments
    
    This means we can systematically pass the environment variables
    through bwrap(1), even if it is setuid and thus is filtering out
    security-sensitive environment variables. bwrap itself ends up being
    run with an empty environment instead.
    
    This fixes a regression when CVE-2021-21261 was fixed: before the
    CVE fixes, LD_LIBRARY_PATH would have been passed through like this
    and appeared in the `flatpak build` shell, but during the CVE fixes,
    the special case that protected LD_LIBRARY_PATH was removed in favour
    of the more general flatpak_bwrap_envp_to_args(). That reasoning only
    works if we use flatpak_bwrap_envp_to_args(), consistently, everywhere
    that we run the potentially-setuid bwrap.
    
    Fixes: 6d1773d2 "run: Convert all environment variables into bwrap arguments"  
    Resolves: https://github.com/flatpak/flatpak/issues/4080  
    Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=980323

* dir: Pass environment via bwrap --setenv when running apply_extra
    
    This means we can systematically pass the environment variables
    through bwrap(1), even if it is setuid and thus is filtering out
    security-sensitive environment variables. bwrap ends up being
    run with an empty environment instead.
    
    As with the previous commit, this regressed while fixing CVE-2021-21261.
    
    Fixes: 6d1773d2 "run: Convert all environment variables into bwrap arguments"

* run: Pass environment variables via bwrap --setenv when running ldconfig
    
    This means we can systematically pass the environment variables
    through bwrap(1), even if it is setuid and thus is filtering out
    security-sensitive environment variables. bwrap ends up being
    run with an empty environment instead.
    
    This did not regress in 6d1773d "run: Convert all environment variables
    into bwrap arguments", because the LD_LIBRARY_PATH special case in
    flatpak_run_add_environment_args() was already not used here; but it's
    a bug fix along the same lines as fixing the regression.

* run: Remove unused minimal environment
    
    We instantiated this but didn't use it for anything.