### PR TITLE
tests: Generate Makefile-test-matrix.am.inc in $(srcdir)

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -279,7 +279,7 @@ TEST_MATRIX_SOURCE = \
 	$(NULL)
 
 update-test-matrix:
-	$(srcdir)/tests/expand-test-matrix.sh "$(TEST_MATRIX_SOURCE)" > tests/Makefile-test-matrix.am.inc
+	$(srcdir)/tests/expand-test-matrix.sh "$(TEST_MATRIX_SOURCE)" > $(srcdir)/tests/Makefile-test-matrix.am.inc
 
 tests/test-%.wrap:
 	@true


### PR DESCRIPTION
Files that are generated manually by a maintainer and committed to git
should be in the srcdir, not the builddir.