### PR TITLE
[1.10.x] run: Don't let XDG_RUNTIME_DIR from user override the value we set

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1525,6 +1525,10 @@ static const ExportData default_exports[] = {
   {"XDG_DATA_DIRS", "/app/share:/usr/share"},
   {"SHELL", "/bin/sh"},
   {"TMPDIR", NULL}, /* Unset TMPDIR as it may not exist in the sandbox */
+  /* We always use /run/user/UID, even if the user's XDG_RUNTIME_DIR
+   * outside the sandbox is somewhere else. Don't allow a different
+   * setting from outside the sandbox to overwrite this. */
+  {"XDG_RUNTIME_DIR", NULL},
 
   /* Some env vars are common enough and will affect the sandbox badly
      if set on the host. We clear these always. */

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..18"
+echo "1..19"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -73,6 +73,13 @@ run org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ok "hello"
+
+mkdir xrd
+XDG_RUNTIME_DIR="$(pwd)/xrd" run_sh org.test.Platform 'echo $XDG_RUNTIME_DIR' > value-in-sandbox
+head value-in-sandbox >&2
+assert_file_has_content value-in-sandbox "^/run/user/$(id -u)\$"
+
+ok "XDG_RUNTIME_DIR not inherited"
 
 run_sh org.test.Platform cat /.flatpak-info >runtime-fpi
 assert_file_has_content runtime-fpi "[Runtime]"


### PR DESCRIPTION
We use `bwrap --setenv XDG_RUNTIME_DIR` to set it to `/run/user/UID`,
regardless of what it is on the host system, but the changes made
to resolve CVE-2021-21261 unintentionally broke this by overwriting it
with the user's XDG_RUNTIME_DIR.

In practice this worked for most people, who either have
XDG_RUNTIME_DIR set to the same value we use (which is the conventional
setup from systemd-logind and elogind), or entirely unset (if they do not
have systemd-logind or elogind). However, it broke Wayland and other
XDG_RUNTIME_DIR-based protocols for people who intentionally set up an
XDG_RUNTIME_DIR that is different.

Fixes: 6d1773d2 "run: Convert all environment variables into bwrap arguments"  
Resolves: https://github.com/flatpak/flatpak/issues/4372

---

Should not be merged until after #4373 is.