### PR TITLE
Don't use app title from flatpakref as remote title

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -13707,14 +13707,12 @@ parse_ref_file (GKeyFile *keyfile,
                 char    **name_out,
                 char    **branch_out,
                 char    **url_out,
-                char    **title_out,
                 GBytes  **gpg_data_out,
                 gboolean *is_runtime_out,
                 char    **collection_id_out,
                 GError  **error)
 {
   g_autofree char *url = NULL;
-  g_autofree char *title = NULL;
   g_autofree char *name = NULL;
   g_autofree char *branch = NULL;
   g_autofree char *version = NULL;
@@ -13726,7 +13724,6 @@ parse_ref_file (GKeyFile *keyfile,
   *name_out = NULL;
   *branch_out = NULL;
   *url_out = NULL;
-  *title_out = NULL;
   *gpg_data_out = NULL;
   *is_runtime_out = FALSE;
 
@@ -13752,9 +13749,6 @@ parse_ref_file (GKeyFile *keyfile,
                                   FLATPAK_REF_BRANCH_KEY, NULL);
   if (branch == NULL)
     branch = g_strdup ("master");
-
-  title = g_key_file_get_string (keyfile, FLATPAK_REF_GROUP,
-                                 FLATPAK_REF_TITLE_KEY, NULL);
 
   is_runtime = g_key_file_get_boolean (keyfile, FLATPAK_REF_GROUP,
                                        FLATPAK_REF_IS_RUNTIME_KEY, NULL);
@@ -13793,7 +13787,6 @@ parse_ref_file (GKeyFile *keyfile,
   *name_out = g_steal_pointer (&name);
   *branch_out = g_steal_pointer (&branch);
   *url_out = g_steal_pointer (&url);
-  *title_out = g_steal_pointer (&title);
   *gpg_data_out = g_steal_pointer (&gpg_data);
   *is_runtime_out = is_runtime;
   *collection_id_out = g_steal_pointer (&collection_id);
@@ -13814,14 +13807,13 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir         *self,
   g_autofree char *name = NULL;
   g_autofree char *branch = NULL;
   g_autofree char *url = NULL;
-  g_autofree char *title = NULL;
   g_autofree char *remote = NULL;
   gboolean is_runtime = FALSE;
   g_autofree char *collection_id = NULL;
   g_autoptr(GFile) deploy_dir = NULL;
   g_autoptr(FlatpakDecomposed) ref = NULL;
 
-  if (!parse_ref_file (keyfile, &name, &branch, &url, &title, &gpg_data, &is_runtime, &collection_id, error))
+  if (!parse_ref_file (keyfile, &name, &branch, &url, &gpg_data, &is_runtime, &collection_id, error))
     return FALSE;
 
   ref = flatpak_decomposed_new_from_parts (is_runtime ? FLATPAK_KINDS_RUNTIME : FLATPAK_KINDS_APP,
@@ -13844,7 +13836,8 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir         *self,
 
   if (remote == NULL)
     {
-      remote = flatpak_dir_create_origin_remote (self, url, name, title, flatpak_decomposed_get_ref (ref),
+      /* title is NULL because the title from the ref file is the title of the app not the remote */
+      remote = flatpak_dir_create_origin_remote (self, url, name, NULL, flatpak_decomposed_get_ref (ref),
                                                  gpg_data, collection_id, NULL, NULL, error);
       if (remote == NULL)
         return FALSE;

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2260,8 +2260,10 @@ flatpak_parse_repofile (const char   *remote_name,
   if (subset != NULL)
     g_key_file_set_string (config, group, "xa.subset", subset);
 
-  title = g_key_file_get_locale_string (keyfile, source_group,
-                                        FLATPAK_REPO_TITLE_KEY, NULL, NULL);
+  /* Don't use the title from flatpakref files; that's the title of the app */
+  if (!from_ref)
+    title = g_key_file_get_locale_string (keyfile, FLATPAK_REPO_GROUP,
+                                          FLATPAK_REPO_TITLE_KEY, NULL, NULL);
   if (title != NULL)
     g_key_file_set_string (config, group, "xa.title", title);
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -3483,8 +3483,10 @@ test_transaction_flatpakref_remote_creation (void)
   g_autoptr(FlatpakInstallation) user_inst = NULL;
   g_autoptr(FlatpakInstallation) system_inst = NULL;
   g_autoptr(FlatpakTransaction) transaction = NULL;
+  g_autoptr(FlatpakRemote) remote = NULL;
   g_autoptr(GError) error = NULL;
   g_autofree char *s = NULL;
+  g_autofree char *remote_title = NULL;
   g_autoptr(GBytes) data = NULL;
   gboolean res;
 
@@ -3533,6 +3535,13 @@ test_transaction_flatpakref_remote_creation (void)
 
   assert_remote_in_installation (user_inst, "test-without-runtime-repo");
   assert_remote_in_installation (user_inst, "test-runtime-only-repo");
+
+  /* The remote should not use the title of the app as its title */
+  remote = flatpak_installation_get_remote_by_name (user_inst, "test-without-runtime-repo", NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (remote);
+  remote_title = flatpak_remote_get_title (remote);
+  g_assert_null (remote_title);
 
   empty_installation (user_inst);
   remove_remote_user ("test-without-runtime-repo");


### PR DESCRIPTION
On two different code paths we were using the "Title" field in
flatpakref files as the title of a remote, which is incorrect. In most
cases, the remote added via the RuntimeRepo key will be the same as the
remote the app is from, so when the remote is added for the runtime, its
title will be correctly set using the Title value from the flatpakrepo
file and the app will therefore have an origin remote with a title set.
This is not currently true for flatpakref files that use
SuggestRemoteName=, see https://github.com/flatpak/flatpak/pull/4513

For flatpakref files that use a different remote than the RuntimeRepo,
we don't currently have a way for the title to be set automatically;
perhaps we should (https://github.com/flatpak/flatpak/issues/4512).

Fixes https://github.com/flatpak/flatpak/issues/4499