### PR TITLE
Backport regression fixes from 1.10.3 into 1.8.x

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,11 +17,16 @@ For details, see:
   https://github.com/flatpak/flatpak/security/advisories/GHSA-67h7-w3jq-vh4q
 
 Other changes:
+ * Don't inherit an unusual $XDG_RUNTIME_DIR setting into the sandbox, fixing
+   a regression introduced when CVE-2021-21261 was fixed in 1.8.5 and 1.10.0
+ * Fix fd confusion in flatpak-spawn --env=... --forward-fd=..., resolving a
+   regression introduced in 1.8.5
  * Memory leak fixes backported from 1.10.2 and 1.11.2
- * File descriptor leak fixes backported from 1.10.2 and 1.11.2
+ * File descriptor leak fixes backported from 1.10.2, 1.10.3 and 1.11.2
  * Add --enable-asan configure option backported from 1.10.1
  * The .profile snippets now disable GVfs when calling flatpak to
    avoid spawning a gvfs daemon when logging in via ssh
+ * Fix test failures on non-x86_64 systems
  * Update Polish translation
 
 Changes in 1.8.5

--- a/common/flatpak-enum-types.c.template
+++ b/common/flatpak-enum-types.c.template
@@ -15,9 +15,9 @@
 GType
 @enum_name@_get_type (void)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
+  static gsize static_g_@type@_type_id = 0;
 
-  if (g_once_init_enter (&g_define_type_id__volatile))
+  if (g_once_init_enter (&static_g_@type@_type_id))
     {
       static const G@Type@Value values[] = {
 /*** END value-header ***/
@@ -31,10 +31,10 @@ GType
       };
       GType g_define_type_id =
         g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
-      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
+      g_once_init_leave (&static_g_@type@_type_id, g_define_type_id);
     }
 
-  return g_define_type_id__volatile;
+  return static_g_@type@_type_id;
 }
 
 /*** END value-tail ***/

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1377,6 +1377,10 @@ static const ExportData default_exports[] = {
   {"XDG_DATA_DIRS", "/app/share:/usr/share"},
   {"SHELL", "/bin/sh"},
   {"TMPDIR", NULL}, /* Unset TMPDIR as it may not exist in the sandbox */
+  /* We always use /run/user/UID, even if the user's XDG_RUNTIME_DIR
+   * outside the sandbox is somewhere else. Don't allow a different
+   * setting from outside the sandbox to overwrite this. */
+  {"XDG_RUNTIME_DIR", NULL},
 
   /* Some env vars are common enough and will affect the sandbox badly
      if set on the host. We clear these always. */

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -253,7 +253,7 @@ typedef struct
 typedef struct
 {
   FdMapEntry *fd_map;
-  int         fd_map_len;
+  gsize       fd_map_len;
   int         instance_id_fd;
   gboolean    set_tty;
   int         tty;
@@ -479,7 +479,7 @@ child_setup_func (gpointer user_data)
   ChildSetupData *data = (ChildSetupData *) user_data;
   FdMapEntry *fd_map = data->fd_map;
   sigset_t set;
-  int i;
+  gsize i;
 
   flatpak_close_fds_workaround (3);
 
@@ -751,7 +751,7 @@ handle_spawn (PortalFlatpak         *object,
   gsize i, j, n_fds, n_envs;
   const gint *fds = NULL;
   gint fds_len = 0;
-  g_autofree FdMapEntry *fd_map = NULL;
+  g_autoptr(GArray) fd_map = NULL;
   g_auto(GStrv) env = NULL;
   gint32 max_fd;
   GKeyFile *app_info;
@@ -913,14 +913,13 @@ handle_spawn (PortalFlatpak         *object,
   n_fds = 0;
   if (fds != NULL)
     n_fds = g_variant_n_children (arg_fds);
-  fd_map = g_new0 (FdMapEntry, n_fds);
 
-  child_setup_data.fd_map = fd_map;
-  child_setup_data.fd_map_len = n_fds;
+  fd_map = g_array_sized_new (FALSE, FALSE, sizeof (FdMapEntry), n_fds);
 
   max_fd = -1;
   for (i = 0; i < n_fds; i++)
     {
+      FdMapEntry fd_map_entry;
       gint32 handle, dest_fd;
       int handle_fd;
 
@@ -929,9 +928,10 @@ handle_spawn (PortalFlatpak         *object,
         continue;
       handle_fd = fds[handle];
 
-      fd_map[i].to = dest_fd;
-      fd_map[i].from = handle_fd;
-      fd_map[i].final = fd_map[i].to;
+      fd_map_entry.to = dest_fd;
+      fd_map_entry.from = handle_fd;
+      fd_map_entry.final = fd_map_entry.to;
+      g_array_append_val (fd_map, fd_map_entry);
 
       /* If stdin/out/err is a tty we try to set it as the controlling
          tty for the app, this way we can use this to run in a terminal. */
@@ -943,36 +943,8 @@ handle_spawn (PortalFlatpak         *object,
           child_setup_data.tty = handle_fd;
         }
 
-      max_fd = MAX (max_fd, fd_map[i].to);
-      max_fd = MAX (max_fd, fd_map[i].from);
-    }
-
-  /* We make a second pass over the fds to find if any "to" fd index
-     overlaps an already in use fd (i.e. one in the "from" category
-     that are allocated randomly). If a fd overlaps "to" fd then its
-     a caller issue and not our fault, so we ignore that. */
-  for (i = 0; i < n_fds; i++)
-    {
-      int to_fd = fd_map[i].to;
-      gboolean conflict = FALSE;
-
-      /* At this point we're fine with using "from" values for this
-         value (because we handle to==from in the code), or values
-         that are before "i" in the fd_map (because those will be
-         closed at this point when dup:ing). However, we can't
-         reuse a fd that is in "from" for j > i. */
-      for (j = i + 1; j < n_fds; j++)
-        {
-          int from_fd = fd_map[j].from;
-          if (from_fd == to_fd)
-            {
-              conflict = TRUE;
-              break;
-            }
-        }
-
-      if (conflict)
-        fd_map[i].to = ++max_fd;
+      max_fd = MAX (max_fd, fd_map_entry.to);
+      max_fd = MAX (max_fd, fd_map_entry.from);
     }
 
   if (arg_flags & FLATPAK_SPAWN_FLAGS_CLEAR_ENV)
@@ -1274,6 +1246,37 @@ handle_spawn (PortalFlatpak         *object,
 
       g_debug ("Starting: %s\n", cmd->str);
     }
+
+  /* We make a second pass over the fds to find if any "to" fd index
+     overlaps an already in use fd (i.e. one in the "from" category
+     that are allocated randomly). If a fd overlaps "to" fd then its
+     a caller issue and not our fault, so we ignore that. */
+  for (i = 0; i < fd_map->len; i++)
+    {
+      int to_fd = g_array_index (fd_map, FdMapEntry, i).to;
+      gboolean conflict = FALSE;
+
+      /* At this point we're fine with using "from" values for this
+         value (because we handle to==from in the code), or values
+         that are before "i" in the fd_map (because those will be
+         closed at this point when dup:ing). However, we can't
+         reuse a fd that is in "from" for j > i. */
+      for (j = i + 1; j < fd_map->len; j++)
+        {
+          int from_fd = g_array_index(fd_map, FdMapEntry, j).from;
+          if (from_fd == to_fd)
+            {
+              conflict = TRUE;
+              break;
+            }
+        }
+
+      if (conflict)
+        g_array_index (fd_map, FdMapEntry, i).to = ++max_fd;
+    }
+
+  child_setup_data.fd_map = &g_array_index (fd_map, FdMapEntry, 0);
+  child_setup_data.fd_map_len = fd_map->len;
 
   /* We use LEAVE_DESCRIPTORS_OPEN to work around dead-lock, see flatpak_close_fds_workaround */
   if (!g_spawn_async_with_pipes (NULL,

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1062,6 +1062,7 @@ handle_spawn (PortalFlatpak         *object,
 
   if (env_string->len > 0)
     {
+      FdMapEntry fd_map_entry;
       g_auto(GLnxTmpfile) env_tmpf  = { 0, };
 
       if (!flatpak_buffer_to_sealed_memfd_or_tmpfile (&env_tmpf, "environ",
@@ -1073,9 +1074,16 @@ handle_spawn (PortalFlatpak         *object,
         }
 
       env_fd = glnx_steal_fd (&env_tmpf.fd);
-      child_setup_data.env_fd = env_fd;
+
+      /* Use a fd that hasn't been used yet. We might have to reshuffle
+       * fd_map_entry.to, a bit later. */
+      fd_map_entry.from = env_fd;
+      fd_map_entry.to = ++max_fd;
+      fd_map_entry.final = fd_map_entry.to;
+      g_array_append_val (fd_map, fd_map_entry);
+
       g_ptr_array_add (flatpak_argv,
-                       g_strdup_printf ("--env-fd=%d", env_fd));
+                       g_strdup_printf ("--env-fd=%d", fd_map_entry.final));
     }
 
   expose_pids = (arg_flags & FLATPAK_SPAWN_FLAGS_EXPOSE_PIDS) != 0;

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -779,6 +779,7 @@ handle_spawn (PortalFlatpak         *object,
   gboolean notify_start;
   gboolean devel;
   g_autoptr(GString) env_string = g_string_new ("");
+  glnx_autofd int env_fd = -1;
 
   child_setup_data.instance_id_fd = -1;
   child_setup_data.env_fd = -1;
@@ -1099,10 +1100,10 @@ handle_spawn (PortalFlatpak         *object,
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      child_setup_data.env_fd = glnx_steal_fd (&env_tmpf.fd);
+      env_fd = glnx_steal_fd (&env_tmpf.fd);
+      child_setup_data.env_fd = env_fd;
       g_ptr_array_add (flatpak_argv,
-                       g_strdup_printf ("--env-fd=%d",
-                                        child_setup_data.env_fd));
+                       g_strdup_printf ("--env-fd=%d", env_fd));
     }
 
   expose_pids = (arg_flags & FLATPAK_SPAWN_FLAGS_EXPOSE_PIDS) != 0;

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -51,7 +51,7 @@ image=oci/image/blobs/sha256/$DIGEST
 assert_has_file $image
 assert_file_has_content $image "org\.freedesktop\.appstream\.appdata.*<summary>Print a greeting</summary>"
 assert_file_has_content $image "org\.freedesktop\.appstream\.icon-64"
-assert_file_has_content $image org.flatpak.ref.*app/org.test.Hello/x86_64/master
+assert_file_has_content $image org.flatpak.ref.*app/"org.test.Hello/$ARCH/master"
 
 ok "export oci"
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..16"
+echo "1..17"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -73,6 +73,13 @@ run org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ok "hello"
+
+mkdir xrd
+XDG_RUNTIME_DIR="$(pwd)/xrd" run_sh org.test.Platform 'echo $XDG_RUNTIME_DIR' > value-in-sandbox
+head value-in-sandbox >&2
+assert_file_has_content value-in-sandbox "^/run/user/$(id -u)\$"
+
+ok "XDG_RUNTIME_DIR not inherited"
 
 run_sh org.test.Platform cat /.flatpak-info >runtime-fpi
 assert_file_has_content runtime-fpi "[Runtime]"

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -74,12 +74,14 @@ assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ok "hello"
 
-mkdir xrd
-XDG_RUNTIME_DIR="$(pwd)/xrd" run_sh org.test.Platform 'echo $XDG_RUNTIME_DIR' > value-in-sandbox
+# XDG_RUNTIME_DIR is set to <temp directory>/runtime by libtest.sh,
+# so we always have the necessary setup to reproduce #4372
+assert_not_streq "$XDG_RUNTIME_DIR" "/run/user/$(id -u)"
+run_sh org.test.Platform 'echo $XDG_RUNTIME_DIR' > value-in-sandbox
 head value-in-sandbox >&2
 assert_file_has_content value-in-sandbox "^/run/user/$(id -u)\$"
 
-ok "XDG_RUNTIME_DIR not inherited"
+ok "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR not inherited"
 
 run_sh org.test.Platform cat /.flatpak-info >runtime-fpi
 assert_file_has_content runtime-fpi "[Runtime]"


### PR DESCRIPTION
@debarshiray, you might want these if you are doing a new 1.8.x release for RHEL. They fix regressions that happened when we fixed CVE-2021-21261 in 1.8.5.

I haven't tested this, perhaps @debarshiray could take responsibility for that?

This branch is based on #4456, please review that first.

---

* Fix build with GCC 11

    From: Michael Catanzaro
    
    See:
    https://gitlab.gnome.org/GNOME/glib/-/commit/fab561f8d05794329184cd81f9ab9d9d77dcc22a
    (cherry picked from commit 9b34768fa7fa24243439a815ece671a0b2b020dc)

* portal: Don't leak fd used for serialized environment
    
    Otherwise we'll run out of file descriptors eventually, when starting
    a sufficiently large number of subsandboxes.
    
    Resolves: flatpak/flatpak#4285
    Fixes: aeb6a7ab "portal: Convert --env in extra-args into --env-fd"
    (cherry picked from commit f2fbc75827a58cc6b4cba48a0c895c3313274020)
    (cherry picked from commit b4c6aa1cc88625db8b5a26313b34bad3e7c2ed56)

* portal: Use a GArray to store fds
    
    This will allow us to add additional mapping entries for fds to be
    used internally by `flatpak run`, in particular --env-fd.
    
    Defer the second pass through the fd array until the last possible
    moment, so that any extra fds we want to add (like the --env-fd) have
    already been added by then.
    
    Helps: flatpak/flatpak#4286
    (cherry picked from commit a09d07f085d85efdf34934ecc864a6a5ce9af761)
    (cherry picked from commit 77b484cb2e4d7c8ce5937f6c7f3055755980de06)

* portal: Remap --env-fd into child process's fd space
    
    Just because we can allocate a new, unused fd in the portal's fd space,
    that doesn't mean that fd number is going to be unused in the child
    process's fd space: we might need to remap it.
    
    Resolves: flatpak/flatpak#4286
    Fixes: aeb6a7ab "portal: Convert --env in extra-args into --env-fd"
    (cherry picked from commit 526dae92418616c71517945e810227416f160ce6)
    (cherry picked from commit 101a3c5515ccf79d156a1b5272a2e8d7cc90c86a)

* tests: Remove hard-coded references to x86_64
    
    Distributions run these tests on other architectures, but hard-coding
    x86_64 to look for in output dooms that to failure.
    
    (cherry picked from commit ba381ae9368c0e6e233c52254e698f5f64903036)
    (cherry picked from commit 4089b6976938b43de6f165e89a3850222505df33)

* run: Don't let XDG_RUNTIME_DIR from user override the value we set
    
    We use `bwrap --setenv XDG_RUNTIME_DIR` to set it to `/run/user/UID`,
    regardless of what it is on the host system, but the changes made
    to resolve CVE-2021-21261 unintentionally broke this by overwriting it
    with the user's XDG_RUNTIME_DIR.
    
    In practice this worked for most people, who either have
    XDG_RUNTIME_DIR set to the same value we use (which is the conventional
    setup from systemd-logind and elogind), or entirely unset (if they do not
    have systemd-logind or elogind). However, it broke Wayland and other
    XDG_RUNTIME_DIR-based protocols for people who intentionally set up an
    XDG_RUNTIME_DIR that is different.
    
    Fixes: 6d1773d2 "run: Convert all environment variables into bwrap arguments"
    Resolves: https://github.com/flatpak/flatpak/issues/4372
    (cherry picked from commit d3e6e71feec23ae6f6c68c2860a1330e12427357)

* tests: Don't reset XDG_RUNTIME_DIR locally
    
    If we do, it interferes with xdg-dbus-proxy, causing test failure under
    some circumstances: the test passes on a development system, but fails
    when run on a qemu virtual machine in Debian's autopkgtest framework.
    
    Fixes: 6e5b02e2 "run: Don't let XDG_RUNTIME_DIR from user override the value we set"
    (cherry picked from commit 7bf6ecfaa22740daac66e35476c74583c707007c)
    (cherry picked from commit 9c12cb44b899324663463a7cc6c175a72b8fb90d)

* Update NEWS