### PR TITLE
[1.2.x] Backport CVE-2021-41133 seccomp fixes

### DIFF
--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -127,6 +127,7 @@ libflatpak_common_la_SOURCES = \
 	common/flatpak-installation-private.h \
 	common/flatpak-installation.c \
 	common/flatpak-instance.c \
+	common/flatpak-syscalls-private.h \
 	common/valgrind-private.h \
 	$(NULL)
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2389,6 +2389,8 @@ setup_seccomp (FlatpakBwrap   *bwrap,
     {SCMP_SYS (unshare), EPERM},
     {SCMP_SYS (setns), EPERM},
     {SCMP_SYS (mount), EPERM},
+    {SCMP_SYS (umount), EPERM},
+    {SCMP_SYS (umount2), EPERM},
     {SCMP_SYS (pivot_root), EPERM},
 #if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)
     /* Architectures with CONFIG_CLONE_BACKWARDS2: the child stack

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2392,6 +2392,7 @@ setup_seccomp (FlatpakBwrap   *bwrap,
     {SCMP_SYS (umount), EPERM},
     {SCMP_SYS (umount2), EPERM},
     {SCMP_SYS (pivot_root), EPERM},
+    {SCMP_SYS (chroot), EPERM},
 #if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)
     /* Architectures with CONFIG_CLONE_BACKWARDS2: the child stack
      * and flags arguments are reversed so the flags come second */

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2382,7 +2382,14 @@ setup_seccomp (FlatpakBwrap   *bwrap,
     {SCMP_SYS (unshare)},
     {SCMP_SYS (mount)},
     {SCMP_SYS (pivot_root)},
+#if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)
+    /* Architectures with CONFIG_CLONE_BACKWARDS2: the child stack
+     * and flags arguments are reversed so the flags come second */
+    {SCMP_SYS (clone), &SCMP_A1 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
+#else
+    /* Normally the flags come first */
     {SCMP_SYS (clone), &SCMP_A0 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
+#endif
 
     /* Don't allow faking input to the controlling tty (CVE-2017-5226) */
     {SCMP_SYS (ioctl), &SCMP_A1 (SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, (int) TIOCSTI)},

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2347,6 +2347,10 @@ setup_seccomp (FlatpakBwrap   *bwrap,
    *  https://git.gnome.org/browse/linux-user-chroot
    *    in src/setup-seccomp.c
    *
+   * Other useful resources:
+   * https://github.com/systemd/systemd/blob/HEAD/src/shared/seccomp-util.c
+   * https://github.com/moby/moby/blob/HEAD/profiles/seccomp/default.json
+   *
    **** END NOTE ON CODE SHARING
    */
   struct

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -36,6 +36,8 @@
 #include <dconf/dconf.h>
 #endif
 
+#include "flatpak-syscalls-private.h"
+
 #ifdef ENABLE_SECCOMP
 #include <seccomp.h>
 #endif

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2406,6 +2406,18 @@ setup_seccomp (FlatpakBwrap   *bwrap,
      * Return ENOSYS so user-space will fall back to clone().
      * (GHSA-67h7-w3jq-vh4q; see also https://github.com/moby/moby/commit/9f6b562d) */
     {SCMP_SYS (clone3), ENOSYS},
+
+    /* New mount manipulation APIs can also change our VFS. There's no
+     * legitimate reason to do these in the sandbox, so block all of them
+     * rather than thinking about which ones might be dangerous.
+     * (GHSA-67h7-w3jq-vh4q) */
+    {SCMP_SYS (open_tree), ENOSYS},
+    {SCMP_SYS (move_mount), ENOSYS},
+    {SCMP_SYS (fsopen), ENOSYS},
+    {SCMP_SYS (fsconfig), ENOSYS},
+    {SCMP_SYS (fsmount), ENOSYS},
+    {SCMP_SYS (fspick), ENOSYS},
+    {SCMP_SYS (mount_setattr), ENOSYS},
   };
 
   struct

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2400,6 +2400,12 @@ setup_seccomp (FlatpakBwrap   *bwrap,
 
     /* Don't allow faking input to the controlling tty (CVE-2017-5226) */
     {SCMP_SYS (ioctl), EPERM, &SCMP_A1 (SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, (int) TIOCSTI)},
+
+    /* seccomp can't look into clone3()'s struct clone_args to check whether
+     * the flags are OK, so we have no choice but to block clone3().
+     * Return ENOSYS so user-space will fall back to clone().
+     * (GHSA-67h7-w3jq-vh4q; see also https://github.com/moby/moby/commit/9f6b562d) */
+    {SCMP_SYS (clone3), ENOSYS},
   };
 
   struct

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2352,61 +2352,63 @@ setup_seccomp (FlatpakBwrap   *bwrap,
   struct
   {
     int                  scall;
+    int                  errnum;
     struct scmp_arg_cmp *arg;
   } syscall_blocklist[] = {
     /* Block dmesg */
-    {SCMP_SYS (syslog)},
+    {SCMP_SYS (syslog), EPERM},
     /* Useless old syscall */
-    {SCMP_SYS (uselib)},
+    {SCMP_SYS (uselib), EPERM},
     /* Don't allow disabling accounting */
-    {SCMP_SYS (acct)},
+    {SCMP_SYS (acct), EPERM},
     /* 16-bit code is unnecessary in the sandbox, and modify_ldt is a
        historic source of interesting information leaks. */
-    {SCMP_SYS (modify_ldt)},
+    {SCMP_SYS (modify_ldt), EPERM},
     /* Don't allow reading current quota use */
-    {SCMP_SYS (quotactl)},
+    {SCMP_SYS (quotactl), EPERM},
 
     /* Don't allow access to the kernel keyring */
-    {SCMP_SYS (add_key)},
-    {SCMP_SYS (keyctl)},
-    {SCMP_SYS (request_key)},
+    {SCMP_SYS (add_key), EPERM},
+    {SCMP_SYS (keyctl), EPERM},
+    {SCMP_SYS (request_key), EPERM},
 
     /* Scary VM/NUMA ops */
-    {SCMP_SYS (move_pages)},
-    {SCMP_SYS (mbind)},
-    {SCMP_SYS (get_mempolicy)},
-    {SCMP_SYS (set_mempolicy)},
-    {SCMP_SYS (migrate_pages)},
+    {SCMP_SYS (move_pages), EPERM},
+    {SCMP_SYS (mbind), EPERM},
+    {SCMP_SYS (get_mempolicy), EPERM},
+    {SCMP_SYS (set_mempolicy), EPERM},
+    {SCMP_SYS (migrate_pages), EPERM},
 
     /* Don't allow subnamespace setups: */
-    {SCMP_SYS (unshare)},
-    {SCMP_SYS (mount)},
-    {SCMP_SYS (pivot_root)},
+    {SCMP_SYS (unshare), EPERM},
+    {SCMP_SYS (mount), EPERM},
+    {SCMP_SYS (pivot_root), EPERM},
 #if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)
     /* Architectures with CONFIG_CLONE_BACKWARDS2: the child stack
      * and flags arguments are reversed so the flags come second */
-    {SCMP_SYS (clone), &SCMP_A1 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
+    {SCMP_SYS (clone), EPERM, &SCMP_A1 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
 #else
     /* Normally the flags come first */
-    {SCMP_SYS (clone), &SCMP_A0 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
+    {SCMP_SYS (clone), EPERM, &SCMP_A0 (SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER)},
 #endif
 
     /* Don't allow faking input to the controlling tty (CVE-2017-5226) */
-    {SCMP_SYS (ioctl), &SCMP_A1 (SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, (int) TIOCSTI)},
+    {SCMP_SYS (ioctl), EPERM, &SCMP_A1 (SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, (int) TIOCSTI)},
   };
 
   struct
   {
     int                  scall;
+    int                  errnum;
     struct scmp_arg_cmp *arg;
   } syscall_nondevel_blocklist[] = {
     /* Profiling operations; we expect these to be done by tools from outside
      * the sandbox.  In particular perf has been the source of many CVEs.
      */
-    {SCMP_SYS (perf_event_open)},
+    {SCMP_SYS (perf_event_open), EPERM},
     /* Don't allow you to switch to bsd emulation or whatnot */
-    {SCMP_SYS (personality), &SCMP_A0 (SCMP_CMP_NE, allowed_personality)},
-    {SCMP_SYS (ptrace)}
+    {SCMP_SYS (personality), EPERM, &SCMP_A0 (SCMP_CMP_NE, allowed_personality)},
+    {SCMP_SYS (ptrace), EPERM}
   };
   /* Blocklist all but unix, inet, inet6 and netlink */
   struct
@@ -2491,10 +2493,14 @@ setup_seccomp (FlatpakBwrap   *bwrap,
   for (i = 0; i < G_N_ELEMENTS (syscall_blocklist); i++)
     {
       int scall = syscall_blocklist[i].scall;
+      int errnum = syscall_blocklist[i].errnum;
+
+      g_return_val_if_fail (errnum == EPERM || errnum == ENOSYS, FALSE);
+
       if (syscall_blocklist[i].arg)
-        r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (EPERM), scall, 1, *syscall_blocklist[i].arg);
+        r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 1, *syscall_blocklist[i].arg);
       else
-        r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (EPERM), scall, 0);
+        r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 0);
       if (r < 0 && r == -EFAULT /* unknown syscall */)
         return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Failed to block syscall %d"), scall);
     }
@@ -2504,10 +2510,14 @@ setup_seccomp (FlatpakBwrap   *bwrap,
       for (i = 0; i < G_N_ELEMENTS (syscall_nondevel_blocklist); i++)
         {
           int scall = syscall_nondevel_blocklist[i].scall;
+          int errnum = syscall_nondevel_blocklist[i].errnum;
+
+          g_return_val_if_fail (errnum == EPERM || errnum == ENOSYS, FALSE);
+
           if (syscall_nondevel_blocklist[i].arg)
-            r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (EPERM), scall, 1, *syscall_nondevel_blocklist[i].arg);
+            r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 1, *syscall_nondevel_blocklist[i].arg);
           else
-            r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (EPERM), scall, 0);
+            r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 0);
 
           if (r < 0 && r == -EFAULT /* unknown syscall */)
             return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Failed to block syscall %d"), scall);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2387,6 +2387,7 @@ setup_seccomp (FlatpakBwrap   *bwrap,
 
     /* Don't allow subnamespace setups: */
     {SCMP_SYS (unshare), EPERM},
+    {SCMP_SYS (setns), EPERM},
     {SCMP_SYS (mount), EPERM},
     {SCMP_SYS (pivot_root), EPERM},
 #if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)

--- a/common/flatpak-syscalls-private.h
+++ b/common/flatpak-syscalls-private.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <sys/syscall.h>
+
+#if defined(_MIPS_SIM)
+# if _MIPS_SIM == _MIPS_SIM_ABI32
+#   define FLATPAK_MISSING_SYSCALL_BASE 4000
+# elif _MIPS_SIM == _MIPS_SIM_ABI64
+#   define FLATPAK_MISSING_SYSCALL_BASE 5000
+# elif _MIPS_SIM == _MIPS_SIM_NABI32
+#   define FLATPAK_MISSING_SYSCALL_BASE 6000
+# else
+#   error "Unknown MIPS ABI"
+# endif
+#endif
+
+#if defined(__ia64__)
+# define FLATPAK_MISSING_SYSCALL_BASE 1024
+#endif
+
+#if defined(__alpha__)
+# define FLATPAK_MISSING_SYSCALL_BASE 110
+#endif
+
+#if defined(__x86_64__) && defined(__ILP32__)
+# define FLATPAK_MISSING_SYSCALL_BASE 0x40000000
+#endif
+
+/*
+ * FLATPAK_MISSING_SYSCALL_BASE:
+ *
+ * Number to add to the syscall numbers of recently-added syscalls
+ * to get the appropriate syscall for the current ABI.
+ */
+#ifndef FLATPAK_MISSING_SYSCALL_BASE
+# define FLATPAK_MISSING_SYSCALL_BASE 0
+#endif
+
+#ifndef __NR_open_tree
+# define __NR_open_tree (FLATPAK_MISSING_SYSCALL_BASE + 428)
+#endif
+#ifndef __SNR_open_tree
+# define __SNR_open_tree __NR_open_tree
+#endif
+
+#ifndef __NR_move_mount
+# define __NR_move_mount (FLATPAK_MISSING_SYSCALL_BASE + 429)
+#endif
+#ifndef __SNR_move_mount
+# define __SNR_move_mount __NR_move_mount
+#endif
+
+#ifndef __NR_fsopen
+# define __NR_fsopen (FLATPAK_MISSING_SYSCALL_BASE + 430)
+#endif
+#ifndef __SNR_fsopen
+# define __SNR_fsopen __NR_fsopen
+#endif
+
+#ifndef __NR_fsconfig
+# define __NR_fsconfig (FLATPAK_MISSING_SYSCALL_BASE + 431)
+#endif
+#ifndef __SNR_fsconfig
+# define __SNR_fsconfig __NR_fsconfig
+#endif
+
+#ifndef __NR_fsmount
+# define __NR_fsmount (FLATPAK_MISSING_SYSCALL_BASE + 432)
+#endif
+#ifndef __SNR_fsmount
+# define __SNR_fsmount __NR_fsmount
+#endif
+
+#ifndef __NR_fspick
+# define __NR_fspick (FLATPAK_MISSING_SYSCALL_BASE + 433)
+#endif
+#ifndef __SNR_fspick
+# define __SNR_fspick __NR_fspick
+#endif
+
+#ifndef __NR_pidfd_open
+# define __NR_pidfd_open (FLATPAK_MISSING_SYSCALL_BASE + 434)
+#endif
+#ifndef __SNR_pidfd_open
+# define __SNR_pidfd_open __NR_pidfd_open
+#endif
+
+#ifndef __NR_clone3
+# define __NR_clone3 (FLATPAK_MISSING_SYSCALL_BASE + 435)
+#endif
+#ifndef __SNR_clone3
+# define __SNR_clone3 __NR_clone3
+#endif
+
+#ifndef __NR_close_range
+# define __NR_close_range (FLATPAK_MISSING_SYSCALL_BASE + 436)
+#endif
+#ifndef __SNR_close_range
+# define __SNR_close_range __NR_close_range
+#endif
+
+#ifndef __NR_openat2
+# define __NR_openat2 (FLATPAK_MISSING_SYSCALL_BASE + 437)
+#endif
+#ifndef __SNR_openat2
+# define __SNR_openat2 __NR_openat2
+#endif
+
+#ifndef __NR_pidfd_getfd
+# define __NR_pidfd_getfd (FLATPAK_MISSING_SYSCALL_BASE + 438)
+#endif
+#ifndef __SNR_pidfd_getfd
+# define __SNR_pidfd_getfd __NR_pidfd_getfd
+#endif
+
+#ifndef __NR_faccessat2
+# define __NR_faccessat2 (FLATPAK_MISSING_SYSCALL_BASE + 439)
+#endif
+#ifndef __SNR_faccessat2
+# define __SNR_faccessat2 __NR_faccessat2
+#endif
+
+#ifndef __NR_process_madvise
+# define __NR_process_madvise (FLATPAK_MISSING_SYSCALL_BASE + 440)
+#endif
+#ifndef __SNR_process_madvise
+# define __SNR_process_madvise __NR_process_madvise
+#endif
+
+#ifndef __NR_epoll_pwait2
+# define __NR_epoll_pwait2 (FLATPAK_MISSING_SYSCALL_BASE + 441)
+#endif
+#ifndef __SNR_epoll_pwait2
+# define __SNR_epoll_pwait2 __NR_epoll_pwait2
+#endif
+
+#ifndef __NR_mount_setattr
+# define __NR_mount_setattr (FLATPAK_MISSING_SYSCALL_BASE + 442)
+#endif
+#ifndef __SNR_mount_setattr
+# define __SNR_mount_setattr __NR_mount_setattr
+#endif
+
+#ifndef __NR_quotactl_fd
+# define __NR_quotactl_fd (FLATPAK_MISSING_SYSCALL_BASE + 443)
+#endif
+#ifndef __SNR_quotactl_fd
+# define __SNR_quotactl_fd __NR_quotactl_fd
+#endif
+
+#ifndef __NR_landlock_create_ruleset
+# define __NR_landlock_create_ruleset (FLATPAK_MISSING_SYSCALL_BASE + 444)
+#endif
+#ifndef __SNR_landlock_create_ruleset
+# define __SNR_landlock_create_ruleset __NR_landlock_create_ruleset
+#endif
+
+#ifndef __NR_landlock_add_rule
+# define __NR_landlock_add_rule (FLATPAK_MISSING_SYSCALL_BASE + 445)
+#endif
+#ifndef __SNR_landlock_add_rule
+# define __SNR_landlock_add_rule __NR_landlock_add_rule
+#endif
+
+#ifndef __NR_landlock_restrict_self
+# define __NR_landlock_restrict_self (FLATPAK_MISSING_SYSCALL_BASE + 446)
+#endif
+#ifndef __SNR_landlock_restrict_self
+# define __SNR_landlock_restrict_self __NR_landlock_restrict_self
+#endif
+
+#ifndef __NR_memfd_secret
+# define __NR_memfd_secret (FLATPAK_MISSING_SYSCALL_BASE + 447)
+#endif
+#ifndef __SNR_memfd_secret
+# define __SNR_memfd_secret __NR_memfd_secret
+#endif
+
+/* Last updated: Linux 5.14, syscall numbers < 448 */


### PR DESCRIPTION
1.2.x is unmaintained upstream, but I need to support it in Debian for one more year, so I might as well send my backports upstream.

Backport of #3777, part of #3666, and the GHSA-67h7-w3jq-vh4q fixes.

* Fix argument order of clone() for s390x in seccomp filter

    From: Julian Andres Klode

    (cherry picked from commit 8ba141c38f85c8ad82d0ad6d9bde503ec4a971b6)

* tree-wide: Replace usages of whitelist/blacklist

    [Backported to 1.2.x to make subsequent security fixes apply without
    conflicts: don't touch the documentation, only the code. -smcv]
    
    (cherry picked from commit a994cdb30e78c52d10a5c86bcc86783b86d11648)

* run: Add an errno value to seccomp filters

    (cherry picked from commit e26ac7586c392b5eb35ff4609fe232c52523b2cf)

* run: Add cross-references for some other seccomp syscall filters

    (cherry picked from commit 89ae9fe74c6d445bb1b3a40e568d77cf5de47e48)

* common: Add a list of recently-added Linux syscalls

    (cherry picked from commit 26b12484eb8a6219b9e7aa287b298a894b2f34ca)

* un: Block clone3() in sandbox

    (cherry picked from commit a10f52a7565c549612c92b8e736a6698a53db330)

* run: Disallow recently-added mount-manipulation syscalls

    (cherry picked from commit 9766ee05b1425db397d2cf23afd24c7f6146a69f)

* run: Block setns()

    (cherry picked from commit 4c34815784e9ffda5733225c7d95824f96375e36)

* run: Don't allow unmounting filesystems

    (cherry picked from commit 1330662f33a55e88bfe18e76de28b7922d91a999)

* run: Don't allow chroot()

    (cherry picked from commit 462fca2c666e0cd2b60d6d2593a7216a83047aaf)