### PR TITLE
app: Use autocleanup for FlatpakTablePrinter

### DIFF
--- a/app/flatpak-builtins-document-list.c
+++ b/app/flatpak-builtins-document-list.c
@@ -64,7 +64,7 @@ print_documents (const char   *app_id,
   g_autoptr(GVariantIter) iter = NULL;
   const char *id;
   const char *origin;
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   g_autofree char *mountpoint = NULL;
   gboolean need_perms = FALSE;
   int i;
@@ -153,7 +153,6 @@ print_documents (const char   *app_id,
     }
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-history.c
+++ b/app/flatpak-builtins-history.c
@@ -124,7 +124,7 @@ print_history (GPtrArray    *dirs,
                GCancellable *cancellable,
                GError      **error)
 {
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   sd_journal *j;
   int r;
   int i;
@@ -348,7 +348,6 @@ print_history (GPtrArray    *dirs,
       }
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 
   sd_journal_close (j);
 

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -120,7 +120,7 @@ print_table_for_refs (gboolean      print_apps,
                       GCancellable *cancellable,
                       GError      **error)
 {
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   int i;
   FlatpakKinds match_kinds;
   g_autofree char *match_id = NULL;
@@ -352,8 +352,6 @@ print_table_for_refs (gboolean      print_apps,
       flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
       g_print ("\n");
     }
-
-  flatpak_table_printer_free (printer);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-permission-list.c
+++ b/app/flatpak-builtins-permission-list.c
@@ -133,7 +133,7 @@ flatpak_builtin_permission_list (int argc, char **argv,
   XdpDbusPermissionStore *store = NULL;
   const char *table;
   const char *id;
-  FlatpakTablePrinter *printer = NULL;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
 
   context = g_option_context_new (_("[TABLE] [ID] - List permissions"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
@@ -194,7 +194,6 @@ flatpak_builtin_permission_list (int argc, char **argv,
     }
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-permission-show.c
+++ b/app/flatpak-builtins-permission-show.c
@@ -105,7 +105,7 @@ flatpak_builtin_permission_show (int argc, char **argv,
   g_autoptr(GDBusConnection) session_bus = NULL;
   XdpDbusPermissionStore *store = NULL;
   const char *app_id;
-  FlatpakTablePrinter *printer = NULL;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   int i;
   g_auto(GStrv) tables = NULL;
 
@@ -150,7 +150,6 @@ flatpak_builtin_permission_show (int argc, char **argv,
     }
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-ps.c
+++ b/app/flatpak-builtins-ps.c
@@ -117,7 +117,7 @@ static gboolean
 enumerate_instances (Column *columns, GError **error)
 {
   g_autoptr(GPtrArray) instances = NULL;
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   int i, j;
   g_autoptr(GVariant) compositor_apps = NULL;
 
@@ -225,7 +225,6 @@ enumerate_instances (Column *columns, GError **error)
     }
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-remote-list.c
+++ b/app/flatpak-builtins-remote-list.c
@@ -64,7 +64,7 @@ static Column all_columns[] = {
 static gboolean
 list_remotes (GPtrArray *dirs, Column *columns, GCancellable *cancellable, GError **error)
 {
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   int i, j, k;
 
   if (columns[0].name == NULL)
@@ -212,7 +212,6 @@ list_remotes (GPtrArray *dirs, Column *columns, GCancellable *cancellable, GErro
     }
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -120,7 +120,7 @@ strip_last_element (const char *id,
 static gboolean
 ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, Column *columns, GCancellable *cancellable, GError **error)
 {
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   guint n_keys;
   g_autofree FlatpakDecomposed **keys = NULL;
   int i, j;
@@ -377,8 +377,6 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
       flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
       g_print ("\n");
     }
-
-  flatpak_table_printer_free (printer);
 
   return TRUE;
 }

--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -327,7 +327,7 @@ print_branches (OstreeRepo *repo,
                 GVariant   *index,
                 GVariant   *summary)
 {
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
 
   printer = flatpak_table_printer_new ();
   flatpak_table_printer_set_column_title (printer, 0, _("Ref"));
@@ -377,14 +377,13 @@ print_branches (OstreeRepo *repo,
   flatpak_table_printer_sort (printer, (GCompareFunc) strcmp);
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 }
 
 static void
 print_subsets (OstreeRepo *repo,
                GVariant   *index)
 {
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
 
   printer = flatpak_table_printer_new ();
   flatpak_table_printer_set_column_title (printer, 0, _("Subset"));
@@ -427,7 +426,6 @@ print_subsets (OstreeRepo *repo,
     }
 
   flatpak_table_printer_print (printer);
-  flatpak_table_printer_free (printer);
 }
 
 

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -245,7 +245,7 @@ print_app (Column *columns, MatchResult *res, FlatpakTablePrinter *printer)
 static void
 print_matches (Column *columns, GSList *matches)
 {
-  FlatpakTablePrinter *printer = NULL;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   int rows, cols;
   GSList *s;
 
@@ -262,8 +262,6 @@ print_matches (Column *columns, GSList *matches)
   flatpak_get_window_size (&rows, &cols);
   flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
   g_print ("\n");
-
-  flatpak_table_printer_free (printer);
 }
 
 gboolean

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -931,7 +931,7 @@ print_permissions (FlatpakCliTransaction *self,
   g_autoptr(GPtrArray) system_bus_talk = g_ptr_array_new_with_free_func (g_free);
   g_autoptr(GPtrArray) system_bus_own = g_ptr_array_new_with_free_func (g_free);
   g_autoptr(GPtrArray) tags = g_ptr_array_new_with_free_func (g_free);
-  FlatpakTablePrinter *printer;
+  g_autoptr(FlatpakTablePrinter) printer = NULL;
   int max_permission_width;
   int n_permission_cols;
   int i, j;
@@ -1014,7 +1014,6 @@ print_permissions (FlatpakCliTransaction *self,
     flatpak_table_printer_set_column_expand (printer, i, TRUE);
 
   flatpak_table_printer_print_full (printer, 0, cols, &table_rows, &table_cols);
-  flatpak_table_printer_free (printer);
 
   g_print ("\n\n");
 

--- a/app/flatpak-table-printer.h
+++ b/app/flatpak-table-printer.h
@@ -97,4 +97,6 @@ void               flatpak_table_printer_set_column_skip_unique (FlatpakTablePri
                                                                  int                  column,
                                                                  gboolean             skip_unique);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakTablePrinter, flatpak_table_printer_free)
+
 #endif /* __FLATPAK_TABLE_PRINTER_H__ */


### PR DESCRIPTION
Fixes: https://github.com/flatpak/flatpak/issues/4223  
Fixes: https://github.com/flatpak/flatpak/issues/4224

---

@setharnold, you can probably ignore any memory leaks where a FlatpakTablePrinter is leaked: this should fix all of them, and in any case I think they're all in contexts where O(1) bytes get leaked by a non-long-running process.