### PR TITLE
Add FLATPAK_QUERY_FLAGS_ALL_ARCHES for list_remote_refs()

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -513,12 +513,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
           g_autoptr(FlatpakRemoteState) state = NULL;
 
           state = flatpak_transaction_ensure_remote_state (transaction, FLATPAK_TRANSACTION_OPERATION_INSTALL,
-                                                           remote, error);
+                                                           remote, arch, error);
           if (state == NULL)
-            return FALSE;
-
-          if (arch != NULL &&
-              !flatpak_remote_state_ensure_subsummary (state, dir, arch, FALSE, cancellable, error))
             return FALSE;
 
           refs = flatpak_dir_find_remote_refs (dir, state, id, branch, default_branch, arch,

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -198,6 +198,12 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
       g_autoptr(GError) local_error2 = NULL;
       g_autoptr(GPtrArray) ref_dir_pairs = NULL;
       RefDirPair *chosen_pair = NULL;
+      const char *runtime_arch = arch;
+
+      /* If arch is not specified, only run the default arch to avoid asking for prompts for non-primary arches,
+         still asks for prompts if there are multiple branches though */
+      if (runtime_arch == NULL)
+        runtime_arch = flatpak_get_arch ();
 
       /* Whereas for apps we want to default to using the "current" one (see
        * flatpak-make-current(1)) runtimes don't have a concept of currentness.
@@ -208,7 +214,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
           FlatpakDir *dir = g_ptr_array_index (dirs, i);
           g_autoptr(GPtrArray) refs = NULL;
 
-          refs = flatpak_dir_find_installed_refs (dir, id, branch, arch, FLATPAK_KINDS_RUNTIME,
+          refs = flatpak_dir_find_installed_refs (dir, id, branch, runtime_arch, FLATPAK_KINDS_RUNTIME,
                                                   FIND_MATCHING_REFS_FLAGS_NONE, error);
           if (refs == NULL)
             return FALSE;

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1125,7 +1125,10 @@ transaction_ready_pre_auth (FlatpakTransaction *transaction)
 
   flatpak_table_printer_set_column_expand (printer, i, TRUE);
   if (!self->non_default_arch)
-    flatpak_table_printer_set_column_skip_unique (printer, i, TRUE);
+    {
+      flatpak_table_printer_set_column_skip_unique (printer, i, TRUE);
+      flatpak_table_printer_set_column_skip_unique_string (printer, i, flatpak_get_arch ());
+    }
   flatpak_table_printer_set_column_title (printer, i++, _("Arch"));
 
   flatpak_table_printer_set_column_expand (printer, i, TRUE);

--- a/app/flatpak-table-printer.h
+++ b/app/flatpak-table-printer.h
@@ -96,6 +96,10 @@ void               flatpak_table_printer_set_column_ellipsize (FlatpakTablePrint
 void               flatpak_table_printer_set_column_skip_unique (FlatpakTablePrinter *printer,
                                                                  int                  column,
                                                                  gboolean             skip_unique);
+void               flatpak_table_printer_set_column_skip_unique_string (FlatpakTablePrinter *printer,
+                                                                        int                  column,
+                                                                        const char          *str);
+
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakTablePrinter, flatpak_table_printer_free)
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -155,6 +155,11 @@ gboolean flatpak_remote_state_ensure_subsummary (FlatpakRemoteState *self,
                                                  gboolean            only_cached,
                                                  GCancellable       *cancellable,
                                                  GError            **error);
+gboolean flatpak_remote_state_ensure_subsummary_all_arches (FlatpakRemoteState *self,
+                                                            FlatpakDir         *dir,
+                                                            gboolean            only_cached,
+                                                            GCancellable       *cancellable,
+                                                            GError            **error);
 gboolean flatpak_remote_state_allow_ref (FlatpakRemoteState *self,
                                          const char *ref);
 gboolean flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,

--- a/common/flatpak-installation.h
+++ b/common/flatpak-installation.h
@@ -131,6 +131,7 @@ typedef enum {
  * lot more efficient if you're doing many requests.
  * @FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED: Only list refs available from sideload
  * repos; see flatpak(1). (Snce: 1.7)
+ * @FLATPAK_QUERY_FLAGS_ALL_ARCHES: Include refs from all arches, not just the primary ones. (Snce: 1.11.2)
  *
  * Flags to alter the behavior of e.g flatpak_installation_list_remote_refs_sync_full().
  *
@@ -140,6 +141,7 @@ typedef enum {
   FLATPAK_QUERY_FLAGS_NONE        = 0,
   FLATPAK_QUERY_FLAGS_ONLY_CACHED = (1 << 0),
   FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED = (1 << 1),
+  FLATPAK_QUERY_FLAGS_ALL_ARCHES = (1 << 2),
 } FlatpakQueryFlags;
 
 /**

--- a/common/flatpak-transaction-private.h
+++ b/common/flatpak-transaction-private.h
@@ -27,6 +27,7 @@
 FlatpakRemoteState *flatpak_transaction_ensure_remote_state (FlatpakTransaction             *self,
                                                              FlatpakTransactionOperationType kind,
                                                              const char                     *remote,
+                                                             const char                     *opt_arch,
                                                              GError                        **error);
 
 FlatpakDecomposed * flatpak_transaction_operation_get_decomposed (FlatpakTransactionOperation *self);


### PR DESCRIPTION
This allows flatpak_installation_list_remote_refs_sync_full() to list
refs for all arches on remotes that use the new subsummary format.

Fixess #4252