### PR TITLE
docs: Switch from freenode to libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ desktop applications on Linux.
 
 See https://flatpak.org/ for more information.
 
-Community discussion happens in [#flatpak on Freenode](ircs://chat.freenode.net/flatpak), on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak), and on [the Flathub Discourse](https://discourse.flathub.org/).
+Community discussion happens in [#flatpak on libera.chat](ircs://irc.libera.chat/flatpak), on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak), and on [the Flathub Discourse](https://discourse.flathub.org/).
 
 Read documentation for Flatpak [here](https://docs.flatpak.org/en/latest/index.html).
 


### PR DESCRIPTION
It appears freenode is imploding.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>