### PR TITLE
oci-registry: Fix error reporting

### DIFF
--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -2829,7 +2829,7 @@ load_oci_index (GFile        *index,
   if (json == NULL)
     return NULL;
 
-  if (!g_input_stream_close (G_INPUT_STREAM (in), cancellable, error))
+  if (!g_input_stream_close (G_INPUT_STREAM (in), cancellable, &local_error))
     g_warning ("Error closing http stream: %s", local_error->message);
 
   return (FlatpakOciIndexResponse *) g_steal_pointer (&json);


### PR DESCRIPTION
The intention here seems to have been that failing to close the http
stream provokes a warning but does not make the function fail, but we
were setting the wrong error, resulting in a NULL dereference if closing
the http stream somehow fails.