### PR TITLE
Improve exports test coverage

### DIFF
--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -61,8 +61,21 @@ FlatpakFilesystemMode flatpak_exports_path_get_mode (FlatpakExports *exports,
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakExports, flatpak_exports_free);
 
+/*
+ * FlatpakExportsTestFlags:
+ * @FLATPAK_EXPORTS_TEST_FLAGS_AUTOFS: Pretend everything is an autofs.
+ *
+ * Flags used to provide mock behaviour during unit testing.
+ */
+typedef enum
+{
+  FLATPAK_EXPORTS_TEST_FLAGS_AUTOFS = (1 << 0),
+  FLATPAK_EXPORTS_TEST_FLAGS_NONE = 0
+} FlatpakExportsTestFlags;
+
 void flatpak_exports_take_host_fd (FlatpakExports *exports,
                                    int             fd);
-
+void flatpak_exports_set_test_flags (FlatpakExports *exports,
+                                     FlatpakExportsTestFlags flags);
 
 #endif /* __FLATPAK_EXPORTS_H__ */

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -178,6 +178,7 @@ flatpak_exports_new (void)
 void
 flatpak_exports_free (FlatpakExports *exports)
 {
+  glnx_close_fd (&exports->host_fd);
   g_hash_table_destroy (exports->hash);
   g_free (exports);
 }

--- a/common/flatpak-utils-base.c
+++ b/common/flatpak-utils-base.c
@@ -100,6 +100,12 @@ flatpak_resolve_link (const char *path,
   return g_build_filename (dirname, link, NULL);
 }
 
+/*
+ * Syntactically canonicalize a filename, similar to
+ * g_canonicalize_filename() in newer GLib.
+ *
+ * This function does not do I/O.
+ */
 char *
 flatpak_canonicalize_filename (const char *path)
 {

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1290,6 +1290,7 @@ test_exports_unusual (void)
   static const FakeFile files[] =
   {
     { "TMP", FAKE_DIR },
+    { "dangling-link", FAKE_SYMLINK, "nonexistent" },
     { "etc", FAKE_DIR },
     { "etc/ld.so.cache", FAKE_FILE },
     { "etc/ld.so.conf", FAKE_FILE },
@@ -1319,7 +1320,13 @@ test_exports_unusual (void)
                                    "/broken-autofs");
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/dangling-link");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "/home/me");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/nonexistent");
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "/recursion");

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1296,11 +1296,13 @@ test_exports_unusual (void)
     { "etc/ld.so.conf.d", FAKE_DIR },
     { "bin", FAKE_SYMLINK, "usr/bin" },
     { "broken-autofs", FAKE_DIR },
+    { "home", FAKE_SYMLINK, "var/home" },
     { "lib", FAKE_SYMLINK, "usr/lib" },
     { "tmp", FAKE_SYMLINK, "TMP" },
     { "usr/bin", FAKE_DIR },
     { "usr/lib", FAKE_DIR },
     { "usr/share", FAKE_DIR },
+    { "var/home/me", FAKE_DIR },
     { NULL }
   };
   g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
@@ -1316,6 +1318,9 @@ test_exports_unusual (void)
                                    "/broken-autofs");
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/home/me");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "/tmp");
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
@@ -1326,7 +1331,10 @@ test_exports_unusual (void)
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
 
+  i = assert_next_is_bind (bwrap, i, "--symlink", "var/home", "/home");
   i = assert_next_is_bind (bwrap, i, "--ro-bind", "/tmp", "/tmp");
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", "/var/home/me",
+                           "/var/home/me");
   i = assert_next_is_bind (bwrap, i, "--ro-bind", "/usr", "/run/host/usr");
   i = assert_next_is_symlink (bwrap, i, "usr/bin", "/run/host/bin");
   i = assert_next_is_symlink (bwrap, i, "usr/lib", "/run/host/lib");

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1298,6 +1298,7 @@ test_exports_unusual (void)
     { "broken-autofs", FAKE_DIR },
     { "home", FAKE_SYMLINK, "var/home" },
     { "lib", FAKE_SYMLINK, "usr/lib" },
+    { "recursion", FAKE_SYMLINK, "recursion" },
     { "tmp", FAKE_SYMLINK, "TMP" },
     { "usr/bin", FAKE_DIR },
     { "usr/lib", FAKE_DIR },
@@ -1319,6 +1320,9 @@ test_exports_unusual (void)
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "/home/me");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/recursion");
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "/tmp");

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1312,6 +1312,9 @@ test_exports_unusual (void)
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "/broken-autofs");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "not-absolute");
   test_host_exports_finish (exports, bwrap);
 
   i = 0;

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1289,6 +1289,7 @@ test_exports_unusual (void)
 {
   static const FakeFile files[] =
   {
+    { "TMP", FAKE_DIR },
     { "etc", FAKE_DIR },
     { "etc/ld.so.cache", FAKE_FILE },
     { "etc/ld.so.conf", FAKE_FILE },
@@ -1296,6 +1297,7 @@ test_exports_unusual (void)
     { "bin", FAKE_SYMLINK, "usr/bin" },
     { "broken-autofs", FAKE_DIR },
     { "lib", FAKE_SYMLINK, "usr/lib" },
+    { "tmp", FAKE_SYMLINK, "TMP" },
     { "usr/bin", FAKE_DIR },
     { "usr/lib", FAKE_DIR },
     { "usr/share", FAKE_DIR },
@@ -1314,6 +1316,9 @@ test_exports_unusual (void)
                                    "/broken-autofs");
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/tmp");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "not-absolute");
   test_host_exports_finish (exports, bwrap);
 
@@ -1321,6 +1326,7 @@ test_exports_unusual (void)
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
 
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", "/tmp", "/tmp");
   i = assert_next_is_bind (bwrap, i, "--ro-bind", "/usr", "/run/host/usr");
   i = assert_next_is_symlink (bwrap, i, "usr/bin", "/run/host/bin");
   i = assert_next_is_symlink (bwrap, i, "usr/lib", "/run/host/lib");


### PR DESCRIPTION
This branch makes `exports->host_fd` more consistently used (hence more realistic), and uses it to expand test coverage.

My ulterior motive for this is that I want to use the more realistic `exports->host_fd` to [unit-test Steam's pressure-vessel tool](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/merge_requests/337), which contains a fork of various bits of Flatpak, including FlatpakExports; but I think this extra coverage is an improvement for Flatpak too, so everyone wins.

---

* tests: Add test coverage for a mock Fedora-like system
    
    In particular this tests commit 3aaea7d2 "Expose /var/usrlocal if
    "--filesystem=host" is specified" and checks that /var/usrlocal is
    counted as part of --filesystem=host-usr.

* exports: Close mock host fd when destroyed
    
    Previously this was leaked.

* utils: Document that flatpak_canonicalize_filename() does not do I/O

* tests: Add a skeleton for testing unusual/corner-case situations

* tests: Exercise failure to export a broken autofs
    
    To achieve this, add a flag to FlatpakExports to make it fake a broken
    autofs.

* tests: Exercise failure to export a non-absolute path

* tests: Test the special case for --filesystem=/tmp if /tmp is a symlink
    
    If /tmp is a symlink, we mount the target directory on /tmp instead of
    replicating the symlink, so that it will not interfere with "--dir /tmp".

* tests: Exercise exporting a directory whose parent is a symlink

* tests: Exercise refusal to export a self-recursive symlink

* tests: Exercise attempting to export a nonexistent directory