### PR TITLE
Share /tmp between instances of the same app

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -553,7 +553,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
     return FALSE;
 
   if (!flatpak_run_add_environment_args (bwrap, app_info_path, run_flags, id,
-                                         app_context, app_id_dir, NULL, NULL, cancellable, error))
+                                         app_context, app_id_dir, NULL, -1,
+                                         NULL, cancellable, error))
     return FALSE;
 
   for (i = 0; opt_bind_mounts != NULL && opt_bind_mounts[i] != NULL; i++)

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -145,8 +145,9 @@ void flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
                                               FlatpakBwrap    *bwrap,
                                               const char      *app_id,
                                               GFile           *app_id_dir,
-                                              GPtrArray       *extra_app_id_dirs,
-                                              FlatpakExports **exports_out);
+                                              FlatpakExports  *exports,
+                                              const char      *xdg_dirs_conf,
+                                              gboolean         home_access);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakContext, flatpak_context_free)
 

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -133,6 +133,13 @@ FlatpakContext *flatpak_context_load_for_deploy (FlatpakDeploy *deploy,
 
 FlatpakExports *flatpak_context_get_exports (FlatpakContext *context,
                                              const char     *app_id);
+FlatpakExports *flatpak_context_get_exports_full (FlatpakContext *context,
+                                                  GFile          *app_id_dir,
+                                                  GPtrArray      *extra_app_id_dirs,
+                                                  gboolean        do_create,
+                                                  gboolean        include_default_dirs,
+                                                  GString        *xdg_dirs_conf,
+                                                  gboolean       *home_access_out);
 
 void flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
                                               FlatpakBwrap    *bwrap,

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -138,7 +138,7 @@ FlatpakExports *flatpak_context_get_exports_full (FlatpakContext *context,
                                                   GPtrArray      *extra_app_id_dirs,
                                                   gboolean        do_create,
                                                   gboolean        include_default_dirs,
-                                                  GString        *xdg_dirs_conf,
+                                                  gchar         **xdg_dirs_conf,
                                                   gboolean       *home_access_out);
 
 void flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2501,19 +2501,12 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
                                          FlatpakBwrap    *bwrap,
                                          const char      *app_id,
                                          GFile           *app_id_dir,
-                                         GPtrArray       *extra_app_id_dirs,
-                                         FlatpakExports **exports_out)
+                                         FlatpakExports  *exports,
+                                         const char      *xdg_dirs_conf,
+                                         gboolean         home_access)
 {
-  g_autoptr(FlatpakExports) exports = NULL;
-  g_autofree char *xdg_dirs_conf = NULL;
-  gboolean home_access = FALSE;
   GHashTableIter iter;
   gpointer key, value;
-
-  exports = flatpak_context_get_exports_full (context,
-                                              app_id_dir, extra_app_id_dirs,
-                                              TRUE, TRUE,
-                                              &xdg_dirs_conf, &home_access);
 
   if (app_id_dir != NULL)
     flatpak_run_apply_env_appid (bwrap, app_id_dir);
@@ -2610,7 +2603,4 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
       flatpak_bwrap_add_args_data (bwrap, "xdg-config-dirs",
                                    xdg_dirs_conf, strlen (xdg_dirs_conf), path, NULL);
     }
-
-  if (exports_out)
-    *exports_out = g_steal_pointer (&exports);
 }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7852,7 +7852,8 @@ apply_extra_data (FlatpakDir   *self,
                                          FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY |
                                          FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY,
                                          id,
-                                         app_context, NULL, NULL, NULL, cancellable, error))
+                                         app_context, NULL, NULL, -1,
+                                         NULL, cancellable, error))
     return FALSE;
 
   flatpak_bwrap_envp_to_args (bwrap);

--- a/common/flatpak-instance-private.h
+++ b/common/flatpak-instance-private.h
@@ -36,5 +36,9 @@ gboolean flatpak_instance_ensure_per_app_dir (const char *app_id,
                                               int *lock_fd_out,
                                               char **lock_path_out,
                                               GError **error);
+gboolean flatpak_instance_ensure_per_app_tmp (const char *app_id,
+                                              int per_app_dir_lock_fd,
+                                              char **shared_tmp_out,
+                                              GError **error);
 
 #endif /* __FLATPAK_INSTANCE_PRIVATE_H__ */

--- a/common/flatpak-instance-private.h
+++ b/common/flatpak-instance-private.h
@@ -25,10 +25,16 @@
 
 FlatpakInstance *flatpak_instance_new (const char *dir);
 FlatpakInstance *flatpak_instance_new_for_id (const char *id);
+char *flatpak_instance_get_apps_directory (void);
 char *flatpak_instance_get_instances_directory (void);
 char *flatpak_instance_allocate_id (char **host_dir_out,
                                     int *lock_fd_out);
 
 void flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances);
+
+gboolean flatpak_instance_ensure_per_app_dir (const char *app_id,
+                                              int *lock_fd_out,
+                                              char **lock_path_out,
+                                              GError **error);
 
 #endif /* __FLATPAK_INSTANCE_PRIVATE_H__ */

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -130,6 +130,7 @@ gboolean flatpak_run_add_environment_args (FlatpakBwrap       *bwrap,
                                            FlatpakContext     *context,
                                            GFile              *app_id_dir,
                                            GPtrArray          *previous_app_id_dirs,
+                                           int                 per_app_dir_lock_fd,
                                            FlatpakExports    **exports_out,
                                            GCancellable       *cancellable,
                                            GError            **error);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1352,8 +1352,10 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
   g_autoptr(GError) my_error = NULL;
   g_autoptr(FlatpakExports) exports = NULL;
   g_autoptr(FlatpakBwrap) proxy_arg_bwrap = flatpak_bwrap_new (flatpak_bwrap_empty_env);
+  g_autofree char *xdg_dirs_conf = NULL;
   gboolean has_wayland = FALSE;
   gboolean allow_x11 = FALSE;
+  gboolean home_access = FALSE;
 
   if ((context->shares & FLATPAK_CONTEXT_SHARED_IPC) == 0)
     {
@@ -1460,7 +1462,13 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
         }
     }
 
-  flatpak_context_append_bwrap_filesystem (context, bwrap, app_id, app_id_dir, previous_app_id_dirs, &exports);
+
+  exports = flatpak_context_get_exports_full (context,
+                                              app_id_dir, previous_app_id_dirs,
+                                              TRUE, TRUE,
+                                              &xdg_dirs_conf, &home_access);
+  flatpak_context_append_bwrap_filesystem (context, bwrap, app_id, app_id_dir,
+                                           exports, xdg_dirs_conf, home_access);
 
   if (context->sockets & FLATPAK_CONTEXT_SOCKET_WAYLAND)
     {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2307,6 +2307,8 @@ flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
   g_autofree char *instance_id_lock_file = NULL;
   g_autofree char *arch = flatpak_decomposed_dup_arch (runtime_ref);
 
+  g_return_val_if_fail (app_id != NULL, FALSE);
+
   instance_id = flatpak_instance_allocate_id (&instance_id_host_dir, &lock_fd);
   if (instance_id == NULL)
     return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Unable to allocate instance id"));
@@ -3708,11 +3710,15 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
   const char *runtime_target_path = "/usr";
   struct stat s;
 
+  g_return_val_if_fail (app_ref != NULL, FALSE);
+
   if (!check_sudo (error))
     return FALSE;
 
   app_id = flatpak_decomposed_dup_id (app_ref);
+  g_return_val_if_fail (app_id != NULL, FALSE);
   app_arch = flatpak_decomposed_dup_arch (app_ref);
+  g_return_val_if_fail (app_arch != NULL, FALSE);
 
   /* Check the user is allowed to run this flatpak. */
   if (!check_parental_controls (app_ref, app_deploy, cancellable, error))

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -910,6 +910,8 @@ null_safe_g_ptr_array_unref (gpointer data)
 int flatpak_envp_cmp (const void *p1,
                       const void *p2);
 
+gboolean flatpak_str_is_integer (const char *s);
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 #endif /* __FLATPAK_UTILS_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -8682,3 +8682,22 @@ flatpak_envp_cmp (const void *p1,
   /* Fall back to plain string comparison */
   return ret;
 }
+
+/*
+ * Return %TRUE if @s consists of one or more digits.
+ * This is the same as Python bytes.isdigit().
+ */
+gboolean
+flatpak_str_is_integer (const char *s)
+{
+  if (s == NULL || *s == '\0')
+    return FALSE;
+
+  for (; *s != '\0'; s++)
+    {
+      if (!g_ascii_isdigit (*s))
+        return FALSE;
+    }
+
+  return TRUE;
+}

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -167,6 +167,8 @@ test_empty_context (void)
   g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
   g_autoptr(FlatpakContext) context = flatpak_context_new ();
   g_autoptr(FlatpakExports) exports = NULL;
+  g_autofree char *xdg_dirs_conf = NULL;
+  gboolean home_access = FALSE;
 
   g_assert_cmpuint (g_hash_table_size (context->env_vars), ==, 0);
   g_assert_cmpuint (g_hash_table_size (context->persistent), ==, 0);
@@ -188,13 +190,17 @@ test_empty_context (void)
   g_assert_nonnull (exports);
 
   g_clear_pointer (&exports, flatpak_exports_free);
+  exports = flatpak_context_get_exports_full (context,
+                                              NULL, NULL,
+                                              TRUE, TRUE,
+                                              &xdg_dirs_conf, &home_access);
+  g_assert_nonnull (exports);
+  g_assert_nonnull (xdg_dirs_conf);
   flatpak_context_append_bwrap_filesystem (context, bwrap,
                                            "com.example.App",
-                                           NULL,
-                                           NULL,
-                                           &exports);
+                                           NULL, exports, xdg_dirs_conf,
+                                           home_access);
   print_bwrap (bwrap);
-  g_assert_nonnull (exports);
 }
 
 static void
@@ -206,8 +212,10 @@ test_full_context (void)
   g_autoptr(GError) error = NULL;
   g_autoptr(GKeyFile) keyfile = g_key_file_new ();
   g_autofree gchar *text = NULL;
+  g_autofree char *xdg_dirs_conf = NULL;
   g_auto(GStrv) strv = NULL;
   gsize i, n;
+  gboolean home_access = FALSE;
 
   g_key_file_set_value (keyfile,
                         FLATPAK_METADATA_GROUP_CONTEXT,
@@ -306,13 +314,17 @@ test_full_context (void)
   g_assert_nonnull (exports);
 
   g_clear_pointer (&exports, flatpak_exports_free);
+  exports = flatpak_context_get_exports_full (context,
+                                              NULL, NULL,
+                                              TRUE, TRUE,
+                                              &xdg_dirs_conf, &home_access);
+  g_assert_nonnull (exports);
+  g_assert_nonnull (xdg_dirs_conf);
   flatpak_context_append_bwrap_filesystem (context, bwrap,
                                            "com.example.App",
-                                           NULL,
-                                           NULL,
-                                           &exports);
+                                           NULL, exports, xdg_dirs_conf,
+                                           home_access);
   print_bwrap (bwrap);
-  g_assert_nonnull (exports);
 
   g_clear_pointer (&keyfile, g_key_file_unref);
   keyfile = g_key_file_new ();

--- a/tests/test-instance.c
+++ b/tests/test-instance.c
@@ -30,6 +30,7 @@
 
 #include "flatpak.h"
 #include "flatpak-instance-private.h"
+#include "flatpak-run-private.h"
 
 #include "libglnx/libglnx.h"
 
@@ -41,29 +42,64 @@ test_gc (void)
   g_autoptr(GBytes) bytes = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GPtrArray) instances = NULL;
-  g_autofree char *base_dir = flatpak_instance_get_instances_directory ();
-  g_autofree char *alive_dir = g_build_filename (base_dir, "1", NULL);
-  g_autofree char *alive_lock = g_build_filename (alive_dir, ".ref", NULL);
-  g_autofree char *dead_dir = g_build_filename (base_dir, "2", NULL);
-  g_autofree char *dead_lock = g_build_filename (dead_dir, ".ref", NULL);
+  g_autofree char *instances_dir = flatpak_instance_get_instances_directory ();
   g_autofree char *hold_lock = g_test_build_filename (G_TEST_BUILT, "hold-lock", NULL);
+  g_autofree char *alive_instance_dir = NULL;
+  g_autofree char *alive_instance_info = NULL;
+  g_autofree char *alive_instance_lock = NULL;
+  g_autofree char *alive_dead_instance_dir = NULL;
+  g_autofree char *alive_dead_instance_info = NULL;
+  g_autofree char *alive_dead_instance_lock = NULL;
+  g_autofree char *dead_instance_dir = NULL;
+  g_autofree char *dead_instance_info = NULL;
+  g_autofree char *dead_instance_lock = NULL;
   struct utimbuf a_while_ago = {};
-  const char *hold_lock_argv[] = { "hold-lock", "--lock-file", ".ref", NULL };
+  const char *hold_lock_argv[] =
+  {
+    "<BUILT>/hold-lock",
+    "--lock-file",
+    "<instance>/.ref",
+    NULL
+  };
   GPid pid = -1;
   int stdout_fd = -1;
   int wstatus = 0;
   FlatpakInstance *instance;
   struct stat stat_buf;
 
-  g_assert_no_errno (g_mkdir_with_parents (alive_dir, 0700));
-  g_assert_no_errno (g_mkdir_with_parents (dead_dir, 0700));
-  g_file_set_contents (alive_lock, "", 0, &error);
+  /* com.example.Alive has one instance, #1, running.
+   * A second instance, #2, was running until recently but has exited. */
+
+  alive_instance_dir = g_build_filename (instances_dir, "1", NULL);
+  g_assert_no_errno (g_mkdir_with_parents (alive_instance_dir, 0700));
+  alive_instance_info = g_build_filename (alive_instance_dir, "info", NULL);
+  g_file_set_contents (alive_instance_info,
+                       "[" FLATPAK_METADATA_GROUP_APPLICATION "]\n"
+                       FLATPAK_METADATA_KEY_NAME "=com.example.Alive\n",
+                       -1, &error);
   g_assert_no_error (error);
-  g_file_set_contents (dead_lock, "", 0, &error);
+  alive_instance_lock = g_build_filename (alive_instance_dir, ".ref", NULL);
+  g_file_set_contents (alive_instance_lock, "", 0, &error);
   g_assert_no_error (error);
 
+  alive_dead_instance_dir = g_build_filename (instances_dir, "2", NULL);
+  g_assert_no_errno (g_mkdir_with_parents (alive_dead_instance_dir, 0700));
+  alive_dead_instance_info = g_build_filename (alive_dead_instance_dir, "info", NULL);
+  g_file_set_contents (alive_dead_instance_info,
+                       "[" FLATPAK_METADATA_GROUP_APPLICATION "]\n"
+                       FLATPAK_METADATA_KEY_NAME "=com.example.Alive\n",
+                       -1, &error);
+  g_assert_no_error (error);
+  alive_dead_instance_lock = g_build_filename (alive_dead_instance_dir, ".ref", NULL);
+  g_file_set_contents (alive_dead_instance_lock, "", 0, &error);
+  g_assert_no_error (error);
+
+  /* This represents the running instance #1. We have to do this
+   * out-of-process because the locks we use are process-oriented,
+   * so the locks we take during GC would not conflict with locks held
+   * by our own process. */
   hold_lock_argv[0] = hold_lock;
-  hold_lock_argv[2] = alive_lock;
+  hold_lock_argv[2] = alive_instance_lock;
   g_spawn_async_with_pipes (NULL,
                             (gchar **) hold_lock_argv,
                             NULL,
@@ -79,20 +115,38 @@ test_gc (void)
   g_assert_cmpint (pid, >, 1);
   g_assert_cmpint (stdout_fd, >=, 0);
 
+  /* com.example.Dead has no instances running.
+   * Instance #4 was running until recently but has exited. */
+
+  dead_instance_dir = g_build_filename (instances_dir, "4", NULL);
+  g_assert_no_errno (g_mkdir_with_parents (dead_instance_dir, 0700));
+  dead_instance_info = g_build_filename (dead_instance_dir, "info", NULL);
+  g_file_set_contents (dead_instance_info,
+                       "[" FLATPAK_METADATA_GROUP_APPLICATION "]\n"
+                       FLATPAK_METADATA_KEY_NAME "=com.example.Dead\n",
+                       -1, &error);
+  g_assert_no_error (error);
+  dead_instance_lock = g_build_filename (dead_instance_dir, ".ref", NULL);
+  g_file_set_contents (dead_instance_lock, "", 0, &error);
+  g_assert_no_error (error);
+
   /* Wait for the child to be ready */
   bytes = glnx_fd_readall_bytes (stdout_fd, NULL, &error);
   g_assert_no_error (error);
 
   /* Pretend the locks were created in early 1970, to bypass the workaround
    * for a race */
-  g_assert_no_errno (g_utime (alive_lock, &a_while_ago));
-  g_assert_no_errno (g_utime (dead_lock, &a_while_ago));
+  g_assert_no_errno (g_utime (alive_instance_lock, &a_while_ago));
+  g_assert_no_errno (g_utime (alive_dead_instance_lock, &a_while_ago));
+  g_assert_no_errno (g_utime (dead_instance_lock, &a_while_ago));
 
   /* This has the side-effect of GC'ing instances */
   instances = flatpak_instance_get_all ();
 
-  g_assert_no_errno (stat (alive_dir, &stat_buf));
-  g_assert_cmpint (stat (dead_dir, &stat_buf) == 0 ? 0 : errno, ==, ENOENT);
+  /* We GC exactly those instances that are no longer running */
+  g_assert_no_errno (stat (alive_instance_dir, &stat_buf));
+  g_assert_cmpint (stat (alive_dead_instance_dir, &stat_buf) == 0 ? 0 : errno, ==, ENOENT);
+  g_assert_cmpint (stat (dead_instance_dir, &stat_buf) == 0 ? 0 : errno, ==, ENOENT);
 
   g_assert_cmpuint (instances->len, ==, 1);
   instance = g_ptr_array_index (instances, 0);

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1743,6 +1743,20 @@ test_quote_argv (void)
   g_assert_cmpstr (argv[i], ==, NULL);
 }
 
+static void
+test_str_is_integer (void)
+{
+  g_assert_true (flatpak_str_is_integer ("0"));
+  g_assert_true (flatpak_str_is_integer ("1234567890987654356765432121245674"));
+  g_assert_false (flatpak_str_is_integer (NULL));
+  g_assert_false (flatpak_str_is_integer (""));
+  g_assert_false (flatpak_str_is_integer ("0.0"));
+  g_assert_false (flatpak_str_is_integer ("0e0"));
+  g_assert_false (flatpak_str_is_integer ("bees"));
+  g_assert_false (flatpak_str_is_integer ("1234a"));
+  g_assert_false (flatpak_str_is_integer ("a1234"));
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -1774,6 +1788,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/common/envp-cmp", test_envp_cmp);
   g_test_add_func ("/common/needs-quoting", test_needs_quoting);
   g_test_add_func ("/common/quote-argv", test_quote_argv);
+  g_test_add_func ("/common/str-is-integer", test_str_is_integer);
 
   g_test_add_func ("/app/looks-like-branch", test_looks_like_branch);
   g_test_add_func ("/app/columns", test_columns);


### PR DESCRIPTION
Part of #4091.

## Design

This no longer depends on #4126, and instead contains the parts of #4126 that it needs, so that we can try to land this feature without being blocked by the concerns about symlink attacks in the `XDG_RUNTIME_DIR`.

The `g_get_user_runtime_dir()` on the host now looks like this:

```
real host g_get_user_runtime_dir()
    \- app
        \- com.example.App (gets mounted as XDG_RUNTIME_DIR/app/com.example.App as before)
    \- .flatpak
        \- 123 (instance-specific directory, already used)
        \- 456 (instance-specific directory, already used)
        \- com.example.App (per-app directory, not visible in sandbox, new)
            \- .ref (locked non-exclusively by app, new)
            \- tmp (gets mounted as /tmp in app sandbox, new)
```

The shared `/tmp` is only used for `flatpak run`, not for `flatpak build` (which reinvents a lot of `flatpak_run_app()`), and also not for `apply_extra`.

Whenever we garbage-collect the numbered per-instance directories, we check their app info. If an instance is disappearing, we attempt to garbage-collect the corresponding `tmp` if no apps are still using them.

The shared `/tmp` is backed by a directory in `g_get_user_runtime_dir()`, so that unrelated Flatpak apps that happen to have `--filesystem=/tmp` don't see it. `g_get_user_runtime_dir()` will usually be a `tmpfs` (except on systems using e.g. `sysvinit` to boot).

The per-app-ID directory and the `.ref` file are never garbage-collected, to avoid defeating the locking scheme: `$XDG_RUNTIME_DIR/.flatpak/` will contain one subdirectory for each app that the user has run during the current session, each containing an empty `.ref` file. These will normally get cleaned up when the user fully logs out (at the transition from 1 to 0 concurrent login sessions).

## Commits

Best reviewed commit-by-commit, I think.

* utils: Add flatpak_str_is_integer() (previously part of #4126)

* run: Mark some preconditions around the app ID

* test-instance: Provide app-IDs for our mock apps
    
    Previously, this only had to consider two situations: either an instance
    is still running (alive), or it is not (dead).
    
    When we start sharing directories between all instances of a particular
    app-ID (#4120, #4093), we'll also need to consider whether instances
    share an app-ID, expanding the test to three situations: either an
    instance is still running (alive), or it has exited but shares its
    app-ID with a different instance that is still running (the app is
    alive but the instance is dead, abbreviated here as alive_dead),
    or it has exited and does not share its app-ID with any running
    instances (dead).

* instance: Create and destroy per-app-ID subdirs of XRD/.flatpak
    
    If we want to provide a per-app-ID XDG_RUNTIME_DIR (#4120) or a
    per-app-ID /tmp or /dev/shm (#4093) then we'll need somewhere to put
    them. Unlike $XDG_RUNTIME_DIR/app/$FLATPAK_ID, this should be somewhere
    that is *not* accessible to the app, so that we can trust its contents.

* context: Factor out flatpak_context_get_exports_full()
    
    This combines the functionality of flatpak_context_get_exports() and its
    open-coded version in flatpak_context_append_bwrap_filesystem().

* context: Build xdg_dirs_conf as an "out" argument
    
    flatpak_context_get_exports_full() previously copied the interface of
    flatpak_context_export(), which appended entries to a caller-supplied
    GString, but it's a more GLib-style API if we use an "out" argument.

* common: Separate creation of FlatpakExports from append_bwrap_filesystem
    
    A subsequent commit will need to look at the FlatpakExports before
    we are ready to append their arguments to the FlatpakBwrap.

* run: Share /tmp between all instances of an app-ID
    
    This allows apps that use /tmp as an IPC rendezvous point, such as those
    that embed Chromium-derived browsers, to communicate between instances;
    this would not previously have worked without --filesystem=/tmp, which
    is a significant weakening of the sandbox.
    
    It also allows /tmp to be shared with subsandboxes (if they are not
    sandboxed more strictly).
        
    The temporary directory is actually created in XDG_RUNTIME_DIR,
    to avoid it becoming visible to unrelated apps that happen to have
    --filesystem=/tmp.