### PR TITLE
OCI: Switch to pax format for tar archives

### DIFF
--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -1476,7 +1476,7 @@ flatpak_oci_registry_write_layer (FlatpakOciRegistry *self,
     }
 
   a = archive_write_new ();
-  if (archive_write_set_format_gnutar (a) != ARCHIVE_OK ||
+  if (archive_write_set_format_pax (a) != ARCHIVE_OK ||
       archive_write_add_filter_none (a) != ARCHIVE_OK)
     {
       propagate_libarchive_error (error, a);


### PR DESCRIPTION
For reasons unknown, libarchive appears to generate broken gnutar format
tar archives when the archive contains files that are larger than 2 GB.
This commit switches to the pax format to work this around.

This should be a better default as it also removes 256 char filename
length limitation and matches what other libraries are doing, e.g.
Python 3.8 switched to the pax format by default as well.

See https://pagure.io/fedora-infrastructure/issue/9840