### PR TITLE
run: Bind-mount gai.conf from host if present

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2741,6 +2741,7 @@ add_monitor_path_args (gboolean      use_session_helper,
                                 "--symlink", "/run/host/monitor/resolv.conf", "/etc/resolv.conf",
                                 "--symlink", "/run/host/monitor/host.conf", "/etc/host.conf",
                                 "--symlink", "/run/host/monitor/hosts", "/etc/hosts",
+                                "--symlink", "/run/host/monitor/gai.conf", "/etc/gai.conf",
                                 NULL);
 
       if (g_variant_lookup (session_data, "pkcs11-socket", "s", &pkcs11_socket_path))
@@ -2775,6 +2776,10 @@ add_monitor_path_args (gboolean      use_session_helper,
       if (g_file_test ("/etc/hosts", G_FILE_TEST_EXISTS))
         flatpak_bwrap_add_args (bwrap,
                                 "--ro-bind", "/etc/hosts", "/etc/hosts",
+                                NULL);
+      if (g_file_test ("/etc/gai.conf", G_FILE_TEST_EXISTS))
+        flatpak_bwrap_add_args (bwrap,
+                                "--ro-bind", "/etc/gai.conf", "/etc/gai.conf",
                                 NULL);
     }
 }
@@ -3248,6 +3253,7 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
               strcmp (dent->d_name, "resolv.conf") == 0 ||
               strcmp (dent->d_name, "host.conf") == 0 ||
               strcmp (dent->d_name, "hosts") == 0 ||
+              strcmp (dent->d_name, "gai.conf") == 0 ||
               strcmp (dent->d_name, "localtime") == 0 ||
               strcmp (dent->d_name, "timezone") == 0 ||
               strcmp (dent->d_name, "pkcs11") == 0)

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -778,7 +778,11 @@ main (int    argc,
     { "version", 0, 0, G_OPTION_ARG_NONE, &show_version, "Show program version.", NULL},
     { NULL }
   };
-  g_autoptr(MonitorData) m_resolv_conf = NULL, m_host_conf = NULL, m_hosts = NULL, m_localtime = NULL;
+  g_autoptr(MonitorData) m_resolv_conf = NULL,
+                         m_host_conf = NULL,
+                         m_hosts = NULL,
+                         m_gai_conf = NULL,
+                         m_localtime = NULL;
   struct sigaction action;
 
   atexit (do_atexit);
@@ -857,6 +861,7 @@ main (int    argc,
   m_resolv_conf = setup_file_monitor ("/etc/resolv.conf");
   m_host_conf   = setup_file_monitor ("/etc/host.conf");
   m_hosts       = setup_file_monitor ("/etc/hosts");
+  m_gai_conf    = setup_file_monitor ("/etc/gai.conf");
   m_localtime   = setup_file_monitor ("/etc/localtime");
 
   flags = G_BUS_NAME_OWNER_FLAGS_ALLOW_REPLACEMENT;


### PR DESCRIPTION
Fixes #4419.
Since the file should only affect networking, it makes sense to bind-mount it only if network is shared.