### PR TITLE
Support PulseAudio socket path without unix: prefix

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -591,6 +591,10 @@ flatpak_run_parse_pulse_server (const char *value)
       const char *server = servers[i];
       if (g_str_has_prefix (server, "{"))
         {
+          /*
+           * TODO: compare the value within {} to the local hostname and D-Bus machine ID,
+           * and skip if it matches neither.
+           */
           const char * closing = strstr (server, "}");
           if (closing == NULL)
             continue;
@@ -601,6 +605,8 @@ flatpak_run_parse_pulse_server (const char *value)
         return g_strdup (server + 5);
       if (server[0] == '/')
         return g_strdup (server);
+
+      /* TODO: Support TCP connections? */
     }
 
   return NULL;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -575,6 +575,11 @@ flatpak_run_get_pulseaudio_server (void)
   return NULL;
 }
 
+/*
+ * Parse a PulseAudio server string, as documented on
+ * https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/ServerStrings/.
+ * Returns the first supported server address, or NULL if none are supported.
+ */
 static char *
 flatpak_run_parse_pulse_server (const char *value)
 {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -591,8 +591,11 @@ flatpak_run_parse_pulse_server (const char *value)
             continue;
           server = closing + 1;
         }
+
       if (g_str_has_prefix (server, "unix:"))
         return g_strdup (server + 5);
+      if (server[0] == '/')
+        return g_strdup (server);
     }
 
   return NULL;


### PR DESCRIPTION
https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/ServerStrings/ says:

> If the string starts with / or unix: the remaining address string is taken as UNIX socket name.

but previously the string was only taken to be a UNIX socket name if it began with "unix:". This is an issue in practice with [WSLg](https://github.com/microsoft/wslg) which sets `$PULSE_SERVER` to `/mnt/wslg/PulseServer`, without a `unix:` prefix.

The first patch in this series addresses this problem. Without this patch, the `$PULSE_SERVER` environment variable is ignored and Flatpak falls back to the default socket paths. With this patch, the `$PULSE_SERVER` environment variable is respected and Flatpak apps with `--socket=pulseaudio` can talk to the miraculous WSLg PulseAudio daemon (which forwards audio over RDP to the Windows host).

The other two just add documentation, and some other shortcomings of the code that parses PulseAudio server addresses that I noticed while reading that documentation.