### PR TITLE
Support dynamic export path into scripts

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7009,6 +7009,7 @@ export_desktop_file (const char         *app,
   g_autofree char *escaped_branch = maybe_quote (branch);
   g_autofree char *escaped_arch = maybe_quote (arch);
   int i;
+  const char *flatpak;
 
   if (!flatpak_openat_noatime (parent_fd, name, &desktop_fd, cancellable, error))
     return FALSE;
@@ -7129,8 +7130,12 @@ export_desktop_file (const char         *app,
       g_key_file_remove_key (keyfile, groups[i], "X-GNOME-Bugzilla-ExtraInfoScript", NULL);
 
       new_exec = g_string_new ("");
+      if ((flatpak = g_getenv ("FLATPAK_BINARY")) == NULL)
+        flatpak = FLATPAK_BINDIR "/flatpak";
+
       g_string_append_printf (new_exec,
-                              FLATPAK_BINDIR "/flatpak run --branch=%s --arch=%s",
+                              "%s run --branch=%s --arch=%s",
+                              flatpak,
                               escaped_branch,
                               escaped_arch);
 
@@ -8143,6 +8148,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autoptr(GFile) metadata_file = NULL;
   g_autofree char *metadata_contents = NULL;
   gboolean is_oci;
+  const char *flatpak;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -8452,9 +8458,11 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                        cancellable,
                                        error))
         return FALSE;
+      if ((flatpak = g_getenv ("FLATPAK_BINARY")) == NULL)
+        flatpak = FLATPAK_BINDIR "/flatpak";
 
-      bin_data = g_strdup_printf ("#!/bin/sh\nexec %s/flatpak run --branch=%s --arch=%s %s \"$@\"\n",
-                                  FLATPAK_BINDIR, escaped_branch, escaped_arch, escaped_app);
+      bin_data = g_strdup_printf ("#!/bin/sh\nexec %s run --branch=%s --arch=%s %s \"$@\"\n",
+                                  flatpak, escaped_branch, escaped_arch, escaped_app);
       if (!g_file_replace_contents (wrapper, bin_data, strlen (bin_data), NULL, FALSE,
                                     G_FILE_CREATE_REPLACE_DESTINATION, NULL, cancellable, error))
         return FALSE;


### PR DESCRIPTION
This is part of fix to https://github.com/flathub/org.flatpak.Builder/issues/5 which involves org.flatpak.Builder to allow flatpak-builder running in flatpak to tell flatpak which paths to write into export files