### PR TITLE
Fix an intermittent test failure when head -2 exits before flatpak does

### DIFF
--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -73,10 +73,11 @@ for cmd in install update uninstall list info config repair create-usb \
            build-sign build-update-repo build-commit-from repo kill history \
            mask;
 do
-  ${FLATPAK} $cmd --help | head -2 > help_out
+  ${FLATPAK} $cmd --help > help_out
+  head -2 help_out > help_out2
 
-  assert_file_has_content help_out "^Usage:$"
-  assert_file_has_content help_out "flatpak $cmd"
+  assert_file_has_content help_out2 "^Usage:$"
+  assert_file_has_content help_out2 "flatpak $cmd"
 done
 
 ok "command help"


### PR DESCRIPTION
* test-basic: Don't fail if head -2 exits before flatpak does

     The output might be written to the pipe by `flatpak --help` and/or read
from the pipe by `head -2` in more than one batch. If `head -2` reads
the first two lines before `flatpak --help` has written everything, it
will exit, causing the pipe to have no process at the read end. This
results in `flatpak --help` being killed by `SIGPIPE` next time it tries
to write to the pipe, because it has not opted out of this behaviour
(as shell tools usually shouldn't).

    We're running under `set -o pipefail`, so this causes a nonzero exit
status that makes the test fail. Worse, this failure is intermittent,
because `head -2` *usually* doesn't exit until `flatpak --help` has
already written out everything it is going to write - it depends on
the precise behaviour of read(), write() and kernel scheduling.

    We know that `flatpak --help` output is not *that* long, so it's OK
for `flatpak --help` not to be terminated early: we can send it all
into an intermediate file, and then run `head` on the file.