### PR TITLE
Backport #4081 for 1.2.x

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -566,6 +566,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                               NULL);
     }
 
+  flatpak_bwrap_envp_to_args (bwrap);
+
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return FALSE;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6799,6 +6799,8 @@ apply_extra_data (FlatpakDir   *self,
                                          app_context, NULL, NULL, cancellable, error))
     return FALSE;
 
+  flatpak_bwrap_envp_to_args (bwrap);
+
   flatpak_bwrap_add_arg (bwrap, "/app/bin/apply_extra");
 
   flatpak_bwrap_finish (bwrap);


### PR DESCRIPTION
Backported because I need to maintain 1.2.x in Debian 10, and anyone else still stuck on the same branch might as well be able to share them. I've proposed these patches for inclusion in an updated package via security.debian.org.

---

* build: Convert environment into a sequence of bwrap arguments
    
    This means we can systematically pass the environment variables
    through bwrap(1), even if it is setuid and thus is filtering out
    security-sensitive environment variables. bwrap itself ends up being
    run with an empty environment instead.
    
    This fixes a regression when CVE-2021-21261 was fixed: before the
    CVE fixes, LD_LIBRARY_PATH would have been passed through like this
    and appeared in the `flatpak build` shell, but during the CVE fixes,
    the special case that protected LD_LIBRARY_PATH was removed in favour
    of the more general flatpak_bwrap_envp_to_args(). That reasoning only
    works if we use flatpak_bwrap_envp_to_args(), consistently, everywhere
    that we run the potentially-setuid bwrap.
    
    Fixes: 6d1773d2 "run: Convert all environment variables into bwrap arguments"
    Resolves: https://github.com/flatpak/flatpak/issues/4080
    Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=980323
    (cherry picked from commit 9a61d2c44f0a58cebcb9b2787ae88db07ca68bb0)

* dir: Pass environment via bwrap --setenv when running apply_extra
    
    This means we can systematically pass the environment variables
    through bwrap(1), even if it is setuid and thus is filtering out
    security-sensitive environment variables. bwrap ends up being
    run with an empty environment instead.
    
    As with the previous commit, this regressed while fixing CVE-2021-21261.
    
    Fixes: 6d1773d2 "run: Convert all environment variables into bwrap arguments"  
    (cherry picked from commit fb473cad801c6b61706353256cab32330557374a)