### PR TITLE
Backport 49e8bfce "system-helper: Fix deploys of local remotes" to 1.10.x

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -410,49 +410,6 @@ handle_deploy (FlatpakSystemHelper   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  src_dir = g_path_get_dirname (arg_repo_path);
-  ongoing_pull = take_ongoing_pull_by_dir (src_dir);
-  if (ongoing_pull != NULL)
-    {
-      g_autoptr(GError) local_error = NULL;
-      uid_t uid;
-
-      /* Ensure that pull's uid is same as the caller's uid */
-      if (!get_connection_uid (invocation, &uid, &local_error))
-        {
-          g_dbus_method_invocation_return_gerror (invocation, local_error);
-          return G_DBUS_METHOD_INVOCATION_HANDLED;
-        }
-      else
-        {
-          if (ongoing_pull->uid != uid)
-            {
-              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
-                                                     "Ongoing pull's uid(%d) does not match with peer uid(%d)",
-                                                     ongoing_pull->uid, uid);
-              return G_DBUS_METHOD_INVOCATION_HANDLED;
-            }
-        }
-
-      terminate_revokefs_backend (ongoing_pull);
-
-      if (!flatpak_canonicalize_permissions (AT_FDCWD,
-                                             arg_repo_path,
-                                             getuid() == 0 ? 0 : -1,
-                                             getuid() == 0 ? 0 : -1,
-                                             &local_error))
-        {
-          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
-                                                 "Failed to canonicalize permissions of repo %s: %s",
-                                                 arg_repo_path, local_error->message);
-          return G_DBUS_METHOD_INVOCATION_HANDLED;
-        }
-
-      /* At this point, the cache-dir's repo is owned by root. Hence, any failure
-       * from here on, should always cleanup the cache-dir and not preserve it to be re-used. */
-      ongoing_pull->preserve_pull = FALSE;
-    }
-
   if ((arg_flags & ~FLATPAK_HELPER_DEPLOY_FLAGS_ALL) != 0)
     {
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
@@ -460,11 +417,57 @@ handle_deploy (FlatpakSystemHelper   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  if (!g_file_query_exists (repo_file, NULL))
+  if (strlen (arg_repo_path) > 0)
     {
-      g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
-                                             "Path does not exist");
-      return G_DBUS_METHOD_INVOCATION_HANDLED;
+      if (!g_file_query_exists (repo_file, NULL))
+        {
+          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                                                 "Path does not exist");
+          return G_DBUS_METHOD_INVOCATION_HANDLED;
+        }
+
+      src_dir = g_path_get_dirname (arg_repo_path);
+      ongoing_pull = take_ongoing_pull_by_dir (src_dir);
+      if (ongoing_pull != NULL)
+        {
+          g_autoptr(GError) local_error = NULL;
+          uid_t uid;
+
+          /* Ensure that pull's uid is same as the caller's uid */
+          if (!get_connection_uid (invocation, &uid, &local_error))
+            {
+              g_dbus_method_invocation_return_gerror (invocation, local_error);
+              return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+          else
+            {
+              if (ongoing_pull->uid != uid)
+                {
+                  g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
+                                                         "Ongoing pull's uid(%d) does not match with peer uid(%d)",
+                                                         ongoing_pull->uid, uid);
+                  return G_DBUS_METHOD_INVOCATION_HANDLED;
+                }
+            }
+
+          terminate_revokefs_backend (ongoing_pull);
+
+          if (!flatpak_canonicalize_permissions (AT_FDCWD,
+                                                 arg_repo_path,
+                                                 getuid() == 0 ? 0 : -1,
+                                                 getuid() == 0 ? 0 : -1,
+                                                 &local_error))
+            {
+              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
+                                                     "Failed to canonicalize permissions of repo %s: %s",
+                                                     arg_repo_path, local_error->message);
+              return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+
+          /* At this point, the cache-dir's repo is owned by root. Hence, any failure
+           * from here on, should always cleanup the cache-dir and not preserve it to be re-used. */
+          ongoing_pull->preserve_pull = FALSE;
+        }
     }
 
   ref = flatpak_decomposed_new_from_ref (arg_ref, &error);


### PR DESCRIPTION
* system-helper: Fix deploys of local remotes
    
    For updates in remotes with a local (file:) uri we just do a deploy
    with a LOCAL_PULL flag set and an empty arg_repo_path. However, our
    arg_repo_path checking at some point seemed to stop properly handling
    the case where it is empty. I got it to report "No such file" wich
    broke the tests.
    
    (cherry picked from commit 49e8bfcea516e96eb950109d0fa45811a352a517)
    
    Fixes: #4339

Tested-by: [Milan Crha](https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1204#note_1204340)