### PR TITLE
flatpak-dir: Fix crash on updating app with no deploy data or subpaths

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9684,6 +9684,7 @@ flatpak_dir_update (FlatpakDir                           *self,
 {
   g_autoptr(GBytes) deploy_data = NULL;
   const char **subpaths = NULL;
+  const char *empty_subpaths[] = {NULL};
   g_autofree char *url = NULL;
   FlatpakPullFlags flatpak_flags;
   g_autofree const char **old_subpaths = NULL;
@@ -9706,8 +9707,10 @@ flatpak_dir_update (FlatpakDir                           *self,
 
   if (opt_subpaths)
     subpaths = opt_subpaths;
-  else
+  else if (old_subpaths)
     subpaths = old_subpaths;
+  else
+    subpaths = empty_subpaths;
 
   if (!ostree_repo_remote_get_url (self->repo, state->remote_name, &url, error))
     return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2078,6 +2078,8 @@ flatpak_dir_system_helper_call_deploy (FlatpakDir         *self,
 {
   const char *empty[] = { NULL };
 
+  if (arg_subpaths == NULL)
+    arg_subpaths = empty;
   if (arg_previous_ids == NULL)
     arg_previous_ids = empty;
 


### PR DESCRIPTION
If an app had no deploy data, and `flatpak_dir_update()` was called with
`opt_subpaths == NULL`, then `arg_subpaths` passed to
`flatpak_dir_system_helper_call_deploy()` would be `NULL`, which causes
an assertion failure from an internal `g_variant_new()` call:
```
g_variant_new_strv: assertion 'length == 0 || strv != NULL' failed
```

Fix that by setting the `subpaths` to an empty array if nothing else is
specified.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>