### PR TITLE
Disallow @@ and @@u magic tokens in desktop files

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7140,7 +7140,11 @@ export_desktop_file (const char         *app,
               else if (strcasecmp (arg, "%u") == 0)
                 g_string_append_printf (new_exec, " @@u %s @@", arg);
               else if (g_str_has_prefix (arg, "@@"))
-                g_print (_("Skipping invalid Exec argument %s\n"), arg);
+                {
+                  flatpak_fail_error (error, FLATPAK_ERROR_EXPORT_FAILED,
+                                     _("Invalid Exec argument %s"), arg);
+                  goto out;
+                }
               else
                 g_string_append_printf (new_exec, " %s", arg);
             }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7139,6 +7139,8 @@ export_desktop_file (const char         *app,
                 g_string_append_printf (new_exec, " @@ %s @@", arg);
               else if (strcasecmp (arg, "%u") == 0)
                 g_string_append_printf (new_exec, " @@u %s @@", arg);
+              else if (strcmp (arg, "@@") == 0 || strcmp (arg, "@@u") == 0)
+                g_print (_("Skipping invalid Exec argument %s\n"), arg);
               else
                 g_string_append_printf (new_exec, " %s", arg);
             }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7139,7 +7139,7 @@ export_desktop_file (const char         *app,
                 g_string_append_printf (new_exec, " @@ %s @@", arg);
               else if (strcasecmp (arg, "%u") == 0)
                 g_string_append_printf (new_exec, " @@u %s @@", arg);
-              else if (strcmp (arg, "@@") == 0 || strcmp (arg, "@@u") == 0)
+              else if (g_str_has_prefix (arg, "@@"))
                 g_print (_("Skipping invalid Exec argument %s\n"), arg);
               else
                 g_string_append_printf (new_exec, " %s", arg);


### PR DESCRIPTION
* Disallow `@@` and `@@u` usage in desktop files

    From: @refi64 

    Fixes #4146.

* dir: Reserve the whole `@@` prefix
    
    If we add new features analogous to file forwarding later, we might
    find that we need a different magic token. Let's reserve the whole
    `@@*` namespace so we can call it `@@something-else`.

* dir: Refuse to export .desktop files with suspicious uses of `@@` tokens
    
    This is either a malicious/compromised app trying to do an attack, or
    a mistake that will break handling of %f, %u and so on. Either way,
    if we refuse to export the .desktop file, resulting in installation
    failing, then it makes the rejection more obvious than quietly
    removing the magic tokens.

---

This is a revised version of #4148, incorporating my suggestions. With this version, installing the app fails:

```
Error: Invalid Exec argument @@
error: Failed to install bundle com.example.Foo: Invalid Exec argument @@
```

cc @refi64 @matthiasclasen 