### PR TITLE
utils: Quote empty strings when debug-logging argv, and add a test

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -1415,6 +1415,9 @@ flatpak_switch_symlink_and_remove (const char *symlink_path,
 gboolean
 flatpak_argument_needs_quoting (const char *arg)
 {
+  if (*arg == '\0')
+    return TRUE;
+
   while (*arg != 0)
     {
       char c = *arg;


### PR DESCRIPTION
* utils: Quote empty strings when debug-logging argv
    
    If an argument takes a value, and the value is empty, then it's
    misleading to quote `{"--foo", "--empty", "", "--bar"}` as
    `--foo --empty  --bar`. It's better to get `--foo --empty '' --bar`.

* tests: Test flatpak_quote_argv and flatpak_argument_needs_quoting