### PR TITLE
Change how automatic pinning is implemented (option 2)

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -216,7 +216,7 @@ typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION = 1 << 4,
   FLATPAK_HELPER_DEPLOY_FLAGS_APP_HINT = 1 << 5,
   FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT = 1 << 6,
-  FLATPAK_HELPER_DEPLOY_FLAGS,
+  FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED = 1 << 7,
 } FlatpakHelperDeployFlags;
 
 #define FLATPAK_HELPER_DEPLOY_FLAGS_ALL (FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE | \
@@ -225,7 +225,8 @@ typedef enum {
                                          FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL | \
                                          FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION | \
                                          FLATPAK_HELPER_DEPLOY_FLAGS_APP_HINT | \
-                                         FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT)
+                                         FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT | \
+                                         FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED)
 
 typedef enum {
   FLATPAK_HELPER_UNINSTALL_FLAGS_NONE = 0,
@@ -715,6 +716,7 @@ gboolean              flatpak_dir_deploy_install                            (Fla
                                                                              const char                   **subpaths,
                                                                              const char                   **previous_ids,
                                                                              gboolean                       reinstall,
+                                                                             gboolean                       pin_on_deploy,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
 gboolean              flatpak_dir_install                                   (FlatpakDir                    *self,
@@ -723,6 +725,7 @@ gboolean              flatpak_dir_install                                   (Fla
                                                                              gboolean                       no_static_deltas,
                                                                              gboolean                       reinstall,
                                                                              gboolean                       app_hint,
+                                                                             gboolean                       pin_on_deploy,
                                                                              FlatpakRemoteState            *state,
                                                                              FlatpakDecomposed             *ref,
                                                                              const char                    *opt_commit,

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1926,7 +1926,7 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_PULL) != 0,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_DEPLOY) != 0,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_STATIC_DELTAS) != 0,
-                            FALSE, FALSE, state,
+                            FALSE, FALSE, FALSE, state,
                             ref, NULL, (const char **) subpaths, NULL, NULL, NULL, NULL,
                             progress, cancellable, error))
     return NULL;

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -399,6 +399,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   gboolean no_deploy;
   gboolean local_pull;
   gboolean reinstall;
+  gboolean update_pinned;
   g_autofree char *url = NULL;
   g_autoptr(OngoingPull) ongoing_pull = NULL;
   g_autofree gchar *src_dir = NULL;
@@ -483,6 +484,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   no_deploy = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_DEPLOY) != 0;
   local_pull = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_LOCAL_PULL) != 0;
   reinstall = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL) != 0;
+  update_pinned = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED) != 0;
 
   deploy_dir = flatpak_dir_get_if_deployed (system, ref, NULL, NULL);
 
@@ -699,7 +701,7 @@ handle_deploy (FlatpakSystemHelper   *object,
           if (!flatpak_dir_deploy_install (system, ref, arg_origin,
                                            (const char **) arg_subpaths,
                                            (const char **) arg_previous_ids,
-                                           reinstall, NULL, &error))
+                                           reinstall, update_pinned, NULL, &error))
             {
               flatpak_invocation_return_error (invocation, error, "Error deploying");
               return G_DBUS_METHOD_INVOCATION_HANDLED;


### PR DESCRIPTION
This commit re-works how we automatically "pin" runtimes that are
explicitly installed, to prevent them from being removed automatically.
In this implementation we do the update to the config as part of the
deploy, which has the following advantages:
(1) It ensures that there's never a confusing polkit prompt about
configuring the software installation when the user asked for a runtime
to be installed (https://github.com/flatpak/flatpak/issues/4200)
(2) It means we don't have to rely on the code on the error path of
flatpak_transaction_real_run() to un-pin the runtime in case something
went wrong with the installation, since we pin it almost atomically with
the deploy.

Fixes #4200