### PR TITLE
portal: Fix --env-fd regressions

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -150,6 +150,14 @@ void flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
                                               const char      *xdg_dirs_conf,
                                               gboolean         home_access);
 
+gboolean flatpak_context_parse_env_block (FlatpakContext *context,
+                                          const char *data,
+                                          gsize length,
+                                          GError **error);
+gboolean flatpak_context_parse_env_fd (FlatpakContext *context,
+                                       int fd,
+                                       GError **error);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakContext, flatpak_context_free)
 
 #endif /* __FLATPAK_CONTEXT_H__ */

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1120,30 +1120,14 @@ option_env_cb (const gchar *option_name,
   return TRUE;
 }
 
-static gboolean
-option_env_fd_cb (const gchar *option_name,
-                  const gchar *value,
-                  gpointer     data,
-                  GError     **error)
+gboolean
+flatpak_context_parse_env_block (FlatpakContext *context,
+                                 const char *data,
+                                 gsize length,
+                                 GError **error)
 {
-  FlatpakContext *context = data;
-  g_autoptr(GBytes) env_block = NULL;
-  gsize remaining;
-  const char *p;
-  guint64 fd;
-  gchar *endptr;
-
-  fd = g_ascii_strtoull (value, &endptr, 10);
-
-  if (endptr == NULL || *endptr != '\0' || fd > G_MAXINT)
-    return glnx_throw (error, "Not a valid file descriptor: %s", value);
-
-  env_block = glnx_fd_readall_bytes ((int) fd, NULL, error);
-
-  if (env_block == NULL)
-    return FALSE;
-
-  p = g_bytes_get_data (env_block, &remaining);
+  const char *p = data;
+  gsize remaining = length;
 
   /* env_block might not be \0-terminated */
   while (remaining > 0)
@@ -1175,10 +1159,49 @@ option_env_fd_cb (const gchar *option_name,
         }
     }
 
+  return TRUE;
+}
+
+gboolean
+flatpak_context_parse_env_fd (FlatpakContext *context,
+                              int fd,
+                              GError **error)
+{
+  g_autoptr(GBytes) env_block = NULL;
+  const char *data;
+  gsize len;
+
+  env_block = glnx_fd_readall_bytes (fd, NULL, error);
+
+  if (env_block == NULL)
+    return FALSE;
+
+  data = g_bytes_get_data (env_block, &len);
+  return flatpak_context_parse_env_block (context, data, len, error);
+}
+
+static gboolean
+option_env_fd_cb (const gchar *option_name,
+                  const gchar *value,
+                  gpointer     data,
+                  GError     **error)
+{
+  FlatpakContext *context = data;
+  guint64 fd;
+  gchar *endptr;
+  gboolean ret;
+
+  fd = g_ascii_strtoull (value, &endptr, 10);
+
+  if (endptr == NULL || *endptr != '\0' || fd > G_MAXINT)
+    return glnx_throw (error, "Not a valid file descriptor: %s", value);
+
+  ret = flatpak_context_parse_env_fd (context, (int) fd, error);
+
   if (fd >= 3)
     close (fd);
 
-  return TRUE;
+  return ret;
 }
 
 static gboolean

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -793,6 +793,7 @@ handle_spawn (PortalFlatpak         *object,
   gboolean devel;
   gboolean empty_app;
   g_autoptr(GString) env_string = g_string_new ("");
+  glnx_autofd int env_fd = -1;
 
   child_setup_data.instance_id_fd = -1;
   child_setup_data.env_fd = -1;
@@ -1129,10 +1130,10 @@ handle_spawn (PortalFlatpak         *object,
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      child_setup_data.env_fd = glnx_steal_fd (&env_tmpf.fd);
+      env_fd = glnx_steal_fd (&env_tmpf.fd);
+      child_setup_data.env_fd = env_fd;
       g_ptr_array_add (flatpak_argv,
-                       g_strdup_printf ("--env-fd=%d",
-                                        child_setup_data.env_fd));
+                       g_strdup_printf ("--env-fd=%d", env_fd));
     }
 
   for (i = 0; unset_env != NULL && unset_env[i] != NULL; i++)

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1092,6 +1092,7 @@ handle_spawn (PortalFlatpak         *object,
 
   if (env_string->len > 0)
     {
+      FdMapEntry fd_map_entry;
       g_auto(GLnxTmpfile) env_tmpf  = { 0, };
 
       if (!flatpak_buffer_to_sealed_memfd_or_tmpfile (&env_tmpf, "environ",
@@ -1103,9 +1104,16 @@ handle_spawn (PortalFlatpak         *object,
         }
 
       env_fd = glnx_steal_fd (&env_tmpf.fd);
-      child_setup_data.env_fd = env_fd;
+
+      /* Use a fd that hasn't been used yet. We might have to reshuffle
+       * fd_map_entry.to, a bit later. */
+      fd_map_entry.from = env_fd;
+      fd_map_entry.to = ++max_fd;
+      fd_map_entry.final = fd_map_entry.to;
+      g_array_append_val (fd_map, fd_map_entry);
+
       g_ptr_array_add (flatpak_argv,
-                       g_strdup_printf ("--env-fd=%d", env_fd));
+                       g_strdup_printf ("--env-fd=%d", fd_map_entry.final));
     }
 
   for (i = 0; unset_env != NULL && unset_env[i] != NULL; i++)

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -253,7 +253,7 @@ typedef struct
 typedef struct
 {
   FdMapEntry *fd_map;
-  int         fd_map_len;
+  gsize       fd_map_len;
   int         instance_id_fd;
   gboolean    set_tty;
   int         tty;
@@ -479,7 +479,7 @@ child_setup_func (gpointer user_data)
   ChildSetupData *data = (ChildSetupData *) user_data;
   FdMapEntry *fd_map = data->fd_map;
   sigset_t set;
-  int i;
+  gsize i;
 
   flatpak_close_fds_workaround (3);
 
@@ -760,7 +760,7 @@ handle_spawn (PortalFlatpak         *object,
   gsize i, j, n_fds, n_envs;
   const gint *fds = NULL;
   gint fds_len = 0;
-  g_autofree FdMapEntry *fd_map = NULL;
+  g_autoptr(GArray) fd_map = NULL;
   g_auto(GStrv) env = NULL;
   gint32 max_fd;
   GKeyFile *app_info;
@@ -930,14 +930,13 @@ handle_spawn (PortalFlatpak         *object,
   n_fds = 0;
   if (fds != NULL)
     n_fds = g_variant_n_children (arg_fds);
-  fd_map = g_new0 (FdMapEntry, n_fds);
 
-  child_setup_data.fd_map = fd_map;
-  child_setup_data.fd_map_len = n_fds;
+  fd_map = g_array_sized_new (FALSE, FALSE, sizeof (FdMapEntry), n_fds);
 
   max_fd = -1;
   for (i = 0; i < n_fds; i++)
     {
+      FdMapEntry fd_map_entry;
       gint32 handle, dest_fd;
       int handle_fd;
 
@@ -954,9 +953,10 @@ handle_spawn (PortalFlatpak         *object,
 
       handle_fd = fds[handle];
 
-      fd_map[i].to = dest_fd;
-      fd_map[i].from = handle_fd;
-      fd_map[i].final = fd_map[i].to;
+      fd_map_entry.to = dest_fd;
+      fd_map_entry.from = handle_fd;
+      fd_map_entry.final = fd_map_entry.to;
+      g_array_append_val (fd_map, fd_map_entry);
 
       /* If stdin/out/err is a tty we try to set it as the controlling
          tty for the app, this way we can use this to run in a terminal. */
@@ -968,36 +968,8 @@ handle_spawn (PortalFlatpak         *object,
           child_setup_data.tty = handle_fd;
         }
 
-      max_fd = MAX (max_fd, fd_map[i].to);
-      max_fd = MAX (max_fd, fd_map[i].from);
-    }
-
-  /* We make a second pass over the fds to find if any "to" fd index
-     overlaps an already in use fd (i.e. one in the "from" category
-     that are allocated randomly). If a fd overlaps "to" fd then its
-     a caller issue and not our fault, so we ignore that. */
-  for (i = 0; i < n_fds; i++)
-    {
-      int to_fd = fd_map[i].to;
-      gboolean conflict = FALSE;
-
-      /* At this point we're fine with using "from" values for this
-         value (because we handle to==from in the code), or values
-         that are before "i" in the fd_map (because those will be
-         closed at this point when dup:ing). However, we can't
-         reuse a fd that is in "from" for j > i. */
-      for (j = i + 1; j < n_fds; j++)
-        {
-          int from_fd = fd_map[j].from;
-          if (from_fd == to_fd)
-            {
-              conflict = TRUE;
-              break;
-            }
-        }
-
-      if (conflict)
-        fd_map[i].to = ++max_fd;
+      max_fd = MAX (max_fd, fd_map_entry.to);
+      max_fd = MAX (max_fd, fd_map_entry.from);
     }
 
   /* TODO: Ideally we should let `flatpak run` inherit the portal's
@@ -1439,6 +1411,37 @@ handle_spawn (PortalFlatpak         *object,
 
       g_debug ("Starting: %s\n", cmd->str);
     }
+
+  /* We make a second pass over the fds to find if any "to" fd index
+     overlaps an already in use fd (i.e. one in the "from" category
+     that are allocated randomly). If a fd overlaps "to" fd then its
+     a caller issue and not our fault, so we ignore that. */
+  for (i = 0; i < fd_map->len; i++)
+    {
+      int to_fd = g_array_index (fd_map, FdMapEntry, i).to;
+      gboolean conflict = FALSE;
+
+      /* At this point we're fine with using "from" values for this
+         value (because we handle to==from in the code), or values
+         that are before "i" in the fd_map (because those will be
+         closed at this point when dup:ing). However, we can't
+         reuse a fd that is in "from" for j > i. */
+      for (j = i + 1; j < fd_map->len; j++)
+        {
+          int from_fd = g_array_index(fd_map, FdMapEntry, j).from;
+          if (from_fd == to_fd)
+            {
+              conflict = TRUE;
+              break;
+            }
+        }
+
+      if (conflict)
+        g_array_index (fd_map, FdMapEntry, i).to = ++max_fd;
+    }
+
+  child_setup_data.fd_map = &g_array_index (fd_map, FdMapEntry, 0);
+  child_setup_data.fd_map_len = fd_map->len;
 
   /* We use LEAVE_DESCRIPTORS_OPEN to work around dead-lock, see flatpak_close_fds_workaround */
   if (!g_spawn_async_with_pipes (NULL,

--- a/portal/flatpak-portal.h
+++ b/portal/flatpak-portal.h
@@ -36,6 +36,7 @@ typedef enum {
   FLATPAK_SPAWN_FLAGS_NOTIFY_START = 1 << 6,
   FLATPAK_SPAWN_FLAGS_SHARE_PIDS = 1 << 7,
   FLATPAK_SPAWN_FLAGS_EMPTY_APP = 1 << 8,
+  FLATPAK_SPAWN_FLAGS_NONE = 0
 } FlatpakSpawnFlags;
 
 typedef enum {
@@ -44,11 +45,13 @@ typedef enum {
   FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_GPU = 1 << 2,
   FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS = 1 << 3,
   FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y = 1 << 4,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_NONE = 0
 } FlatpakSpawnSandboxFlags;
 
 
 typedef enum {
   FLATPAK_SPAWN_SUPPORT_FLAGS_EXPOSE_PIDS = 1 << 0,
+  FLATPAK_SPAWN_SUPPORT_FLAGS_NONE = 0
 } FlatpakSpawnSupportFlags;
 
 /* The same flag is reused: this feature is available under the same

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -82,6 +82,10 @@ testcommon_LDADD = \
 	$(NULL)
 testcommon_SOURCES = tests/testcommon.c
 
+test_context_CFLAGS = $(testcommon_CFLAGS)
+test_context_LDADD = $(testcommon_LDADD) libtestlib.la
+test_context_SOURCES = tests/test-context.c
+
 test_exports_CFLAGS = $(testcommon_CFLAGS)
 test_exports_LDADD = $(testcommon_LDADD) libtestlib.la
 test_exports_SOURCES = tests/test-exports.c
@@ -281,6 +285,7 @@ dist_test_scripts = ${TEST_MATRIX_DIST}
 dist_installed_test_extra_scripts += ${TEST_MATRIX_EXTRA_DIST}
 
 test_programs = \
+	test-context \
 	test-exports \
 	test-instance \
 	testcommon \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -1,5 +1,6 @@
 AM_TESTS_ENVIRONMENT = FLATPAK_TESTS_DEBUG=1 \
 	FLATPAK_CONFIG_DIR=/dev/null \
+	FLATPAK_PORTAL=$$(cd $(top_builddir) && pwd)/flatpak-portal \
 	FLATPAK_TRIGGERSDIR=$$(cd $(top_srcdir) && pwd)/triggers \
 	FLATPAK_VALIDATE_ICON=$$(cd $(top_builddir) && pwd)/flatpak-validate-icon \
 	FLATPAK_REVOKEFS_FUSE=$$(cd $(top_builddir) && pwd)/revokefs-fuse \
@@ -65,6 +66,7 @@ testcommon_CFLAGS = \
 	$(JSON_CFLAGS) \
 	$(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
+	-DLIBEXECDIR=\"$(libexecdir)\" \
 	-I$(srcdir)/app \
 	-I$(builddir)/app \
 	$(NULL)
@@ -98,6 +100,14 @@ test_instance_SOURCES = \
 	tests/test-instance.c \
 	$(NULL)
 
+test_portal_CFLAGS = $(testcommon_CFLAGS)
+test_portal_LDADD = $(testcommon_LDADD) libtestlib.la
+test_portal_SOURCES = \
+	portal/flatpak-portal-dbus.c \
+	portal/flatpak-portal-dbus.h \
+	tests/test-portal.c \
+	$(NULL)
+
 tests_hold_lock_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
 tests_hold_lock_LDADD = $(AM_LDADD) $(BASE_LIBS) libglnx.la
 tests_hold_lock_SOURCES = tests/hold-lock.c
@@ -107,6 +117,10 @@ tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFL
 	-DLOCALEDIR=\"$(localedir)\"
 tests_httpcache_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) $(APPSTREAM_GLIB_LIBS) \
 	libflatpak-common.la libflatpak-common-base.la libglnx.la
+
+tests_mock_flatpak_CFLAGS = $(testcommon_CFLAGS)
+tests_mock_flatpak_LDADD = $(testcommon_LDADD) libtestlib.la
+tests_mock_flatpak_SOURCES = tests/mock-flatpak.c
 
 tests_test_update_portal_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) \
 	-DFLATPAK_COMPILATION \
@@ -288,6 +302,7 @@ test_programs = \
 	test-context \
 	test-exports \
 	test-instance \
+	test-portal \
 	testcommon \
 	testlibrary \
 	$(NULL)
@@ -296,6 +311,7 @@ test_extra_programs = \
 	tests/hold-lock \
 	tests/httpcache \
 	tests/list-unused \
+	tests/mock-flatpak \
 	tests/test-authenticator \
 	tests/test-portal-impl \
 	tests/test-update-portal \

--- a/tests/mock-flatpak.c
+++ b/tests/mock-flatpak.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018-2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "libglnx.h"
+
+#include <glib.h>
+#include <gio/gio.h>
+
+#include "flatpak-context-private.h"
+
+int
+main (int argc,
+      char **argv)
+{
+  int i;
+
+  g_debug ("This is a mock implementation of `flatpak run` for the portal");
+
+  for (i = 0; i < argc; i++)
+    g_print ("argv[%d] = %s\n", i, argv[i]);
+
+  for (i = 0; i < argc; i++)
+    {
+      if (g_str_has_prefix (argv[i], "--env-fd="))
+        {
+          g_autoptr(FlatpakContext) context = flatpak_context_new ();
+          const char *value = argv[i] + strlen ("--env-fd=");
+          g_autoptr(GError) error = NULL;
+          guint64 fd;
+          gchar *endptr;
+          GHashTableIter iter;
+          gpointer k, v;
+
+          fd = g_ascii_strtoull (value, &endptr, 10);
+
+          if (endptr == NULL || *endptr != '\0' || fd > G_MAXINT)
+            g_error ("Not a valid file descriptor: %s", value);
+
+          flatpak_context_parse_env_fd (context, (int) fd, &error);
+          g_assert_no_error (error);
+
+          g_hash_table_iter_init (&iter, context->env_vars);
+
+          while (g_hash_table_iter_next (&iter, &k, &v))
+            g_print ("env[%s] = %s\n", (const char *) k, (const char *) v);
+        }
+    }
+
+  for (i = 0; i < 256; i++)
+    {
+      struct stat stat_buf;
+
+      if (fstat (i, &stat_buf) < 0)
+        {
+          int saved_errno = errno;
+
+          g_assert_cmpint (saved_errno, ==, EBADF);
+        }
+      else
+        {
+          g_print ("fd[%d] = (dev=%" G_GUINT64_FORMAT " ino=%" G_GUINT64_FORMAT ")\n",
+                   i,
+                   (guint64) stat_buf.st_dev,
+                   (guint64) stat_buf.st_ino);
+        }
+    }
+
+  return 0;
+}

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <glib.h>
+#include "flatpak.h"
+#include "flatpak-context-private.h"
+
+#include "tests/testlib.h"
+
+static void
+test_context_env (void)
+{
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(GError) error = NULL;
+  gboolean ok;
+  const char env[] = "ONE=one\0TWO=two\0THREE=three\0EMPTY=\0X=x";
+
+  ok = flatpak_context_parse_env_block (context, env, sizeof (env), &error);
+  g_assert_no_error (error);
+  g_assert_true (ok);
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "ONE"), ==, "one");
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "EMPTY"), ==, "");
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "nope"), ==, NULL);
+
+  ok = flatpak_context_parse_env_block (context,
+                                        "FOO=barnstorming past the end",
+                                        strlen ("FOO=bar"),
+                                        &error);
+  g_assert_no_error (error);
+  g_assert_true (ok);
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "FOO"), ==, "bar");
+
+  ok = flatpak_context_parse_env_block (context,
+                                        "BAD=barnstorming past the end",
+                                        strlen ("BA"),
+                                        &error);
+  g_assert_nonnull (error);
+  g_test_message ("Got error as expected: %s #%d: %s",
+                  g_quark_to_string (error->domain), error->code,
+                  error->message);
+  g_assert_false (ok);
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "BA"), ==, NULL);
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "BAD"), ==, NULL);
+  g_clear_error (&error);
+
+  ok = flatpak_context_parse_env_block (context, "=x", strlen ("=x"), &error);
+  g_assert_nonnull (error);
+  g_test_message ("Got error as expected: %s #%d: %s",
+                  g_quark_to_string (error->domain), error->code,
+                  error->message);
+  g_assert_false (ok);
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, ""), ==, NULL);
+  g_clear_error (&error);
+
+  ok = flatpak_context_parse_env_block (context, "\0", 1, &error);
+  g_assert_nonnull (error);
+  g_test_message ("Got error as expected: %s #%d: %s",
+                  g_quark_to_string (error->domain), error->code,
+                  error->message);
+  g_assert_false (ok);
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, ""), ==, NULL);
+  g_clear_error (&error);
+
+  ok = flatpak_context_parse_env_block (context, "", 0, &error);
+  g_assert_no_error (error);
+  g_assert_true (ok);
+}
+
+static void
+test_context_env_fd (void)
+{
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(GError) error = NULL;
+  gboolean ok;
+  const char env[] = "ONE=one\0TWO=two\0THREE=three\0EMPTY=\0X=x";
+  glnx_autofd int fd = -1;
+  g_autofree char *path = NULL;
+  int bad_fd;
+
+  path = g_strdup_printf ("/tmp/flatpak-test.XXXXXX");
+  fd = g_mkstemp (path);
+  g_assert_no_errno (glnx_loop_write (fd, env, sizeof (env)));
+  g_assert_no_errno (lseek (fd, 0, SEEK_SET));
+
+  ok = flatpak_context_parse_env_fd (context, fd, &error);
+  g_assert_no_error (error);
+  g_assert_true (ok);
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "ONE"), ==, "one");
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "EMPTY"), ==, "");
+  g_assert_cmpstr (g_hash_table_lookup (context->env_vars, "nope"), ==, NULL);
+
+  bad_fd = fd;
+  glnx_close_fd (&fd);
+  ok = flatpak_context_parse_env_fd (context, bad_fd, &error);
+  g_assert_nonnull (error);
+  g_test_message ("Got error as expected: %s #%d: %s",
+                  g_quark_to_string (error->domain), error->code,
+                  error->message);
+  g_assert_false (ok);
+  g_clear_error (&error);
+}
+
+int
+main (int argc, char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/context/env", test_context_env);
+  g_test_add_func ("/context/env-fd", test_context_env_fd);
+
+  return g_test_run ();
+}

--- a/tests/test-portal.c
+++ b/tests/test-portal.c
@@ -1,0 +1,483 @@
+/*
+ * Copyright © 2018-2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "libglnx.h"
+
+#include <glib.h>
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+#include "portal/flatpak-portal.h"
+#include "portal/flatpak-portal-dbus.h"
+#include "testlib.h"
+
+typedef struct
+{
+  TestsDBusDaemon dbus_daemon;
+  GSubprocess *portal;
+  gchar *portal_path;
+  gchar *mock_flatpak;
+  PortalFlatpak *proxy;
+  GDBusConnection *conn;
+} Fixture;
+
+typedef struct
+{
+  int dummy;
+} Config;
+
+static void
+setup (Fixture *f,
+       gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+
+  tests_dbus_daemon_setup (&f->dbus_daemon);
+
+  f->portal_path = g_strdup (g_getenv ("FLATPAK_PORTAL"));
+
+  if (f->portal_path == NULL)
+    f->portal_path = g_strdup (LIBEXECDIR "/flatpak-portal");
+
+  f->mock_flatpak = g_test_build_filename (G_TEST_BUILT, "mock-flatpak", NULL);
+
+  f->conn = g_dbus_connection_new_for_address_sync (f->dbus_daemon.dbus_address,
+                                                    (G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT |
+                                                     G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION),
+                                                    NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->conn);
+}
+
+/* Don't corrupt TAP output if portal outputs on stdout */
+static void
+launcher_stdout_to_our_stderr (GSubprocessLauncher *launcher)
+{
+  glnx_autofd int stderr_copy = -1;
+
+  stderr_copy = dup (STDERR_FILENO);
+  g_assert_no_errno (stderr_copy);
+  g_assert_no_errno (fcntl (stderr_copy, F_SETFD, FD_CLOEXEC));
+  g_subprocess_launcher_take_stdout_fd (launcher, glnx_steal_fd (&stderr_copy));
+}
+
+static GSubprocessLauncher *
+fixture_make_launcher (Fixture *f)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_NONE);
+  launcher_stdout_to_our_stderr (launcher);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_daemon.dbus_address,
+                                TRUE);
+  g_subprocess_launcher_setenv (launcher,
+                                "FLATPAK_PORTAL_MOCK_FLATPAK",
+                                f->mock_flatpak,
+                                TRUE);
+
+  return g_steal_pointer (&launcher);
+}
+
+static void
+name_appeared_cb (GDBusConnection *conn,
+                  const char *name,
+                  const char *owner,
+                  gpointer user_data)
+{
+  gchar **name_owner_p = user_data;
+
+  g_clear_pointer (name_owner_p, g_free);
+  *name_owner_p = g_strdup (owner);
+}
+
+static void
+name_vanished_cb (GDBusConnection *conn,
+                  const char *name,
+                  gpointer user_data)
+{
+  gchar **name_owner_p = user_data;
+
+  g_clear_pointer (name_owner_p, g_free);
+  *name_owner_p = g_strdup ("");
+}
+
+static void
+name_owner_watch_removed_cb (gpointer user_data)
+{
+  gchar **name_owner_p = user_data;
+
+  g_clear_pointer (name_owner_p, g_free);
+}
+
+static void
+fixture_wait_for_name_to_be_owned (Fixture *f,
+                                   const char *name)
+{
+  g_autofree gchar *name_owner = NULL;
+  guint watch;
+
+  watch = g_bus_watch_name_on_connection (f->conn,
+                                          name,
+                                          G_BUS_NAME_WATCHER_FLAGS_NONE,
+                                          name_appeared_cb,
+                                          name_vanished_cb,
+                                          &name_owner,
+                                          name_owner_watch_removed_cb);
+
+  /* Wait for name to become owned */
+  while (name_owner == NULL || name_owner[0] == '\0')
+    g_main_context_iteration (NULL, TRUE);
+
+  g_bus_unwatch_name (watch);
+
+  /* Wait for watch to be cleaned up */
+  while (name_owner != NULL)
+    g_main_context_iteration (NULL, TRUE);
+}
+
+static void
+fixture_start_portal (Fixture *f)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+
+  launcher = fixture_make_launcher (f);
+  f->portal = g_subprocess_launcher_spawn (launcher, &error,
+                                           f->portal_path,
+                                           NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->portal);
+
+  fixture_wait_for_name_to_be_owned (f, FLATPAK_PORTAL_BUS_NAME);
+
+  f->proxy = portal_flatpak_proxy_new_sync (f->conn,
+                                            G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                            FLATPAK_PORTAL_BUS_NAME,
+                                            FLATPAK_PORTAL_PATH,
+                                            NULL,
+                                            &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->proxy);
+}
+
+static void
+test_help (Fixture *f,
+           gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autofree gchar *stdout_buf;
+  g_autofree gchar *stderr_buf;
+  g_autoptr(GError) error = NULL;
+
+  /* Don't use fixture_make_launcher() here because we want to
+   * capture stdout */
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE |
+                                        G_SUBPROCESS_FLAGS_STDERR_PIPE);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_daemon.dbus_address,
+                                TRUE);
+
+  f->portal = g_subprocess_launcher_spawn (launcher, &error,
+                                           f->portal_path,
+                                           "--help",
+                                           NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->portal);
+
+  g_subprocess_communicate_utf8 (f->portal, NULL, NULL, &stdout_buf,
+                                 &stderr_buf, &error);
+  g_assert_nonnull (stdout_buf);
+  g_assert_nonnull (stderr_buf);
+  g_test_message ("flatpak-portal --help: %s", stdout_buf);
+  g_assert_true (strstr (stdout_buf, "--replace") != NULL);
+
+  g_subprocess_wait_check (f->portal, NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+count_successful_exit_cb (PortalFlatpak *proxy,
+                          guint pid,
+                          guint wait_status,
+                          gpointer user_data)
+{
+  gsize *times_exited_p = user_data;
+
+  g_debug ("Process %u exited with wait status %u", pid, wait_status);
+  g_assert_true (WIFEXITED (wait_status));
+  g_assert_cmpuint (WEXITSTATUS (wait_status), ==, 0);
+  (*times_exited_p) += 1;
+}
+
+static void
+test_basic (Fixture *f,
+            gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GUnixFDList) fds_out = NULL;
+  guint pid;
+  gboolean ok;
+  const char * const argv[] = { "hello", NULL };
+  gsize times_exited = 0;
+  gulong handler_id;
+
+  fixture_start_portal (f);
+
+  /* We can't easily tell whether EXPOSE_PIDS ought to be set or not */
+  g_assert_cmpuint ((portal_flatpak_get_supports (f->proxy) &
+                     (~FLATPAK_SPAWN_SUPPORT_FLAGS_EXPOSE_PIDS)), ==, 0);
+  g_assert_cmpuint (portal_flatpak_get_version (f->proxy), ==, 6);
+
+  handler_id = g_signal_connect (f->proxy, "spawn-exited",
+                                 G_CALLBACK (count_successful_exit_cb),
+                                 &times_exited);
+
+  ok = portal_flatpak_call_spawn_sync (f->proxy,
+                                       "/",           /* cwd */
+                                       argv,          /* argv */
+                                       g_variant_new ("a{uh}", NULL),
+                                       g_variant_new ("a{ss}", NULL),
+                                       FLATPAK_SPAWN_FLAGS_NONE,
+                                       g_variant_new ("a{sv}", NULL),
+                                       NULL,          /* fd list */
+                                       &pid,
+                                       &fds_out,
+                                       NULL,
+                                       &error);
+  g_assert_no_error (error);
+  g_assert_true (ok);
+  g_assert_cmpuint (pid, >, 1);
+
+  while (times_exited == 0)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_signal_handler_disconnect (f->proxy, handler_id);
+
+  if (fds_out != NULL)
+    g_assert_cmpint (g_unix_fd_list_get_length (fds_out), ==, 0);
+
+  g_subprocess_send_signal (f->portal, SIGTERM);
+  g_subprocess_wait (f->portal, NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+test_fd_passing (Fixture *f,
+                 gconstpointer context G_GNUC_UNUSED)
+{
+#define SOME_FDS 16
+  g_autoptr(GError) error = NULL;
+  char *tempfile_paths[SOME_FDS];
+  int tempfile_fds[SOME_FDS];
+  guint gap_size;
+  gsize times_exited = 0;
+  gulong handler_id;
+  gsize i;
+
+  fixture_start_portal (f);
+
+  handler_id = g_signal_connect (f->proxy, "spawn-exited",
+                                 G_CALLBACK (count_successful_exit_cb),
+                                 &times_exited);
+
+  for (i = 0; i < SOME_FDS; i++)
+    {
+      tempfile_paths[i] = g_strdup ("/tmp/flatpak-portal-test.XXXXXX");
+      tempfile_fds[i] = g_mkstemp (tempfile_paths[i]);
+      g_assert_no_errno (tempfile_fds[i]);
+    }
+
+  /* Using a non-contiguous block of fds can help to tickle bugs in the
+   * portal. */
+  for (gap_size = 0; gap_size < 128; gap_size += 16)
+    {
+      g_autoptr(GUnixFDList) fds_in = g_unix_fd_list_new ();
+      g_autoptr(GUnixFDList) fds_out = NULL;
+      g_auto(GVariantBuilder) fd_map_builder = {};
+      g_auto(GVariantBuilder) env_builder = {};
+      guint pid;
+      gboolean ok;
+      const char * const argv[] = { "hello", NULL };
+      g_autofree char *output = NULL;
+
+      g_variant_builder_init (&fd_map_builder, G_VARIANT_TYPE ("a{uh}"));
+      g_variant_builder_init (&env_builder, G_VARIANT_TYPE ("a{ss}"));
+      times_exited = 0;
+
+      g_variant_builder_add (&env_builder, "{ss}", "FOO", "bar");
+
+      for (i = 0; i < SOME_FDS; i++)
+        {
+          int handle = g_unix_fd_list_append (fds_in, tempfile_fds[i], &error);
+          guint32 desired_fd;
+
+          g_assert_no_error (error);
+          g_assert_cmpint (handle, >=, 0);
+
+          if (i <= STDERR_FILENO)
+            desired_fd = i;
+          else
+            desired_fd = i + gap_size;
+
+          g_variant_builder_add (&fd_map_builder, "{uh}",
+                                 desired_fd, (gint32) handle);
+        }
+
+      ok = portal_flatpak_call_spawn_sync (f->proxy,
+                                           "/",           /* cwd */
+                                           argv,          /* argv */
+                                           g_variant_builder_end (&fd_map_builder),
+                                           g_variant_builder_end (&env_builder),
+                                           FLATPAK_SPAWN_FLAGS_NONE,
+                                           g_variant_new ("a{sv}", NULL),
+                                           fds_in,
+                                           &pid,
+                                           &fds_out,
+                                           NULL,
+                                           &error);
+      g_assert_no_error (error);
+      g_assert_true (ok);
+      g_assert_cmpuint (pid, >, 1);
+
+      /* Wait for this one to exit */
+      while (times_exited == 0)
+        g_main_context_iteration (NULL, TRUE);
+
+      if (fds_out != NULL)
+        g_assert_cmpint (g_unix_fd_list_get_length (fds_out), ==, 0);
+
+      /* stdout from the portal should have ended up in temp file [1] */
+      g_assert_no_errno (lseek (tempfile_fds[1], 0, SEEK_SET));
+      output = glnx_fd_readall_utf8 (tempfile_fds[1], NULL, NULL, &error);
+      g_assert_no_error (error);
+      g_assert_nonnull (output);
+      g_assert_no_errno (lseek (tempfile_fds[1], 0, SEEK_SET));
+      g_assert_no_errno (ftruncate (tempfile_fds[1], 0));
+      g_test_message ("Output from mock Flatpak: %s", output);
+
+      if (strstr (output, "env[FOO] = bar") != NULL)
+        g_test_message ("Found env[FOO] = bar in output");
+      else
+        g_error ("env[FOO] = bar not found in \"%s\"", output);
+
+      for (i = 0; i < SOME_FDS; i++)
+        {
+          struct stat stat_buf;
+          g_autofree char *expected = NULL;
+          int desired_fd;
+
+          g_assert_no_errno (fstat (tempfile_fds[i], &stat_buf));
+
+          if (i <= STDERR_FILENO)
+            desired_fd = i;
+          else
+            desired_fd = i + gap_size;
+
+          expected = g_strdup_printf ("fd[%d] = (dev=%" G_GUINT64_FORMAT " ino=%" G_GUINT64_FORMAT ")",
+                                      desired_fd,
+                                      (guint64) stat_buf.st_dev,
+                                      (guint64) stat_buf.st_ino);
+
+          if (strstr (output, expected) != NULL)
+            g_test_message ("fd %d OK: \"%s\"", desired_fd, expected);
+          else
+            g_error ("\"%s\" not found in \"%s\"", expected, output);
+        }
+    }
+
+  g_signal_handler_disconnect (f->proxy, handler_id);
+
+  g_subprocess_send_signal (f->portal, SIGTERM);
+  g_subprocess_wait (f->portal, NULL, &error);
+  g_assert_no_error (error);
+
+  for (i = 0; i < SOME_FDS; i++)
+    {
+      g_assert_no_errno (unlink (tempfile_paths[i]));
+      glnx_close_fd (&tempfile_fds[i]);
+      g_free (tempfile_paths[i]);
+    }
+}
+
+static void
+test_replace (Fixture *f,
+              gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GSubprocess) gets_replaced = NULL;
+
+  /* Not using fixture_start_portal() here because we want to --replace */
+  launcher = fixture_make_launcher (f);
+  gets_replaced = g_subprocess_launcher_spawn (launcher, &error,
+                                               f->portal_path,
+                                               "--replace",
+                                               NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (gets_replaced);
+
+  fixture_wait_for_name_to_be_owned (f, FLATPAK_PORTAL_BUS_NAME);
+
+  g_clear_object (&launcher);
+  launcher = fixture_make_launcher (f);
+  f->portal = g_subprocess_launcher_spawn (launcher, &error,
+                                           f->portal_path,
+                                           "--replace",
+                                           NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->portal);
+
+  /* f->portal replaces gets_replaced, which exits 0 */
+  g_subprocess_wait_check (gets_replaced, NULL, &error);
+  g_assert_no_error (error);
+
+  g_subprocess_send_signal (f->portal, SIGTERM);
+  g_subprocess_wait (f->portal, NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+teardown (Fixture *f,
+          gconstpointer context G_GNUC_UNUSED)
+{
+  tests_dbus_daemon_teardown (&f->dbus_daemon);
+  g_clear_object (&f->portal);
+  g_free (f->portal_path);
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add ("/help", Fixture, NULL, setup, test_help, teardown);
+  g_test_add ("/basic", Fixture, NULL, setup, test_basic, teardown);
+  g_test_add ("/fd-passing", Fixture, NULL, setup, test_fd_passing, teardown);
+  g_test_add ("/replace", Fixture, NULL, setup, test_replace, teardown);
+
+  return g_test_run ();
+}

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2021 Collabora Ltd.
+ * Copyright © 2018-2021 Collabora Ltd.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -94,4 +94,148 @@ isolated_test_dir_global_teardown (void)
   glnx_shutil_rm_rf_at (-1, isolated_test_dir, NULL, NULL);
   g_free (isolated_test_dir);
   isolated_test_dir = NULL;
+}
+
+static void
+replace_tokens (const char *in_path,
+                const char *out_path)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GString) buffer = NULL;
+  g_autofree char *contents = NULL;
+  const char *iter;
+
+  g_file_get_contents (in_path, &contents, NULL, &error);
+  g_assert_no_error (error);
+
+  buffer = g_string_new ("");
+  iter = contents;
+
+  while (iter[0] != '\0')
+    {
+      const char *first_at = strchr (iter, '@');
+      const char *second_at;
+
+      if (first_at == NULL)
+        {
+          /* no more @token@s, append [iter..end] and stop */
+          g_string_append (buffer, iter);
+          break;
+        }
+
+      second_at = strchr (first_at + 1, '@');
+
+      if (second_at == NULL)
+        g_error ("Unterminated @token@ in %s: %s", in_path, first_at);
+
+      /* append the literal text [iter..first_at - 1], if non-empty */
+      if (first_at != iter)
+        g_string_append_len (buffer, iter, first_at - iter);
+
+      /* append the replacement for [first_at..second_at] if known */
+      if (g_str_has_prefix (first_at, "@testdir@"))
+        {
+          g_autofree char *testdir = g_test_build_filename (G_TEST_DIST, ".", NULL);
+
+          g_string_append (buffer, testdir);
+        }
+      else
+        {
+          g_error ("Unknown @token@ in %s: %.*s",
+                   in_path, (int) (second_at - first_at) + 1, first_at);
+        }
+
+      /* continue to process [second_at + 1..end] */
+      iter = second_at + 1;
+    }
+
+  g_file_set_contents (out_path, buffer->str, -1, &error);
+  g_assert_no_error (error);
+}
+
+void
+tests_dbus_daemon_setup (TestsDBusDaemon *self)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autofree char *config_arg = NULL;
+  g_autofree char *session_conf = NULL;
+  g_autofree char *session_conf_in = NULL;
+  GInputStream *address_pipe;
+  gchar address_buffer[4096] = { 0 };
+  char *newline;
+
+  g_return_if_fail (self != NULL);
+  g_return_if_fail (self->dbus_daemon == NULL);
+  g_return_if_fail (self->dbus_address == NULL);
+  g_return_if_fail (self->temp_dir == NULL);
+
+  self->temp_dir = g_dir_make_tmp ("flatpak-test.XXXXXX", &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (self->temp_dir);
+
+  session_conf_in = g_test_build_filename (G_TEST_DIST, "session.conf.in", NULL);
+  session_conf = g_build_filename (self->temp_dir, "test-bus.conf", NULL);
+  replace_tokens (session_conf_in, session_conf);
+  config_arg = g_strdup_printf ("--config-file=%s", session_conf);
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+  self->dbus_daemon = g_subprocess_launcher_spawn (launcher, &error,
+                                                   "dbus-daemon",
+                                                   config_arg,
+                                                   "--print-address=1",
+                                                   "--nofork",
+                                                   NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (self->dbus_daemon);
+
+  address_pipe = g_subprocess_get_stdout_pipe (self->dbus_daemon);
+  g_assert_nonnull (address_pipe);
+
+  /* Crash if it takes too long to get the address */
+  alarm (30);
+
+  while (strchr (address_buffer, '\n') == NULL)
+    {
+      if (strlen (address_buffer) >= sizeof (address_buffer) - 1)
+        g_error ("Read %" G_GSIZE_FORMAT " bytes from dbus-daemon with "
+                 "no newline",
+                 sizeof (address_buffer) - 1);
+
+      g_input_stream_read (address_pipe,
+                           address_buffer + strlen (address_buffer),
+                           sizeof (address_buffer) - strlen (address_buffer),
+                           NULL, &error);
+      g_assert_no_error (error);
+    }
+
+  /* Disable alarm */
+  alarm (0);
+
+  newline = strchr (address_buffer, '\n');
+  g_assert_nonnull (newline);
+  *newline = '\0';
+  self->dbus_address = g_strdup (address_buffer);
+}
+
+void
+tests_dbus_daemon_teardown (TestsDBusDaemon *self)
+{
+  g_autoptr(GError) error = NULL;
+
+  if (self->dbus_daemon != NULL)
+    {
+      g_subprocess_send_signal (self->dbus_daemon, SIGTERM);
+      g_subprocess_wait (self->dbus_daemon, NULL, &error);
+      g_assert_no_error (error);
+    }
+
+  if (self->temp_dir != NULL)
+    {
+      glnx_shutil_rm_rf_at (AT_FDCWD, self->temp_dir, NULL, &error);
+      g_assert_no_error (error);
+    }
+
+  g_clear_object (&self->dbus_daemon);
+  g_clear_pointer (&self->dbus_address, g_free);
+  g_clear_pointer (&self->temp_dir, g_free);
 }

--- a/tests/testlib.h
+++ b/tests/testlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2021 Collabora Ltd.
+ * Copyright © 2018-2021 Collabora Ltd.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,6 +19,7 @@
 #define TESTLIB_H
 
 #include <glib.h>
+#include <gio/gio.h>
 
 #ifndef g_assert_no_errno
 #define g_assert_no_errno(expr) \
@@ -30,5 +31,15 @@ char *assert_mkdtemp (char *tmpl);
 extern char *isolated_test_dir;
 void isolated_test_dir_global_setup (void);
 void isolated_test_dir_global_teardown (void);
+
+typedef struct
+{
+  GSubprocess *dbus_daemon;
+  gchar *dbus_address;
+  gchar *temp_dir;
+} TestsDBusDaemon;
+
+void tests_dbus_daemon_setup (TestsDBusDaemon *self);
+void tests_dbus_daemon_teardown (TestsDBusDaemon *self);
 
 #endif


### PR DESCRIPTION
* portal: Don't leak fd used for serialized environment
    
    Otherwise we'll run out of file descriptors eventually, when starting
    a sufficiently large number of subsandboxes.
    
    Resolves: flatpak/flatpak#4285  
    Fixes: aeb6a7ab "portal: Convert --env in extra-args into --env-fd"

* portal: Use a GArray to store fds
    
    This will allow us to add additional mapping entries for fds to be
    used internally by `flatpak run`, in particular --env-fd.
    
    Defer the second pass through the fd array until the last possible
    moment, so that any extra fds we want to add (like the --env-fd) have
    already been added by then.
    
    Helps: flatpak/flatpak#4286

* portal: Remap --env-fd into child process's fd space
    
    Just because we can allocate a new, unused fd in the portal's fd space,
    that doesn't mean that fd number is going to be unused in the child
    process's fd space: we might need to remap it.
    
    Resolves: flatpak/flatpak#4286
    Fixes: aeb6a7ab "portal: Convert --env in extra-args into --env-fd"

* context: Factor out functions to parse an environment block
    
    This makes them easier to test, and easier to use in related tests.

* tests: Test environment block parsing

* portal: Add NONE values for flags sets

* portal: Add some design-for-test
    
    During unit testing we don't have a complete Flatpak app or runtime
    available, and `flatpak run` is not necessarily in FLATPAK_BINDIR yet;
    but we can run the portal with this environment variable set, to
    specify a mock implementation of Flatpak.
    
    This helps to reproduce #4286.

* portal: Add some test coverage
    
    This exercises Spawn() and reproduces #4286.

---

The first 3 commits should also be applied to 1.10.x, 1.8.x and anything else that got aeb6a7ab backported to it.