### PR TITLE
portal: Fix a typo in D-Bus API documentation

### DIFF
--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -138,10 +138,10 @@
              <listitem><para>
                Don't provide app files at <filename>/app</filename> in the
                new sandbox. Instead, <filename>/app</filename> will be an
-               empty directory. This flag and the <option>app-path</option>
+               empty directory. This flag and the <option>app-fd</option>
                option are mutually exclusive.
              </para><para>
-               As with the <option>app-path</option> option, the caller's
+               As with the <option>app-fd</option> option, the caller's
                Flatpak app files and extensions will be mounted on
                <filename>/run/parent/app</filename>, with
                filenames like <filename>/run/parent/app/bin/myapp</filename>.


### PR DESCRIPTION
The client-side proposed for flatpak-spawn (flatpak/flatpak-xdg-utils#39) uses `--app-path`, but the actual implementation on D-Bus uses file descriptor passing and an option named `app-fd`, so the documentation of the D-Bus interface should be written in terms of `app-fd`.

Fixes: 3ebf371f "run: Allow caller to replace /app and/or /usr"