### PR TITLE
Backport CVE-2021-21381 fixes to 1.2.x

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6104,7 +6104,11 @@ export_desktop_file (const char   *app,
               else if (strcasecmp (arg, "%u") == 0)
                 g_string_append_printf (new_exec, " @@u %s @@", arg);
               else if (g_str_has_prefix (arg, "@@"))
-                g_print (_("Skipping invalid Exec argument %s\n"), arg);
+                {
+                  flatpak_fail_error (error, FLATPAK_ERROR_EXPORT_FAILED,
+                                     _("Invalid Exec argument %s"), arg);
+                  goto out;
+                }
               else
                 g_string_append_printf (new_exec, " %s", arg);
             }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6103,6 +6103,8 @@ export_desktop_file (const char   *app,
                 g_string_append_printf (new_exec, " @@ %s @@", arg);
               else if (strcasecmp (arg, "%u") == 0)
                 g_string_append_printf (new_exec, " @@u %s @@", arg);
+              else if (strcmp (arg, "@@") == 0 || strcmp (arg, "@@u") == 0)
+                g_print (_("Skipping invalid Exec argument %s\n"), arg);
               else
                 g_string_append_printf (new_exec, " %s", arg);
             }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6103,7 +6103,7 @@ export_desktop_file (const char   *app,
                 g_string_append_printf (new_exec, " @@ %s @@", arg);
               else if (strcasecmp (arg, "%u") == 0)
                 g_string_append_printf (new_exec, " @@u %s @@", arg);
-              else if (strcmp (arg, "@@") == 0 || strcmp (arg, "@@u") == 0)
+              else if (g_str_has_prefix (arg, "@@"))
                 g_print (_("Skipping invalid Exec argument %s\n"), arg);
               else
                 g_string_append_printf (new_exec, " %s", arg);


### PR DESCRIPTION
I know 1.2.x is unsupported upstream, but I have to maintain a fork of 1.2.x for about 1 more year for Debian 10, so I might as well have these upstream.

---

* Disallow @@ and @@u usage in desktop files

    From: Ryan Gonzalez

    (cherry picked from commit 652a28ffab67cb6cd7d12dc3a93979bcd3731c7f)

* dir: Reserve the whole @@ prefix

    (cherry picked from commit 1e7e8fdb24b51078f4c48e0711e24a14930ba1f0)

* dir: Refuse to export .desktop files with suspicious uses of @@ tokens

    (cherry picked from commit 46b3ede5241561c7d588951048c687c5075a3eac)