### PR TITLE
flatpak-utils-http: Ensure to wake up the main context on error

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -503,7 +503,10 @@ load_uri_callback (GObject      *source_object,
       if (!glnx_open_tmpfile_linkable_at (data->out_tmpfile_parent_dfd, ".",
                                           O_WRONLY, data->out_tmpfile,
                                           &data->error))
-        return;
+        {
+          g_main_context_wakeup (data->context);
+          return;
+        }
 
       g_assert (data->out == NULL);
 


### PR DESCRIPTION
All the other code paths which set `data->done` or `data->error` ensure
to wake up the main context so its loop exit conditions can be checked
again — this code path was missing a wakeup though.

Spotted by code inspection; I haven’t hit this in the wild.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>