### PR TITLE
Make test suite logs prettier

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -124,7 +124,7 @@ add_new_remote (FlatpakTransaction            *transaction,
 
   if (self->disable_interaction)
     {
-      g_print (_("Configuring %s as new remote '%s'"), url, remote_name);
+      g_print (_("Configuring %s as new remote '%s'\n"), url, remote_name);
       return TRUE;
     }
 
@@ -397,7 +397,7 @@ progress_changed_cb (FlatpakTransactionProgress *progress,
         g_print ("\r%s", str->str); /* redraw failed, just update the progress */
     }
   else
-    g_print ("\n%s", str->str);
+    g_print ("%s\n", str->str);
 }
 
 static void
@@ -455,7 +455,7 @@ new_operation (FlatpakTransaction          *transaction,
       redraw (self);
     }
   else
-    g_print ("\n%-*s", self->table_width, text);
+    g_print ("%s\n", text);
 
   g_free (self->progress_msg);
   self->progress_msg = g_steal_pointer (&text);
@@ -509,7 +509,7 @@ operation_error (FlatpakTransaction            *transaction,
           redraw (self);
         }
       else
-        g_print ("\n%-*s\n", self->table_width, msg); /* override progress, and go to next line */
+        g_print ("%s\n", msg);
 
       return TRUE;
     }
@@ -548,7 +548,7 @@ operation_error (FlatpakTransaction            *transaction,
       redraw (self);
     }
   else
-    g_printerr ("\n%-*s\n", self->table_width, text);
+    g_printerr ("%s\n", text);
 
   if (!non_fatal && self->stop_on_first_error)
     return FALSE;
@@ -1066,7 +1066,7 @@ message_handler (const gchar   *log_domain,
       redraw (self);
     }
   else
-    g_print ("\n%-*s\n", self->table_width, text);
+    g_print ("%s\n", text);
 }
 
 static gboolean
@@ -1428,7 +1428,7 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
           redraw (self);
         }
       else
-        g_print ("\n%-*s", self->table_width, text);
+        g_print ("%s", text);
 
       g_print ("\n");
     }

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -18,6 +18,10 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
+# redirect stdout to stderr, otherwise the log will have command output out of
+# order with xtrace output
+exec 2>&1
+
 if [ -n "${G_TEST_SRCDIR:-}" ]; then
     test_srcdir="${G_TEST_SRCDIR}"
 else


### PR DESCRIPTION
This fixes a few issues with the unit test logs that make them ugly:
1. Currently some lines of output from a command will appear after the
   line from xtrace which has the next command, since the command was
   printing to stdout and xtrace uses stderr. E.g. "Installation complete."
   will appear after "+ flatpak --user install -y ..." but it is from the
   previous install command.
2. Lines of output have many spaces after them to pad them to the table
   width but this is not needed for non-fancy output.
3. Lines of output are mixed with output from httpd since they don't end
   with a newline character, e.g. "Installing… ▊
   4%127.0.0.1 - - [16/Nov/2021 00:18:24] "GET /..."