### PR TITLE
tests: Disable revokefs if FUSE doesn't work

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -23,17 +23,23 @@ endif
 testlibrary_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
+	$(FUSE_CFLAGS) \
 	$(OSTREE_CFLAGS) \
 	-DFLATPAK_COMPILATION \
 	$(NULL)
 testlibrary_LDADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
+	$(FUSE_LIBS) \
 	$(OSTREE_LIBS) \
 	libglnx.la \
 	libflatpak.la \
 	$(NULL)
-testlibrary_SOURCES = tests/testlibrary.c
+testlibrary_SOURCES = \
+	tests/can-use-fuse.c \
+	tests/can-use-fuse.h \
+	tests/testlibrary.c \
+	$(NULL)
 
 testcommon_CFLAGS = \
 	$(AM_CFLAGS) \

--- a/tests/can-use-fuse.c
+++ b/tests/can-use-fuse.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019-2021 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "can-use-fuse.h"
+
+#include <unistd.h>
+
+#include <glib/gstdio.h>
+
+#include "libglnx/libglnx.h"
+
+#define FUSE_USE_VERSION 26
+#include <fuse_lowlevel.h>
+
+gchar *cannot_use_fuse = NULL;
+
+/*
+ * If we cannot use FUSE, set cannot_use_fuse and return %FALSE.
+ */
+gboolean
+check_fuse (void)
+{
+  g_autofree gchar *fusermount = NULL;
+  g_autofree gchar *path = NULL;
+  char *argv[] = { "flatpak-fuse-test" };
+  struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (argv), argv);
+  struct fuse_chan *chan = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (cannot_use_fuse != NULL)
+    return FALSE;
+
+  if (access ("/dev/fuse", W_OK) != 0)
+    {
+      cannot_use_fuse = g_strdup_printf ("access /dev/fuse: %s",
+                                         g_strerror (errno));
+      return FALSE;
+    }
+
+  fusermount = g_find_program_in_path ("fusermount");
+
+  if (fusermount == NULL)
+    {
+      cannot_use_fuse = g_strdup ("fusermount not found in PATH");
+      return FALSE;
+    }
+
+  if (!g_file_test (fusermount, G_FILE_TEST_IS_EXECUTABLE))
+    {
+      cannot_use_fuse = g_strdup_printf ("%s not executable", fusermount);
+      return FALSE;
+    }
+
+  if (!g_file_test ("/etc/mtab", G_FILE_TEST_EXISTS))
+    {
+      cannot_use_fuse = g_strdup ("fusermount won't work without /etc/mtab");
+      return FALSE;
+    }
+
+  path = g_dir_make_tmp ("flatpak-test.XXXXXX", &error);
+  g_assert_no_error (error);
+
+  chan = fuse_mount (path, &args);
+
+  if (chan == NULL)
+    {
+      fuse_opt_free_args (&args);
+      cannot_use_fuse = g_strdup_printf ("fuse_mount: %s",
+                                         g_strerror (errno));
+      return FALSE;
+    }
+
+  g_test_message ("Successfully set up test FUSE fs on %s", path);
+
+  fuse_unmount (path, chan);
+
+  if (g_rmdir (path) != 0)
+    g_error ("rmdir %s: %s", path, g_strerror (errno));
+
+  fuse_opt_free_args (&args);
+
+  return TRUE;
+}
+
+gboolean
+check_fuse_or_skip_test (void)
+{
+  if (!check_fuse ())
+    {
+      g_assert (cannot_use_fuse != NULL);
+      g_test_skip (cannot_use_fuse);
+      return FALSE;
+    }
+
+  return TRUE;
+}

--- a/tests/can-use-fuse.h
+++ b/tests/can-use-fuse.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2019-2021 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+extern gchar *cannot_use_fuse;
+gboolean check_fuse (void);
+gboolean check_fuse_or_skip_test (void);


### PR DESCRIPTION
There are various reasons why distro autobuilder environments might not be able to use FUSE in build-time tests: they might not have fusermount(1), they might be locked-down to be unable to load the FUSE kernel module as a result of security hardening, they might not have the /etc/mtab symlink, they might not have CAP_SYS_ADMIN in their capability bounding set, or they might not have write access to /dev/fuse. Try to check for all of these conditions.

Heavily based on code that I previously contributed to xdg-desktop-portal (flatpak/xdg-desktop-portal#345), as updated by flatpak/xdg-desktop-portal#560.

---

This fixes builds of Flatpak 1.10.1 in Debian's `pbuilder` tool, and I'm hoping it will also fix builds of 1.10.1 on Ubuntu/Canonical Launchpad.