### PR TITLE
README: Update chat room link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ desktop applications on Linux.
 
 See https://flatpak.org/ for more information.
 
-Community discussion happens in [#flatpak on Freenode](ircs://chat.freenode.net/flatpak), on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak), and on [the Flathub Discourse](https://discourse.flathub.org/).
+Community discussion happens in [#flatpak:matrix.org](https://matrix.to/#flatpak:matrix.org), on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak), and on [the Flathub Discourse](https://discourse.flathub.org/).
 
 Read documentation for Flatpak [here](https://docs.flatpak.org/en/latest/index.html).
 


### PR DESCRIPTION
We've moved from Freenode to Matrix, see:
https://discourse.flathub.org/t/should-flathub-flatpak-move-to-another-communication-channel-if-so-where-and-why/1443
https://lists.freedesktop.org/archives/flatpak/2021-May/002127.html