### PR TITLE
[flatpak-1.8.x] profile.d: Disable gvfs plugins when listing flatpak installations

### DIFF
--- a/env.d/60-flatpak
+++ b/env.d/60-flatpak
@@ -9,7 +9,7 @@ do
         *":$share_path/:"*) :;;
         *) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
     esac
-done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; flatpak  --installations)
+done < <(echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"; GIO_USE_VFS=local flatpak  --installations)
 
 XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"

--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -5,7 +5,7 @@ if command -v flatpak > /dev/null; then
         (
             unset G_MESSAGES_DEBUG
             echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
-            flatpak --installations
+            GIO_USE_VFS=local flatpak --installations
         ) | (
             new_dirs=
             while read -r install_path


### PR DESCRIPTION
This is meant to be applied after https://github.com/flatpak/flatpak/pull/4448

The second patch was practically re-written and is not a straight cherry-pick of commit afe7f2bf78b97579c652989d2577d05229f56256 It might be good to take a close look at it. :)