### PR TITLE
session-helper: Move FlatpakHostCommandFlags to header file

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -32,11 +32,6 @@
 #include "flatpak-session-helper.h"
 #include "flatpak-utils-base-private.h"
 
-typedef enum {
-  FLATPAK_HOST_COMMAND_FLAGS_CLEAR_ENV = 1 << 0,
-  FLATPAK_HOST_COMMAND_FLAGS_WATCH_BUS = 1 << 1,
-} FlatpakHostCommandFlags;
-
 static char *monitor_dir;
 static char *p11_kit_server_socket_path;
 static int p11_kit_server_pid = 0;

--- a/session-helper/flatpak-session-helper.h
+++ b/session-helper/flatpak-session-helper.h
@@ -26,4 +26,9 @@
 #define FLATPAK_SESSION_HELPER_PATH_DEVELOPMENT "/org/freedesktop/Flatpak/Development"
 #define FLATPAK_SESSION_HELPER_INTERFACE_DEVELOPMENT "org.freedesktop.Flatpak.Development"
 
+typedef enum {
+  FLATPAK_HOST_COMMAND_FLAGS_CLEAR_ENV = 1 << 0,
+  FLATPAK_HOST_COMMAND_FLAGS_WATCH_BUS = 1 << 1,
+} FlatpakHostCommandFlags;
+
 #endif

--- a/session-helper/flatpak-session-helper.h
+++ b/session-helper/flatpak-session-helper.h
@@ -29,6 +29,7 @@
 typedef enum {
   FLATPAK_HOST_COMMAND_FLAGS_CLEAR_ENV = 1 << 0,
   FLATPAK_HOST_COMMAND_FLAGS_WATCH_BUS = 1 << 1,
+  FLATPAK_HOST_COMMAND_FLAGS_NONE = 0
 } FlatpakHostCommandFlags;
 
 #endif


### PR DESCRIPTION
* session-helper: Move FlatpakHostCommandFlags to header file

* session-helper: Add FLATPAK_HOST_COMMAND_FLAGS_NONE

---

This is similar to how the portal has behaved since e196efbf6b. I intend to make use of this in `flatpak-xdg-utils` and Steam's `pressure-vessel`.