### PR TITLE
build: Move Makefile-*.am.inc up one level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ po/*.gmo
 po/*.sed
 po/*.header
 po/*.sin
+/subprojects/Makefile-*.am.inc
 system-helper/org.freedesktop.Flatpak.policy
 system-helper/org.freedesktop.Flatpak.rules
 flatpak-bwrap

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,7 @@ libglnx_cflags := \
 	$(HIDDEN_VISIBILITY_CFLAGS) \
 	$(NULL)
 libglnx_libs := $(BASE_LIBS)
-include subprojects/libglnx/Makefile-libglnx.am.inc
+include subprojects/Makefile-libglnx.am.inc
 
 include common/Makefile.am.inc
 include data/Makefile.am.inc
@@ -132,7 +132,7 @@ flatpak_bwrap_SOURCES = $(bwrap_SOURCES)
 flatpak_bwrap_CFLAGS = $(AM_CFLAGS) $(bwrap_CFLAGS)
 flatpak_bwrap_LDADD = $(AM_LDADD) $(bwrap_LDADD) $(CAP_LIB)
 bwrapdir = $(libexecdir)
-include subprojects/bubblewrap/Makefile-bwrap.am.inc
+include subprojects/Makefile-bwrap.am.inc
 
 endif # !WITH_SYSTEM_BWRAP
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -22,8 +22,8 @@ if ! test -f subprojects/libglnx/README.md -a -f subprojects/bubblewrap/README.m
     git submodule update --init
 fi
 # Workaround automake bug with subdir-objects and computed paths
-sed -e 's,$(libglnx_srcpath),subprojects/libglnx,g' < subprojects/libglnx/Makefile-libglnx.am >subprojects/libglnx/Makefile-libglnx.am.inc
-sed -e 's,$(bwrap_srcpath),subprojects/bubblewrap,g' < subprojects/bubblewrap/Makefile-bwrap.am >subprojects/bubblewrap/Makefile-bwrap.am.inc
+sed -e 's,$(libglnx_srcpath),subprojects/libglnx,g' < subprojects/libglnx/Makefile-libglnx.am > subprojects/Makefile-libglnx.am.inc
+sed -e 's,$(bwrap_srcpath),subprojects/bubblewrap,g' < subprojects/bubblewrap/Makefile-bwrap.am > subprojects/Makefile-bwrap.am.inc
 
 GTKDOCIZE=$(which gtkdocize 2>/dev/null)
 if test -z "$GTKDOCIZE"; then


### PR DESCRIPTION
This takes them out of the directory that is "owned" by the subproject,
which will not be ignoring our Flatpak-specific generated files in
its .gitignore, and puts them in a directory that is "owned" by Flatpak,
which can ignore them.