### PR TITLE
[1.10] tests: Remove hard-coded references to x86_64

### DIFF
--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -51,7 +51,7 @@ image=oci/image/blobs/sha256/$DIGEST
 assert_has_file $image
 assert_file_has_content $image "org\.freedesktop\.appstream\.appdata.*<summary>Print a greeting</summary>"
 assert_file_has_content $image "org\.freedesktop\.appstream\.icon-64"
-assert_file_has_content $image org.flatpak.ref.*app/org.test.Hello/x86_64/master
+assert_file_has_content $image org.flatpak.ref.*app/"org.test.Hello/$ARCH/master"
 
 ok "export oci"
 

--- a/tests/test-unused.sh
+++ b/tests/test-unused.sh
@@ -391,7 +391,7 @@ ok "list unused regular"
 
 mv unused.txt old-unused.txt
 
-${test_builddir}/list-unused --exclude app/org.app.APP_A/x86_64/stable | sed s@^app/@@g | sed s@^runtime/@@g | sort > unused.txt
+${test_builddir}/list-unused --exclude "app/org.app.APP_A/$ARCH/stable" | sed s@^app/@@g | sed s@^runtime/@@g | sort > unused.txt
 
 # We don't report the excluded ref itself as unused. It's as if it wasn't even installed
 assert_not_file_has_content unused.txt "org.app.APP_A/"


### PR DESCRIPTION
Distributions run these tests on other architectures, but hard-coding
x86_64 to look for in output dooms that to failure.

(cherry picked from commit ba381ae9368c0e6e233c52254e698f5f64903036)

---

Backported from 1.11.x. I've been applying this to 1.10.x in Debian for a while, since failing tests are a release blocker there.