### PR TITLE
revokefs: Use FUSE version 3 if possible

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
-        libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
+        libfuse3-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev bubblewrap xdg-dbus-proxy \

--- a/configure.ac
+++ b/configure.ac
@@ -315,7 +315,14 @@ AC_ARG_ENABLE([auto-sideloading],
               [enable_auto_sideloading=no])
 AM_CONDITIONAL(BUILD_AUTO_SIDELOADING, test x$enable_auto_sideloading = xyes)
 
-PKG_CHECK_MODULES(FUSE, fuse >= 2.9.2)
+PKG_CHECK_MODULES([FUSE3], [fuse3 >= 3.1.1],
+                  [
+                    FUSE_USE_VERSION=31
+                    FUSE_CFLAGS="$FUSE3_CFLAGS"
+                    FUSE_LIBS="$FUSE3_LIBS"
+                  ],
+                  [PKG_CHECK_MODULES([FUSE], [fuse >= 2.9.2], [FUSE_USE_VERSION=26])])
+AC_DEFINE_UNQUOTED([FUSE_USE_VERSION], [$FUSE_USE_VERSION], [Define to the FUSE API version])
 
 AC_ARG_ENABLE([xauth],
               AC_HELP_STRING([--disable-xauth],

--- a/revokefs/main.c
+++ b/revokefs/main.c
@@ -20,7 +20,9 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#define FUSE_USE_VERSION 26
+#ifndef FUSE_USE_VERSION
+#error config.h needs to define FUSE_USE_VERSION
+#endif
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -60,7 +62,11 @@ ENSURE_RELPATH (const char *path)
 }
 
 static int
+#if FUSE_USE_VERSION >= 31
+callback_getattr (const char *path, struct stat *st_data, struct fuse_file_info *finfo)
+#else
 callback_getattr (const char *path, struct stat *st_data)
+#endif
 {
   path = ENSURE_RELPATH (path);
   if (!*path)
@@ -94,8 +100,13 @@ callback_readlink (const char *path, char *buf, size_t size)
 }
 
 static int
+#if FUSE_USE_VERSION >= 31
+callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
+                  off_t offset, struct fuse_file_info *fi, enum fuse_readdir_flags flags)
+#else
 callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
                   off_t offset, struct fuse_file_info *fi)
+#endif
 {
   DIR *dp;
   struct dirent *de;
@@ -128,8 +139,14 @@ callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
       memset (&st, 0, sizeof (st));
       st.st_ino = de->d_ino;
       st.st_mode = de->d_type << 12;
+
+#if FUSE_USE_VERSION >= 31
+      if (filler (buf, de->d_name, &st, 0, 0))
+        break;
+#else
       if (filler (buf, de->d_name, &st, 0))
         break;
+#endif
     }
 
   (void) closedir (dp);
@@ -185,12 +202,20 @@ callback_symlink (const char *from, const char *to)
 }
 
 static int
+#if FUSE_USE_VERSION >= 31
+callback_rename (const char *from, const char *to, unsigned int flags)
+#else
 callback_rename (const char *from, const char *to)
+#endif
 {
+#if FUSE_USE_VERSION < 31
+  unsigned int flags = 0;
+#endif
+
   from = ENSURE_RELPATH (from);
   to = ENSURE_RELPATH (to);
 
-  return request_rename (writer_socket, from, to);
+  return request_rename (writer_socket, from, to, flags);
 }
 
 static int
@@ -203,28 +228,44 @@ callback_link (const char *from, const char *to)
 }
 
 static int
+#if FUSE_USE_VERSION >= 31
+callback_chmod (const char *path, mode_t mode, struct fuse_file_info *finfo)
+#else
 callback_chmod (const char *path, mode_t mode)
+#endif
 {
   path = ENSURE_RELPATH (path);
   return request_chmod (writer_socket, path, mode);
 }
 
 static int
+#if FUSE_USE_VERSION >= 31
+callback_chown (const char *path, uid_t uid, gid_t gid, struct fuse_file_info *finfo)
+#else
 callback_chown (const char *path, uid_t uid, gid_t gid)
+#endif
 {
   path = ENSURE_RELPATH (path);
   return request_chown (writer_socket, path, uid, gid);
 }
 
 static int
+#if FUSE_USE_VERSION >= 31
+callback_truncate (const char *path, off_t size, struct fuse_file_info *finfo)
+#else
 callback_truncate (const char *path, off_t size)
+#endif
 {
   path = ENSURE_RELPATH (path);
   return request_truncate (writer_socket, path, size);
 }
 
 static int
+#if FUSE_USE_VERSION >= 31
+callback_utimens (const char *path, const struct timespec tv[2], struct fuse_file_info *finfo)
+#else
 callback_utimens (const char *path, const struct timespec tv[2])
+#endif
 {
   path = ENSURE_RELPATH (path);
 

--- a/revokefs/writer.h
+++ b/revokefs/writer.h
@@ -27,7 +27,7 @@ int request_rmdir (int writer_socket, const char *path);
 int request_unlink (int writer_socket, const char *path);
 int request_symlink (int writer_socket, const char *from, const char *to);
 int request_link (int writer_socket, const char *from, const char *to);
-int request_rename (int writer_socket, const char *from, const char *to);
+int request_rename (int writer_socket, const char *from, const char *to, unsigned int flags);
 int request_chmod(int writer_socket, const char *path, mode_t mode);
 int request_chown(int writer_socket, const char *path, uid_t uid, gid_t gid);
 int request_truncate (int writer_socket, const char *path, off_t size);

--- a/tests/can-use-fuse.c
+++ b/tests/can-use-fuse.c
@@ -13,8 +13,15 @@
 
 #include "libglnx.h"
 
-#define FUSE_USE_VERSION 26
+#ifndef FUSE_USE_VERSION
+#error config.h needs to define FUSE_USE_VERSION
+#endif
+
+#if FUSE_USE_VERSION >= 31
+#include <fuse.h>
+#else
 #include <fuse_lowlevel.h>
+#endif
 
 gchar *cannot_use_fuse = NULL;
 
@@ -26,10 +33,15 @@ check_fuse (void)
 {
   g_autofree gchar *fusermount = NULL;
   g_autofree gchar *path = NULL;
-  char *argv[] = { "flatpak-fuse-test" };
-  struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (argv), argv);
-  struct fuse_chan *chan = NULL;
+  char *argv[] = { "flatpak-fuse-test", NULL };
+  struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (argv) - 1, argv);
   g_autoptr(GError) error = NULL;
+#if FUSE_USE_VERSION >= 31
+  struct fuse *fuse = NULL;
+  const struct fuse_operations ops = { NULL };
+#else
+  struct fuse_chan *chan = NULL;
+#endif
 
   if (cannot_use_fuse != NULL)
     return FALSE;
@@ -64,6 +76,26 @@ check_fuse (void)
   path = g_dir_make_tmp ("flatpak-test.XXXXXX", &error);
   g_assert_no_error (error);
 
+#if FUSE_USE_VERSION >= 31
+  fuse = fuse_new (&args, &ops, sizeof (ops), NULL);
+
+  if (fuse == NULL)
+    {
+      fuse_opt_free_args (&args);
+      cannot_use_fuse = g_strdup_printf ("fuse_new: %s",
+                                         g_strerror (errno));
+      return FALSE;
+    }
+
+  if (fuse_mount (fuse, path) != 0)
+    {
+      fuse_destroy (fuse);
+      fuse_opt_free_args (&args);
+      cannot_use_fuse = g_strdup_printf ("fuse_mount: %s",
+                                         g_strerror (errno));
+      return FALSE;
+    }
+#else
   chan = fuse_mount (path, &args);
 
   if (chan == NULL)
@@ -73,10 +105,16 @@ check_fuse (void)
                                          g_strerror (errno));
       return FALSE;
     }
+#endif
 
   g_test_message ("Successfully set up test FUSE fs on %s", path);
 
+#if FUSE_USE_VERSION >= 31
+  fuse_unmount (fuse);
+  fuse_destroy (fuse);
+#else
   fuse_unmount (path, chan);
+#endif
 
   if (g_rmdir (path) != 0)
     g_error ("rmdir %s: %s", path, g_strerror (errno));

--- a/tests/flatpak.supp
+++ b/tests/flatpak.supp
@@ -254,3 +254,14 @@
    fun:g_file_new_for_path
    fun:flatpak_get_user_base_dir_location
 }
+
+# https://github.com/ostreedev/ostree/issues/2592
+{
+   ostree_issue_2592
+   Memcheck:Cond
+   ...
+   fun:_ostree_repo_auto_transaction_unref
+   fun:glib_autoptr_clear_OstreeRepoAutoTransaction
+   fun:glib_autoptr_cleanup_OstreeRepoAutoTransaction
+   fun:ostree_repo_prepare_transaction
+}


### PR DESCRIPTION
* revokefs: Use FUSE version 3 if possible

    Based on a change contributed by Léo Stefanesco (#3661); but instead of
    unconditionally using FUSE 3, leave a fallback code path for FUSE 2 for
    older distros.

    Co-authored-by: @ineol

* tests: Add valgrind suppression for ostreedev/ostree#2592

    This is fixed in v2022.3, but that version missed the boat for Ubuntu
    22.04.

* workflows: Build with FUSE 3 for Ubuntu 22.04
    
    This ensures we exercise both code paths.