### PR TITLE
run: Reinstate special case for LD_LIBRARY_PATH, TMPDIR

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1463,6 +1463,24 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
   flatpak_run_add_system_dbus_args (bwrap, proxy_arg_bwrap, context, flags);
   flatpak_run_add_a11y_dbus_args (bwrap, proxy_arg_bwrap, context, flags);
 
+  if (g_environ_getenv (bwrap->envp, "LD_LIBRARY_PATH") != NULL)
+    {
+      /* LD_LIBRARY_PATH is overridden for setuid helper, so pass it as cmdline arg */
+      flatpak_bwrap_add_args (bwrap,
+                              "--setenv", "LD_LIBRARY_PATH", g_environ_getenv (bwrap->envp, "LD_LIBRARY_PATH"),
+                              NULL);
+      flatpak_bwrap_unset_env (bwrap, "LD_LIBRARY_PATH");
+    }
+
+  if (g_environ_getenv (bwrap->envp, "TMPDIR") != NULL)
+    {
+      /* TMPDIR is overridden for setuid helper, so pass it as cmdline arg */
+      flatpak_bwrap_add_args (bwrap,
+                              "--setenv", "TMPDIR", g_environ_getenv (bwrap->envp, "TMPDIR"),
+                              NULL);
+      flatpak_bwrap_unset_env (bwrap, "TMPDIR");
+    }
+
   /* Must run this before spawning the dbus proxy, to ensure it
      ends up in the app cgroup */
   if (!flatpak_run_in_transient_unit (app_id, &my_error))


### PR DESCRIPTION
This code was removed in 6d1773d while fixing CVE-2021-21261, because
it seemed redundant with the more general mechanism in
flatpak_bwrap_envp_to_args(). However, it was not *completely*
redundant, because not all callers of flatpak_run_add_environment_args()
were converted to call flatpak_bwrap_envp_to_args() afterwards.

This partially reverts commit 6d1773d.

Fixes: 6d1773d "run: Convert all environment variables into bwrap arguments"
Resolves: #4080
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=980323

---

This is an alternative to #4081 as a solution to #4080. I think I prefer #4081.

Of the uses of bwrap listed in https://github.com/flatpak/flatpak/issues/4080#issuecomment-762400524, this fixes `app/flatpak-builtins-build.c` (tested and confirmed to work) and `apply_extra_data()` (untested, but it goes through the same code path).

If this approach is the preferred one, then backports to versions older than 1.6.2 will have to decide whether to just special-case `LD_LIBRARY_PATH` (strictly just fixing the regression), or both `LD_LIBRARY_PATH` and `TMPDIR` (fixing #2641, which was not previously fixed on those branches).