### PR TITLE
CI: Add mono apt repo to fix build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:alexlarsson/flatpak
         sudo add-apt-repository ppa:alexlarsson/glib260
+        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
@@ -114,6 +115,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:alexlarsson/flatpak
         sudo add-apt-repository ppa:alexlarsson/glib260
+        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
@@ -141,6 +143,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo add-apt-repository ppa:alexlarsson/flatpak
+        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-xenial main' # Needed for updates to work
         sudo apt-get update
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
@@ -167,6 +170,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
+        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-focal main' # Needed for updates to work
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \


### PR DESCRIPTION
For whatever reason parts of mono is installed, but the repo is not
configured so there is a version conflict on update:

libglib2.0-cil is already the newest version (2.12.45-0xamarin19+ubuntu1604b1).
libglib2.0-cil set to manually installed.
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libglib2.0-cil-dev : Depends: libglib2.0-cil (= 2.12.10-6) but 2.12.45-0xamarin19+ubuntu1604b1 is to be installed
E: Unable to correct problems, you have held broken packages.