### PR TITLE
.github: Add Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: flatpak


### PR DESCRIPTION
Flatpak can now accept donations on the OpenCollective platform, which can then be used to fund development, or to further the project's goals in other ways. I plan to send an email to the mailing list soon to announce this and solicit feedback on how best to go about raising and distributing funds.

This idea was discussed on the Matrix channel and via email already, and well received.