### PR TITLE
portal: fix flatpak-spawn --clear-env on NixOS

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1005,7 +1005,7 @@ handle_spawn (PortalFlatpak         *object,
   else
     env = g_get_environ ();
 
-  g_ptr_array_add (flatpak_argv, g_strdup ("flatpak"));
+  g_ptr_array_add (flatpak_argv, g_strdup (FLATPAK_BINDIR "/flatpak"));
   g_ptr_array_add (flatpak_argv, g_strdup ("run"));
 
   sandboxed = (arg_flags & FLATPAK_SPAWN_FLAGS_SANDBOX) != 0;


### PR DESCRIPTION
Running Flatpak Chromium on NixOS fails with the following error:

> Error calling Spawn(): org.freedesktop.DBus.Error.FileNotFound: Failed to start command: Failed to execute child process “flatpak” (No such file or directory)

Presumably, Chromium calls portal’s `Spawn` method with `FLATPAK_SPAWN_FLAGS_CLEAR_ENV` flag, which also removes `PATH`.
Since NixOS does not install programs to global `/usr/bin` and relies solely on `PATH`, this is probably what prevents `flatpak` command itself from being found.

There is a relevant TODO note in the code about `LD_LIBRARY_PATH` but at least for `PATH`, we can solve the issue by hardcoding the path to the binary.

Fixes: https://github.com/flathub/org.chromium.Chromium/issues/81

cc @JoshuaFern @refi64 