### PR TITLE
Make better use of G_GNUC_PRINTF

### DIFF
--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -36,10 +36,7 @@ flatpak_completion_debug (const gchar *format, ...)
   static FILE *f = NULL;
 
   va_start (var_args, format);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   s = g_strdup_vprintf (format, var_args);
-#pragma GCC diagnostic pop
   if (f == NULL)
     f = fopen ("/tmp/flatpak-completion-debug.txt", "a+");
   fprintf (f, "%s\n", s);

--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -632,7 +632,7 @@ flatpak_completion_new (const char *arg_line,
 
   flatpak_completion_debug ("completion_argv %i:", completion->original_argc);
   for (i = 0; i < completion->original_argc; i++)
-    flatpak_completion_debug (completion->original_argv[i]);
+    flatpak_completion_debug ("%s", completion->original_argv[i]);
 
   flatpak_completion_debug ("----");
 

--- a/app/flatpak-complete.h
+++ b/app/flatpak-complete.h
@@ -41,7 +41,7 @@ struct FlatpakCompletion
 };
 
 void flatpak_completion_debug (const gchar *format,
-                               ...);
+                               ...) G_GNUC_PRINTF (1, 2);
 
 FlatpakCompletion *flatpak_completion_new (const char *arg_line,
                                            const char *arg_point,

--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -274,12 +274,9 @@ flatpak_table_printer_append_with_comma_printf (FlatpakTablePrinter *printer,
   va_list var_args;
   g_autofree char *s = NULL;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   va_start (var_args, format);
   s = g_strdup_vprintf (format, var_args);
   va_end (var_args);
-#pragma GCC diagnostic pop
 
   flatpak_table_printer_append_with_comma (printer, s);
 }

--- a/app/flatpak-table-printer.h
+++ b/app/flatpak-table-printer.h
@@ -53,7 +53,7 @@ void                flatpak_table_printer_append_with_comma (FlatpakTablePrinter
                                                              const char          *text);
 void                flatpak_table_printer_append_with_comma_printf (FlatpakTablePrinter *printer,
                                                                     const char          *format,
-                                                                    ...);
+                                                                    ...) G_GNUC_PRINTF (2, 3);
 void                flatpak_table_printer_set_key (FlatpakTablePrinter *printer,
                                                    const char          *key);
 void                flatpak_table_printer_finish_row (FlatpakTablePrinter *printer);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -179,7 +179,7 @@ static void flatpak_dir_log (FlatpakDir *self,
                              const char *old_commit,
                              const char *url,
                              const char *format,
-                             ...);
+                             ...) G_GNUC_PRINTF (12, 13);
 
 #define flatpak_dir_log(self, change, remote, ref, commit, old_commit, url, format, ...) \
   (flatpak_dir_log) (self, __FILE__, __LINE__, __FUNCTION__, \
@@ -15689,11 +15689,7 @@ static void
   len = g_snprintf (message, sizeof (message), "%s: ", installation);
 
   va_start (args, format);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   g_vsnprintf (message + len, sizeof (message) - len, format, args);
-#pragma GCC diagnostic pop
-
   va_end (args);
 
   /* See systemd.journal-fields(7) for the meaning of the

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -122,14 +122,11 @@ flatpak_debug2 (const char *format, ...)
 {
   va_list var_args;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   va_start (var_args, format);
   g_logv (G_LOG_DOMAIN "2",
           G_LOG_LEVEL_DEBUG,
           format, var_args);
   va_end (var_args);
-#pragma GCC diagnostic pop
 }
 
 gboolean
@@ -7345,12 +7342,9 @@ flatpak_prompt (gboolean allow_empty,
   g_autofree char *s = NULL;
 
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   va_start (var_args, prompt);
   s = g_strdup_vprintf (prompt, var_args);
   va_end (var_args);
-#pragma GCC diagnostic pop
 
   while (TRUE)
     {
@@ -7381,12 +7375,9 @@ flatpak_password_prompt (const char *prompt, ...)
   gboolean was_echo;
 
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   va_start (var_args, prompt);
   s = g_strdup_vprintf (prompt, var_args);
   va_end (var_args);
-#pragma GCC diagnostic pop
 
   while (TRUE)
     {
@@ -7419,12 +7410,9 @@ flatpak_yes_no_prompt (gboolean default_yes, const char *prompt, ...)
   g_autofree char *s = NULL;
 
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   va_start (var_args, prompt);
   s = g_strdup_vprintf (prompt, var_args);
   va_end (var_args);
-#pragma GCC diagnostic pop
 
   while (TRUE)
     {


### PR DESCRIPTION
* completion: Always pass a format string to flatpak_completion_debug
    
    In principle this could have been subject to a format string attack
    via an argument containing %n, although in practice the code that uses
    this format string is #if 0.

* Add missing G_GNUC_PRINTF attributes
    
    This allows callers to be checked for mismatches between format string
    and arguments, and also means gcc can assume that the format string and
    the arguments match up correctly when forwarding them to functions
    like g_strdup_vprintf, removing the need to suppress -Wformat-nonliteral
    warnings.

* Don't disable -Wformat-nonliteral unnecessarily
    
    These functions were already annotated with G_GNUC_PRINTF, so gcc
    can assume that the format string and arguments match up.

---

Noticed while looking into unrelated issue #4286.