### PR TITLE
[1.10.x] Fix several memory leaks

### DIFF
--- a/app/flatpak-builtins-document-export.c
+++ b/app/flatpak-builtins-document-export.c
@@ -90,8 +90,8 @@ flatpak_builtin_document_export (int argc, char **argv,
   g_autofree char *dirname = NULL;
   g_autofree char *doc_path = NULL;
   XdpDbusDocuments *documents;
-  int fd, fd_id;
-  int i;
+  glnx_autofd int fd = -1;
+  int i, fd_id;
   GUnixFDList *fd_list = NULL;
   const char *doc_id;
   struct stat stbuf;
@@ -173,7 +173,7 @@ flatpak_builtin_document_export (int argc, char **argv,
 
   fd_list = g_unix_fd_list_new ();
   fd_id = g_unix_fd_list_append (fd_list, fd, error);
-  close (fd);
+  glnx_close_fd (&fd);
 
   if (opt_noexist)
     {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13671,14 +13671,15 @@ parse_ref_file (GKeyFile *keyfile,
   collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
                                          FLATPAK_REF_DEPLOY_COLLECTION_ID_KEY, NULL);
 
-  if (collection_id == NULL || *collection_id == '\0')
+  if (collection_id != NULL && *collection_id == '\0')
+    g_clear_pointer (&collection_id, g_free);
+  if (collection_id == NULL)
     {
       collection_id = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
                                              FLATPAK_REF_COLLECTION_ID_KEY, NULL);
     }
-
   if (collection_id != NULL && *collection_id == '\0')
-    collection_id = NULL;
+    g_clear_pointer (&collection_id, g_free);
 
   if (collection_id != NULL && gpg_data == NULL)
     return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Collection ID requires GPG key to be provided"));

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2285,6 +2285,7 @@ flatpak_parse_repofile (const char   *remote_name,
       decoded = g_base64_decode (gpg_key, &decoded_len);
       if (decoded_len < 10) /* Check some minimal size so we don't get crap */
         {
+          g_free (decoded);
           flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Invalid gpg key"));
           return NULL;
         }

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -759,7 +759,7 @@ handle_spawn (PortalFlatpak         *object,
   const gint *fds = NULL;
   gint fds_len = 0;
   g_autofree FdMapEntry *fd_map = NULL;
-  gchar **env;
+  g_auto(GStrv) env = NULL;
   gint32 max_fd;
   GKeyFile *app_info;
   g_autoptr(GPtrArray) flatpak_argv = g_ptr_array_new_with_free_func (g_free);


### PR DESCRIPTION
Cherry-picked from commit 404d7c6941baf63d1b3ccbe9ee9d34f3ff12f35f by @mwleeds, originally part of #4254.

Some (all?) of the other leak fixes in #4254 should probably go to 1.10, but fast-tracking this one avoids conflicts in a backport of #4283. It applies cleanly and I've checked that the changes are correct.