### PR TITLE
revokefs: Use the right variable name in an error message

### DIFF
--- a/revokefs/writer.c
+++ b/revokefs/writer.c
@@ -876,7 +876,7 @@ do_writer (int basefd_arg,
 
       if (response_data_size < 0 || response_data_size > MAX_DATA_SIZE)
         {
-          g_printerr ("Invalid response size %ld", response_size);
+          g_printerr ("Invalid response size %ld", response_data_size);
           exit (1);
         }
 


### PR DESCRIPTION
scan-build detected that response_size is uninitialized here, presumably
a typo for response_data_size.