### PR TITLE
Fix some warn_unused_result warnings

### DIFF
--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -76,8 +76,8 @@ void flatpak_get_window_size (int *rows,
                               int *cols);
 gboolean flatpak_get_cursor_pos (int *row,
                                  int *col);
-void flatpak_hide_cursor (void);
-void flatpak_show_cursor (void);
+ssize_t flatpak_hide_cursor (void);
+ssize_t flatpak_show_cursor (void);
 
 void flatpak_enable_raw_mode (void);
 void flatpak_disable_raw_mode (void);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -8057,16 +8057,16 @@ flatpak_get_cursor_pos (int * row, int *col)
   return res == 2;
 }
 
-void
+ssize_t
 flatpak_hide_cursor (void)
 {
-  write (STDOUT_FILENO, FLATPAK_ANSI_HIDE_CURSOR, strlen (FLATPAK_ANSI_HIDE_CURSOR));
+  return write (STDOUT_FILENO, FLATPAK_ANSI_HIDE_CURSOR, strlen (FLATPAK_ANSI_HIDE_CURSOR));
 }
 
-void
+ssize_t
 flatpak_show_cursor (void)
 {
-  write (STDOUT_FILENO, FLATPAK_ANSI_SHOW_CURSOR, strlen (FLATPAK_ANSI_SHOW_CURSOR));
+  return write (STDOUT_FILENO, FLATPAK_ANSI_SHOW_CURSOR, strlen (FLATPAK_ANSI_SHOW_CURSOR));
 }
 
 void

--- a/revokefs/demo.c
+++ b/revokefs/demo.c
@@ -74,7 +74,11 @@ main (int argc, char *argv[])
     }
 
   g_print ("Started revokefs, press enter to revoke");
-  fgets(buf, sizeof(buf), stdin);
+  if (!fgets(buf, sizeof(buf), stdin))
+    {
+      perror ("fgets");
+    }
+
   g_print ("Revoking write permissions");
   shutdown (sockets[1], SHUT_RDWR);
 }


### PR DESCRIPTION
While building on gcc 9.3.0