### PR TITLE
Drop old-glib ci test as ubuntu 16.04 is no longer available

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,32 +136,6 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
 
-  xenial:
-    name: Build with old glib
-    runs-on: ubuntu-16.04
-    steps:
-    - name: Install Dependencies
-      run: |
-        sudo add-apt-repository ppa:alexlarsson/flatpak
-        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-xenial main' # Needed for updates to work
-        sudo apt-get update
-        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
-        libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
-        libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-        libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang e2fslibs-dev
-    - name: Check out flatpak
-      uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: configure
-      run: ./autogen.sh
-      env:
-        CC: clang
-        CFLAGS: -Werror=unused-variable
-    - name: Build flatpak
-      run: make -j $(getconf _NPROCESSORS_ONLN)
-
   valgrind:
     name: Run tests in valgrind
     needs: check # Don't run expensive test if main check fails


### PR DESCRIPTION
As per https://github.com/actions/virtual-environments/issues/3287 the support for ubuntu-16.04 stopped working on september 20:th, so our CI job stopped starting.

This test was useful to detect changes that made flatpak no longer build with ancient glib versions. However, at some point maybe we no longer care about glib versions that old? Should we just drop this, or do we try to find some kind of replacement? 

Maybe we even bump the glib req to something we test.  We currently require 2.44, but both ubuntu 18.08 and rhel8 seems to have 2.56.4, whereas ubuntu 16.04 has 2.48.2, and rhel7.9 has  2.56.1.

I wouldn't mind bumping this to 2.56.0, released march 2018?

@debarshiray  @smcv @mwleeds opinions?