### PR TITLE
flatpak_dir_find_local_related_for_metadata: Skip invalid branch

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -15121,6 +15121,9 @@ flatpak_dir_find_local_related_for_metadata (FlatpakDir        *self,
 
               extension_ref = flatpak_decomposed_new_from_parts (FLATPAK_KINDS_RUNTIME,
                                                                  extension, ref_arch, branch, NULL);
+              if (extension_ref == NULL)
+                continue;
+
               if (remote_name != NULL &&
                   flatpak_repo_resolve_rev (self->repo,
                                             NULL,


### PR DESCRIPTION
Fixes #4234


I tested this against the 1.10.2 tag and master branch with my test case.

Let me know if you have questions or I need to do anything else.
I can also submit a PR for the 1.10.x branch if you want (in addition or instead)