### PR TITLE
Add G_BEGIN_DECLS/G_END_DECLS to public headers

### DIFF
--- a/common/flatpak-bundle-ref.h
+++ b/common/flatpak-bundle-ref.h
@@ -30,6 +30,8 @@ typedef struct _FlatpakBundleRef FlatpakBundleRef;
 #include <gio/gio.h>
 #include <flatpak-ref.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_BUNDLE_REF flatpak_bundle_ref_get_type ()
 #define FLATPAK_BUNDLE_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_BUNDLE_REF, FlatpakBundleRef))
 #define FLATPAK_IS_BUNDLE_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_BUNDLE_REF))
@@ -61,5 +63,7 @@ FLATPAK_EXTERN char            *flatpak_bundle_ref_get_runtime_repo_url (Flatpak
 #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakBundleRef, g_object_unref)
 #endif
+
+G_END_DECLS
 
 #endif /* __FLATPAK_BUNDLE_REF_H__ */

--- a/common/flatpak-installation.h
+++ b/common/flatpak-installation.h
@@ -32,6 +32,8 @@ typedef struct _FlatpakInstallation FlatpakInstallation;
 #include <flatpak-instance.h>
 #include <flatpak-remote.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_INSTALLATION flatpak_installation_get_type ()
 #define FLATPAK_INSTALLATION(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_INSTALLATION, FlatpakInstallation))
 #define FLATPAK_IS_INSTALLATION(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_INSTALLATION))
@@ -482,5 +484,6 @@ FLATPAK_EXTERN gboolean          flatpak_installation_run_triggers (FlatpakInsta
                                                                     GCancellable        *cancellable,
                                                                     GError             **error);
 
+G_END_DECLS
 
 #endif /* __FLATPAK_INSTALLATION_H__ */

--- a/common/flatpak-installed-ref.h
+++ b/common/flatpak-installed-ref.h
@@ -30,6 +30,8 @@ typedef struct _FlatpakInstalledRef FlatpakInstalledRef;
 #include <gio/gio.h>
 #include <flatpak-ref.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_INSTALLED_REF flatpak_installed_ref_get_type ()
 #define FLATPAK_INSTALLED_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_INSTALLED_REF, FlatpakInstalledRef))
 #define FLATPAK_IS_INSTALLED_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_INSTALLED_REF))
@@ -70,5 +72,7 @@ FLATPAK_EXTERN GBytes      *flatpak_installed_ref_load_appdata (FlatpakInstalled
                                                                 GError             **error);
 FLATPAK_EXTERN const char * flatpak_installed_ref_get_eol (FlatpakInstalledRef *self);
 FLATPAK_EXTERN const char * flatpak_installed_ref_get_eol_rebase (FlatpakInstalledRef *self);
+
+G_END_DECLS
 
 #endif /* __FLATPAK_INSTALLED_REF_H__ */

--- a/common/flatpak-instance.h
+++ b/common/flatpak-instance.h
@@ -29,6 +29,8 @@ typedef struct _FlatpakInstance FlatpakInstance;
 
 #include <glib-object.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_INSTANCE flatpak_instance_get_type ()
 #define FLATPAK_INSTANCE(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_INSTANCE, FlatpakInstance))
 #define FLATPAK_IS_INSTANCE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_INSTANCE))
@@ -64,5 +66,7 @@ FLATPAK_EXTERN int          flatpak_instance_get_child_pid (FlatpakInstance *sel
 FLATPAK_EXTERN GKeyFile *   flatpak_instance_get_info (FlatpakInstance *self);
 
 FLATPAK_EXTERN gboolean     flatpak_instance_is_running (FlatpakInstance *self);
+
+G_END_DECLS
 
 #endif /* __FLATPAK_INSTANCE_H__ */

--- a/common/flatpak-ref.h
+++ b/common/flatpak-ref.h
@@ -29,6 +29,8 @@ typedef struct _FlatpakRef FlatpakRef;
 
 #include <glib-object.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_REF flatpak_ref_get_type ()
 #define FLATPAK_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_REF, FlatpakRef))
 #define FLATPAK_IS_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_REF))
@@ -72,5 +74,7 @@ FLATPAK_EXTERN const char *   flatpak_ref_format_ref_cached (FlatpakRef *self);
 FLATPAK_EXTERN FlatpakRef *   flatpak_ref_parse (const char *ref,
                                                  GError    **error);
 FLATPAK_EXTERN const char *   flatpak_ref_get_collection_id (FlatpakRef *self);
+
+G_END_DECLS
 
 #endif /* __FLATPAK_REF_H__ */

--- a/common/flatpak-related-ref.h
+++ b/common/flatpak-related-ref.h
@@ -30,6 +30,8 @@ typedef struct _FlatpakRelatedRef FlatpakRelatedRef;
 #include <gio/gio.h>
 #include <flatpak-ref.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_RELATED_REF flatpak_related_ref_get_type ()
 #define FLATPAK_RELATED_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_RELATED_REF, FlatpakRelatedRef))
 #define FLATPAK_IS_RELATED_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_RELATED_REF))
@@ -54,5 +56,7 @@ FLATPAK_EXTERN const char * const *flatpak_related_ref_get_subpaths (FlatpakRela
 FLATPAK_EXTERN gboolean     flatpak_related_ref_should_download (FlatpakRelatedRef *self);
 FLATPAK_EXTERN gboolean     flatpak_related_ref_should_delete (FlatpakRelatedRef *self);
 FLATPAK_EXTERN gboolean     flatpak_related_ref_should_autoprune (FlatpakRelatedRef *self);
+
+G_END_DECLS
 
 #endif /* __FLATPAK_RELATED_REF_H__ */

--- a/common/flatpak-remote-ref.h
+++ b/common/flatpak-remote-ref.h
@@ -30,6 +30,8 @@ typedef struct _FlatpakRemoteRef FlatpakRemoteRef;
 #include <gio/gio.h>
 #include <flatpak-ref.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_REMOTE_REF flatpak_remote_ref_get_type ()
 #define FLATPAK_REMOTE_REF(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_REMOTE_REF, FlatpakRemoteRef))
 #define FLATPAK_IS_REMOTE_REF(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_REMOTE_REF))
@@ -56,5 +58,7 @@ FLATPAK_EXTERN const char * flatpak_remote_ref_get_eol_rebase (FlatpakRemoteRef 
 #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRemoteRef, g_object_unref)
 #endif
+
+G_END_DECLS
 
 #endif /* __FLATPAK_REMOTE_REF_H__ */

--- a/common/flatpak-remote.h
+++ b/common/flatpak-remote.h
@@ -44,6 +44,8 @@ typedef struct _FlatpakRemote FlatpakRemote;
 #include <gio/gio.h>
 #include <flatpak-remote-ref.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_REMOTE flatpak_remote_get_type ()
 #define FLATPAK_REMOTE(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), FLATPAK_TYPE_REMOTE, FlatpakRemote))
 #define FLATPAK_IS_REMOTE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), FLATPAK_TYPE_REMOTE))
@@ -124,5 +126,6 @@ FLATPAK_EXTERN void          flatpak_remote_set_filter (FlatpakRemote *self,
 
 FLATPAK_EXTERN FlatpakRemoteType flatpak_remote_get_remote_type (FlatpakRemote *self);
 
+G_END_DECLS
 
 #endif /* __FLATPAK_REMOTE_H__ */

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -28,6 +28,8 @@
 #include <gio/gio.h>
 #include <flatpak-installation.h>
 
+G_BEGIN_DECLS
+
 #define FLATPAK_TYPE_TRANSACTION flatpak_transaction_get_type ()
 #define FLATPAK_TYPE_TRANSACTION_PROGRESS flatpak_transaction_progress_get_type ()
 #define FLATPAK_TYPE_TRANSACTION_OPERATION flatpak_transaction_operation_get_type ()
@@ -314,5 +316,7 @@ gboolean            flatpak_transaction_add_uninstall (FlatpakTransaction *self,
                                                        GError            **error);
 FLATPAK_EXTERN
 gboolean            flatpak_transaction_is_empty (FlatpakTransaction *self);
+
+G_END_DECLS
 
 #endif /* __FLATPAK_TRANSACTION_H__ */


### PR DESCRIPTION
This ensures that we correctly specify C linkage when including flatpak
headers from C++ code.

This should fix fallout from glib's change to include C++ code in its
headers, see https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1935
for discussion.

Fixes https://github.com/flatpak/flatpak/issues/4117