### PR TITLE
flatpak-transaction: Fix finding runtime with non-default remote+arch

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2199,8 +2199,8 @@ search_for_dependency (FlatpakTransaction  *self,
       state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_INSTALL, remote, NULL, &local_error);
       if (state == NULL)
         {
-          g_debug ("Can't get state for remote %s: %s", remote, local_error->message);
-          return FALSE;
+          g_debug ("Can't get state for remote %s, ignoring: %s", remote, local_error->message);
+          continue;
         }
 
       if (flatpak_remote_state_lookup_ref (state, flatpak_decomposed_get_ref (runtime_ref), NULL, NULL, NULL, NULL, NULL))

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2189,6 +2189,7 @@ search_for_dependency (FlatpakTransaction  *self,
 {
   g_autoptr(GPtrArray) found = g_ptr_array_new_with_free_func (g_free);
   int i;
+  g_autofree char *arch = flatpak_decomposed_dup_arch (runtime_ref);
 
   for (i = 0; remotes != NULL && remotes[i] != NULL; i++)
     {
@@ -2196,7 +2197,7 @@ search_for_dependency (FlatpakTransaction  *self,
       g_autoptr(GError) local_error = NULL;
       g_autoptr(FlatpakRemoteState) state = NULL;
 
-      state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_INSTALL, remote, NULL, &local_error);
+      state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_INSTALL, remote, arch, &local_error);
       if (state == NULL)
         {
           g_debug ("Can't get state for remote %s, ignoring: %s", remote, local_error->message);


### PR DESCRIPTION
Fix an “The application foo requires the runtime bla which was not
found” error when using libflatpak (not the CLI) to install an
application whose runtime is provided by a different repo, and which is
for a non-default architecture.

This is a follow-up to commit f2ff664ff.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>