### PR TITLE
Backport LD_LIBRARY_PATH vs setuid bwrap fixes

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -569,6 +569,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                               NULL);
     }
 
+  flatpak_bwrap_envp_to_args (bwrap);
+
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return FALSE;
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7426,6 +7426,8 @@ apply_extra_data (FlatpakDir   *self,
                                          app_context, NULL, NULL, NULL, cancellable, error))
     return FALSE;
 
+  flatpak_bwrap_envp_to_args (bwrap);
+
   flatpak_bwrap_add_arg (bwrap, "/app/bin/apply_extra");
 
   flatpak_bwrap_finish (bwrap);


### PR DESCRIPTION
Backport some fixes from #4081

This fixes a regression on systems with setuid bwrap, so they can run e.g. flatpak build.