### PR TITLE
app: Fix behavior when installing end-of-life-rebased ref

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -772,8 +772,7 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
     {
       g_autoptr(GError) error = NULL;
 
-      if (!flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error) ||
-          !flatpak_transaction_add_uninstall (transaction, ref_str, &error))
+      if (!flatpak_transaction_add_rebase (transaction, remote, rebased_to_ref, NULL, previous_ids, &error))
         {
           g_propagate_prefixed_error (&self->first_operation_error,
                                       g_error_copy (error),
@@ -782,7 +781,22 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
           return FALSE;
         }
 
-      return TRUE; /* skip update op, in favour of added uninstall */
+      if (!flatpak_transaction_add_uninstall (transaction, ref_str, &error))
+        {
+          /* NOT_INSTALLED error is expected in case the op that triggered this was install not update */
+          if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED))
+            g_clear_error (&error);
+          else
+            {
+              g_propagate_prefixed_error (&self->first_operation_error,
+                                          g_error_copy (error),
+                                          _("Failed to uninstall %s for rebase to %s: "),
+                                          name, rebased_to_ref);
+              return FALSE;
+            }
+        }
+
+      return TRUE; /* skip install/update op of end-of-life ref */
     }
   else /* IGNORE or NO_REBASE */
     return FALSE;


### PR DESCRIPTION
Currently if the user specifies a ref to install that has been renamed
via the end-of-life-rebased mechanism, for example "flatpak install
com.visualstudio.code.oss", Flatpak erroneously tries to install both
the old and new versions of the app. This happens because the code
handling end-of-life-rebase conditions is written assuming the rebased
app is being updated rather than installed for the first time.

Specifically, in FlatpakCliTransaction and FlatpakQuietTransaction, in
end_of_lifed_with_rebase(), we treat a failure of
flatpak_transaction_add_uninstall() as fatal and return FALSE from the
signal handler, which means that the install operation that triggered
the signal will not be skipped (see the docs for
FlatpakTransaction::end-of-lifed-with-rebase).

So, instead check for the FLATPAK_ERROR_NOT_INSTALLED error code and
ignore it, so that the installation of the old version of the renamed
app will be properly cancelled.

Fixes https://github.com/flatpak/flatpak/issues/3754