### PR TITLE
Add XDG_STATE_HOME and HOST_XDG_STATE_HOME env variables

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1828,13 +1828,16 @@ flatpak_run_apply_env_appid (FlatpakBwrap *bwrap,
   g_autoptr(GFile) app_dir_data = NULL;
   g_autoptr(GFile) app_dir_config = NULL;
   g_autoptr(GFile) app_dir_cache = NULL;
+  g_autoptr(GFile) app_dir_state = NULL;
 
   app_dir_data = g_file_get_child (app_dir, "data");
   app_dir_config = g_file_get_child (app_dir, "config");
   app_dir_cache = g_file_get_child (app_dir, "cache");
+  app_dir_state = g_file_get_child (app_dir, ".local/state");
   flatpak_bwrap_set_env (bwrap, "XDG_DATA_HOME", flatpak_file_get_path_cached (app_dir_data), TRUE);
   flatpak_bwrap_set_env (bwrap, "XDG_CONFIG_HOME", flatpak_file_get_path_cached (app_dir_config), TRUE);
   flatpak_bwrap_set_env (bwrap, "XDG_CACHE_HOME", flatpak_file_get_path_cached (app_dir_cache), TRUE);
+  flatpak_bwrap_set_env (bwrap, "XDG_STATE_HOME", flatpak_file_get_path_cached (app_dir_state), TRUE);
 
   if (g_getenv ("XDG_DATA_HOME"))
     flatpak_bwrap_set_env (bwrap, "HOST_XDG_DATA_HOME", g_getenv ("XDG_DATA_HOME"), TRUE);
@@ -1842,6 +1845,8 @@ flatpak_run_apply_env_appid (FlatpakBwrap *bwrap,
     flatpak_bwrap_set_env (bwrap, "HOST_XDG_CONFIG_HOME", g_getenv ("XDG_CONFIG_HOME"), TRUE);
   if (g_getenv ("XDG_CACHE_HOME"))
     flatpak_bwrap_set_env (bwrap, "HOST_XDG_CACHE_HOME", g_getenv ("XDG_CACHE_HOME"), TRUE);
+  if (g_getenv ("XDG_STATE_HOME"))
+    flatpak_bwrap_set_env (bwrap, "HOST_XDG_STATE_HOME", g_getenv ("XDG_STATE_HOME"), TRUE);
 }
 
 void

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1833,6 +1833,9 @@ flatpak_run_apply_env_appid (FlatpakBwrap *bwrap,
   app_dir_data = g_file_get_child (app_dir, "data");
   app_dir_config = g_file_get_child (app_dir, "config");
   app_dir_cache = g_file_get_child (app_dir, "cache");
+  /* Yes, this is inconsistent with data, config and cache. However, using
+   * this path lets apps provide backwards-compatibility with older Flatpak
+   * versions by using `--persist=.local/state --unset-env=XDG_STATE_DIR`. */
   app_dir_state = g_file_get_child (app_dir, ".local/state");
   flatpak_bwrap_set_env (bwrap, "XDG_DATA_HOME", flatpak_file_get_path_cached (app_dir_data), TRUE);
   flatpak_bwrap_set_env (bwrap, "XDG_CONFIG_HOME", flatpak_file_get_path_cached (app_dir_config), TRUE);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1890,6 +1890,7 @@ flatpak_ensure_data_dir (GFile        *app_id_dir,
   g_autoptr(GFile) fontconfig_cache_dir = g_file_get_child (cache_dir, "fontconfig");
   g_autoptr(GFile) tmp_dir = g_file_get_child (cache_dir, "tmp");
   g_autoptr(GFile) config_dir = g_file_get_child (app_id_dir, "config");
+  g_autoptr(GFile) state_dir = g_file_get_child (app_id_dir, ".local/state");
 
   if (!flatpak_mkdir_p (data_dir, cancellable, error))
     return FALSE;
@@ -1904,6 +1905,9 @@ flatpak_ensure_data_dir (GFile        *app_id_dir,
     return FALSE;
 
   if (!flatpak_mkdir_p (config_dir, cancellable, error))
+    return FALSE;
+
+  if (!flatpak_mkdir_p (state_dir, cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -101,6 +101,12 @@
             <member>XDG_STATE_HOME (since Flatpak 1.13)</member>
         </simplelist>
         <para>
+            Apps can use the <option>--persist=.local/state</option> and
+            <option>--unset-env=XDG_STATE_HOME</option> options to get a
+            Flatpak 1.13-compatible <filename>~/.local/state</filename>
+            on older versions of Flatpak.
+        </para>
+        <para>
             The host values of these variables are made available inside the sandbox via these
             HOST_-prefixed variables:
         </para>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -98,7 +98,7 @@
             <member>XDG_DATA_HOME</member>
             <member>XDG_CONFIG_HOME</member>
             <member>XDG_CACHE_HOME</member>
-            <member>XDG_STATE_HOME</member>
+            <member>XDG_STATE_HOME (since Flatpak 1.13)</member>
         </simplelist>
         <para>
             The host values of these variables are made available inside the sandbox via these
@@ -108,7 +108,7 @@
             <member>HOST_XDG_DATA_HOME</member>
             <member>HOST_XDG_CONFIG_HOME</member>
             <member>HOST_XDG_CACHE_HOME</member>
-            <member>HOST_XDG_STATE_HOME</member>
+            <member>HOST_XDG_STATE_HOME (since Flatpak 1.13)</member>
         </simplelist>
         <para>
             Flatpak sets the environment variable <envar>FLATPAK_ID</envar> to the application

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -98,6 +98,7 @@
             <member>XDG_DATA_HOME</member>
             <member>XDG_CONFIG_HOME</member>
             <member>XDG_CACHE_HOME</member>
+            <member>XDG_STATE_HOME</member>
         </simplelist>
         <para>
             The host values of these variables are made available inside the sandbox via these
@@ -107,6 +108,7 @@
             <member>HOST_XDG_DATA_HOME</member>
             <member>HOST_XDG_CONFIG_HOME</member>
             <member>HOST_XDG_CACHE_HOME</member>
+            <member>HOST_XDG_STATE_HOME</member>
         </simplelist>
         <para>
             Flatpak sets the environment variable <envar>FLATPAK_ID</envar> to the application

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -100,6 +100,7 @@ export HOME=${TEST_DATA_DIR}/home
 export XDG_CACHE_HOME=${TEST_DATA_DIR}/home/cache
 export XDG_CONFIG_HOME=${TEST_DATA_DIR}/home/config
 export XDG_DATA_HOME=${TEST_DATA_DIR}/home/share
+export XDG_STATE_HOME=${TEST_DATA_DIR}/home/state
 export XDG_RUNTIME_DIR=${TEST_DATA_DIR}/runtime
 
 export XDG_DESKTOP_PORTAL_DIR=${test_builddir}/share/xdg-desktop-portal/portals

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..19"
+echo "1..20"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -82,6 +82,40 @@ head value-in-sandbox >&2
 assert_file_has_content value-in-sandbox "^/run/user/$(id -u)\$"
 
 ok "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR not inherited"
+
+assert_streq "$XDG_CACHE_HOME" "${TEST_DATA_DIR}/home/cache"
+run_sh org.test.Hello 'echo "$XDG_CACHE_HOME"' > value-in-sandbox
+head value-in-sandbox >&2
+assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/cache\$"
+run_sh org.test.Hello 'echo "$HOST_XDG_CACHE_HOME"' > host-value-in-sandbox
+head host-value-in-sandbox >&2
+assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/cache\$"
+
+assert_streq "$XDG_CONFIG_HOME" "${TEST_DATA_DIR}/home/config"
+run_sh org.test.Hello 'echo "$XDG_CONFIG_HOME"' > value-in-sandbox
+head value-in-sandbox >&2
+assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/config\$"
+run_sh org.test.Hello 'echo "$HOST_XDG_CONFIG_HOME"' > host-value-in-sandbox
+head host-value-in-sandbox >&2
+assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/config\$"
+
+assert_streq "$XDG_DATA_HOME" "${TEST_DATA_DIR}/home/share"
+run_sh org.test.Hello 'echo "$XDG_DATA_HOME"' > value-in-sandbox
+head value-in-sandbox >&2
+assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/data\$"
+run_sh org.test.Hello 'echo "$HOST_XDG_DATA_HOME"' > host-value-in-sandbox
+head host-value-in-sandbox >&2
+assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/share\$"
+
+assert_streq "$XDG_STATE_HOME" "${TEST_DATA_DIR}/home/state"
+run_sh org.test.Hello 'echo "$XDG_STATE_HOME"' > value-in-sandbox
+head value-in-sandbox >&2
+assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/\\.local/state\$"
+run_sh org.test.Hello 'echo "$HOST_XDG_STATE_HOME"' > host-value-in-sandbox
+head host-value-in-sandbox >&2
+assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/state\$"
+
+ok "XDG_foo_HOME work as expected"
 
 run_sh org.test.Platform cat /.flatpak-info >runtime-fpi
 assert_file_has_content runtime-fpi "[Runtime]"

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -87,6 +87,7 @@ assert_streq "$XDG_CACHE_HOME" "${TEST_DATA_DIR}/home/cache"
 run_sh org.test.Hello 'echo "$XDG_CACHE_HOME"' > value-in-sandbox
 head value-in-sandbox >&2
 assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/cache\$"
+test -d "${TEST_DATA_DIR}/home/.var/app/org.test.Hello/cache"
 run_sh org.test.Hello 'echo "$HOST_XDG_CACHE_HOME"' > host-value-in-sandbox
 head host-value-in-sandbox >&2
 assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/cache\$"
@@ -95,6 +96,7 @@ assert_streq "$XDG_CONFIG_HOME" "${TEST_DATA_DIR}/home/config"
 run_sh org.test.Hello 'echo "$XDG_CONFIG_HOME"' > value-in-sandbox
 head value-in-sandbox >&2
 assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/config\$"
+test -d "${TEST_DATA_DIR}/home/.var/app/org.test.Hello/config"
 run_sh org.test.Hello 'echo "$HOST_XDG_CONFIG_HOME"' > host-value-in-sandbox
 head host-value-in-sandbox >&2
 assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/config\$"
@@ -103,6 +105,7 @@ assert_streq "$XDG_DATA_HOME" "${TEST_DATA_DIR}/home/share"
 run_sh org.test.Hello 'echo "$XDG_DATA_HOME"' > value-in-sandbox
 head value-in-sandbox >&2
 assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/data\$"
+test -d "${TEST_DATA_DIR}/home/.var/app/org.test.Hello/data"
 run_sh org.test.Hello 'echo "$HOST_XDG_DATA_HOME"' > host-value-in-sandbox
 head host-value-in-sandbox >&2
 assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/share\$"
@@ -111,6 +114,7 @@ assert_streq "$XDG_STATE_HOME" "${TEST_DATA_DIR}/home/state"
 run_sh org.test.Hello 'echo "$XDG_STATE_HOME"' > value-in-sandbox
 head value-in-sandbox >&2
 assert_file_has_content value-in-sandbox "^${TEST_DATA_DIR}/home/\\.var/app/org\\.test\\.Hello/\\.local/state\$"
+test -d "${TEST_DATA_DIR}/home/.var/app/org.test.Hello/.local/state"
 run_sh org.test.Hello 'echo "$HOST_XDG_STATE_HOME"' > host-value-in-sandbox
 head host-value-in-sandbox >&2
 assert_file_has_content host-value-in-sandbox "^${TEST_DATA_DIR}/home/state\$"

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -44,6 +44,7 @@ isolated_test_dir_global_setup (void)
   g_autofree char *cachedir = NULL;
   g_autofree char *configdir = NULL;
   g_autofree char *datadir = NULL;
+  g_autofree char *statedir = NULL;
   g_autofree char *homedir = NULL;
   g_autofree char *runtimedir = NULL;
 
@@ -72,6 +73,11 @@ isolated_test_dir_global_setup (void)
   g_setenv ("XDG_DATA_HOME", datadir, TRUE);
   g_test_message ("setting XDG_DATA_HOME=%s", datadir);
 
+  statedir = g_strconcat (isolated_test_dir, "/home/state", NULL);
+  g_assert_no_errno (g_mkdir_with_parents (statedir, S_IRWXU | S_IRWXG | S_IRWXO));
+  g_setenv ("XDG_STATE_HOME", statedir, TRUE);
+  g_test_message ("setting XDG_STATE_HOME=%s", statedir);
+
   runtimedir = g_strconcat (isolated_test_dir, "/runtime", NULL);
   g_assert_no_errno (g_mkdir_with_parents (runtimedir, S_IRWXU));
   g_setenv ("XDG_RUNTIME_DIR", runtimedir, TRUE);
@@ -82,6 +88,7 @@ isolated_test_dir_global_setup (void)
   g_assert_cmpstr (g_get_user_cache_dir (), ==, cachedir);
   g_assert_cmpstr (g_get_user_config_dir (), ==, configdir);
   g_assert_cmpstr (g_get_user_data_dir (), ==, datadir);
+  g_assert_cmpstr (g_getenv ("XDG_STATE_HOME"), ==, statedir);
   g_assert_cmpstr (g_get_user_runtime_dir (), ==, runtimedir);
 }
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -2648,6 +2648,7 @@ global_setup (void)
   g_autofree char *cachedir = NULL;
   g_autofree char *configdir = NULL;
   g_autofree char *datadir = NULL;
+  g_autofree char *statedir = NULL;
   g_autofree char *homedir = NULL;
   g_autofree char *services_dir = NULL;
 
@@ -2675,6 +2676,11 @@ global_setup (void)
   g_mkdir_with_parents (datadir, S_IRWXU | S_IRWXG | S_IRWXO);
   g_setenv ("XDG_DATA_HOME", datadir, TRUE);
   g_test_message ("setting XDG_DATA_HOME=%s", datadir);
+
+  statedir = g_strconcat (testdir, "/home/state", NULL);
+  g_mkdir_with_parents (statedir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_STATE_HOME", statedir, TRUE);
+  g_test_message ("setting XDG_STATE_HOME=%s", statedir);
 
   flatpak_runtimedir = g_strconcat (testdir, "/runtime", NULL);
   g_mkdir_with_parents (flatpak_runtimedir, S_IRWXU | S_IRWXG | S_IRWXO);


### PR DESCRIPTION
This gives new support for the new XDG_STATE_HOME addition to XDG_BASE_DIRS which allows applications to use this without breaking because they would assume $HOME/.local/state which may be unavailable to the flatpak

This adds it as .local/state as to make --persist=.local/state the same behaviour as in new flatpak. This in turn means that the transition should be seamless between old and new flatpak.

This also has the benefit of working if the application doesn't follow XDG spec thanks to --persist=.local/state.

This fixes flatpak#4477