### PR TITLE
system-helper: Set interactivity on the FlatpakDir from D-Bus call flags

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -224,6 +224,7 @@ schedule_idle_callback (void)
 static FlatpakDir *
 dir_get_system (const char *installation,
                 pid_t       source_pid,
+                gboolean    no_interaction,
                 GError    **error)
 {
   FlatpakDir *system = NULL;
@@ -239,6 +240,7 @@ dir_get_system (const char *installation,
 
   flatpak_dir_set_source_pid (system, source_pid);
   flatpak_dir_set_no_system_helper (system, TRUE);
+  flatpak_dir_set_no_interaction (system, no_interaction);
 
   return system;
 }
@@ -403,7 +405,7 @@ handle_deploy (FlatpakSystemHelper   *object,
 
   g_debug ("Deploy %s %u %s %s %s", arg_repo_path, arg_flags, arg_ref, arg_origin, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -723,7 +725,7 @@ handle_cancel_pull (FlatpakSystemHelper   *object,
 
   g_debug ("CancelPull %s %u %s", arg_installation, arg_flags, arg_src_dir);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CANCEL_PULL_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -781,7 +783,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
 
   g_debug ("DeployAppstream %s %u %s %s %s", arg_repo_path, arg_flags, arg_origin, arg_arch, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_DEPLOY_APPSTREAM_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -949,7 +951,7 @@ handle_uninstall (FlatpakSystemHelper   *object,
 
   g_debug ("Uninstall %u %s %s", arg_flags, arg_ref, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UNINSTALL_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1002,7 +1004,7 @@ handle_install_bundle (FlatpakSystemHelper   *object,
 
   g_debug ("InstallBundle %s %u %s %s", arg_bundle_path, arg_flags, arg_remote, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_INSTALL_BUNDLE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1053,7 +1055,7 @@ handle_configure_remote (FlatpakSystemHelper   *object,
 
   g_debug ("ConfigureRemote %u %s %s", arg_flags, arg_remote, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CONFIGURE_REMOTE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1128,7 +1130,7 @@ handle_configure (FlatpakSystemHelper   *object,
 
   g_debug ("Configure %u %s=%s %s", arg_flags, arg_key, arg_value, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CONFIGURE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1194,7 +1196,7 @@ handle_update_remote (FlatpakSystemHelper   *object,
 
   g_debug ("UpdateRemote %u %s %s %s %s", arg_flags, arg_remote, arg_installation, arg_summary_path, arg_summary_sig_path);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UPDATE_REMOTE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1273,7 +1275,7 @@ handle_remove_local_ref (FlatpakSystemHelper   *object,
 
   g_debug ("RemoveLocalRef %u %s %s %s", arg_flags, arg_remote, arg_ref, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_REMOVE_LOCAL_REF_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1322,7 +1324,7 @@ handle_prune_local_repo (FlatpakSystemHelper   *object,
 
   g_debug ("PruneLocalRepo %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_PRUNE_LOCAL_REPO_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1366,7 +1368,7 @@ handle_ensure_repo (FlatpakSystemHelper   *object,
 
   g_debug ("EnsureRepo %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_ENSURE_REPO_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1405,7 +1407,7 @@ handle_run_triggers (FlatpakSystemHelper   *object,
 
   g_debug ("RunTriggers %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_RUN_TRIGGERS_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1696,7 +1698,7 @@ handle_get_revokefs_fd (FlatpakSystemHelper   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_GET_REVOKEFS_FD_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1793,7 +1795,7 @@ handle_update_summary (FlatpakSystemHelper   *object,
 
   g_debug ("UpdateSummary %u %s", arg_flags, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1839,7 +1841,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
 
   g_debug ("GenerateOciSummary %u %s %s", arg_flags, arg_origin, arg_installation);
 
-  system = dir_get_system (arg_installation, get_sender_pid (invocation), &error);
+  system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
     {
       g_dbus_method_invocation_return_gerror (invocation, error);
@@ -1950,6 +1952,8 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
               return FALSE;
             }
 
+          no_interaction = (flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION) != 0;
+
           /* These flags allow clients to "upgrade" the permission,
            * avoiding the need for multiple polkit dialogs when we first
            * update a runtime, then install the app that needs it.
@@ -1970,7 +1974,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
             is_install = TRUE;
           else
             {
-              g_autoptr(FlatpakDir) system = dir_get_system (installation, 0, &error);
+              g_autoptr(FlatpakDir) system = dir_get_system (installation, 0, no_interaction, &error);
 
               if (system == NULL)
                 {
@@ -1996,8 +2000,6 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
               else
                 action = "org.freedesktop.Flatpak.runtime-update";
             }
-
-          no_interaction = (flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION) != 0;
         }
 
       polkit_details_insert (details, "origin", origin);
@@ -2071,7 +2073,7 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
           g_autoptr(GError) sys_error = NULL;
           const char *name = NULL;
 
-          system = dir_get_system (installation, 0, &sys_error);
+          system = dir_get_system (installation, 0, no_interaction, &sys_error);
           if (system == NULL)
             {
               g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,


### PR DESCRIPTION
The system helper was already correctly using the `NO_INTERACTION` flag
in the D-Bus call flags to determine whether polkit calls from
`flatpak_authorize_method_handler()` should allow interactivity.

However, the system helper was not setting the no-interaction property
on the `FlatpakDir` used in the subsequent operation. When parental
controls are enabled, this sometimes results in polkit allowing
interaction when prompting for the `override-parental-controls` action,
even if the D-Bus call which activated the system helper specified the
`NO_INTERACTION` flag.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>