### PR TITLE
common: Add API for listing related refs of installed ref

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -986,6 +986,7 @@ GPtrArray *           flatpak_dir_find_remote_related_for_metadata          (Fla
 GPtrArray *           flatpak_dir_find_remote_related                       (FlatpakDir                    *dir,
                                                                              FlatpakRemoteState            *state,
                                                                              FlatpakDecomposed             *ref,
+                                                                             gboolean                       use_installed_metadata,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
 GPtrArray *           flatpak_dir_find_local_related_for_metadata           (FlatpakDir                    *self,

--- a/common/flatpak-installation.h
+++ b/common/flatpak-installation.h
@@ -456,6 +456,11 @@ FLATPAK_EXTERN GPtrArray    *    flatpak_installation_list_remote_related_refs_s
                                                                                      const char          *ref,
                                                                                      GCancellable        *cancellable,
                                                                                      GError             **error);
+FLATPAK_EXTERN GPtrArray    *    flatpak_installation_list_remote_related_refs_for_installed_sync (FlatpakInstallation *self,
+                                                                                                   const char          *remote_name,
+                                                                                                   const char          *ref,
+                                                                                                   GCancellable        *cancellable,
+                                                                                                   GError             **error);
 FLATPAK_EXTERN GPtrArray    *    flatpak_installation_list_installed_related_refs_sync (FlatpakInstallation *self,
                                                                                         const char          *remote_name,
                                                                                         const char          *ref,

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -47,6 +47,25 @@ autodelete=true
 locale-subset=true
 EOF
 
+cat >> ${DIR}/metadata <<EOF
+[Extension $APP_ID.Plugin]
+directory=share/hello/extra
+autodelete=true
+no-autodownload=true
+subdirectories=true
+merge-dirs=plug-ins
+EOF
+
+if [ "$EXTRA" = "EXTENSIONS" ]; then
+cat >> ${DIR}/metadata <<EOF
+version=v2
+EOF
+else
+cat >> ${DIR}/metadata <<EOF
+version=v1
+EOF
+fi
+
 mkdir -p ${DIR}/files/bin
 cat > ${DIR}/files/bin/hello.sh <<EOF
 #!/bin/sh
@@ -162,4 +181,30 @@ msgfmt --output-file ${DIR}/files/fr/share/fr/LC_MESSAGES/helloworld.mo fr.po
 flatpak build-finish ${DIR}
 mkdir -p repos
 flatpak build-export --no-update-summary --runtime ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} ${BRANCH}
+rm -rf ${DIR}
+
+# build a plugin extension
+
+DIR=`mktemp -d`
+
+# Init dir
+cat > ${DIR}/metadata <<EOF
+[Runtime]
+name=${APP_ID}.Plugin.fun
+
+[ExtensionOf]
+ref=app/$APP_ID/$ARCH/$BRANCH
+EOF
+
+mkdir -p ${DIR}/files/plug-ins/fun
+
+flatpak build-finish ${DIR}
+mkdir -p repos
+
+if [ "$EXTRA" = "EXTENSIONS" ]; then
+  flatpak build-export --no-update-summary --runtime ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} v2
+else
+  flatpak build-export --no-update-summary --runtime ${collection_args} ${GPGARGS-} ${EXPORT_ARGS-} ${REPO} ${DIR} v1
+fi
+
 rm -rf ${DIR}

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -608,7 +608,7 @@ ok "install with --no-deploy and then --no-pull"
 
 ${FLATPAK} ${U} uninstall -y org.test.Hello org.test.Platform
 
-${FLATPAK} ${U} install -y --no-deploy test-repo hello
+${FLATPAK} ${U} install -y --no-deploy --app test-repo hello
 
 ${FLATPAK} ${U} list -d > list-log
 assert_not_file_has_content list-log "org\.test\.Hello"
@@ -619,7 +619,7 @@ port=$(cat httpd-port)
 ${FLATPAK} ${U} remote-modify --url="http://127.0.0.1:${port}/disable-test" test-repo
 
 # Note: The partial ref is only auto-corrected without user interaction because we're using -y
-${FLATPAK} ${U} install -y --no-pull test-repo hello
+${FLATPAK} ${U} install -y --no-pull --app test-repo hello
 
 # re-enable remote
 ${FLATPAK} ${U} remote-modify --url="http://127.0.0.1:${port}/test" test-repo

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1352,10 +1352,10 @@ test_list_remote_related_refs (void)
   // Make the test with extra-languages, instead of languages
   clean_languages();
   configure_extra_languages();
-
-  inst = flatpak_installation_new_user (NULL, &error);
+  flatpak_installation_drop_caches (inst, NULL, &error);
   g_assert_no_error (error);
 
+  g_clear_pointer (&refs, g_ptr_array_unref);
   refs = flatpak_installation_list_remote_related_refs_sync (inst, repo_name, app, NULL, &error);
   g_assert_nonnull (refs);
   g_assert_no_error (error);


### PR DESCRIPTION
Currently if a user of libflatpak wants to list the related refs (such
as extensions and plugins) of something, they have three options:
1. They can parse the metadata manually with e.g.
   flatpak_remote_ref_get_metadata() and then key-file operations, but
   this means re-implementing parts of libflatpak and using key file
   strings that are not actually public (FLATPAK_METADATA_KEY_...).
2. They can use flatpak_installation_list_installed_related_refs_sync()
   but this only works for installed related refs not remote ones.
3. They can use flatpak_installation_list_remote_related_refs_sync() but
   this lists all remotely available related refs, including ones that
   may not be compatible with the installed version of the main ref
   (because they don't match any of the values in the "versions"
   metadata key).

So since none of these provide a way to get the remote related refs
corresponding to an installed application, add new API for that. For the
motivation of this see
https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1132