### PR TITLE
Various fixes for the history command

### DIFF
--- a/app/flatpak-builtins-history.c
+++ b/app/flatpak-builtins-history.c
@@ -217,35 +217,43 @@ print_history (GPtrArray    *dirs,
                      strcmp (columns[k].name, "arch") == 0 ||
                      strcmp (columns[k].name, "branch") == 0)
               {
-                g_autoptr(FlatpakDecomposed) ref = NULL;
-                g_autofree char *ref_str = get_field (j, "REF", error);
+                g_autofree char *ref_str = NULL;
+                g_autofree char *value = NULL;
+
+                ref_str = get_field (j, "REF", error);
                 if (*error)
                   return FALSE;
 
-                if (ref_str && ref_str[0])
-                  {
-                    ref = flatpak_decomposed_new_from_ref (ref_str, error);
-                    if (ref == NULL)
-                      return FALSE;
-                  }
+                if (ref_str && ref_str[0] &&
+                    !flatpak_is_app_runtime_or_appstream_ref (ref_str) &&
+                    g_strcmp0 (ref_str, OSTREE_REPO_METADATA_REF) != 0)
+                  g_warning ("Unknown ref in history: %s", ref_str);
 
                 if (strcmp (columns[k].name, "ref") == 0)
-                  flatpak_table_printer_add_column (printer, ref_str);
-                else
+                  value = g_strdup (ref_str);
+                else if (strcmp (columns[k].name, "arch") == 0)
                   {
-                    g_autofree char *value = NULL;
-                    if (ref)
+                    if (ref_str != NULL)
+                      value = flatpak_get_arch_for_ref (ref_str);
+                  }
+                else if (ref_str && ref_str[0] &&
+                         (g_str_has_prefix (ref_str, "app/") ||
+                          g_str_has_prefix (ref_str, "runtime/")))
+                  {
+                    g_autoptr(FlatpakDecomposed) ref = NULL;
+                    ref = flatpak_decomposed_new_from_ref (ref_str, NULL);
+                    if (ref == NULL)
+                      g_warning ("Invalid ref in history: %s", ref_str);
+                    else
                       {
                         if (strcmp (columns[k].name, "application") == 0)
                           value = flatpak_decomposed_dup_id (ref);
-                        else if (strcmp (columns[k].name, "arch") == 0)
-                          value = flatpak_decomposed_dup_arch (ref);
                         else
                           value = flatpak_decomposed_dup_branch (ref);
                       }
-
-                    flatpak_table_printer_add_column (printer, value);
                   }
+
+                  flatpak_table_printer_add_column (printer, value);
               }
             else if (strcmp (columns[k].name, "installation") == 0)
               {

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -817,10 +817,11 @@ flatpak_run (int      argc,
     check_environment ();
 
   /* Don't talk to dbus in enter, as it must be thread-free to setns, also
-     skip run/build for performance reasons (no need to connect to dbus). */
+     skip run/build/history for performance reasons (no need to connect to dbus). */
   if (g_strcmp0 (command->name, "enter") != 0 &&
       g_strcmp0 (command->name, "run") != 0 &&
-      g_strcmp0 (command->name, "build") != 0)
+      g_strcmp0 (command->name, "build") != 0 &&
+      g_strcmp0 (command->name, "history") != 0)
     polkit_agent = install_polkit_agent ();
 
   /* g_vfs_get_default can spawn threads */

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -15814,7 +15814,7 @@ flatpak_dir_delete_mirror_refs (FlatpakDir    *self,
        * remotes, but that would not cover the case of if a remote was
        * deleted.
        */
-      if (is_flatpak_ref (c_r->ref_name) ||
+      if (flatpak_is_app_runtime_or_appstream_ref (c_r->ref_name) ||
           g_strcmp0 (c_r->ref_name, OSTREE_REPO_METADATA_REF) == 0)
         {
           if (dry_run)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -15814,10 +15814,7 @@ flatpak_dir_delete_mirror_refs (FlatpakDir    *self,
        * remotes, but that would not cover the case of if a remote was
        * deleted.
        */
-      if (g_str_has_prefix (c_r->ref_name, "app/") ||
-          g_str_has_prefix (c_r->ref_name, "runtime/") ||
-          g_str_has_prefix (c_r->ref_name, "appstream/") ||
-          g_str_has_prefix (c_r->ref_name, "appstream2/") ||
+      if (is_flatpak_ref (c_r->ref_name) ||
           g_strcmp0 (c_r->ref_name, OSTREE_REPO_METADATA_REF) == 0)
         {
           if (dry_run)

--- a/common/flatpak-ref-utils-private.h
+++ b/common/flatpak-ref-utils-private.h
@@ -43,6 +43,7 @@ char * flatpak_make_valid_id_prefix (const char *orig_id);
 gboolean flatpak_id_has_subref_suffix (const char *id,
                                        gssize      id_len);
 
+gboolean flatpak_is_app_runtime_or_appstream_ref (const char *ref);
 char * flatpak_get_arch_for_ref (const char *ref);
 const char *flatpak_get_compat_arch_reverse (const char *compat_arch);
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3173,8 +3173,8 @@ flatpak_repo_save_digested_summary_delta (OstreeRepo   *repo,
 }
 
 
-static gboolean
-is_flatpak_ref (const char *ref)
+gboolean
+flatpak_is_app_runtime_or_appstream_ref (const char *ref)
 {
   return
     g_str_has_prefix (ref, "appstream/") ||
@@ -3289,7 +3289,7 @@ populate_commit_data_cache (OstreeRepo *repo,
           VarVariantRef xa_data_v;
           VarCacheDataRef xa_data;
 
-          if (!is_flatpak_ref (ref))
+          if (!flatpak_is_app_runtime_or_appstream_ref (ref))
             continue;
 
           commit_bytes = var_ref_info_peek_checksum (info, &commit_bytes_len);
@@ -4363,7 +4363,7 @@ generate_summary (OstreeRepo   *repo,
       if (!g_hash_table_contains (commits, rev))
         continue; /* Filter out commit (by arch & subset) */
 
-      if (is_flatpak_ref (ref))
+      if (flatpak_is_app_runtime_or_appstream_ref (ref))
         rev_data = g_hash_table_lookup (commit_data_cache, rev);
 
       if (rev_data != NULL)
@@ -4804,7 +4804,7 @@ flatpak_repo_update (OstreeRepo   *repo,
         g_hash_table_add (arches, g_steal_pointer (&arch));
 
       /* Add CommitData for flatpak refs that we didn't already pre-populate */
-      if (is_flatpak_ref (ref))
+      if (flatpak_is_app_runtime_or_appstream_ref (ref))
         {
           rev_data = g_hash_table_lookup (commit_data_cache, rev);
           if (rev_data == NULL)

--- a/doc/flatpak-history.xml
+++ b/doc/flatpak-history.xml
@@ -48,7 +48,8 @@
         </para>
         <para>
             The information for the history command is taken from the systemd journal,
-            and can also be accessed using e.g. the journalctl command.
+            and can also be accessed using e.g.
+            <command>journalctl MESSAGE_ID=c7b39b1e006b464599465e105b361485</command>
         </para>
 
     </refsect1>

--- a/tests/Makefile-test-matrix.am.inc
+++ b/tests/Makefile-test-matrix.am.inc
@@ -35,6 +35,7 @@ TEST_MATRIX_DIST= \
 	tests/test-config.sh \
 	tests/test-build-update-repo.sh \
 	tests/test-http-utils.sh \
+	tests/test-history.sh \
 	tests/test-default-remotes.sh \
 	tests/test-extensions.sh \
 	tests/test-oci.sh \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -266,6 +266,7 @@ TEST_MATRIX_SOURCE = \
 	tests/test-run.sh{{user+system+system-norevokefs},{nodeltas+deltas}} \
 	tests/test-info.sh{user+system} \
 	tests/test-repo.sh{{user+system+system-norevokefs}+{{user+system},oldsummary}} \
+	tests/test-history.sh \
 	tests/test-sideload.sh{user+system} \
 	tests/test-default-remotes.sh \
 	tests/test-extensions.sh \

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright (C) 2021 Matthew Leeds <mwleeds@protonmail.com>
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+set -euo pipefail
+
+USE_SYSTEMDIR=yes
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+skip_revokefs_without_fuse
+
+echo "1..1"
+
+sleep 1
+HISTORY_START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
+
+mkdir -p ${TEST_DATA_DIR}/system-history-installation
+mkdir -p ${FLATPAK_CONFIG_DIR}/installations.d
+cat << EOF > ${FLATPAK_CONFIG_DIR}/installations.d/history-installation.conf
+[Installation "history-installation"]
+Path=${TEST_DATA_DIR}/system-history-installation
+EOF
+
+# setup repo and install from it
+setup_repo_no_add
+port=$(cat httpd-port)
+${FLATPAK} --installation=history-installation remote-add \
+    --gpg-import=${FL_GPG_HOMEDIR}/pubring.gpg test-repo "http://127.0.0.1:${port}/test"
+${FLATPAK} --installation=history-installation install -y test-repo org.test.Hello master
+
+# appstream update shouldn't show up in history
+${FLATPAK} ${U} --appstream update test-repo
+
+# update, uninstall, and remote-delete should show up
+EXPORT_ARGS="" make_updated_app
+${FLATPAK} --installation=history-installation update -y org.test.Hello
+${FLATPAK} --installation=history-installation uninstall -y org.test.Platform org.test.Hello
+${FLATPAK} --installation=history-installation remote-delete test-repo
+
+# need --since and --columns here to make the test idempotent
+${FLATPAK} --installation=history-installation history --since="${HISTORY_START_TIME}" \
+    --columns=change,application,branch,installation,remote > history-log 2>&1
+
+diff history-log - << EOF
+add remote			system (history-installation)	test-repo
+deploy install	org.test.Hello.Locale	master	system (history-installation)	test-repo
+deploy install	org.test.Platform	master	system (history-installation)	test-repo
+deploy install	org.test.Hello	master	system (history-installation)	test-repo
+deploy update	org.test.Hello.Locale	master	system (history-installation)	test-repo
+deploy update	org.test.Hello	master	system (history-installation)	test-repo
+uninstall	org.test.Hello	master	system (history-installation)
+uninstall	org.test.Platform	master	system (history-installation)
+uninstall	org.test.Hello.Locale	master	system (history-installation)
+remove remote			system (history-installation)	test-repo
+EOF
+
+rm -f ${FLATPAK_CONFIG_DIR}/installations.d/history-inst.conf
+rm -rf ${TEST_DATA_DIR}/system-history-installation
+
+ok "history looks correct"


### PR DESCRIPTION
Currently the `history` command is broken if any of the columns [ref, application, arch, branch] are used, as they are by default (see #4332 and #4121). This branch fixes that issue and makes a few other improvements to the history command.

Fixes #4332 