### PR TITLE
Export share/metainfo not share/appdata

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -235,7 +235,8 @@ collect_exports (GFile          *base,
     "share/icons",                        /* Icons */
     "share/dbus-1/services",              /* D-Bus service files */
     "share/gnome-shell/search-providers", /* Search providers */
-    "share/appdata",                      /* Copy appdata/metainfo files */
+    "share/appdata",                      /* Copy appdata/metainfo files (legacy path) */
+    "share/metainfo",                     /* Copy appdata/metainfo files */
     NULL,
   };
 
@@ -267,7 +268,12 @@ collect_exports (GFile          *base,
           g_debug ("Exporting from %s", path);
           g_autoptr(GFile) dest = NULL;
           g_autoptr(GFile) dest_parent = NULL;
-          dest = g_file_resolve_relative_path (export, path);
+
+          if (strcmp (path, "share/appdata") == 0)
+            dest = g_file_resolve_relative_path (export, "share/metainfo");
+          else
+            dest = g_file_resolve_relative_path (export, path);
+
           dest_parent = g_file_get_parent (dest);
           g_debug ("Ensuring export/%s parent exists", path);
           if (!flatpak_mkdir_p (dest_parent, cancellable, error))

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7527,7 +7527,7 @@ flatpak_export_dir (GFile        *source,
     "share/dbus-1/services",               "../../..",
     "share/gnome-shell/search-providers",  "../../..",
     "share/mime/packages",                 "../../..",
-    "share/appdata",                       "../..",
+    "share/metainfo",                      "../..",
     "bin",                                 "..",
   };
   int i;

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -733,7 +733,8 @@ flatpak_get_allowed_exports (const char     *source_path,
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
     }
-  else if (strcmp (source_path, "share/appdata") == 0)
+  else if (strcmp (source_path, "share/metainfo") == 0 ||
+           strcmp (source_path, "share/appdata") == 0)
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
     }

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -44,10 +44,10 @@
             <arg choice="plain">DIRECTORY</arg> is the name of the directory.
         </para>
         <para>
-            The result of this command is that desktop files, icons and
-            D-Bus service files from the <filename>files</filename> subdirectory
-            are copied to a new <filename>export</filename> subdirectory. In the
-            <filename>metadata</filename> file, the command key is set in the
+            The result of this command is that desktop files, icons, D-Bus service
+            files, and AppStream metainfo files from the <filename>files</filename>
+            subdirectory are copied to a new <filename>export</filename> subdirectory.
+            In the <filename>metadata</filename> file, the command key is set in the
             [Application] group, and the supported keys in the [Environment]
             group are set according to the options.
         </para>

--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -113,8 +113,8 @@ mkdir -p ${DIR}/files/share/icons/HighContrast/64x64/apps
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/icons/HighContrast/64x64/apps/${APP_ID}.png
 
 
-mkdir -p ${DIR}/files/share/appdata
-cat <<EOF > ${DIR}/files/share/appdata/${APP_ID}.xml
+mkdir -p ${DIR}/files/share/metainfo
+cat <<EOF > ${DIR}/files/share/metainfo/${APP_ID}.metainfo.xml
 <?xml version="1.0" encoding="UTF-8"?>
 <components version="0.8">
   <component type="desktop">
@@ -132,9 +132,27 @@ cat <<EOF > ${DIR}/files/share/appdata/${APP_ID}.xml
   </component>
 </components>
 EOF
+
+# Also check that the legacy path works
+mkdir -p ${DIR}/files/share/appdata
+cat <<EOF > ${DIR}/files/share/appdata/${APP_ID}.cmd.appdata.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<components version="0.8">
+  <component type="console-application">
+    <id>$APP_ID.cmd</id>
+    <name>Command line client for Hello world test app</name>
+    <summary>Adds cool functionality</summary>
+    <provides>
+      <binary>hello</binary>
+    </provides>
+  </component>
+</components>
+EOF
+
 mkdir -p ${DIR}/files/share/app-info/xmls
 mkdir -p ${DIR}/files/share/app-info/icons/flatpak/64x64
-gzip -c ${DIR}/files/share/appdata/${APP_ID}.xml > ${DIR}/files/share/app-info/xmls/${APP_ID}.xml.gz
+gzip -c ${DIR}/files/share/metainfo/${APP_ID}.metainfo.xml > ${DIR}/files/share/app-info/xmls/${APP_ID}.xml.gz
+gzip -c ${DIR}/files/share/appdata/${APP_ID}.cmd.appdata.xml > ${DIR}/files/share/app-info/xmls/${APP_ID}.cmd.xml.gz
 cp $(dirname $0)/org.test.Hello.png ${DIR}/files/share/app-info/icons/flatpak/64x64/${APP_ID}.png
 
 if [ x$COLLECTION_ID != x ]; then

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -44,7 +44,8 @@ assert_has_file $FL_DIR/app/org.test.Hello/$ARCH/stable/active/metadata
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/files
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
-assert_has_file $FL_DIR/exports/share/appdata/org.test.Hello.xml
+assert_has_file $FL_DIR/exports/share/metainfo/org.test.Hello.metainfo.xml
+assert_has_file $FL_DIR/exports/share/metainfo/org.test.Hello.cmd.appdata.xml
 # Ensure Exec key is rewritten
 assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
 assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini


### PR DESCRIPTION
The addition of share/appdata wasn't released yet so we don't need
backwards compat for it.

Fixes https://github.com/flatpak/flatpak/issues/4599