### PR TITLE
history: Handle transaction log entry with empty REF field

### DIFF
--- a/app/flatpak-builtins-history.c
+++ b/app/flatpak-builtins-history.c
@@ -222,7 +222,7 @@ print_history (GPtrArray    *dirs,
                 if (*error)
                   return FALSE;
 
-                if (ref_str)
+                if (ref_str && ref_str[0])
                   {
                     ref = flatpak_decomposed_new_from_ref (ref_str, error);
                     if (ref == NULL)


### PR DESCRIPTION
This checks that the value of the REF field is not an empty string
before calling `flatpak_decomposed_new_from_ref`.  Attempting to
decompose an empty string leads to a validation error and prevents
any history from being printed.

Fixes https://github.com/flatpak/flatpak/issues/4121