### PR TITLE
Fix fish profile script install directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,7 +162,7 @@ profiledir = $(PROFILE_DIR)
 profile_DATA = profile/flatpak.sh
 EXTRA_DIST += $(profile_DATA)
 
-fishconfdir = $(sysconfdir)/fish/conf.d
+fishconfdir = $(datadir)/fish/vendor_conf.d
 fishconf_DATA = profile/flatpak.fish
 EXTRA_DIST += $(fishconf_DATA)
 


### PR DESCRIPTION
Caught by @gasinvein on #4575 post-merge: I didn't realize fish has a
separate folder for config files provided by the vendor vs added by the
user. This changes the install directory to match the vendor config dir.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>