### PR TITLE
Add an initial security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security policy for Flatpak
+
+ * [Supported Versions](#Supported-Versions)
+ * [Reporting a Vulnerability](#Reporting-a-Vulnerability)
+ * [Security Announcements](#Security-Announcements)
+ * [Acknowledgements](#Acknowledgements)
+
+## Supported Versions
+
+In stable branches and released packages, this table is likely to be outdated;
+please check
+[the latest version](https://github.com/flatpak/flatpak/blob/master/SECURITY.md).
+
+| Version  | Supported          | Status
+| -------- | ------------------ | -------------------------------------------------------------- |
+| 1.11.x   | :white_check_mark: | Development branch, releases may include non-security changes  |
+| 1.10.x   | :white_check_mark: | Stable branch, recommended for use in distributions            |
+| 1.9.x    | :x:                | Old development branch, no longer supported                    |
+| 1.8.x    | :white_check_mark: | Old stable branch, still supported                             |
+| <= 1.7.x | :x:                | Older branches, no longer supported                            |
+
+## Reporting a Vulnerability
+
+If you think you've identified a security issue in Flatpak, please DO NOT
+report the issue publicly via the Github issue tracker, mailing list, or IRC.
+Instead, send an email with as many details as possible to
+[flatpak-security@lists.freedesktop.org](mailto:flatpak-security@lists.freedesktop.org).
+This is a private mailing list for the Flatpak maintainers.
+
+Please do **not** create a public issue.
+
+## Security Announcements
+
+The [flatpak@lists.freedesktop.org](mailto:flatpak@lists.freedesktop.org) email list is used for messages about
+Flatpak security announcements, as well as general announcements and
+discussions.
+You can join the list [here](https://lists.freedesktop.org/mailman/listinfo/flatpak).
+
+## Acknowledgements
+
+This text was partially based on the [github.com/containers security policy](https://github.com/containers/common/blob/master/SECURITY.md).


### PR DESCRIPTION
If we can get people to report security issues privately, then we can do coordinated disclosure instead of having to rush to fix issues that are already known to the public.