### PR TITLE
build-finish: Export appstream metainfo into a single directory

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -235,6 +235,7 @@ collect_exports (GFile          *base,
     "share/icons",                        /* Icons */
     "share/dbus-1/services",              /* D-Bus service files */
     "share/gnome-shell/search-providers", /* Search providers */
+    "share/appdata",                      /* Copy appdata/metainfo files */
     NULL,
   };
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7520,6 +7520,7 @@ flatpak_export_dir (GFile        *source,
     "share/dbus-1/services",               "../../..",
     "share/gnome-shell/search-providers",  "../../..",
     "share/mime/packages",                 "../../..",
+    "share/appdata",                       "../..",
     "bin",                                 "..",
   };
   int i;

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -732,6 +732,10 @@ flatpak_get_allowed_exports (const char     *source_path,
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
     }
+  else if (strcmp (source_path, "share/appdata") == 0)
+    {
+      g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
+    }
   else
     return FALSE;
 

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -113,9 +113,8 @@ mkdir -p ${DIR}/files/share/icons/HighContrast/64x64/apps
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/HighContrast/64x64/apps/${APP_ID}.png
 
 
-mkdir -p ${DIR}/files/share/app-info/xmls
-mkdir -p ${DIR}/files/share/app-info/icons/flatpak/64x64
-gzip -c > ${DIR}/files/share/app-info/xmls/${APP_ID}.xml.gz <<EOF
+mkdir -p ${DIR}/files/share/appdata
+cat <<EOF > ${DIR}/files/share/appdata/${APP_ID}.xml
 <?xml version="1.0" encoding="UTF-8"?>
 <components version="0.8">
   <component type="desktop">
@@ -133,6 +132,9 @@ gzip -c > ${DIR}/files/share/app-info/xmls/${APP_ID}.xml.gz <<EOF
   </component>
 </components>
 EOF
+mkdir -p ${DIR}/files/share/app-info/xmls
+mkdir -p ${DIR}/files/share/app-info/icons/flatpak/64x64
+gzip -c ${DIR}/files/share/appdata/${APP_ID}.xml > ${DIR}/files/share/app-info/xmls/${APP_ID}.xml.gz
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/app-info/icons/flatpak/64x64/${APP_ID}.png
 
 if [ x$COLLECTION_ID != x ]; then

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -44,6 +44,7 @@ assert_has_file $FL_DIR/app/org.test.Hello/$ARCH/stable/active/metadata
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/files
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
+assert_has_file $FL_DIR/exports/share/appdata/org.test.Hello.xml
 # Ensure Exec key is rewritten
 assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
 assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini


### PR DESCRIPTION
 build-finish: Export appstream metainfo into a single directory
    
This is similar to what is done for desktop files and allows
applications like desktop or mobile shell to use a flatpak's metainfo to retrieve e.g.  required
input controllers or the supported screen sizes. Similar to what can be
done for non-flatpak'ed apps by looking at `/usr/share/{metainfo,appdata}`.

This information is e.g. useful for desktop and mobile shells to figure out if an
application is currently usable (does meed the current input and screen 
requirements) and hence where it should be placed in a menu.

Since flatpak moves the metadata from `metainfo/` to `appdata/` during build
we only need to export files from that single directory.