### PR TITLE
icon-validator: Mount ld.so.cache only if it exists

### DIFF
--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -157,7 +157,7 @@ rerun_in_sandbox (const char *arg_width,
             "--unshare-net",
             "--unshare-pid",
             "--ro-bind", "/usr", "/usr",
-            "--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache",
+            "--ro-bind-try", "/etc/ld.so.cache", "/etc/ld.so.cache",
             "--ro-bind", validate_icon, validate_icon,
             NULL);
 


### PR DESCRIPTION
On musl-based systems, /etc/ld.so.cache does not exist, causing icon validation to fail.

This has been improperly reported at [1] instead of Flatpak repo.

[1] https://github.com/flathub/com.valvesoftware.Steam/issues/638