### PR TITLE
[1.10.x] Fix portal --env-fd regressions in 1.10.0

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -253,7 +253,7 @@ typedef struct
 typedef struct
 {
   FdMapEntry *fd_map;
-  int         fd_map_len;
+  gsize       fd_map_len;
   int         instance_id_fd;
   gboolean    set_tty;
   int         tty;
@@ -479,7 +479,7 @@ child_setup_func (gpointer user_data)
   ChildSetupData *data = (ChildSetupData *) user_data;
   FdMapEntry *fd_map = data->fd_map;
   sigset_t set;
-  int i;
+  gsize i;
 
   flatpak_close_fds_workaround (3);
 
@@ -758,7 +758,7 @@ handle_spawn (PortalFlatpak         *object,
   gsize i, j, n_fds, n_envs;
   const gint *fds = NULL;
   gint fds_len = 0;
-  g_autofree FdMapEntry *fd_map = NULL;
+  g_autoptr(GArray) fd_map = NULL;
   g_auto(GStrv) env = NULL;
   gint32 max_fd;
   GKeyFile *app_info;
@@ -923,14 +923,13 @@ handle_spawn (PortalFlatpak         *object,
   n_fds = 0;
   if (fds != NULL)
     n_fds = g_variant_n_children (arg_fds);
-  fd_map = g_new0 (FdMapEntry, n_fds);
 
-  child_setup_data.fd_map = fd_map;
-  child_setup_data.fd_map_len = n_fds;
+  fd_map = g_array_sized_new (FALSE, FALSE, sizeof (FdMapEntry), n_fds);
 
   max_fd = -1;
   for (i = 0; i < n_fds; i++)
     {
+      FdMapEntry fd_map_entry;
       gint32 handle, dest_fd;
       int handle_fd;
 
@@ -947,9 +946,10 @@ handle_spawn (PortalFlatpak         *object,
 
       handle_fd = fds[handle];
 
-      fd_map[i].to = dest_fd;
-      fd_map[i].from = handle_fd;
-      fd_map[i].final = fd_map[i].to;
+      fd_map_entry.to = dest_fd;
+      fd_map_entry.from = handle_fd;
+      fd_map_entry.final = fd_map_entry.to;
+      g_array_append_val (fd_map, fd_map_entry);
 
       /* If stdin/out/err is a tty we try to set it as the controlling
          tty for the app, this way we can use this to run in a terminal. */
@@ -961,36 +961,8 @@ handle_spawn (PortalFlatpak         *object,
           child_setup_data.tty = handle_fd;
         }
 
-      max_fd = MAX (max_fd, fd_map[i].to);
-      max_fd = MAX (max_fd, fd_map[i].from);
-    }
-
-  /* We make a second pass over the fds to find if any "to" fd index
-     overlaps an already in use fd (i.e. one in the "from" category
-     that are allocated randomly). If a fd overlaps "to" fd then its
-     a caller issue and not our fault, so we ignore that. */
-  for (i = 0; i < n_fds; i++)
-    {
-      int to_fd = fd_map[i].to;
-      gboolean conflict = FALSE;
-
-      /* At this point we're fine with using "from" values for this
-         value (because we handle to==from in the code), or values
-         that are before "i" in the fd_map (because those will be
-         closed at this point when dup:ing). However, we can't
-         reuse a fd that is in "from" for j > i. */
-      for (j = i + 1; j < n_fds; j++)
-        {
-          int from_fd = fd_map[j].from;
-          if (from_fd == to_fd)
-            {
-              conflict = TRUE;
-              break;
-            }
-        }
-
-      if (conflict)
-        fd_map[i].to = ++max_fd;
+      max_fd = MAX (max_fd, fd_map_entry.to);
+      max_fd = MAX (max_fd, fd_map_entry.from);
     }
 
   /* TODO: Ideally we should let `flatpak run` inherit the portal's
@@ -1360,6 +1332,37 @@ handle_spawn (PortalFlatpak         *object,
 
       g_debug ("Starting: %s\n", cmd->str);
     }
+
+  /* We make a second pass over the fds to find if any "to" fd index
+     overlaps an already in use fd (i.e. one in the "from" category
+     that are allocated randomly). If a fd overlaps "to" fd then its
+     a caller issue and not our fault, so we ignore that. */
+  for (i = 0; i < fd_map->len; i++)
+    {
+      int to_fd = g_array_index (fd_map, FdMapEntry, i).to;
+      gboolean conflict = FALSE;
+
+      /* At this point we're fine with using "from" values for this
+         value (because we handle to==from in the code), or values
+         that are before "i" in the fd_map (because those will be
+         closed at this point when dup:ing). However, we can't
+         reuse a fd that is in "from" for j > i. */
+      for (j = i + 1; j < fd_map->len; j++)
+        {
+          int from_fd = g_array_index(fd_map, FdMapEntry, j).from;
+          if (from_fd == to_fd)
+            {
+              conflict = TRUE;
+              break;
+            }
+        }
+
+      if (conflict)
+        g_array_index (fd_map, FdMapEntry, i).to = ++max_fd;
+    }
+
+  child_setup_data.fd_map = &g_array_index (fd_map, FdMapEntry, 0);
+  child_setup_data.fd_map_len = fd_map->len;
 
   /* We use LEAVE_DESCRIPTORS_OPEN to work around dead-lock, see flatpak_close_fds_workaround */
   if (!g_spawn_async_with_pipes (NULL,

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -788,6 +788,7 @@ handle_spawn (PortalFlatpak         *object,
   gboolean notify_start;
   gboolean devel;
   g_autoptr(GString) env_string = g_string_new ("");
+  glnx_autofd int env_fd = -1;
 
   child_setup_data.instance_id_fd = -1;
   child_setup_data.env_fd = -1;
@@ -1122,10 +1123,10 @@ handle_spawn (PortalFlatpak         *object,
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      child_setup_data.env_fd = glnx_steal_fd (&env_tmpf.fd);
+      env_fd = glnx_steal_fd (&env_tmpf.fd);
+      child_setup_data.env_fd = env_fd;
       g_ptr_array_add (flatpak_argv,
-                       g_strdup_printf ("--env-fd=%d",
-                                        child_setup_data.env_fd));
+                       g_strdup_printf ("--env-fd=%d", env_fd));
     }
 
   for (i = 0; unset_env != NULL && unset_env[i] != NULL; i++)


### PR DESCRIPTION
This fixes two related bugs in the Flatpak portal, which I introduced while fixing CVE-2021-21261:

* The temporary file descriptor used to transfer environment variables was leaked. If enough apps start a subsandbox with `flatpak-spawn --env=...` or equivalent D-Bus calls, the portal will run out of file descriptors and become unusable. (#4285)

* The file descriptor used for the serialized environment was not correctly remapped into the child process's fd space. If the subsandbox was started with `flatpak-spawn --forward-fd=...` then this could result in the forwarded fd and the serialized environment getting mixed up; if it does, `flatpak run` will try to read environment variables from one of the fds from `--forward-fd` instead of from the intended temporary file, resulting in failure to launch or launching with unintended environment variables. The file descriptor leak mitigates this by making the collision less likely to happen, particularly in the second and subsequent calls to the portal. (#4286)

These are not security issues, just bugs.