### PR TITLE
doc: Unify DocBook versions again

### DIFF
--- a/doc/flatpak-pin.xml
+++ b/doc/flatpak-pin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0'?> <!--*-nxml-*-->
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+    "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
 <refentry id="flatpak-pin">
 

--- a/doc/reference/Makefile.am
+++ b/doc/reference/Makefile.am
@@ -88,6 +88,10 @@ TESTS = $(GTKDOC_CHECK)
 endif
 
 sgml.stamp: $(dbus_stamp_files)
+# gdbus-codegen hardcodes DocBook version
+	$(AM_V_GEN)$(SED) -i \
+		-e 's|http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd|http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd|' \
+		-e 's|-//OASIS//DTD DocBook XML V4.1.2//EN|-//OASIS//DTD DocBook XML V4.5//EN|' $(xml_files)
 
 dbus-%.stamp: $(top_srcdir)/data/%.xml
 	$(AM_V_GEN)$(GDBUS_CODEGEN) --generate-docbook=dbus $<


### PR DESCRIPTION
Fixes a regression in version monoculture that occurred since the first attempt in https://github.com/flatpak/flatpak/pull/3760
