### PR TITLE
Define macros for various D-Bus names

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -56,6 +56,7 @@
 #include "flatpak-variant-private.h"
 #include "flatpak-variant-impl-private.h"
 #include "libglnx/libglnx.h"
+#include "system-helper/flatpak-system-helper.h"
 
 #ifdef HAVE_LIBMALCONTENT
 #include <libmalcontent/malcontent.h>
@@ -2047,9 +2048,9 @@ flatpak_dir_system_helper_call (FlatpakDir         *self,
 
   g_debug ("Calling system helper: %s", method_name);
   res = g_dbus_connection_call_with_unix_fd_list_sync (self->system_helper_bus,
-                                                       "org.freedesktop.Flatpak.SystemHelper",
-                                                       "/org/freedesktop/Flatpak/SystemHelper",
-                                                       "org.freedesktop.Flatpak.SystemHelper",
+                                                       FLATPAK_SYSTEM_HELPER_BUS_NAME,
+                                                       FLATPAK_SYSTEM_HELPER_PATH,
+                                                       FLATPAK_SYSTEM_HELPER_INTERFACE,
                                                        method_name,
                                                        parameters,
                                                        reply_type,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -62,6 +62,7 @@
 #include "flatpak-systemd-dbus-generated.h"
 #include "flatpak-document-dbus-generated.h"
 #include "flatpak-error.h"
+#include "session-helper/flatpak-session-helper.h"
 
 #define DEFAULT_SHELL "/bin/sh"
 
@@ -2587,8 +2588,8 @@ add_monitor_path_args (gboolean      use_session_helper,
       session_helper =
         flatpak_session_helper_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
                                                        G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
-                                                       "org.freedesktop.Flatpak",
-                                                       "/org/freedesktop/Flatpak/SessionHelper",
+                                                       FLATPAK_SESSION_HELPER_BUS_NAME,
+                                                       FLATPAK_SESSION_HELPER_PATH,
                                                        NULL, NULL);
     }
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -230,8 +230,8 @@ child_watch_died (GPid     pid,
   signal_variant = g_variant_ref_sink (g_variant_new ("(uu)", pid, status));
   g_dbus_connection_emit_signal (session_bus,
                                  pid_data->client,
-                                 "/org/freedesktop/portal/Flatpak",
-                                 "org.freedesktop.portal.Flatpak",
+                                 FLATPAK_PORTAL_PATH,
+                                 FLATPAK_PORTAL_INTERFACE,
                                  "SpawnExited",
                                  signal_variant,
                                  NULL);
@@ -422,8 +422,8 @@ check_child_pid_status (void *user_data)
   signal_variant = g_variant_ref_sink (g_variant_new ("(uu)", pid, relative_child_pid));
   g_dbus_connection_emit_signal (session_bus,
                                  pid_data->client,
-                                 "/org/freedesktop/portal/Flatpak",
-                                 "org.freedesktop.portal.Flatpak",
+                                 FLATPAK_PORTAL_PATH,
+                                 FLATPAK_PORTAL_INTERFACE,
                                  "SpawnStarted",
                                  signal_variant,
                                  NULL);
@@ -813,7 +813,7 @@ handle_spawn (PortalFlatpak         *object,
     {
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                              G_DBUS_ERROR_INVALID_ARGS,
-                                             "org.freedesktop.portal.Flatpak.Spawn only works in a flatpak");
+                                             FLATPAK_PORTAL_INTERFACE ".Spawn only works in a flatpak");
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
@@ -1896,7 +1896,7 @@ check_for_updates (PortalFlatpakUpdateMonitor *monitor)
           !g_dbus_connection_emit_signal (update_monitor_get_connection (monitor),
                                           m->sender,
                                           m->obj_path,
-                                          "org.freedesktop.portal.Flatpak.UpdateMonitor",
+                                          FLATPAK_PORTAL_INTERFACE_UPDATE_MONITOR,
                                           "UpdateAvailable",
                                           g_variant_new ("(a{sv})", &builder),
                                           &error))
@@ -2014,7 +2014,8 @@ handle_create_update_monitor (PortalFlatpak *object,
         sender_escaped[i] = '_';
     }
 
-  obj_path = g_strdup_printf ("/org/freedesktop/portal/Flatpak/update_monitor/%s/%s",
+  obj_path = g_strdup_printf ("%s/update_monitor/%s/%s",
+                              FLATPAK_PORTAL_PATH,
                               sender_escaped,
                               token);
 
@@ -2315,7 +2316,7 @@ emit_progress (PortalFlatpakUpdateMonitor *monitor,
   if (!g_dbus_connection_emit_signal (connection,
                                       m->sender,
                                       m->obj_path,
-                                      "org.freedesktop.portal.Flatpak.UpdateMonitor",
+                                      FLATPAK_PORTAL_INTERFACE_UPDATE_MONITOR,
                                       "Progress",
                                       g_variant_new ("(a{sv})", &builder),
                                       &error))
@@ -2879,7 +2880,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (portal),
                                          connection,
-                                         "/org/freedesktop/portal/Flatpak",
+                                         FLATPAK_PORTAL_PATH,
                                          &error))
     {
       g_warning ("error: %s", error->message);
@@ -3041,7 +3042,7 @@ main (int    argc,
     flags |= G_BUS_NAME_OWNER_FLAGS_REPLACE;
 
   name_owner_id = g_bus_own_name (G_BUS_TYPE_SESSION,
-                                  "org.freedesktop.portal.Flatpak",
+                                  FLATPAK_PORTAL_BUS_NAME,
                                   flags,
                                   on_bus_acquired,
                                   on_name_acquired,

--- a/portal/flatpak-portal.h
+++ b/portal/flatpak-portal.h
@@ -21,6 +21,11 @@
 #ifndef __FLATPAK_PORTAL_H__
 #define __FLATPAK_PORTAL_H__
 
+#define FLATPAK_PORTAL_BUS_NAME "org.freedesktop.portal.Flatpak"
+#define FLATPAK_PORTAL_PATH "/org/freedesktop/portal/Flatpak"
+#define FLATPAK_PORTAL_INTERFACE FLATPAK_PORTAL_BUS_NAME
+#define FLATPAK_PORTAL_INTERFACE_UPDATE_MONITOR FLATPAK_PORTAL_BUS_NAME ".UpdateMonitor"
+
 typedef enum {
   FLATPAK_SPAWN_FLAGS_CLEAR_ENV = 1 << 0,
   FLATPAK_SPAWN_FLAGS_LATEST_VERSION = 1 << 1,

--- a/session-helper/Makefile.am.inc
+++ b/session-helper/Makefile.am.inc
@@ -10,6 +10,7 @@ dbus_service_DATA += session-helper/org.freedesktop.Flatpak.service
 
 flatpak_session_helper_SOURCES = \
 	session-helper/flatpak-session-helper.c	\
+	session-helper/flatpak-session-helper.h	\
 	$(NULL)
 
 flatpak_session_helper_LDADD = $(AM_LDADD) $(BASE_LIBS) libflatpak-common-base.la libglnx.la

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -29,6 +29,7 @@
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 #include "flatpak-dbus-generated.h"
+#include "flatpak-session-helper.h"
 #include "flatpak-utils-base-private.h"
 
 typedef enum {
@@ -107,8 +108,8 @@ child_watch_died (GPid     pid,
   signal_variant = g_variant_ref_sink (g_variant_new ("(uu)", pid, status));
   g_dbus_connection_emit_signal (session_bus,
                                  pid_data->client,
-                                 "/org/freedesktop/Flatpak/Development",
-                                 "org.freedesktop.Flatpak.Development",
+                                 FLATPAK_SESSION_HELPER_PATH_DEVELOPMENT,
+                                 FLATPAK_SESSION_HELPER_INTERFACE_DEVELOPMENT,
                                  "HostCommandExited",
                                  signal_variant,
                                  NULL);
@@ -469,7 +470,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (helper),
                                          connection,
-                                         "/org/freedesktop/Flatpak/SessionHelper",
+                                         FLATPAK_SESSION_HELPER_PATH,
                                          &error))
     {
       g_warning ("error: %s", error->message);
@@ -483,7 +484,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (devel),
                                          connection,
-                                         "/org/freedesktop/Flatpak/Development",
+                                         FLATPAK_SESSION_HELPER_PATH_DEVELOPMENT,
                                          &error))
     {
       g_warning ("error: %s", error->message);
@@ -863,7 +864,7 @@ main (int    argc,
     flags |= G_BUS_NAME_OWNER_FLAGS_REPLACE;
 
   owner_id = g_bus_own_name (G_BUS_TYPE_SESSION,
-                             "org.freedesktop.Flatpak",
+                             FLATPAK_SESSION_HELPER_BUS_NAME,
                              flags,
                              on_bus_acquired,
                              on_name_acquired,

--- a/session-helper/flatpak-session-helper.h
+++ b/session-helper/flatpak-session-helper.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __FLATPAK_SESSION_HELPER_H__
+#define __FLATPAK_SESSION_HELPER_H__
+
+#define FLATPAK_SESSION_HELPER_BUS_NAME "org.freedesktop.Flatpak"
+
+#define FLATPAK_SESSION_HELPER_PATH "/org/freedesktop/Flatpak/SessionHelper"
+#define FLATPAK_SESSION_HELPER_INTERFACE "org.freedesktop.Flatpak.SessionHelper"
+
+#define FLATPAK_SESSION_HELPER_PATH_DEVELOPMENT "/org/freedesktop/Flatpak/Development"
+#define FLATPAK_SESSION_HELPER_INTERFACE_DEVELOPMENT "org.freedesktop.Flatpak.Development"
+
+#endif

--- a/system-helper/Makefile.am.inc
+++ b/system-helper/Makefile.am.inc
@@ -16,6 +16,7 @@ systemdsystemunit_DATA += system-helper/flatpak-system-helper.service
 
 flatpak_system_helper_SOURCES = \
 	system-helper/flatpak-system-helper.c	\
+	system-helper/flatpak-system-helper.h	\
 	$(NULL)
 
 flatpak_system_helper_LDADD = $(BASE_LIBS) $(OSTREE_LIBS) $(JSON_LIBS) $(POLKIT_LIBS) libflatpak-common.la libflatpak-common-base.la libglnx.la

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -39,6 +39,7 @@
 #include "flatpak-error.h"
 #include "flatpak-oci-registry-private.h"
 #include "flatpak-progress-private.h"
+#include "flatpak-system-helper.h"
 #include "flatpak-utils-base-private.h"
 #include "flatpak-utils-private.h"
 
@@ -2236,7 +2237,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (helper),
                                          connection,
-                                         "/org/freedesktop/Flatpak/SystemHelper",
+                                         FLATPAK_SYSTEM_HELPER_PATH,
                                          &error))
     {
       g_warning ("error: %s", error->message);
@@ -2412,7 +2413,7 @@ main (int    argc,
     flags |= G_BUS_NAME_OWNER_FLAGS_REPLACE;
 
   name_owner_id = g_bus_own_name (on_session_bus ? G_BUS_TYPE_SESSION  : G_BUS_TYPE_SYSTEM,
-                                  "org.freedesktop.Flatpak.SystemHelper",
+                                  FLATPAK_SYSTEM_HELPER_BUS_NAME,
                                   flags,
                                   on_bus_acquired,
                                   on_name_acquired,

--- a/system-helper/flatpak-system-helper.h
+++ b/system-helper/flatpak-system-helper.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __FLATPAK_SYSTEM_HELPER_H__
+#define __FLATPAK_SYSTEM_HELPER_H__
+
+#define FLATPAK_SYSTEM_HELPER_BUS_NAME "org.freedesktop.Flatpak.SystemHelper"
+#define FLATPAK_SYSTEM_HELPER_PATH "/org/freedesktop/Flatpak/SystemHelper"
+#define FLATPAK_SYSTEM_HELPER_INTERFACE FLATPAK_SYSTEM_HELPER_BUS_NAME
+
+#endif

--- a/tests/test-update-portal.c
+++ b/tests/test-update-portal.c
@@ -8,12 +8,13 @@
 #include <fcntl.h>
 
 #include <gio/gio.h>
+#include "portal/flatpak-portal.h"
 #include "portal/flatpak-portal-dbus.h"
 
 GDBusConnection *connection;
 
-const char *portal_name = "org.freedesktop.portal.Flatpak";
-const char *portal_path = "/org/freedesktop/portal/Flatpak";
+const char *portal_name = FLATPAK_PORTAL_BUS_NAME;
+const char *portal_path = FLATPAK_PORTAL_PATH;
 
 static PortalFlatpakUpdateMonitor *
 create_monitor (PortalFlatpak *portal,
@@ -36,7 +37,7 @@ create_monitor (PortalFlatpak *portal,
 
   token = g_strdup_printf ("test_token%d", counter++);
 
-  monitor_path = g_strdup_printf ("/org/freedesktop/portal/Flatpak/update_monitor/%s/%s", sender, token);
+  monitor_path = g_strdup_printf ("%s/update_monitor/%s/%s", FLATPAK_PORTAL_PATH, sender, token);
   monitor = portal_flatpak_update_monitor_proxy_new_sync (connection, G_DBUS_PROXY_FLAGS_NONE,
                                                           portal_name, monitor_path,
                                                           NULL, error);


### PR DESCRIPTION
* session-helper: Move D-Bus names and paths to a header file

* system-helper: Move D-Bus names and paths to a header file

* portal: Define constants for the D-Bus names and path

---

This mitigates any typos in these names that might otherwise creep in, and also provides a somewhat canonical name to use for these strings in other projects.

The new headers are not (yet?) installed or part of the API, but they're self-contained and can be copied into dependent projects.