### PR TITLE
WIP: Make bwrap commands more debuggable

### DIFF
--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -75,6 +75,7 @@ void          flatpak_bwrap_add_bind_arg (FlatpakBwrap *bwrap,
                                           const char   *type,
                                           const char   *src,
                                           const char   *dest);
+void          flatpak_bwrap_sort_envp (FlatpakBwrap *bwrap);
 void          flatpak_bwrap_envp_to_args (FlatpakBwrap *bwrap);
 gboolean      flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
                                          int           start,

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -347,10 +347,21 @@ flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
 
   fd = glnx_steal_fd (&args_tmpf.fd);
 
-  {
-    g_autofree char *commandline = flatpak_quote_argv ((const char **) bwrap->argv->pdata + start, end - start);
-    flatpak_debug2 ("bwrap --args %d = %s", fd, commandline);
-  }
+  flatpak_debug2 ("bwrap --args %d = ...", fd);
+
+  for (i = start; i < end; i++)
+    {
+      if (flatpak_argument_needs_quoting (bwrap->argv->pdata[i]))
+        {
+          g_autofree char *quoted = g_shell_quote (bwrap->argv->pdata[i]);
+
+          flatpak_debug2 ("    %s", quoted);
+        }
+      else
+        {
+          flatpak_debug2 ("    %s", (const char *) bwrap->argv->pdata[i]);
+        }
+    }
 
   flatpak_bwrap_add_fd (bwrap, fd);
   g_ptr_array_remove_range (bwrap->argv, start, end - start);

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -287,6 +287,21 @@ flatpak_bwrap_add_bind_arg (FlatpakBwrap *bwrap,
 }
 
 /*
+ * Sort bwrap->envp. This has no practical effect, but it's easier to
+ * see what is going on in a large environment block if the variables
+ * are sorted.
+ */
+void
+flatpak_bwrap_sort_envp (FlatpakBwrap *bwrap)
+{
+  if (bwrap->envp != NULL)
+    {
+      qsort (bwrap->envp, g_strv_length (bwrap->envp), sizeof (char *),
+             flatpak_envp_cmp);
+    }
+}
+
+/*
  * Convert bwrap->envp into a series of --setenv arguments for bwrap(1),
  * assumed to be applied to an empty environment. Reset envp to be an
  * empty environment.

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3463,6 +3463,7 @@ regenerate_ld_cache (GPtrArray    *base_argv_array,
                           "--dev", "/dev",
                           "--bind", flatpak_file_get_path_cached (ld_so_dir), "/run/ld-so-cache-dir",
                           NULL);
+  flatpak_bwrap_sort_envp (bwrap);
   flatpak_bwrap_envp_to_args (bwrap);
 
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
@@ -4076,6 +4077,7 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
       command = default_command;
     }
 
+  flatpak_bwrap_sort_envp (bwrap);
   flatpak_bwrap_envp_to_args (bwrap);
 
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -593,6 +593,7 @@ GList *flatpak_list_extensions (GKeyFile   *metakey,
                                 const char *arch,
                                 const char *branch);
 
+gboolean flatpak_argument_needs_quoting (const char *arg);
 char * flatpak_quote_argv (const char *argv[],
                            gssize      len);
 gboolean flatpak_file_arg_has_suffix (const char *arg,

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -907,6 +907,9 @@ null_safe_g_ptr_array_unref (gpointer data)
   g_clear_pointer (&data, g_ptr_array_unref);
 }
 
+int flatpak_envp_cmp (const void *p1,
+                      const void *p2);
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 #endif /* __FLATPAK_UTILS_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -1412,8 +1412,8 @@ flatpak_switch_symlink_and_remove (const char *symlink_path,
   return flatpak_fail (error, "flatpak_switch_symlink_and_remove looped too many times");
 }
 
-static gboolean
-needs_quoting (const char *arg)
+gboolean
+flatpak_argument_needs_quoting (const char *arg)
 {
   while (*arg != 0)
     {
@@ -1443,7 +1443,7 @@ flatpak_quote_argv (const char *argv[],
       if (i != 0)
         g_string_append_c (res, ' ');
 
-      if (needs_quoting (argv[i]))
+      if (flatpak_argument_needs_quoting (argv[i]))
         {
           g_autofree char *quoted = g_shell_quote (argv[i]);
           g_string_append (res, quoted);


### PR DESCRIPTION
* utils: Display bundled bwrap arguments one per line
    
    This makes them easier to deal with when debugging. Otherwise, it's easy
    for the bundled arguments to wrap across 50 or more lines, and with
    linebreaks in arbitrary positions that becomes very hard to read.

* run: Sort environment before serializing it into bwrap arguments
    
    This has no practical effect (assuming environment variables are unique),
    but it makes it easier to find an environment variable of interest
    in a very long bwrap command-line.

---

I think this is perhaps more readable, although still not great. Example output:

```
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169: bwrap --args 35 = ... 
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --fd=34
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     unix:path=/run/user/1000/bus
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     /run/user/1000/.dbus-proxy/session-bus-proxy-J7NCZ0
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --filter
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     '--own=com.valvesoftware.Steam.*'
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     '--own=org.mpris.MediaPlayer2.com.valvesoftware.Steam.*'
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.kde.StatusNotifierWatcher
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.freedesktop.Notifications
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.gnome.SettingsDaemon.MediaKeys
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.freedesktop.ScreenSaver
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.freedesktop.PowerManagement
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     '--call=org.freedesktop.portal.*=*'
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     '--broadcast=org.freedesktop.portal.*=@/org/freedesktop/portal/*'
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     unix:path=/var/run/dbus/system_bus_socket
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     /run/user/1000/.dbus-proxy/system-bus-proxy-G4NCZ0
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --filter
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.freedesktop.NetworkManager
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.freedesktop.UPower
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --talk=org.freedesktop.UDisks2
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     'unix:abstract=/tmp/dbus-2T9XwmNo6g,guid=a5e8007a61df7253caa2890f6033d1b1'
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     /run/user/1000/.dbus-proxy/a11y-bus-proxy-12PCZ0
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --filter
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --sloppy-names
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --call=org.a11y.atspi.Registry=org.a11y.atspi.Socket.Embed@/org/a11y/atspi/accessible/root
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --call=org.a11y.atspi.Registry=org.a11y.atspi.Socket.Unembed@/org/a11y/atspi/accessible/root
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --call=org.a11y.atspi.Registry=org.a11y.atspi.Registry.GetRegisteredEvents@/org/a11y/atspi/registry
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --call=org.a11y.atspi.Registry=org.a11y.atspi.DeviceEventController.GetKeystrokeListeners@/org/a11y/atspi/registry/deviceeventcontroller
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --call=org.a11y.atspi.Registry=org.a11y.atspi.DeviceEventController.GetDeviceEventListeners@/org/a11y/atspi/registry/deviceeventcontroller
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --call=org.a11y.atspi.Registry=org.a11y.atspi.DeviceEventController.NotifyListenersSync@/org/a11y/atspi/registry/deviceeventcontroller
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.169:     --call=org.a11y.atspi.Registry=org.a11y.atspi.DeviceEventController.NotifyListenersAsync@/org/a11y/atspi/registry/deviceeventcontroller
```

and

```
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.186: bwrap --args 35 = ...
...
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     --setenv
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     ALSA_CONFIG_DIR
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     /usr/share/alsa
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     --setenv
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     ALSA_CONFIG_PATH
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     --setenv
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     AT_SPI_BUS_ADDRESS
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     unix:path=/run/user/1000/at-spi-bus
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     --setenv
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     COLORTERM
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     truecolor
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     --setenv
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     DBUS_FATAL_WARNINGS
(flatpak run:107875): flatpak2-DEBUG: 20:32:13.190:     0
...
```