### PR TITLE
Handle /var/tmp mounts when it is a symlink

### DIFF
--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -657,10 +657,10 @@ flatpak_exports_path_is_visible (FlatpakExports *exports,
 static gboolean
 never_export_as_symlink (const char *path)
 {
-  /* Don't export /tmp as a symlink even if it is on the host, because
-     that will fail with the pre-existing directory we created for /tmp,
+  /* Don't export {/var,}/tmp as a symlink even if it is on the host, because
+     that will fail with the pre-existing directory we created for it,
      and anyway, it being a symlink is not useful in the sandbox */
-  if (strcmp (path, "/tmp") == 0)
+  if (strcmp (path, "/tmp") == 0 || strcmp (path, "/var/tmp") == 0)
     return TRUE;
 
   return FALSE;

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1305,6 +1305,8 @@ test_exports_unusual (void)
     { "usr/lib", FAKE_DIR },
     { "usr/share", FAKE_DIR },
     { "var/home/me", FAKE_DIR },
+    { "var/volatile/tmp", FAKE_DIR },
+    { "var/tmp", FAKE_SYMLINK, "volatile/tmp" },
     { NULL }
   };
   g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
@@ -1334,6 +1336,9 @@ test_exports_unusual (void)
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "/tmp");
   flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                   "/var/tmp");
+  flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                    "not-absolute");
   test_host_exports_finish (exports, bwrap);
@@ -1346,6 +1351,8 @@ test_exports_unusual (void)
   i = assert_next_is_bind (bwrap, i, "--ro-bind", "/tmp", "/tmp");
   i = assert_next_is_bind (bwrap, i, "--ro-bind", "/var/home/me",
                            "/var/home/me");
+  i = assert_next_is_bind (bwrap, i, "--bind", "/var/tmp",
+                           "/var/tmp");
   i = assert_next_is_bind (bwrap, i, "--ro-bind", "/usr", "/run/host/usr");
   i = assert_next_is_symlink (bwrap, i, "usr/bin", "/run/host/bin");
   i = assert_next_is_symlink (bwrap, i, "usr/lib", "/run/host/lib");


### PR DESCRIPTION
In Yocto systems /var/tmp is a symlink to /var/volatile/tmp
because in its implementation of read-only rootfs /var is read-only
so /var/volatile is mounted as a tmpfs
and a subset of the paths point into it.

This would result in flatpak emitting mount arguments of
`--symlink ../var/volatile/tmp /var/tmp --bind /var/volatile/tmp /var/volatile/tmp`
which fails because flatpak has already added `--dir /var/tmp`
and the call to symlink fails with EEXIST.

This is fixed by blacklisting /var/tmp from symlink exports
in the same way /tmp is, so the bind is emitted as
`--bind /var/tmp /var/tmp`, which results in /var/volatile/tmp
being mounted into /var/tmp.