### PR TITLE
app: Don't use carriage return for non-fancy output

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -455,7 +455,7 @@ new_operation (FlatpakTransaction          *transaction,
       redraw (self);
     }
   else
-    g_print ("\r%-*s", self->table_width, text);
+    g_print ("\n%-*s", self->table_width, text);
 
   g_free (self->progress_msg);
   self->progress_msg = g_steal_pointer (&text);
@@ -509,7 +509,7 @@ operation_error (FlatpakTransaction            *transaction,
           redraw (self);
         }
       else
-        g_print ("\r%-*s\n", self->table_width, msg); /* override progress, and go to next line */
+        g_print ("\n%-*s\n", self->table_width, msg); /* override progress, and go to next line */
 
       return TRUE;
     }
@@ -548,7 +548,7 @@ operation_error (FlatpakTransaction            *transaction,
       redraw (self);
     }
   else
-    g_printerr ("\r%-*s\n", self->table_width, text);
+    g_printerr ("\n%-*s\n", self->table_width, text);
 
   if (!non_fatal && self->stop_on_first_error)
     return FALSE;
@@ -1052,7 +1052,7 @@ message_handler (const gchar   *log_domain,
       redraw (self);
     }
   else
-    g_print ("\r%-*s\n", self->table_width, text);
+    g_print ("\n%-*s\n", self->table_width, text);
 }
 
 static gboolean
@@ -1414,7 +1414,7 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
           redraw (self);
         }
       else
-        g_print ("\r%-*s", self->table_width, text);
+        g_print ("\n%-*s", self->table_width, text);
 
       g_print ("\n");
     }


### PR DESCRIPTION
flatpak_fancy_output() determines whether the output we write is
intended for e.g. a tty or e.g. a log file, the latter being "not
fancy". Currently we write carriage return characters in the not fancy
case, but change that to new lines, which are interpreted correctly by
editors such as vim (whereas a carriage return shows up as ^M since it
is not the correct newline character on Unixy operating systems).