### PR TITLE
system-helper: Avoid most polkit prompts for pinning (option 1)

### DIFF
--- a/system-helper/org.freedesktop.Flatpak.rules.in
+++ b/system-helper/org.freedesktop.Flatpak.rules.in
@@ -9,6 +9,12 @@ polkit.addRule(function(action, subject) {
             return polkit.Result.YES;
     }
 
+    if (action.id == "org.freedesktop.Flatpak.configure" &&
+        action.lookup("key") == "pinned" &&
+        subject.active == true && subject.local == true &&
+        subject.isInGroup("@privileged_group@"))
+      return polkit.Result.YES;
+
     return polkit.Result.NOT_HANDLED;
 });
 


### PR DESCRIPTION
Currently if the user instructs Flatpak to install a runtime into the
system installation, they are prompted with a polkit dialog saying
"Authentication is required to configure software installation". This is
because we automatically "pin" runtimes that are explicitly installed so
they are not automatically removed. But it is not correct to prompt the
user for authorization, since (a) the runtime install operation itself
is what they initiated, so it's confusing for the prompt to be for
something else, and (b) there are not usually prompts anyway for runtime
install operations when the user is in the privileged group (e.g. sudo),
and (c) the pinning of the runtime is not a particularly security
sensitive configuration option.

This commit shows one way to fix this bug, by avoiding the polkit prompt
in case the user is in the privileged group and in a local active
session, the same conditions used to skip prompts for runtime
installation. However one can argue this is not a great solution as it
still allows the possibility the user would be prompted for this action
in case they don't meet the aforementioned conditions. So I'll propose
another solution as a separate PR.

Unfortunately this is difficult to add a unit test for, since the
system-helper service that runs for the test suite doesn't do polkit
checks; see flatpak_authorize_method_handler()

Fixes #4200