### PR TITLE
Fix cosmetic issues detected by scan-build

### DIFF
--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -89,6 +89,8 @@ flatpak_builtin_enter (int           argc,
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   rest_argc = 0;
+  rest_argv_start = 0;
+
   for (i = 1; i < argc; i++)
     {
       /* The non-option is the command, take it out of the arguments */
@@ -109,6 +111,9 @@ flatpak_builtin_enter (int           argc,
       usage_error (context, _("INSTANCE and COMMAND must be specified"), error);
       return FALSE;
     }
+
+  /* If this wasn't true, rest_argc would still be 0 */
+  g_assert (rest_argv_start >= 1);
 
   pid_s = argv[rest_argv_start];
   pid = atoi (pid_s);

--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -290,7 +290,6 @@ flatpak_builtin_repair (int argc, char **argv, GCancellable *cancellable, GError
   g_autoptr(GPtrArray) refs = NULL;
   FlatpakDir *dir = NULL;
   g_autoptr(GHashTable) all_refs = NULL;
-  g_autoptr(GHashTable) invalid_refs = NULL;
   g_autoptr(GHashTable) object_status_cache = NULL;
   g_autoptr(FlatpakTransaction) transaction = NULL;
   OstreeRepo *repo;
@@ -342,8 +341,6 @@ flatpak_builtin_repair (int argc, char **argv, GCancellable *cancellable, GError
 
   object_status_cache = g_hash_table_new_full (ostree_hash_object_name, g_variant_equal,
                                                (GDestroyNotify) g_variant_unref, NULL);
-
-  invalid_refs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   /* Validate that the commit for each ref is available */
   if (!ostree_repo_list_refs (repo, NULL, &all_refs, cancellable, error))

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -60,12 +60,10 @@ get_remote_stores (GPtrArray *dirs, const char *arch, GCancellable *cancellable)
   for (i = 0; i < dirs->len; ++i)
     {
       FlatpakDir *dir = g_ptr_array_index (dirs, i);
-      g_autofree char *install_path = NULL;
       g_auto(GStrv) remotes = NULL;
 
       flatpak_log_dir_access (dir);
 
-      install_path = g_file_get_path (flatpak_dir_get_path (dir));
       remotes = flatpak_dir_list_enumerated_remotes (dir, cancellable, &error);
       if (error)
         {

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -630,12 +630,10 @@ get_appstream_timestamp (FlatpakDir *dir,
                          const char *arch)
 {
   g_autoptr(GFile) ts_file = NULL;
-  g_autofree char *ts_file_path = NULL;
   g_autofree char *subdir = NULL;
 
   subdir = g_strdup_printf ("appstream/%s/%s/.timestamp", remote, arch);
   ts_file = g_file_resolve_relative_path (flatpak_dir_get_path (dir), subdir);
-  ts_file_path = g_file_get_path (ts_file);
   return get_file_age (ts_file);
 }
 

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -260,17 +260,6 @@ flatpak_quiet_transaction_run (FlatpakTransaction *transaction,
 }
 
 static void
-flatpak_quiet_transaction_finalize (GObject *object)
-{
-  FlatpakQuietTransaction *self = FLATPAK_QUIET_TRANSACTION (object);
-  g_autoptr(FlatpakInstallation) installation = NULL;
-
-  installation = flatpak_transaction_get_installation (FLATPAK_TRANSACTION (self));
-
-  G_OBJECT_CLASS (flatpak_quiet_transaction_parent_class)->finalize (object);
-}
-
-static void
 flatpak_quiet_transaction_init (FlatpakQuietTransaction *transaction)
 {
 }
@@ -278,10 +267,8 @@ flatpak_quiet_transaction_init (FlatpakQuietTransaction *transaction)
 static void
 flatpak_quiet_transaction_class_init (FlatpakQuietTransactionClass *class)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (class);
   FlatpakTransactionClass *transaction_class = FLATPAK_TRANSACTION_CLASS (class);
 
-  object_class->finalize = flatpak_quiet_transaction_finalize;
   transaction_class->choose_remote_for_ref = choose_remote_for_ref;
   transaction_class->add_new_remote = add_new_remote;
   transaction_class->new_operation = new_operation;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5594,7 +5594,6 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
   g_autoptr(FlatpakOciRegistry) registry = NULL;
   g_autoptr(FlatpakOciVersioned) versioned = NULL;
   g_autoptr(FlatpakOciImage) image_config = NULL;
-  g_autofree char *full_ref = NULL;
   const char *oci_repository = NULL;
   const char *delta_url = NULL;
   g_autofree char *oci_digest = NULL;
@@ -5643,8 +5642,6 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
                                                          NULL, cancellable, error);
   if (image_config == NULL)
     return FALSE;
-
-  full_ref = g_strdup_printf ("%s:%s", state->remote_name, ref);
 
   if (repo == NULL)
     repo = self->repo;
@@ -6616,7 +6613,6 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
       if (g_file_info_get_file_type (child_info) == G_FILE_TYPE_REGULAR &&
           g_str_has_suffix (name, ".trigger"))
         {
-          g_autoptr(GPtrArray) argv_array = NULL;
           /* We need to canonicalize the basedir, because if has a symlink
              somewhere the bind mount will be on the target of that, not
              at that exact path. */
@@ -6629,7 +6625,6 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
 
           bwrap = flatpak_bwrap_new (NULL);
 
-          argv_array = g_ptr_array_new_with_free_func (g_free);
 #ifndef DISABLE_SANDBOXED_TRIGGERS
           flatpak_bwrap_add_arg (bwrap, flatpak_get_bwrap ());
           flatpak_bwrap_add_args (bwrap,
@@ -6853,14 +6848,12 @@ rewrite_mime_xml (xmlDoc *doc)
           xmlNode *sub_node = NULL;
           xmlNode *next_sub_node = NULL;
 
-          xml_autofree xmlChar *mimetype = NULL;
           if (mime_node->type != XML_ELEMENT_NODE)
             continue;
 
           if (strcmp ((char *) mime_node->name, "mime-type") != 0)
             return FALSE;
 
-          mimetype = xmlGetProp (mime_node, (xmlChar *) "type");
           for (sub_node = mime_node->children; sub_node; sub_node = next_sub_node)
             {
               next_sub_node = sub_node->next;
@@ -11077,7 +11070,6 @@ flatpak_dir_remote_make_oci_summary (FlatpakDir   *self,
   g_autoptr(GFile) index_cache = NULL;
   g_autofree char *index_uri = NULL;
   g_autoptr(GFile) summary_cache = NULL;
-  g_autofree char *self_name = NULL;
   g_autoptr(GError) local_error = NULL;
   g_autoptr(GMappedFile) mfile = NULL;
   g_autoptr(GBytes) cache_bytes = NULL;
@@ -11104,8 +11096,6 @@ flatpak_dir_remote_make_oci_summary (FlatpakDir   *self,
     }
   else
     {
-      self_name = flatpak_dir_get_name (self);
-
       index_cache = flatpak_dir_update_oci_index (self, remote, &index_uri, cancellable, error);
       if (index_cache == NULL)
         return FALSE;
@@ -12035,8 +12025,6 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
           const char *name = var_summary_index_subsummaries_entry_get_key (entry);
           VarSubsummaryRef subsummary = var_summary_index_subsummaries_entry_get_value (entry);
           gsize checksum_bytes_len;
-          const guchar *checksum_bytes;
-          g_autofree char *digest = NULL;
           const char *dash, *subsummary_arch;
 
           dash = strchr (name, '-');
@@ -12059,13 +12047,12 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
                 }
             }
 
-          checksum_bytes = var_subsummary_peek_checksum (subsummary, &checksum_bytes_len);
+          var_subsummary_peek_checksum (subsummary, &checksum_bytes_len);
           if (G_UNLIKELY (checksum_bytes_len != OSTREE_SHA256_DIGEST_LEN))
             {
               g_debug ("Invalid checksum for digested summary, not using cache");
               continue;
             }
-          digest = ostree_checksum_from_bytes (checksum_bytes);
 
           g_hash_table_insert (state->index_ht, g_strdup (subsummary_arch), var_subsummary_to_owned_gvariant (subsummary, state->index));
         }

--- a/common/flatpak-ref-utils.c
+++ b/common/flatpak-ref-utils.c
@@ -232,7 +232,7 @@ flatpak_name_matches_one_wildcard_prefix (const char         *name,
     {
       const char *prefix = *iter;
       gsize prefix_len = strlen (prefix);
-      gsize match_len = strlen (prefix);
+      gsize match_len;
       gboolean has_wildcard = FALSE;
       const char *end_of_match;
 

--- a/tests/test-instance.c
+++ b/tests/test-instance.c
@@ -176,6 +176,8 @@ test_gc (void)
   /* Wait for the child to be ready */
   bytes = glnx_fd_readall_bytes (stdout_fd, NULL, &error);
   g_assert_no_error (error);
+  g_assert_nonnull (bytes);
+  g_assert_cmpuint (g_bytes_get_size (bytes), ==, 0);
 
   /* Pretend the locks were created in early 1970, to bypass the workaround
    * for a race */

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1349,6 +1349,7 @@ test_parse_datetime (void)
   g_assert_true (ts.tv_sec == now.tv_sec); // close enough
 
   ret = parse_datetime (&ts, "2018-10-29 00:19:07 +0000", NULL);
+  g_assert_true (ret);
   dt = g_date_time_new_utc (2018, 10, 29, 0, 19, 7);
   g_date_time_to_timeval (dt, &tv);
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1927,14 +1927,10 @@ test_list_updates (void)
   FlatpakInstalledRef *update_ref = NULL;
   g_autoptr(FlatpakInstalledRef) updated_ref = NULL;
   g_autofree gchar *app = NULL;
-  g_autofree gchar *runtime = NULL;
   gboolean res;
 
   app = g_strdup_printf ("app/org.test.Hello/%s/master",
                          flatpak_get_default_arch ());
-
-  runtime = g_strdup_printf ("runtime/org.test.Platform/%s/master",
-                             flatpak_get_default_arch ());
 
   inst = flatpak_installation_new_user (NULL, &error);
   g_assert_no_error (error);

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -4035,7 +4035,7 @@ test_overrides (void)
 
   res = flatpak_installation_launch (inst, "org.test.Hello", NULL, "master", NULL, NULL, &error);
   g_assert_no_error (error);
-  g_assert_nonnull (ref);
+  g_assert_true (res);
 
   data = flatpak_installation_load_app_overrides (inst, "org.test.Hello", NULL, &error);
   g_assert_no_error (error);


### PR DESCRIPTION
scan-build has a lot of false positives for this codebase because it doesn't understand [`__attribute__((__cleanup__))`](https://bugs.llvm.org/show_bug.cgi?id=3888) or GLib's GError conventions, so we can't make Flatpak fully scan-build-clean or blindly believe what scan-build says - but some of the things it reports are meaningful.

For issues that can actually matter, I've opened separate MRs #4226, #4227, #4228 and #4229. This lower-priority MR collects changes that don't have any actual effect, mostly removal of dead code.

Any commit here can be cherry-picked if there's some problem that prevents merging the whole branch.

---

* Fix various unused variables detected by scan-build
    
    scan-build has a lot of false positives for this codebase because it
    doesn't understand __attribute__((__cleanup__)) or GLib's GError
    convention, but it seems to have been right about these.

* quiet-transaction: Remove unnecessary finalize
    
    This hasn't done anything useful since 0978826c: it just takes a
    new ref to the installation, and then releases that ref without doing
    anything with it. Detected by scan-build.

* ref-utils: Remove dead store
    
    We always set match_len before using it, discarding the result of this
    assignment. Detected by scan-build.

* testlibrary: Fix an assertion
    
    scan-build detected that res was written but never read. Presumably
    the use of ref here (carried over from the previous test) is a
    copy/paste error.

* testcommon: Assert that parse_datetime succeeds
    
    scan-build detected that ret was written but never read.

* portal: Make it clearer that BwrapinfoWatcherData is freed exactly once
    
    scan-build reported a memory leak here. It was a false positive
    because scan-build doesn't understand __attribute__((__cleanup__)), but
    it did prompt me to check whether we were doing this correctly.
    
    The data is in fact destroyed exactly once (ownership passes from
    instance_id_read_finish to check_child_pid_status, and if we re-queue
    the timeout, from check_child_pid_status to the future
    check_child_pid_status) but that wasn't completely obvious. Now,
    hopefully it is.

* enter: Make it clearer that rest_argv_start always gets initialized
    
    scan-build complained that rest_argv_start could be used uninitialized,
    because it can't see that rest_argc >= 2 implies that rest_argv_start
    got initialized at the same time rest_argc was set. Make this easier
    to understand.