### PR TITLE
fix: link to matrix chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ desktop applications on Linux.
 
 See https://flatpak.org/ for more information.
 
-Community discussion happens in [#flatpak:matrix.org](https://matrix.to/#flatpak:matrix.org), on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak), and on [the Flathub Discourse](https://discourse.flathub.org/).
+Community discussion happens in [#flatpak:matrix.org](https://matrix.to/#/#flatpak:matrix.org), on [the mailing list](https://lists.freedesktop.org/mailman/listinfo/flatpak), and on [the Flathub Discourse](https://discourse.flathub.org/).
 
 Read documentation for Flatpak [here](https://docs.flatpak.org/en/latest/index.html).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ please check
 ## Reporting a Vulnerability
 
 If you think you've identified a security issue in Flatpak, please DO NOT
-report the issue publicly via the Github issue tracker, mailing list, or IRC.
+report the issue publicly via the GitHub issue tracker, mailing list, or IRC.
 Instead, send an email with as many details as possible to
 [flatpak-security@lists.freedesktop.org](mailto:flatpak-security@lists.freedesktop.org).
 This is a private mailing list for the Flatpak maintainers.


### PR DESCRIPTION
* The link to matrix.to was wrong before, the room ID is meant to be after in the fragment (`#`) of the URL.
* Changes an instance of Github → GitHub.