### PR TITLE
install: Avoid a superfluous prompt to choose the only remote

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -438,7 +438,7 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
           if (remote_dir_pairs->len == 0)
             return flatpak_fail (error, _("No remote refs found similar to ‘%s’"), argv[1]);
 
-          if (!flatpak_resolve_matching_remotes (opt_yes, remote_dir_pairs, argv[1], &chosen_pair, error))
+          if (!flatpak_resolve_matching_remotes (remote_dir_pairs, argv[1], &chosen_pair, error))
             return FALSE;
 
           remote = g_strdup (chosen_pair->remote_name);

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -552,8 +552,7 @@ flatpak_resolve_matching_installed_refs (gboolean    assume_yes,
 }
 
 gboolean
-flatpak_resolve_matching_remotes (gboolean        assume_yes,
-                                  GPtrArray      *remote_dir_pairs,
+flatpak_resolve_matching_remotes (GPtrArray      *remote_dir_pairs,
                                   const char     *opt_search_ref,
                                   RemoteDirPair **out_pair,
                                   GError        **error)
@@ -563,7 +562,11 @@ flatpak_resolve_matching_remotes (gboolean        assume_yes,
 
   g_assert (remote_dir_pairs->len > 0);
 
-  if (assume_yes && remote_dir_pairs->len == 1)
+  /* Here we use the only matching remote even if --assumeyes wasn't specified
+   * because the user will still be asked to confirm the operation in the next
+   * step after the dependencies are resolved.
+   */
+  if (remote_dir_pairs->len == 1)
     chosen = 1;
 
   if (chosen == 0)

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -90,8 +90,7 @@ gboolean flatpak_resolve_matching_installed_refs (gboolean    assume_yes,
                                                   GPtrArray  *out_pairs,
                                                   GError    **error);
 
-gboolean flatpak_resolve_matching_remotes (gboolean        assume_yes,
-                                           GPtrArray      *remote_dir_pairs,
+gboolean flatpak_resolve_matching_remotes (GPtrArray      *remote_dir_pairs,
                                            const char     *opt_search_ref,
                                            RemoteDirPair **out_pair,
                                            GError        **error);


### PR DESCRIPTION
The install command can search available remotes for a specified flatpak
when a remote wasn't specified. In case only one remote is configured,
or in case only one of the configured remotes matches the ref specified,
we currently prompt the user to confirm use of the remote anyway (unless
-y/--assumeyes was used). Skip this prompt even when -y/--assumeyes was
not used, since the remote to use will still effectively be confirmed
when the list of refs to be installed is presented for confirmation.

Fixes https://github.com/flatpak/flatpak/issues/4364