### PR TITLE
tests: Fix test-sideload.sh if ostree is built with curl backend

### DIFF
--- a/tests/test-sideload.sh
+++ b/tests/test-sideload.sh
@@ -112,10 +112,8 @@ httpd_clear_log
 if ${FLATPAK} ${U} install -y test-repo org.test.Hello &> install-error-log; then
     assert_not_reached "Disabled online install broken"
 fi
-assert_file_has_content install-error-log "Server returned status 404: Not Found"
+assert_file_has_content install-error-log "Server returned .*404.*"
 assert_file_has_content httpd-log "GET .*commit .*404"
-
-assert_file_has_content install-error-log "Server returned status 404: Not Found"
 
 ln -s $SIDELOAD_REPO $SIDELOAD_REPO_LINK
 


### PR DESCRIPTION
The soup backend and the curl backend give slightly different error
messages, so we need to tweak the 404 assert check to match both.