### PR TITLE
Refactor common/flatpak-instance, add test coverage

### DIFF
--- a/common/flatpak-instance-private.h
+++ b/common/flatpak-instance-private.h
@@ -25,6 +25,7 @@
 
 FlatpakInstance *flatpak_instance_new (const char *dir);
 FlatpakInstance *flatpak_instance_new_for_id (const char *id);
+char *flatpak_instance_get_instances_directory (void);
 char *flatpak_instance_allocate_id (char **host_dir_out,
                                     int *lock_fd_out);
 

--- a/common/flatpak-instance-private.h
+++ b/common/flatpak-instance-private.h
@@ -25,6 +25,8 @@
 
 FlatpakInstance *flatpak_instance_new (const char *dir);
 FlatpakInstance *flatpak_instance_new_for_id (const char *id);
+char *flatpak_instance_allocate_id (char **host_dir_out,
+                                    int *lock_fd_out);
 
 void flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances);
 

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -420,6 +420,71 @@ flatpak_instance_new (const char *dir)
   return self;
 }
 
+/*
+ * @host_dir_out: (not optional): used to return the directory on the host
+ *  system representing this instance
+ * @lock_fd_out: (not optional): used to return a non-exclusive (read) lock
+ *  on the lockdirectory on the host-file
+ */
+char *
+flatpak_instance_allocate_id (char **host_dir_out,
+                              int *lock_fd_out)
+{
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
+  g_autofree char *base_dir = g_build_filename (user_runtime_dir, ".flatpak", NULL);
+  int count;
+
+  g_return_val_if_fail (host_dir_out != NULL, NULL);
+  g_return_val_if_fail (*host_dir_out == NULL, NULL);
+  g_return_val_if_fail (lock_fd_out != NULL, NULL);
+  g_return_val_if_fail (*lock_fd_out == -1, NULL);
+
+  g_mkdir_with_parents (base_dir, 0755);
+
+  flatpak_instance_iterate_all_and_gc (NULL);
+
+  for (count = 0; count < 1000; count++)
+    {
+      g_autofree char *instance_id = NULL;
+      g_autofree char *instance_dir = NULL;
+
+      instance_id = g_strdup_printf ("%u", g_random_int ());
+
+      instance_dir = g_build_filename (base_dir, instance_id, NULL);
+
+      /* We use an atomic mkdir to ensure the instance id is unique */
+      if (mkdir (instance_dir, 0755) == 0)
+        {
+          g_autofree char *lock_file = g_build_filename (instance_dir, ".ref", NULL);
+          glnx_autofd int lock_fd = -1;
+          struct flock l = {
+            .l_type = F_RDLCK,
+            .l_whence = SEEK_SET,
+            .l_start = 0,
+            .l_len = 0
+          };
+
+          /* Then we take a file lock inside the dir, hold that during
+           * setup and in bwrap. Anyone trying to clean up unused
+           * directories need to first verify that there is a .ref
+           * file and take a write lock on .ref to ensure its not in
+           * use. */
+          lock_fd = open (lock_file, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+          /* There is a tiny race here between the open creating the file and the lock succeeding.
+             We work around that by only gc:ing "old" .ref files */
+          if (lock_fd != -1 && fcntl (lock_fd, F_SETLK, &l) == 0)
+            {
+              *lock_fd_out = glnx_steal_fd (&lock_fd);
+              g_debug ("Allocated instance id %s", instance_id);
+              *host_dir_out = g_steal_pointer (&instance_dir);
+              return g_steal_pointer (&instance_id);
+            }
+        }
+    }
+
+  return NULL;
+}
+
 FlatpakInstance *
 flatpak_instance_new_for_id (const char *id)
 {
@@ -462,7 +527,8 @@ flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances)
           glnx_autofd int lock_fd = openat (iter.fd, ref_file, O_RDWR | O_CLOEXEC);
           if (lock_fd != -1 &&
               fstat (lock_fd, &statbuf) == 0 &&
-              /* Only gc if created at least 3 secs ago, to work around race mentioned in flatpak_run_allocate_id() */
+              /* Only gc if created at least 3 secs ago, to work around race mentioned in
+               * flatpak_instance_allocate_id() */
               statbuf.st_mtime + 3 < time (NULL) &&
               fcntl (lock_fd, F_GETLK, &l) == 0 &&
               l.l_type == F_UNLCK)

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -420,6 +420,14 @@ flatpak_instance_new (const char *dir)
   return self;
 }
 
+char *
+flatpak_instance_get_instances_directory (void)
+{
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
+
+  return g_build_filename (user_runtime_dir, ".flatpak", NULL);
+}
+
 /*
  * @host_dir_out: (not optional): used to return the directory on the host
  *  system representing this instance
@@ -430,8 +438,7 @@ char *
 flatpak_instance_allocate_id (char **host_dir_out,
                               int *lock_fd_out)
 {
-  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
-  g_autofree char *base_dir = g_build_filename (user_runtime_dir, ".flatpak", NULL);
+  g_autofree char *base_dir = flatpak_instance_get_instances_directory ();
   int count;
 
   g_return_val_if_fail (host_dir_out != NULL, NULL);
@@ -488,17 +495,17 @@ flatpak_instance_allocate_id (char **host_dir_out,
 FlatpakInstance *
 flatpak_instance_new_for_id (const char *id)
 {
+  g_autofree char *base_dir = flatpak_instance_get_instances_directory ();
   g_autofree char *dir = NULL;
 
-  dir = g_build_filename (g_get_user_runtime_dir (), ".flatpak", id, NULL);
+  dir = g_build_filename (base_dir, id, NULL);
   return flatpak_instance_new (dir);
 }
 
 void
 flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances)
 {
-
-  g_autofree char *base_dir = g_build_filename (g_get_user_runtime_dir (), ".flatpak", NULL);
+  g_autofree char *base_dir = flatpak_instance_get_instances_directory ();
   g_auto(GLnxDirFdIterator) iter = { 0 };
   struct dirent *dent;
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2034,64 +2034,6 @@ flatpak_app_compute_permissions (GKeyFile *app_metadata,
   return g_steal_pointer (&app_context);
 }
 
-static void
-flatpak_run_gc_ids (void)
-{
-  flatpak_instance_iterate_all_and_gc (NULL);
-}
-
-static char *
-flatpak_run_allocate_id (int *lock_fd_out)
-{
-  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
-  g_autofree char *base_dir = g_build_filename (user_runtime_dir, ".flatpak", NULL);
-  int count;
-
-  g_mkdir_with_parents (base_dir, 0755);
-
-  flatpak_run_gc_ids ();
-
-  for (count = 0; count < 1000; count++)
-    {
-      g_autofree char *instance_id = NULL;
-      g_autofree char *instance_dir = NULL;
-
-      instance_id = g_strdup_printf ("%u", g_random_int ());
-
-      instance_dir = g_build_filename (base_dir, instance_id, NULL);
-
-      /* We use an atomic mkdir to ensure the instance id is unique */
-      if (mkdir (instance_dir, 0755) == 0)
-        {
-          g_autofree char *lock_file = g_build_filename (instance_dir, ".ref", NULL);
-          glnx_autofd int lock_fd = -1;
-          struct flock l = {
-            .l_type = F_RDLCK,
-            .l_whence = SEEK_SET,
-            .l_start = 0,
-            .l_len = 0
-          };
-
-          /* Then we take a file lock inside the dir, hold that during
-           * setup and in bwrap. Anyone trying to clean up unused
-           * directories need to first verify that there is a .ref
-           * file and take a write lock on .ref to ensure its not in
-           * use. */
-          lock_fd = open (lock_file, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
-          /* There is a tiny race here between the open creating the file and the lock succeeding.
-             We work around that by only gc:ing "old" .ref files */
-          if (lock_fd != -1 && fcntl (lock_fd, F_SETLK, &l) == 0)
-            {
-              *lock_fd_out = glnx_steal_fd (&lock_fd);
-              g_debug ("Allocated instance id %s", instance_id);
-              return g_steal_pointer (&instance_id);
-            }
-        }
-    }
-
-  return NULL;
-}
-
 #ifdef HAVE_DCONF
 
 static void
@@ -2350,14 +2292,12 @@ flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
   g_autofree char *instance_id_host_dir = NULL;
   g_autofree char *instance_id_sandbox_dir = NULL;
   g_autofree char *instance_id_lock_file = NULL;
-  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
   g_autofree char *arch = flatpak_decomposed_dup_arch (runtime_ref);
 
-  instance_id = flatpak_run_allocate_id (&lock_fd);
+  instance_id = flatpak_instance_allocate_id (&instance_id_host_dir, &lock_fd);
   if (instance_id == NULL)
     return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Unable to allocate instance id"));
 
-  instance_id_host_dir = g_build_filename (user_runtime_dir, ".flatpak", instance_id, NULL);
   instance_id_sandbox_dir = g_strdup_printf ("/run/user/%d/.flatpak/%s", getuid (), instance_id);
   instance_id_lock_file = g_build_filename (instance_id_sandbox_dir, ".ref", NULL);
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -86,6 +86,14 @@ test_exports_CFLAGS = $(testcommon_CFLAGS)
 test_exports_LDADD = $(testcommon_LDADD) libtestlib.la
 test_exports_SOURCES = tests/test-exports.c
 
+test_instance_CFLAGS = $(testcommon_CFLAGS)
+test_instance_LDADD = $(testcommon_LDADD) libtestlib.la
+test_instance_SOURCES = tests/test-instance.c
+
+tests_hold_lock_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
+tests_hold_lock_LDADD = $(AM_LDADD) $(BASE_LIBS) libglnx.la
+tests_hold_lock_SOURCES = tests/hold-lock.c
+
 tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
 	-DLOCALEDIR=\"$(localedir)\"
@@ -267,8 +275,21 @@ test_scripts = ${TEST_MATRIX}
 dist_test_scripts = ${TEST_MATRIX_DIST}
 dist_installed_test_extra_scripts += ${TEST_MATRIX_EXTRA_DIST}
 
-test_programs = testlibrary testcommon test-exports
-test_extra_programs = tests/httpcache tests/test-update-portal tests/test-portal-impl tests/test-authenticator tests/list-unused
+test_programs = \
+	test-exports \
+	test-instance \
+	testcommon \
+	testlibrary \
+	$(NULL)
+
+test_extra_programs = \
+	tests/hold-lock \
+	tests/httpcache \
+	tests/list-unused \
+	tests/test-authenticator \
+	tests/test-portal-impl \
+	tests/test-update-portal \
+	$(NULL)
 
 @VALGRIND_CHECK_RULES@
 VALGRIND_SUPPRESSIONS_FILES=tests/flatpak.supp tests/glib.supp

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -20,6 +20,22 @@ else
 AM_TESTS_ENVIRONMENT += FLATPAK_BWRAP=$$(cd $(top_builddir) && pwd)/flatpak-bwrap
 endif
 
+noinst_LTLIBRARIES += libtestlib.la
+libtestlib_la_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(BASE_CFLAGS) \
+	-DFLATPAK_COMPILATION \
+	$(NULL)
+libtestlib_la_SOURCES = \
+	tests/testlib.c \
+	tests/testlib.h \
+	$(NULL)
+libtestlib_la_LIBADD = \
+	$(AM_LDADD) \
+	$(BASE_LIBS) \
+	libglnx.la \
+	$(NULL)
+
 testlibrary_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
@@ -67,7 +83,7 @@ testcommon_LDADD = \
 testcommon_SOURCES = tests/testcommon.c
 
 test_exports_CFLAGS = $(testcommon_CFLAGS)
-test_exports_LDADD = $(testcommon_LDADD)
+test_exports_LDADD = $(testcommon_LDADD) libtestlib.la
 test_exports_SOURCES = tests/test-exports.c
 
 tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \

--- a/tests/hold-lock.c
+++ b/tests/hold-lock.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright © 2019-2021 Collabora Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include <fcntl.h>
+#include <fcntl.h>
+#include <sysexits.h>
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "libglnx/libglnx.h"
+
+static GArray *global_locks = NULL;
+static gboolean opt_wait = FALSE;
+static gboolean opt_write = FALSE;
+
+static gboolean
+opt_fd_cb (const char *name,
+           const char *value,
+           gpointer data,
+           GError **error)
+{
+  char *endptr;
+  gint64 i64 = g_ascii_strtoll (value, &endptr, 10);
+  int fd;
+  int fd_flags;
+
+  g_return_val_if_fail (global_locks != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (value != NULL, FALSE);
+
+  if (i64 < 0 || i64 > G_MAXINT || endptr == value || *endptr != '\0')
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                   "Integer out of range or invalid: %s", value);
+      return FALSE;
+    }
+
+  fd = (int) i64;
+
+  fd_flags = fcntl (fd, F_GETFD);
+
+  if (fd_flags < 0)
+    return glnx_throw_errno_prefix (error, "Unable to receive --fd %d", fd);
+
+  if ((fd_flags & FD_CLOEXEC) == 0
+      && fcntl (fd, F_SETFD, fd_flags | FD_CLOEXEC) != 0)
+    return glnx_throw_errno_prefix (error,
+                                    "Unable to configure --fd %d for "
+                                    "close-on-exec",
+                                    fd);
+
+  g_array_append_val (global_locks, fd);
+  return TRUE;
+}
+
+static gboolean
+opt_lock_file_cb (const char *name,
+                  const char *value,
+                  gpointer data,
+                  GError **error)
+{
+  int open_flags = O_CLOEXEC | O_CREAT | O_NOCTTY | O_RDWR;
+  int fd;
+  int cmd;
+  struct flock l =
+  {
+    .l_type = F_RDLCK,
+    .l_whence = SEEK_SET,
+    .l_start = 0,
+    .l_len = 0,
+  };
+
+  g_return_val_if_fail (global_locks != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (value != NULL, FALSE);
+
+  fd = TEMP_FAILURE_RETRY (open (value, open_flags, 0644));
+
+  if (fd < 0)
+    return glnx_throw_errno_prefix (error, "open %s", value);
+
+  if (opt_write)
+    l.l_type = F_WRLCK;
+
+  if (opt_wait)
+    cmd = F_SETLKW;
+  else
+    cmd = F_SETLK;
+
+  if (TEMP_FAILURE_RETRY (fcntl (fd, cmd, &l)) < 0)
+    {
+      if (errno == EACCES || errno == EAGAIN)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_BUSY,
+                     "Unable to lock %s: file is busy", value);
+      else
+        glnx_throw_errno_prefix (error, "lock %s", value);
+
+      close (fd);
+      return FALSE;
+    }
+
+  g_array_append_val (global_locks, fd);
+  return TRUE;
+}
+
+static GOptionEntry options[] =
+{
+  { "fd", '\0',
+    G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, opt_fd_cb,
+    "Take a file descriptor, already locked if desired, and keep it "
+    "open. May be repeated.",
+    NULL },
+
+  { "wait", '\0',
+    G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &opt_wait,
+    "Wait for each subsequent lock file.",
+    NULL },
+  { "no-wait", '\0',
+    G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_wait,
+    "Exit unsuccessfully if a lock-file is busy [default].",
+    NULL },
+
+  { "write", '\0',
+    G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &opt_write,
+    "Lock each subsequent lock file for write access.",
+    NULL },
+  { "no-write", '\0',
+    G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_write,
+    "Lock each subsequent lock file for read-only access [default].",
+    NULL },
+
+  { "lock-file", '\0',
+    G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, opt_lock_file_cb,
+    "Open the given file and lock it, affected by options appearing "
+    "earlier on the command-line. May be repeated.",
+    NULL },
+
+  { NULL }
+};
+
+int
+main (int argc,
+      char *argv[])
+{
+  g_autoptr(GArray) locks = NULL;
+  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
+  int ret = EX_USAGE;
+
+  locks = g_array_new (FALSE, FALSE, sizeof (int));
+  global_locks = locks;
+
+  context = g_option_context_new (NULL);
+  g_option_context_add_main_entries (context, options, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, error))
+    {
+      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_BUSY))
+        ret = EX_TEMPFAIL;
+      else if (local_error->domain == G_OPTION_ERROR)
+        ret = EX_USAGE;
+      else
+        ret = EX_UNAVAILABLE;
+
+      goto out;
+    }
+
+  ret = EX_UNAVAILABLE;
+
+  /* Self-destruct when parent exits */
+  if (prctl (PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0) != 0)
+    {
+      glnx_throw_errno_prefix (error,
+                               "Unable to set parent death signal");
+      goto out;
+    }
+
+  /* Signal to caller that we are ready */
+  fclose (stdout);
+
+  while (TRUE)
+    pause ();
+
+  g_assert_not_reached ();
+
+out:
+  global_locks = NULL;
+
+  if (local_error != NULL)
+    g_warning ("%s", local_error->message);
+
+  return ret;
+}

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -29,64 +29,7 @@
 #include "flatpak-run-private.h"
 #include "flatpak-utils-base-private.h"
 
-static char *testdir;
-
-static void
-global_setup (void)
-{
-  g_autofree char *cachedir = NULL;
-  g_autofree char *configdir = NULL;
-  g_autofree char *datadir = NULL;
-  g_autofree char *homedir = NULL;
-  g_autofree char *runtimedir = NULL;
-
-  testdir = g_strdup ("/tmp/flatpak-test-XXXXXX");
-  g_mkdtemp (testdir);
-  g_test_message ("testdir: %s", testdir);
-
-  homedir = g_strconcat (testdir, "/home", NULL);
-  g_mkdir_with_parents (homedir, S_IRWXU | S_IRWXG | S_IRWXO);
-
-  g_setenv ("HOME", homedir, TRUE);
-  g_test_message ("setting HOME=%s", homedir);
-
-  cachedir = g_strconcat (testdir, "/home/cache", NULL);
-  g_mkdir_with_parents (cachedir, S_IRWXU | S_IRWXG | S_IRWXO);
-  g_setenv ("XDG_CACHE_HOME", cachedir, TRUE);
-  g_test_message ("setting XDG_CACHE_HOME=%s", cachedir);
-
-  configdir = g_strconcat (testdir, "/home/config", NULL);
-  g_mkdir_with_parents (configdir, S_IRWXU | S_IRWXG | S_IRWXO);
-  g_setenv ("XDG_CONFIG_HOME", configdir, TRUE);
-  g_test_message ("setting XDG_CONFIG_HOME=%s", configdir);
-
-  datadir = g_strconcat (testdir, "/home/share", NULL);
-  g_mkdir_with_parents (datadir, S_IRWXU | S_IRWXG | S_IRWXO);
-  g_setenv ("XDG_DATA_HOME", datadir, TRUE);
-  g_test_message ("setting XDG_DATA_HOME=%s", datadir);
-
-  runtimedir = g_strconcat (testdir, "/runtime", NULL);
-  g_mkdir_with_parents (runtimedir, S_IRWXU);
-  g_setenv ("XDG_RUNTIME_DIR", runtimedir, TRUE);
-  g_test_message ("setting XDG_RUNTIME_DIR=%s", runtimedir);
-
-  g_reload_user_special_dirs_cache ();
-
-  g_assert_cmpstr (g_get_user_cache_dir (), ==, cachedir);
-  g_assert_cmpstr (g_get_user_config_dir (), ==, configdir);
-  g_assert_cmpstr (g_get_user_data_dir (), ==, datadir);
-  g_assert_cmpstr (g_get_user_runtime_dir (), ==, runtimedir);
-}
-
-static void
-global_teardown (void)
-{
-  if (g_getenv ("SKIP_TEARDOWN"))
-    return;
-
-  glnx_shutil_rm_rf_at (-1, testdir, NULL, NULL);
-  g_free (testdir);
-}
+#include "tests/testlib.h"
 
 /*
  * Assert that the next few arguments starting from @i are setting up
@@ -715,7 +658,7 @@ test_full (void)
   g_autoptr(GError) error = NULL;
   g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
   g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
-  g_autofree gchar *subdir = g_build_filename (testdir, "test_full", NULL);
+  g_autofree gchar *subdir = g_build_filename (isolated_test_dir, "test_full", NULL);
   g_autofree gchar *expose_rw = g_build_filename (subdir, "expose-rw", NULL);
   g_autofree gchar *in_expose_rw = g_build_filename (subdir, "expose-rw",
                                                      "file", NULL);
@@ -937,7 +880,7 @@ create_fake_files (const FakeFile *files)
   for (i = 0; files[i].name != NULL; i++)
     {
       g_autoptr(GError) error = NULL;
-      g_autofree gchar *path = g_build_filename (testdir, "host",
+      g_autofree gchar *path = g_build_filename (isolated_test_dir, "host",
                                                  files[i].name, NULL);
 
       g_assert (files[i].name[0] != '/');
@@ -979,7 +922,7 @@ test_host_exports (const FakeFile *files,
 {
   g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
   g_autoptr(GError) error = NULL;
-  g_autofree gchar *host = g_build_filename (testdir, "host", NULL);
+  g_autofree gchar *host = g_build_filename (isolated_test_dir, "host", NULL);
   glnx_autofd int fd = -1;
 
   glnx_shutil_rm_rf_at (-1, host, NULL, &error);
@@ -1259,7 +1202,7 @@ main (int argc, char *argv[])
 {
   int res;
 
-  global_setup ();
+  isolated_test_dir_global_setup ();
 
   g_test_init (&argc, &argv, NULL);
 
@@ -1275,7 +1218,7 @@ main (int argc, char *argv[])
 
   res = g_test_run ();
 
-  global_teardown ();
+  isolated_test_dir_global_teardown ();
 
   return res;
 }

--- a/tests/test-instance.c
+++ b/tests/test-instance.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <utime.h>
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "flatpak.h"
+#include "flatpak-instance-private.h"
+
+#include "libglnx/libglnx.h"
+
+#include "testlib.h"
+
+static void
+test_gc (void)
+{
+  g_autoptr(GBytes) bytes = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GPtrArray) instances = NULL;
+  g_autofree char *base_dir = flatpak_instance_get_instances_directory ();
+  g_autofree char *alive_dir = g_build_filename (base_dir, "1", NULL);
+  g_autofree char *alive_lock = g_build_filename (alive_dir, ".ref", NULL);
+  g_autofree char *dead_dir = g_build_filename (base_dir, "2", NULL);
+  g_autofree char *dead_lock = g_build_filename (dead_dir, ".ref", NULL);
+  g_autofree char *hold_lock = g_test_build_filename (G_TEST_BUILT, "hold-lock", NULL);
+  struct utimbuf a_while_ago = {};
+  const char *hold_lock_argv[] = { "hold-lock", "--lock-file", ".ref", NULL };
+  GPid pid = -1;
+  int stdout_fd = -1;
+  int wstatus = 0;
+  FlatpakInstance *instance;
+  struct stat stat_buf;
+
+  g_assert_no_errno (g_mkdir_with_parents (alive_dir, 0700));
+  g_assert_no_errno (g_mkdir_with_parents (dead_dir, 0700));
+  g_file_set_contents (alive_lock, "", 0, &error);
+  g_assert_no_error (error);
+  g_file_set_contents (dead_lock, "", 0, &error);
+  g_assert_no_error (error);
+
+  hold_lock_argv[0] = hold_lock;
+  hold_lock_argv[2] = alive_lock;
+  g_spawn_async_with_pipes (NULL,
+                            (gchar **) hold_lock_argv,
+                            NULL,
+                            G_SPAWN_DO_NOT_REAP_CHILD,
+                            NULL,
+                            NULL,
+                            &pid,
+                            NULL,
+                            &stdout_fd,
+                            NULL,
+                            &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (pid, >, 1);
+  g_assert_cmpint (stdout_fd, >=, 0);
+
+  /* Wait for the child to be ready */
+  bytes = glnx_fd_readall_bytes (stdout_fd, NULL, &error);
+  g_assert_no_error (error);
+
+  /* Pretend the locks were created in early 1970, to bypass the workaround
+   * for a race */
+  g_assert_no_errno (g_utime (alive_lock, &a_while_ago));
+  g_assert_no_errno (g_utime (dead_lock, &a_while_ago));
+
+  /* This has the side-effect of GC'ing instances */
+  instances = flatpak_instance_get_all ();
+
+  g_assert_no_errno (stat (alive_dir, &stat_buf));
+  g_assert_cmpint (stat (dead_dir, &stat_buf) == 0 ? 0 : errno, ==, ENOENT);
+
+  g_assert_cmpuint (instances->len, ==, 1);
+  instance = g_ptr_array_index (instances, 0);
+  g_assert_true (FLATPAK_IS_INSTANCE (instance));
+  g_assert_cmpstr (flatpak_instance_get_id (instance), ==, "1");
+
+  kill (pid, SIGTERM);
+  g_assert_no_errno (waitpid (pid, &wstatus, 0));
+  g_assert_true (WIFSIGNALED (wstatus));
+  g_assert_cmpint (WTERMSIG (wstatus), ==, SIGTERM);
+  g_spawn_close_pid (pid);
+}
+
+int
+main (int argc, char *argv[])
+{
+  int res;
+
+  isolated_test_dir_global_setup ();
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/instance/gc", test_gc);
+
+  res = g_test_run ();
+
+  isolated_test_dir_global_teardown ();
+
+  return res;
+}

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2020-2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "testlib.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "libglnx/libglnx.h"
+
+char *isolated_test_dir = NULL;
+
+void
+isolated_test_dir_global_setup (void)
+{
+  g_autofree char *cachedir = NULL;
+  g_autofree char *configdir = NULL;
+  g_autofree char *datadir = NULL;
+  g_autofree char *homedir = NULL;
+  g_autofree char *runtimedir = NULL;
+
+  isolated_test_dir = g_strdup ("/tmp/flatpak-test-XXXXXX");
+  g_mkdtemp (isolated_test_dir);
+  g_test_message ("isolated_test_dir: %s", isolated_test_dir);
+
+  homedir = g_strconcat (isolated_test_dir, "/home", NULL);
+  g_mkdir_with_parents (homedir, S_IRWXU | S_IRWXG | S_IRWXO);
+
+  g_setenv ("HOME", homedir, TRUE);
+  g_test_message ("setting HOME=%s", homedir);
+
+  cachedir = g_strconcat (isolated_test_dir, "/home/cache", NULL);
+  g_mkdir_with_parents (cachedir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_CACHE_HOME", cachedir, TRUE);
+  g_test_message ("setting XDG_CACHE_HOME=%s", cachedir);
+
+  configdir = g_strconcat (isolated_test_dir, "/home/config", NULL);
+  g_mkdir_with_parents (configdir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_CONFIG_HOME", configdir, TRUE);
+  g_test_message ("setting XDG_CONFIG_HOME=%s", configdir);
+
+  datadir = g_strconcat (isolated_test_dir, "/home/share", NULL);
+  g_mkdir_with_parents (datadir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_DATA_HOME", datadir, TRUE);
+  g_test_message ("setting XDG_DATA_HOME=%s", datadir);
+
+  runtimedir = g_strconcat (isolated_test_dir, "/runtime", NULL);
+  g_mkdir_with_parents (runtimedir, S_IRWXU);
+  g_setenv ("XDG_RUNTIME_DIR", runtimedir, TRUE);
+  g_test_message ("setting XDG_RUNTIME_DIR=%s", runtimedir);
+
+  g_reload_user_special_dirs_cache ();
+
+  g_assert_cmpstr (g_get_user_cache_dir (), ==, cachedir);
+  g_assert_cmpstr (g_get_user_config_dir (), ==, configdir);
+  g_assert_cmpstr (g_get_user_data_dir (), ==, datadir);
+  g_assert_cmpstr (g_get_user_runtime_dir (), ==, runtimedir);
+}
+
+void
+isolated_test_dir_global_teardown (void)
+{
+  if (g_getenv ("SKIP_TEARDOWN"))
+    return;
+
+  glnx_shutil_rm_rf_at (-1, isolated_test_dir, NULL, NULL);
+  g_free (isolated_test_dir);
+  isolated_test_dir = NULL;
+}

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -23,6 +23,19 @@
 
 #include "libglnx/libglnx.h"
 
+char *
+assert_mkdtemp (char *tmpl)
+{
+  char *ret = g_mkdtemp (tmpl);
+
+  if (ret == NULL)
+    g_error ("%s", g_strerror (errno));
+  else
+    g_assert_true (ret == tmpl);
+
+  return ret;
+}
+
 char *isolated_test_dir = NULL;
 
 void
@@ -35,32 +48,32 @@ isolated_test_dir_global_setup (void)
   g_autofree char *runtimedir = NULL;
 
   isolated_test_dir = g_strdup ("/tmp/flatpak-test-XXXXXX");
-  g_mkdtemp (isolated_test_dir);
+  assert_mkdtemp (isolated_test_dir);
   g_test_message ("isolated_test_dir: %s", isolated_test_dir);
 
   homedir = g_strconcat (isolated_test_dir, "/home", NULL);
-  g_mkdir_with_parents (homedir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_assert_no_errno (g_mkdir_with_parents (homedir, S_IRWXU | S_IRWXG | S_IRWXO));
 
   g_setenv ("HOME", homedir, TRUE);
   g_test_message ("setting HOME=%s", homedir);
 
   cachedir = g_strconcat (isolated_test_dir, "/home/cache", NULL);
-  g_mkdir_with_parents (cachedir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_assert_no_errno (g_mkdir_with_parents (cachedir, S_IRWXU | S_IRWXG | S_IRWXO));
   g_setenv ("XDG_CACHE_HOME", cachedir, TRUE);
   g_test_message ("setting XDG_CACHE_HOME=%s", cachedir);
 
   configdir = g_strconcat (isolated_test_dir, "/home/config", NULL);
-  g_mkdir_with_parents (configdir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_assert_no_errno (g_mkdir_with_parents (configdir, S_IRWXU | S_IRWXG | S_IRWXO));
   g_setenv ("XDG_CONFIG_HOME", configdir, TRUE);
   g_test_message ("setting XDG_CONFIG_HOME=%s", configdir);
 
   datadir = g_strconcat (isolated_test_dir, "/home/share", NULL);
-  g_mkdir_with_parents (datadir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_assert_no_errno (g_mkdir_with_parents (datadir, S_IRWXU | S_IRWXG | S_IRWXO));
   g_setenv ("XDG_DATA_HOME", datadir, TRUE);
   g_test_message ("setting XDG_DATA_HOME=%s", datadir);
 
   runtimedir = g_strconcat (isolated_test_dir, "/runtime", NULL);
-  g_mkdir_with_parents (runtimedir, S_IRWXU);
+  g_assert_no_errno (g_mkdir_with_parents (runtimedir, S_IRWXU));
   g_setenv ("XDG_RUNTIME_DIR", runtimedir, TRUE);
   g_test_message ("setting XDG_RUNTIME_DIR=%s", runtimedir);
 

--- a/tests/testlib.h
+++ b/tests/testlib.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020-2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TESTLIB_H
+#define TESTLIB_H
+
+#include <glib.h>
+
+extern char *isolated_test_dir;
+void isolated_test_dir_global_setup (void);
+void isolated_test_dir_global_teardown (void);
+
+#endif

--- a/tests/testlib.h
+++ b/tests/testlib.h
@@ -20,6 +20,13 @@
 
 #include <glib.h>
 
+#ifndef g_assert_no_errno
+#define g_assert_no_errno(expr) \
+  g_assert_cmpstr ((expr) >= 0 ? NULL : g_strerror (errno), ==, NULL)
+#endif
+
+char *assert_mkdtemp (char *tmpl);
+
 extern char *isolated_test_dir;
 void isolated_test_dir_global_setup (void);
 void isolated_test_dir_global_teardown (void);


### PR DESCRIPTION
* common: Move flatpak_run_allocate_id() to flatpak-instance
    
    This localizes knowledge of the internal structure of
    $XDG_RUNTIME_DIR/.flatpak into the flatpak-instance module.

* instance: Factor out flatpak_instance_get_instances_directory
    
    The only functional change here is that we consistently use
    flatpak_get_real_xdg_runtime_dir(), instead of a mixture of
    the versions with and without realpath().

* tests: Factor out test setup from test-exports

* tests: Improve error handling for isolated directory setup

    If these simple libc function wrappers fail during setup, we want to
    crash out.

* tests: Add basic test coverage for GC'ing unused instance directories

---

Required by #4126 and #4093.