### PR TITLE
Remove unused variables

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7928,13 +7928,12 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   const char *content_rating_type;
   g_autoptr(GHashTable) content_rating = NULL;
   g_autoptr(AutoPolkitAuthority) authority = NULL;
-  g_autoptr(AutoPolkitDetails) details = NULL;
   g_autoptr(AutoPolkitSubject) subject = NULL;
   gint subject_uid;
   g_autoptr(AutoPolkitAuthorizationResult) result = NULL;
   gboolean authorized;
   gboolean repo_installation_allowed, app_is_appropriate;
-  
+
   /* Assume that root is allowed to install any ref and shouldn't have any
    * parental controls restrictions applied to them */
   if (getuid () == 0)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3514,7 +3514,6 @@ check_parental_controls (FlatpakDecomposed *app_ref,
 #ifdef HAVE_LIBMALCONTENT
   g_autoptr(MctManager) manager = NULL;
   g_autoptr(MctAppFilter) app_filter = NULL;
-  g_autoptr(GAsyncResult) app_filter_result = NULL;
   g_autoptr(GDBusConnection) system_bus = NULL;
   g_autoptr(GError) local_error = NULL;
   g_autoptr(GDesktopAppInfo) app_info = NULL;


### PR DESCRIPTION
This is a trivial PR that removes two variables that were declared but never actually used.

It was spotted by clang `-Wunused-variable` warning.