### PR TITLE
Create a shared XDG_RUNTIME_DIR for each app-ID

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -580,7 +580,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                               NULL);
     }
 
-  flatpak_bwrap_populate_runtime_dir (bwrap);
+  flatpak_bwrap_populate_runtime_dir (bwrap, NULL);
 
   flatpak_bwrap_envp_to_args (bwrap);
 

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -580,6 +580,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                               NULL);
     }
 
+  flatpak_bwrap_populate_runtime_dir (bwrap);
+
   flatpak_bwrap_envp_to_args (bwrap);
 
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))

--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -27,6 +27,7 @@ typedef struct
   GArray    *noinherit_fds; /* Just keep these open while the bwrap lives */
   GArray    *fds;
   GStrv      envp;
+  GPtrArray *runtime_dir_members;
 } FlatpakBwrap;
 
 extern char *flatpak_bwrap_empty_env[1];
@@ -82,6 +83,9 @@ gboolean      flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
                                          int           end,
                                          gboolean      one_arg,
                                          GError      **error);
+void          flatpak_bwrap_add_runtime_dir_member (FlatpakBwrap *bwrap,
+                                                    const char *name);
+void          flatpak_bwrap_populate_runtime_dir (FlatpakBwrap *bwrap);
 
 void          flatpak_bwrap_child_setup_cb (gpointer user_data);
 void          flatpak_bwrap_child_setup (GArray *fd_array,

--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -85,7 +85,8 @@ gboolean      flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
                                          GError      **error);
 void          flatpak_bwrap_add_runtime_dir_member (FlatpakBwrap *bwrap,
                                                     const char *name);
-void          flatpak_bwrap_populate_runtime_dir (FlatpakBwrap *bwrap);
+void          flatpak_bwrap_populate_runtime_dir (FlatpakBwrap *bwrap,
+                                                  const char *shared_xdg_runtime_dir);
 
 void          flatpak_bwrap_child_setup_cb (gpointer user_data);
 void          flatpak_bwrap_child_setup (GArray *fd_array,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2531,7 +2531,7 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
   if (app_id_dir != NULL)
     {
       g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
-      g_autofree char *run_user_app_dst = g_strdup_printf ("/run/user/%d/app/%s", getuid (), app_id);
+      g_autofree char *run_user_app_dst = g_strdup_printf ("/run/flatpak/app/%s", app_id);
       g_autofree char *run_user_app_src = g_build_filename (user_runtime_dir, "app", app_id, NULL);
 
       if (glnx_shutil_mkdir_p_at (AT_FDCWD,
@@ -2542,6 +2542,9 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
         flatpak_bwrap_add_args (bwrap,
                                 "--bind", run_user_app_src, run_user_app_dst,
                                 NULL);
+
+      /* Later, we'll make $XDG_RUNTIME_DIR/app a symlink to /run/flatpak/app */
+      flatpak_bwrap_add_runtime_dir_member (bwrap, "app");
     }
 
   /* This actually outputs the args for the hide/expose operations

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7857,6 +7857,8 @@ apply_extra_data (FlatpakDir   *self,
                                          NULL, cancellable, error))
     return FALSE;
 
+  flatpak_bwrap_populate_runtime_dir (bwrap);
+
   flatpak_bwrap_envp_to_args (bwrap);
 
   flatpak_bwrap_add_arg (bwrap, "/app/bin/apply_extra");

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7857,7 +7857,7 @@ apply_extra_data (FlatpakDir   *self,
                                          NULL, cancellable, error))
     return FALSE;
 
-  flatpak_bwrap_populate_runtime_dir (bwrap);
+  flatpak_bwrap_populate_runtime_dir (bwrap, NULL);
 
   flatpak_bwrap_envp_to_args (bwrap);
 

--- a/common/flatpak-instance-private.h
+++ b/common/flatpak-instance-private.h
@@ -40,5 +40,9 @@ gboolean flatpak_instance_ensure_per_app_tmp (const char *app_id,
                                               int per_app_dir_lock_fd,
                                               char **shared_tmp_out,
                                               GError **error);
+gboolean flatpak_instance_ensure_per_app_xdg_runtime_dir (const char *app_id,
+                                                          int per_app_dir_lock_fd,
+                                                          char **shared_dir_out,
+                                                          GError **error);
 
 #endif /* __FLATPAK_INSTANCE_PRIVATE_H__ */

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -307,6 +307,14 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
     wayland_display = "wayland-0";
 
   wayland_socket = g_build_filename (user_runtime_dir, wayland_display, NULL);
+
+  if (!g_str_has_prefix (wayland_display, "wayland-") ||
+      strchr (wayland_display, '/') != NULL)
+    {
+      wayland_display = "wayland-0";
+      flatpak_bwrap_set_env (bwrap, "WAYLAND_DISPLAY", wayland_display, TRUE);
+    }
+
   sandbox_wayland_socket = g_strdup_printf ("/run/user/%d/%s", getuid (), wayland_display);
 
   if (stat (wayland_socket, &statbuf) == 0 &&

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -323,8 +323,8 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
 static void
 flatpak_run_add_ssh_args (FlatpakBwrap *bwrap)
 {
+  static const char sandbox_auth_socket[] = "/run/flatpak/ssh-auth";
   const char * auth_socket;
-  g_autofree char * sandbox_auth_socket = NULL;
 
   auth_socket = g_getenv ("SSH_AUTH_SOCK");
 
@@ -337,8 +337,6 @@ flatpak_run_add_ssh_args (FlatpakBwrap *bwrap)
       flatpak_bwrap_unset_env (bwrap, "SSH_AUTH_SOCK");
       return;
     }
-
-  sandbox_auth_socket = g_strdup_printf ("/run/user/%d/ssh-auth", getuid ());
 
   flatpak_bwrap_add_args (bwrap,
                           "--ro-bind", auth_socket, sandbox_auth_socket,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -950,6 +950,8 @@ flatpak_run_add_a11y_dbus_args (FlatpakBwrap   *app_bwrap,
                                 FlatpakContext *context,
                                 FlatpakRunFlags flags)
 {
+  static const char sandbox_socket_path[] = "/run/flatpak/at-spi-bus";
+  static const char sandbox_dbus_address[] = "unix:path=/run/flatpak/at-spi-bus";
   g_autoptr(GDBusConnection) session_bus = NULL;
   g_autofree char *a11y_address = NULL;
   g_autoptr(GError) local_error = NULL;
@@ -993,9 +995,6 @@ flatpak_run_add_a11y_dbus_args (FlatpakBwrap   *app_bwrap,
   proxy_socket = create_proxy_socket ("a11y-bus-proxy-XXXXXX");
   if (proxy_socket == NULL)
     return FALSE;
-
-  g_autofree char *sandbox_socket_path = g_strdup_printf ("/run/user/%d/at-spi-bus", getuid ());
-  g_autofree char *sandbox_dbus_address = g_strdup_printf ("unix:path=/run/user/%d/at-spi-bus", getuid ());
 
   flatpak_bwrap_add_args (proxy_arg_bwrap,
                           a11y_address,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -4155,15 +4155,6 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
 
   flags |= flatpak_context_get_run_flags (app_context);
 
-  if (!sandboxed)
-    {
-      if (!flatpak_instance_ensure_per_app_dir (app_id,
-                                                &per_app_dir_lock_fd,
-                                                &per_app_dir_lock_path,
-                                                error))
-        return FALSE;
-    }
-
   if (!flatpak_run_setup_base_argv (bwrap, runtime_files, app_id_dir, app_arch, flags, error))
     return FALSE;
 
@@ -4190,6 +4181,15 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
                                       &app_info_path, instance_id_fd, &instance_id_host_dir,
                                       error))
     return FALSE;
+
+  if (!sandboxed)
+    {
+      if (!flatpak_instance_ensure_per_app_dir (app_id,
+                                                &per_app_dir_lock_fd,
+                                                &per_app_dir_lock_path,
+                                                error))
+        return FALSE;
+    }
 
   if (!flatpak_run_add_dconf_args (bwrap, app_id, metakey, error))
     return FALSE;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -4205,11 +4205,11 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
 
   if (per_app_dir_lock_path != NULL)
     {
-      g_autofree char *dest = g_strdup_printf ("/run/user/%d/.app-ref", getuid ());
+      static const char lock[] = "/run/flatpak/per-app-dirs-ref";
 
       flatpak_bwrap_add_args (bwrap,
-                              "--ro-bind", per_app_dir_lock_path, dest,
-                              "--lock-file", dest,
+                              "--ro-bind", per_app_dir_lock_path, lock,
+                              "--lock-file", lock,
                               NULL);
     }
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -315,7 +315,7 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
       flatpak_bwrap_set_env (bwrap, "WAYLAND_DISPLAY", wayland_display, TRUE);
     }
 
-  sandbox_wayland_socket = g_strdup_printf ("/run/user/%d/%s", getuid (), wayland_display);
+  sandbox_wayland_socket = g_strdup_printf ("/run/flatpak/%s", wayland_display);
 
   if (stat (wayland_socket, &statbuf) == 0 &&
       (statbuf.st_mode & S_IFMT) == S_IFSOCK)
@@ -324,6 +324,7 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
       flatpak_bwrap_add_args (bwrap,
                               "--ro-bind", wayland_socket, sandbox_wayland_socket,
                               NULL);
+      flatpak_bwrap_add_runtime_dir_member (bwrap, wayland_display);
     }
   return res;
 }
@@ -733,11 +734,11 @@ flatpak_run_add_pulseaudio_args (FlatpakBwrap *bwrap)
 
   if (pulseaudio_socket && g_file_test (pulseaudio_socket, G_FILE_TEST_EXISTS))
     {
+      static const char sandbox_socket_path[] = "/run/flatpak/pulse/native";
+      static const char pulse_server[] = "unix:/run/flatpak/pulse/native";
+      static const char config_path[] = "/run/flatpak/pulse/config";
       gboolean share_shm = FALSE; /* TODO: When do we add this? */
       g_autofree char *client_config = g_strdup_printf ("enable-shm=%s\n", share_shm ? "yes" : "no");
-      g_autofree char *sandbox_socket_path = g_strdup_printf ("/run/user/%d/pulse/native", getuid ());
-      g_autofree char *pulse_server = g_strdup_printf ("unix:/run/user/%d/pulse/native", getuid ());
-      g_autofree char *config_path = g_strdup_printf ("/run/user/%d/pulse/config", getuid ());
 
       /* FIXME - error handling */
       if (!flatpak_bwrap_add_args_data (bwrap, "pulseaudio", client_config, -1, config_path, NULL))
@@ -749,6 +750,7 @@ flatpak_run_add_pulseaudio_args (FlatpakBwrap *bwrap)
 
       flatpak_bwrap_set_env (bwrap, "PULSE_SERVER", pulse_server, TRUE);
       flatpak_bwrap_set_env (bwrap, "PULSE_CLIENTCONFIG", config_path, TRUE);
+      flatpak_bwrap_add_runtime_dir_member (bwrap, "pulse");
     }
   else
     g_debug ("Could not find pulseaudio socket");
@@ -879,11 +881,11 @@ flatpak_run_add_session_dbus_args (FlatpakBwrap   *app_bwrap,
                                    FlatpakRunFlags flags,
                                    const char     *app_id)
 {
+  static const char sandbox_socket_path[] = "/run/flatpak/bus";
+  static const char sandbox_dbus_address[] = "unix:path=/run/flatpak/bus";
   gboolean unrestricted, no_proxy;
   const char *dbus_address = g_getenv ("DBUS_SESSION_BUS_ADDRESS");
   g_autofree char *dbus_session_socket = NULL;
-  g_autofree char *sandbox_socket_path = g_strdup_printf ("/run/user/%d/bus", getuid ());
-  g_autofree char *sandbox_dbus_address = g_strdup_printf ("unix:path=/run/user/%d/bus", getuid ());
 
   unrestricted = (context->sockets & FLATPAK_CONTEXT_SOCKET_SESSION_BUS) != 0;
 
@@ -915,6 +917,7 @@ flatpak_run_add_session_dbus_args (FlatpakBwrap   *app_bwrap,
                               "--ro-bind", dbus_session_socket, sandbox_socket_path,
                               NULL);
       flatpak_bwrap_set_env (app_bwrap, "DBUS_SESSION_BUS_ADDRESS", sandbox_dbus_address, TRUE);
+      flatpak_bwrap_add_runtime_dir_member (app_bwrap, "bus");
 
       return TRUE;
     }
@@ -945,6 +948,7 @@ flatpak_run_add_session_dbus_args (FlatpakBwrap   *app_bwrap,
                               "--ro-bind", proxy_socket, sandbox_socket_path,
                               NULL);
       flatpak_bwrap_set_env (app_bwrap, "DBUS_SESSION_BUS_ADDRESS", sandbox_dbus_address, TRUE);
+      flatpak_bwrap_add_runtime_dir_member (app_bwrap, "bus");
 
       return TRUE;
     }
@@ -2364,7 +2368,6 @@ flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
   int fd, fd2, fd3;
   g_autoptr(GKeyFile) keyfile = NULL;
   g_autofree char *runtime_path = NULL;
-  g_autofree char *old_dest = g_strdup_printf ("/run/user/%d/flatpak-info", getuid ());
   const char *group;
   g_autofree char *instance_id = NULL;
   glnx_autofd int lock_fd = -1;
@@ -2379,7 +2382,7 @@ flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
   if (instance_id == NULL)
     return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Unable to allocate instance id"));
 
-  instance_id_sandbox_dir = g_strdup_printf ("/run/user/%d/.flatpak/%s", getuid (), instance_id);
+  instance_id_sandbox_dir = g_strdup_printf ("/run/flatpak/.flatpak/%s", instance_id);
   instance_id_lock_file = g_build_filename (instance_id_sandbox_dir, ".ref", NULL);
 
   flatpak_bwrap_add_args (bwrap,
@@ -2389,6 +2392,7 @@ flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
                           "--lock-file",
                           instance_id_lock_file,
                           NULL);
+  flatpak_bwrap_add_runtime_dir_member (bwrap, ".flatpak");
   /* Keep the .ref lock held until we've started bwrap to avoid races */
   flatpak_bwrap_add_noinherit_fd (bwrap, glnx_steal_fd (&lock_fd));
 
@@ -2530,9 +2534,6 @@ flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
                                   "--file", fd, "/.flatpak-info");
   flatpak_bwrap_add_args_data_fd (bwrap,
                                   "--ro-bind-data", fd2, "/.flatpak-info");
-  flatpak_bwrap_add_args (bwrap,
-                          "--symlink", "../../../.flatpak-info", old_dest,
-                          NULL);
 
   /* Tell the application that it's running under Flatpak in a generic way. */
   flatpak_bwrap_add_args (bwrap,
@@ -2675,7 +2676,7 @@ add_monitor_path_args (gboolean      use_session_helper,
 
       if (g_variant_lookup (session_data, "pkcs11-socket", "s", &pkcs11_socket_path))
         {
-          g_autofree char *sandbox_pkcs11_socket_path = g_strdup_printf ("/run/user/%d/p11-kit/pkcs11", getuid ());
+          static const char sandbox_pkcs11_socket_path[] = "/run/flatpak/p11-kit/pkcs11";
           const char *trusted_module_contents =
             "# This overrides the runtime p11-kit-trusted module with a client one talking to the trust module on the host\n"
             "module: p11-kit-client.so\n";
@@ -2688,6 +2689,7 @@ add_monitor_path_args (gboolean      use_session_helper,
                                       "--ro-bind", pkcs11_socket_path, sandbox_pkcs11_socket_path,
                                       NULL);
               flatpak_bwrap_unset_env (bwrap, "P11_KIT_SERVER_ADDRESS");
+              flatpak_bwrap_add_runtime_dir_member (bwrap, "p11-kit");
             }
         }
     }
@@ -2739,21 +2741,21 @@ add_document_portal_args (FlatpakBwrap *bwrap,
           if (g_dbus_message_to_gerror (reply, &local_error))
             {
               if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))
-                g_debug ("Document portal not available, not mounting /run/user/%d/doc", getuid ());
+                g_debug ("Document portal not available, not mounting /run/flatpak/doc");
               else
                 g_message ("Can't get document portal: %s", local_error->message);
             }
           else
             {
+              static const char dst_path[] = "/run/flatpak/doc";
               g_autofree char *src_path = NULL;
-              g_autofree char *dst_path = NULL;
               g_variant_get (g_dbus_message_get_body (reply),
                              "(^ay)", &doc_mount_path);
 
               src_path = g_strdup_printf ("%s/by-app/%s",
                                           doc_mount_path, app_id);
-              dst_path = g_strdup_printf ("/run/user/%d/doc", getuid ());
               flatpak_bwrap_add_args (bwrap, "--bind", src_path, dst_path, NULL);
+              flatpak_bwrap_add_runtime_dir_member (bwrap, "doc");
             }
         }
     }
@@ -4262,6 +4264,8 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
       if (pidns_fd != -1)
         flatpak_bwrap_add_args_data_fd (bwrap, "--pidns", pidns_fd, NULL);
     }
+
+  flatpak_bwrap_populate_runtime_dir (bwrap);
 
   if (custom_command)
     {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -270,7 +270,7 @@ flatpak_run_add_x11_args (FlatpakBwrap *bwrap,
               int tmp_fd = dup (glnx_steal_fd (&xauth_tmpf.fd));
               if (tmp_fd != -1)
                 {
-                  g_autofree char *dest = g_strdup_printf ("/run/user/%d/Xauthority", getuid ());
+                  static const char dest[] = "/run/flatpak/Xauthority";
 
                   write_xauth (d, output);
                   flatpak_bwrap_add_args_data_fd (bwrap, "--ro-bind-data", tmp_fd, dest);


### PR DESCRIPTION
Fixes #4120.

## Design

The `XDG_RUNTIME_DIR` on the host now looks like this:

```
real host XDG_RUNTIME_DIR
    \- app
        \- com.example.App (gets mounted as XDG_RUNTIME_DIR/app/com.example.App as before)
    \- .flatpak
        \- 123 (instance-specific directory, already used)
        \- 456 (instance-specific directory, already used)
        \- com.example.App (per-app directory, from #4093)
            \- tmp (gets mounted as /tmp in app sandbox, from #4093)
            \- xdg-run (gets mounted as XDG_RUNTIME_DIR in app sandbox, new)
```

In this implementation, we never garbage-collect `xdg-run`, just like the pre-existing `$XDG_RUNTIME_DIR/app/$FLATPAK_ID`. If we wanted to GC it, the procedure would be the same as for `/tmp` (#4093).

I have not removed the special handling of `$XDG_RUNTIME_DIR/app/$FLATPAK_ID`. Those are slightly redundant now, but they might still make sense as a location that is more directly user-visible and has the same path on the host and in the sandbox.

This is only done for `flatpak run`, not for `flatpak build` (which reinvents a lot of `flatpak_run_app()`), and not for `apply_extra` either.

To avoid tricky things happening with symlinks, and to avoid mounting a directory onto a location we have already half-populated, we no longer mount sockets etc. directly onto members of `$XDG_RUNTIME_DIR`. Instead, we mount them in `/run/flatpak`.

For things where there's no real reason to want to use `$XDG_RUNTIME_DIR`, like `Xauthority`, we just use `/run/flatpak` as the new canonical path, and the file/directory doesn't exist in `$XDG_RUNTIME_DIR` at all.

For things where the specification involves `$XDG_RUNTIME_DIR`, most notably the Wayland socket but also D-Bus and PulseAudio, we populate `$XDG_RUNTIME_DIR` with symlinks into `/run/flatpak` as our last piece of filesystem manipulation.

## Commits

* run: Delay allocation of per-app directory
    
    If we call this after flatpak_run_add_app_info_args(), then the
    garbage-collection code will have a chance to run, cleaning up after a
    previous instance of the same app.
    
    In a previous implementation of #4093 that also implemented #4120, we
    had to allocate the per-app directory this early to avoid shadowing the
    XDG_RUNTIME_DIR allocated in flatpak_run_add_app_info_args(), but I'm
    taking a different approach to that now.

* run: Use a constant path for the reference to per-app directories
    
    It's a bit simpler to get a per-app XDG_RUNTIME_DIR safely if we avoid
    putting this in there. Nothing relies on it being in the
    XDG_RUNTIME_DIR.

* run: Create Xauthority in /run/flatpak
    
    There's no real reason why this needs to be in XDG_RUNTIME_DIR: nothing
    relies on it being there, and applications find it via environment
    variable XAUTHORITY.

* run: Create ssh-auth socket in /run/flatpak
    
    There's no real reason why this has to be in the XDG_RUNTIME_DIR:
    nothing looks for it via XDG_RUNTIME_DIR, it's located via environment
    variable SSH_AUTH_SOCK.

* run: Put the AT-SPI bus socket in /run/flatpak
    
    There's no real reason why this has to be in the XDG_RUNTIME_DIR: it's
    located via environment variable AT_SPI_BUS_ADDRESS.

* run: Normalize WAYLAND_DISPLAY to a reasonable name
    
    If it doesn't start with wayland- or contains a directory separator,
    then it's probably not something we want to be creating in the
    sandbox's XDG_RUNTIME_DIR.

* run: Populate XDG_RUNTIME_DIR with symlinks into /run/flatpak
    
    If XDG_RUNTIME_DIR is under app control, as it will be with #4120, we
    don't want to be mounting pieces of filesystem directly into it, because
    that will mean that the app could create a symlink that will cause us
    to create a mount point for it at the target of the symlink, potentially
    elsewhere in the host filesystem.
    
    Instead, we mount them in /run/flatpak, which is a per-instance
    directory entirely controlled by Flatpak; and then create (relative)
    symlinks in XDG_RUNTIME_DIR, pointing into /run/flatpak.
    
    In this commit, we still know that the XDG_RUNTIME_DIR is a
    per-instance tmpfs, so we can safely create the symlinks using
    the --symlink option. In a subsequent commit this will change to
    creating them in a shared XDG_RUNTIME_DIR, if any.

* run: Create a shared XDG_RUNTIME_DIR for each app-ID
    
    Like $XDG_RUNTIME_DIR/app/$FLATPAK_ID, this is shared between all
    instances of the app, except for subsandboxed instances created by
    flatpak-spawn --sandbox or equivalent. Unlike
    $XDG_RUNTIME_DIR/app/$FLATPAK_ID, it does not exist at an equivalent
    path on the host and in the sandboxed app.
    
    Resolves: https://github.com/flatpak/flatpak/issues/4120