### PR TITLE
dir: Fix an issue with fetch_remote_ref_sync()

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -12283,7 +12283,11 @@ flatpak_dir_list_all_remote_refs (FlatpakDir         *self,
         {
           summary = var_summary_from_gvariant (subsummary);
           ref_map = var_summary_get_ref_map (summary);
-          populate_hash_table_from_refs_map (ret_all_refs, NULL, ref_map, state->collection_id, state);
+
+          /* NOTE: collection id is NULL here not state->collection_id, see the
+           * note on flatpak_decomposed_get_collection_id()
+           */
+          populate_hash_table_from_refs_map (ret_all_refs, NULL, ref_map, NULL /* collection id */, state);
         }
     }
   else if (state->summary != NULL)
@@ -14361,7 +14365,7 @@ flatpak_dir_list_remote_refs (FlatpakDir         *self,
           if (!ostree_parse_refspec (refspec, NULL, &ref, error))
             return FALSE;
 
-          d = flatpak_decomposed_new_from_col_ref (ref, state->collection_id, NULL);
+          d = flatpak_decomposed_new_from_ref (ref, NULL);
           if (d)
             g_hash_table_insert (decomposed_local_refs, g_steal_pointer (&d), NULL);
         }


### PR DESCRIPTION
This commit is a follow-up to "Fix implementation of xa.noenumerate
remote option" since that turned out to break
flatpak_installation_fetch_remote_ref_sync() in some cases. I didn't see
it at the time, but flatpak_decomposed_get_collection_id() explains that
the collection ID shouldn't be set on FlatpakDecomposed objects, even
when the remote has a collection ID set, unless they are being used to
enumerate refs from a file:// URI rather than a configured remote. So
this commit changes list_remote_refs() and list_all_remote_refs() to
keep the xa.noenumerate implementation working and to get
fetch_remote_ref_sync() working again (since the latter uses
flatpak_decomposed_new_from_parts() and thus doesn't set a collection ID
on the FlatpakDecomposed object used for comparison).