### PR TITLE
tests: Allow FLATPAK_BINARY=flatpak for exports

### DIFF
--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -67,7 +67,7 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/files
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
 # Ensure Exec key is rewritten
-assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=master --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
+assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*flatpak run --branch=master --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
 assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png
 assert_has_file $FL_DIR/exports/share/icons/HighContrast/64x64/apps/org.test.Hello.png
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -45,7 +45,7 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/files
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
 # Ensure Exec key is rewritten
-assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
+assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
 assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini
 assert_file_has_content $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini "^DefaultDisabled=true$"
 assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png


### PR DESCRIPTION
https://github.com/flatpak/flatpak/commit/a99b748931e6444dadb0d0c8c1565da23f755800 introduced an environment variable for changing the flatpak path for exports. On NixOS, we do not have a stable path we could use so we used to patch Flatpak to use `flatpak` program from `PATH`. With the recent change, we drop our downstream patch in favour of setting the environment variable to `flatpak` but the tests do not expect that.

This is the test part of our former downstream patch so that tests can pass with exports using `flatpak` instead of an absolute path. It still expects the binary path to end with `flatpak` so arbitrary `$FLATPAK_BINARY` will not work but we do not pass the environment variable to tests so we cannot do much better.
