### PR TITLE
Let child process handle SIGINT in flatpak enter

### DIFF
--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -283,6 +283,7 @@ flatpak_builtin_enter (int           argc,
     g_ptr_array_add (argv_array, g_strdup (argv[rest_argv_start + i]));
   g_ptr_array_add (argv_array, NULL);
 
+  signal (SIGINT, SIG_IGN);
   if (!g_spawn_sync (NULL, (char **) argv_array->pdata, (char **) envp_array->pdata,
                      G_SPAWN_SEARCH_PATH_FROM_ENVP | G_SPAWN_CHILD_INHERITS_STDIN,
                      NULL, NULL,


### PR DESCRIPTION
Otherwise when running software that handles SIGINT, such as gdb or python, pressing ^C would kill flatpak-enter and return control to the shell.
