### PR TITLE
transaction: Don’t abort on uninstall if deploy metadata is missing

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3158,6 +3158,11 @@ resolve_ops (FlatpakTransaction *self,
           /* We resolve to the deployed metadata, because we need it to uninstall related ops */
 
           metadata_bytes = load_deployed_metadata (self, op->ref, &checksum, NULL);
+          if (metadata_bytes == NULL)
+            {
+              op->skip = TRUE;
+              continue;
+            }
           mark_op_resolved (op, checksum, NULL, metadata_bytes, NULL);
           continue;
         }


### PR DESCRIPTION
If the deploy metadata is missing for the locale runtime of an app which
is being uninstalled, flatpak will currently abort on an assertion
failure.

Prevent that abort, at the expense of not uninstalling the locale
runtime. A better fix could be found for this in future.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: #3943