### PR TITLE
dir: Avoid a crash when looking up summary for a ref without an arch

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -595,7 +595,7 @@ get_summary_for_ref (FlatpakRemoteState *self,
       if (arch != NULL)
         summary = g_hash_table_lookup (self->subsummaries, arch);
 
-      if (summary == NULL)
+      if (summary == NULL && arch != NULL)
         {
           const char *non_compat_arch = flatpak_get_compat_arch_reverse (arch);
 


### PR DESCRIPTION
If looking up the summary for a ref without an arch (for example,
`ostree-metadata`, which the Endless OS version of flatpak uses in some
backwards-compatibility code), avoid passing `NULL` to `strcmp()` and
hence crashing.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>