### PR TITLE
Remove Souk from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Here are some notable projects in the Flatpak ecosystem:
 * [Flatseal](https://github.com/tchx84/flatseal): An app for managing permissions of Flatpak apps without using the CLI
-* [Souk](https://gitlab.gnome.org/haecker-felix/souk): A Flatpak-only app store
 * [Flat-manager](https://github.com/flatpak/flat-manager): A tool for managing Flatpak repositories


### PR DESCRIPTION
From the [Readme of Souk](https://gitlab.gnome.org/haecker-felix/souk/-/blob/e479e6cc3add76dee83fcba455f5e9b59a9a1201/README.md):

> _Souk is currently no longer being actively developed due to [technical limitations](https://github.com/flatpak/flatpak/issues/4046). Many [design elements](https://gitlab.gnome.org/Teams/Design/software-mockups/-/tree/master/adaptive) of Souk are currently being implemented in GNOME Software 41. More details are explained in [this issue](https://gitlab.gnome.org/haecker-felix/souk/-/issues/61#note_1270615)._

I think that a dead project should not be featured in the Readme.