### PR TITLE
build-update-repo: Don't try to generate deltas of unknown refs

### DIFF
--- a/app/flatpak-builtins-build-update-repo.c
+++ b/app/flatpak-builtins-build-update-repo.c
@@ -395,7 +395,7 @@ generate_all_deltas (OstreeRepo   *repo,
       else
         {
           /* Ignore unknown ref types */
-          ignore_ref = FALSE;
+          ignore_ref = TRUE;
         }
 
       if (ignore_ref)


### PR DESCRIPTION
Spotted this by code inspection. Ignoring such refs was clearly the
intended behavior based on the comment.