### PR TITLE
Make /dev/shm shareable between app instances

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,8 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev
+        # One of the tests wants this
+        sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
       uses: actions/checkout@v1
       with:

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -57,6 +57,7 @@ typedef enum {
   FLATPAK_CONTEXT_FEATURE_MULTIARCH    = 1 << 1,
   FLATPAK_CONTEXT_FEATURE_BLUETOOTH    = 1 << 2,
   FLATPAK_CONTEXT_FEATURE_CANBUS       = 1 << 3,
+  FLATPAK_CONTEXT_FEATURE_PER_APP_DEV_SHM = 1 << 4,
 } FlatpakContextFeatures;
 
 struct FlatpakContext

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -78,6 +78,7 @@ const char *flatpak_context_features[] = {
   "multiarch",
   "bluetooth",
   "canbus",
+  "per-app-dev-shm",
   NULL
 };
 
@@ -2064,6 +2065,11 @@ gboolean
 flatpak_context_adds_permissions (FlatpakContext *old,
                                   FlatpakContext *new)
 {
+  /* We allow upgrade to multiarch, that is really not a huge problem.
+   * Similarly, having sensible semantics for /dev/shm is
+   * not a security concern. */
+  guint32 harmless_features = (FLATPAK_CONTEXT_FEATURE_MULTIARCH |
+                               FLATPAK_CONTEXT_FEATURE_PER_APP_DEV_SHM);
   guint32 old_sockets;
 
   if (adds_flags (old->shares & old->shares_valid,
@@ -2085,8 +2091,7 @@ flatpak_context_adds_permissions (FlatpakContext *old,
                   new->devices & new->devices_valid))
     return TRUE;
 
-  /* We allow upgrade to multiarch, that is really not a huge problem */
-  if (adds_flags ((old->features & old->features_valid) | FLATPAK_CONTEXT_FEATURE_MULTIARCH,
+  if (adds_flags ((old->features & old->features_valid) | harmless_features,
                   new->features & new->features_valid))
     return TRUE;
 

--- a/common/flatpak-instance-private.h
+++ b/common/flatpak-instance-private.h
@@ -30,12 +30,24 @@ char *flatpak_instance_get_instances_directory (void);
 char *flatpak_instance_allocate_id (char **host_dir_out,
                                     int *lock_fd_out);
 
+gboolean flatpak_instance_claim_per_app_temp_directory (const char *app_id,
+                                                        int per_app_dir_lock_fd,
+                                                        int at_fd,
+                                                        const char *link_path,
+                                                        const char *parent,
+                                                        char **path_out,
+                                                        GError **error);
+
 void flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances);
 
 gboolean flatpak_instance_ensure_per_app_dir (const char *app_id,
                                               int *lock_fd_out,
                                               char **lock_path_out,
                                               GError **error);
+gboolean flatpak_instance_ensure_per_app_dev_shm (const char *app_id,
+                                                  int per_app_dir_lock_fd,
+                                                  char **shared_dev_shm_out,
+                                                  GError **error);
 gboolean flatpak_instance_ensure_per_app_tmp (const char *app_id,
                                               int per_app_dir_lock_fd,
                                               char **shared_tmp_out,

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -184,7 +184,8 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth, canbus.
+                    FEATURE must be one of: devel, multiarch, bluetooth, canbus,
+                    per-app-dev-shm.
                     This option can be used multiple times.
                  </para><para>
                     The <code>devel</code> feature allows the application to
@@ -205,6 +206,13 @@
                     The <code>canbus</code> feature allows the application to
                     use canbus (AF_CAN) sockets.
                     Note, for this work you must also have network access.
+                </para>
+                <para>
+                    The <code>per-app-dev-shm</code> feature shares a single
+                    instance of <filename>/dev/shm</filename> between the
+                    application, any unrestricted subsandboxes that it creates,
+                    and any other instances of the application that are
+                    launched while it is running.
                 </para></listitem>
             </varlistentry>
 
@@ -214,7 +222,8 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch, bluetooth, canbus.
+                    FEATURE must be one of: devel, multiarch, bluetooth, canbus,
+                    per-app-dev-shm.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -194,7 +194,9 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of:
+                    devel, multiarch, bluetooth, canbus,
+                    per-app-dev-shm.
                     This option can be used multiple times.
                     </para><para>
                     See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
@@ -208,7 +210,9 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of:
+                    devel, multiarch, bluetooth, canbus,
+                    per-app-dev-shm.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -478,6 +478,19 @@
                               Available since 1.0.3.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>per-app-dev-shm</option></term>
+                            <listitem><para>
+                              Share a single instance of
+                              <filename>/dev/shm</filename> between all
+                              instances of this application run by the same
+                              user ID, including sub-sandboxes.
+                              If the application has the
+                              <option>shm</option> device permission in its
+                              <option>devices</option> list, then this
+                              feature flag is ignored.
+                              Available since 1.12.0.
+                            </para></listitem></varlistentry>
+
                         </variablelist>
                         A feature can be prefixed with <option>!</option> to
                         indicate the absence of that feature, for example

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -176,7 +176,9 @@
                 <listitem><para>
                     Allow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of:
+                    devel, multiarch, bluetooth, canbus,
+                    per-app-dev-shm.
                     This option can be used multiple times.
                  </para><para>
                     See <citerefentry><refentrytitle>flatpak-build-finish</refentrytitle><manvolnum>1</manvolnum></citerefentry>
@@ -190,7 +192,9 @@
                 <listitem><para>
                     Disallow access to a specific feature. This updates
                     the [Context] group in the metadata.
-                    <arg choice="plain">FEATURE</arg> must be one of: devel, multiarch, bluetooth, canbus.
+                    <arg choice="plain">FEATURE</arg> must be one of:
+                    devel, multiarch, bluetooth, canbus,
+                    per-app-dev-shm.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -88,7 +88,11 @@ test_exports_SOURCES = tests/test-exports.c
 
 test_instance_CFLAGS = $(testcommon_CFLAGS)
 test_instance_LDADD = $(testcommon_LDADD) libtestlib.la
-test_instance_SOURCES = tests/test-instance.c
+test_instance_SOURCES = \
+	subprojects/libglnx/tests/libglnx-testlib.c \
+	subprojects/libglnx/tests/libglnx-testlib.h \
+	tests/test-instance.c \
+	$(NULL)
 
 tests_hold_lock_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
 tests_hold_lock_LDADD = $(AM_LDADD) $(BASE_LIBS) libglnx.la

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -122,6 +122,7 @@ bluetooth
 canbus 
 devel 
 multiarch 
+per-app-dev-shm 
 EOF
 
 ok "complete --allow"

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -233,7 +233,7 @@ test_full_context (void)
   g_key_file_set_value (keyfile,
                         FLATPAK_METADATA_GROUP_CONTEXT,
                         FLATPAK_METADATA_KEY_FEATURES,
-                        "devel;multiarch;bluetooth;canbus;");
+                        "devel;multiarch;bluetooth;canbus;per-app-dev-shm;");
   g_key_file_set_value (keyfile,
                         FLATPAK_METADATA_GROUP_CONTEXT,
                         FLATPAK_METADATA_KEY_FILESYSTEMS,
@@ -292,7 +292,8 @@ test_full_context (void)
                     (FLATPAK_CONTEXT_FEATURE_DEVEL |
                      FLATPAK_CONTEXT_FEATURE_MULTIARCH |
                      FLATPAK_CONTEXT_FEATURE_BLUETOOTH |
-                     FLATPAK_CONTEXT_FEATURE_CANBUS));
+                     FLATPAK_CONTEXT_FEATURE_CANBUS |
+                     FLATPAK_CONTEXT_FEATURE_PER_APP_DEV_SHM));
   g_assert_cmpuint (context->features_valid, ==, context->features);
 
   g_assert_cmpuint (flatpak_context_get_run_flags (context), ==,


### PR DESCRIPTION
Fixes #4091.

## Design

The interesting subset of the host filesystem is now:

```
real host g_get_user_runtime_dir()
    \- app
        \- com.example.App (gets mounted as XDG_RUNTIME_DIR/app/com.example.App as before)
    \- .flatpak
        \- 123 (instance-specific directory, already used)
        \- 456 (instance-specific directory, already used)
        \- com.example.App (per-app directory, new in #4093)
            \- .ref (locked non-exclusively by app, new in #4093)
            \- tmp (gets mounted as /tmp in app sandbox, new in #4093)
            \- dev-shm (symlink to /dev/shm/flatpak-com.example.App-abcdef, new)

real host /dev/shm
    \- flatpak-com.example.App-abcdef (or similar unpredictable name, new)
        \- .flatpak-tmpdir
```

As with #4093, the shared `/dev/shm` is only used for `flatpak run`, not for `flatpak build` (which reinvents a lot of `flatpak_run_app()`), and also not for `apply_extra`.

Whenever we garbage-collect the numbered per-instance directories, we check their app info. If an instance is disappearing, we attempt to garbage-collect the corresponding `dev-shm` if no apps are still using it. The shared `/dev/shm` is currently backed by a directory `/dev/shm/flatpak-com.example.App-XXXXXX`, so that it's basically guaranteed to be genuinely a tmpfs.

The format of the temporary directory `/dev/shm/flatpak-com.example.App-XXXXXX` is checked, to defend against being tricked into deleting a directory that we didn't mean to. The app name is included in the directory name, so that if an app uses an excessive amount of space, users can blame the app and not Flatpak itself.

The flag file `.flatpak-tmpdir` is also checked for, again as a safety-catch against deleting unintended directories. This is loosely based on the `.testtmp` used in the libostree and Flatpak unit tests.

Having a shared `/dev/shm` is guarded by a feature flag as @alexlarsson requested: we don't expect so many apps to need this.

## Commits

* run: Add option to share /dev/shm between instances of an app-ID
    
    Similar to /tmp, applications might well use /dev/shm as an IPC
    rendezvous between instances, which wouldn't have worked without
    --device=shm until now.
    
    Because /dev/shm has specific characteristics (in particular it's
    meant to always be a tmpfs), we offload the actual storage into a
    subdirectory of the real /dev/shm. Because /dev/shm is a shared
    directory between all uids, we have to be extra-careful how we
    do this, which is why the test coverage here is important.
    
    This is done on an opt-in basis because of its extra complexity.