### PR TITLE
Retrieve user languages for all locale categories

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -15397,18 +15397,14 @@ get_locale_langs_from_localed_dbus (GDBusProxy *proxy, GPtrArray *langs)
       const gchar *locale = NULL;
       g_autofree char *lang = NULL;
 
-      /* See locale(7) for these categories */
-      const char * const categories[] = { "LANG=", "LC_ALL=", "LC_MESSAGES=", "LC_ADDRESS=",
-                                          "LC_COLLATE=", "LC_CTYPE=", "LC_IDENTIFICATION=",
-                                          "LC_MONETARY=", "LC_MEASUREMENT=", "LC_NAME=",
-                                          "LC_NUMERIC=", "LC_PAPER=", "LC_TELEPHONE=",
-                                          "LC_TIME=", NULL };
+      const char * const *categories = flatpak_get_locale_categories ();
 
       for (j = 0; categories[j]; j++)
         {
-          if (g_str_has_prefix (strv[i], categories[j]))
+          g_autofree char *prefix = g_strdup_printf ("%s=", categories[j]);
+          if (g_str_has_prefix (strv[i], prefix))
             {
-              locale = strv[i] + strlen (categories[j]);
+              locale = strv[i] + strlen (prefix);
               break;
             }
         }

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -138,6 +138,7 @@ char **flatpak_strv_merge (char   **strv1,
 char **flatpak_subpaths_merge (char **subpaths1,
                                char **subpaths2);
 
+const char * const *flatpak_get_locale_categories (void);
 char *flatpak_get_lang_from_locale (const char *locale);
 char **flatpak_get_current_locale_langs (void);
 


### PR DESCRIPTION
g_get_language_names() only returns the language names for the
LC_MESSAGES category, so mixed locale scenarios would result in missing
languages. Now, the languages are listed for each individual category.

Note that this issue was only present with the user installation. For
the system installation, the locales were queried from localed, and all
categories were checked.

Fixes #3712.