### PR TITLE
transaction: Utilize runtime repo info for origin remote

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13858,34 +13858,6 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir         *self,
   return TRUE;
 }
 
-static gboolean
-_flatpak_uri_equal (const char *uri1,
-                    const char *uri2)
-{
-  g_autofree char *uri1_norm = NULL;
-  g_autofree char *uri2_norm = NULL;
-  gsize uri1_len = strlen (uri1);
-  gsize uri2_len = strlen (uri2);
-
-  /* URIs handled by libostree are equivalent with or without a trailing slash,
-   * but this isn't otherwise guaranteed to be the case.
-   */
-  if (g_str_has_prefix (uri1, "oci+") || g_str_has_prefix (uri2, "oci+"))
-    return g_strcmp0 (uri1, uri2) == 0;
-
-  if (g_str_has_suffix (uri1, "/"))
-    uri1_norm = g_strndup (uri1, uri1_len - 1);
-  else
-    uri1_norm = g_strdup (uri1);
-
-  if (g_str_has_suffix (uri2, "/"))
-    uri2_norm = g_strndup (uri2, uri2_len - 1);
-  else
-    uri2_norm = g_strdup (uri2);
-
-  return g_strcmp0 (uri1_norm, uri2_norm) == 0;
-}
-
 /* This tries to find a pre-configured remote for the specified uri.
  *
  *  We consider non-OCI URLs equal even if one lacks a trailing slash.
@@ -13918,7 +13890,7 @@ flatpak_dir_find_remote_by_uri (FlatpakDir *self,
                                            NULL))
             continue;
 
-          if (_flatpak_uri_equal (uri, remote_uri))
+          if (flatpak_uri_equal (uri, remote_uri))
             return g_strdup (remote);
         }
     }

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -913,6 +913,9 @@ int flatpak_envp_cmp (const void *p1,
 
 gboolean flatpak_str_is_integer (const char *s);
 
+gboolean flatpak_uri_equal (const char *uri1,
+                            const char *uri2);
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 #endif /* __FLATPAK_UTILS_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -9042,3 +9042,31 @@ flatpak_str_is_integer (const char *s)
 
   return TRUE;
 }
+
+gboolean
+flatpak_uri_equal (const char *uri1,
+                   const char *uri2)
+{
+  g_autofree char *uri1_norm = NULL;
+  g_autofree char *uri2_norm = NULL;
+  gsize uri1_len = strlen (uri1);
+  gsize uri2_len = strlen (uri2);
+
+  /* URIs handled by libostree are equivalent with or without a trailing slash,
+   * but this isn't otherwise guaranteed to be the case.
+   */
+  if (g_str_has_prefix (uri1, "oci+") || g_str_has_prefix (uri2, "oci+"))
+    return g_strcmp0 (uri1, uri2) == 0;
+
+  if (g_str_has_suffix (uri1, "/"))
+    uri1_norm = g_strndup (uri1, uri1_len - 1);
+  else
+    uri1_norm = g_strdup (uri1);
+
+  if (g_str_has_suffix (uri2, "/"))
+    uri2_norm = g_strndup (uri2, uri2_len - 1);
+  else
+    uri2_norm = g_strdup (uri2);
+
+  return g_strcmp0 (uri1_norm, uri2_norm) == 0;
+}

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..41"
+echo "1..42"
 
 #Regular repo
 setup_repo
@@ -185,7 +185,7 @@ cat << EOF > repos/flatpakref/flatpakref-repo.flatpakrepo
 [Flatpak Repo]
 Version=1
 Url=http://127.0.0.1:$(cat httpd-port)/flatpakref/
-Title=The Title
+Title=The Remote Title
 GPGKey=${FL_GPG_BASE64}
 EOF
 
@@ -198,6 +198,7 @@ cat << EOF > org.test.Hello.flatpakref
 Name=org.test.Hello
 Branch=master
 Url=http://127.0.0.1:$(cat httpd-port)/flatpakref
+SuggestRemoteName=allthegoodstuff
 GPGKey=${FL_GPG_BASE64}
 RuntimeRepo=http://127.0.0.1:$(cat httpd-port)/flatpakref/flatpakref-repo.flatpakrepo
 EOF
@@ -215,6 +216,10 @@ if [ $NUM_REMOTES_AFTER -ne $((NUM_REMOTES_BEFORE + 1)) ]; then
 fi
 
 ok "install flatpakref normalizes remote URL trailing slash"
+
+assert_remote_has_config allthegoodstuff xa.title "The Remote Title"
+
+ok "install flatpakref uses RuntimeRepo metadata for remote"
 
 ${FLATPAK} ${U} uninstall -y org.test.Platform org.test.Hello
 


### PR DESCRIPTION
Many of the fields allowed in flatpakrepo files are not allowed in
flatpakref files, e.g. Comment, Description, Homepage, etc. So there is
no straightforward way to ensure those are set correctly when the user
installs something with a flatpakref file. However in most cases the
repo specified by the RuntimeRepo key is also the repo providing the
main ref, so in those cases it makes sense to utilize all the metadata
provided in the flatpakrepo file when creating a remote to provide
updates for the app being installed. We were already doing this when the
SuggestRemoteName key was unset; this commit makes it so that we utilize
that metadata also when SuggestRemoteName is present.