### PR TITLE
run: Handle unknown syscalls as intended

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3073,7 +3073,16 @@ setup_seccomp (FlatpakBwrap   *bwrap,
         r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 1, *syscall_blocklist[i].arg);
       else
         r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 0);
-      if (r < 0 && r == -EFAULT /* unknown syscall */)
+
+      /* EFAULT means "internal libseccomp error", but in practice we get
+       * this for syscall numbers added via flatpak-syscalls-private.h
+       * when trying to filter them on a non-native architecture, because
+       * libseccomp cannot map the syscall number to a name and back to a
+       * number for the non-native architecture. */
+      if (r == -EFAULT)
+        flatpak_debug2 ("Unable to block syscall %d: syscall not known to libseccomp?",
+                        scall);
+      else if (r < 0)
         return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Failed to block syscall %d"), scall);
     }
 
@@ -3091,7 +3100,11 @@ setup_seccomp (FlatpakBwrap   *bwrap,
           else
             r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 0);
 
-          if (r < 0 && r == -EFAULT /* unknown syscall */)
+          /* See above for the meaning of EFAULT. */
+          if (errno == EFAULT)
+            flatpak_debug2 ("Unable to block syscall %d: syscall not known to libseccomp?",
+                            scall);
+          else if (r < 0)
             return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Failed to block syscall %d"), scall);
         }
     }


### PR DESCRIPTION
The error-handling here was

    if (r < 0 && r == -EFAULT)

but Alex says it was almost certainly intended to be

    if (r < 0 && r != -EFAULT)

so that syscalls not known to libseccomp are not a fatal error.

Instead of literally making that change, emit a debug message on -EFAULT
so we can see what is going on.

This temporarily weakens our defence against CVE-2021-41133
(GHSA-67h7-w3jq-vh4q) in order to avoid regressions: if the installed
version of libseccomp does not know about the recently-added syscalls,
but the kernel does, then we will not prevent non-native executables
from using those syscalls.

Resolves: https://github.com/flatpak/flatpak/issues/4458