### PR TITLE
Fix handling of syscalls only allowed by --devel

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3101,7 +3101,7 @@ setup_seccomp (FlatpakBwrap   *bwrap,
             r = seccomp_rule_add (seccomp, SCMP_ACT_ERRNO (errnum), scall, 0);
 
           /* See above for the meaning of EFAULT. */
-          if (errno == EFAULT)
+          if (r == -EFAULT)
             flatpak_debug2 ("Unable to block syscall %d: syscall not known to libseccomp?",
                             scall);
           else if (r < 0)


### PR DESCRIPTION
This was incorrectly looking at errno instead of -r.

Fixes: 0b38b0f0 "run: Handle unknown syscalls as intended"
