### PR TITLE
repair: Properly mark invalid commits as partial

### DIFF
--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -221,7 +221,17 @@ fsck_commit (OstreeRepo *repo,
 
   if (!ostree_repo_load_commit (repo, checksum, &commit, &commitstate, &local_error))
     {
-      g_print ("%s\n", local_error->message);
+      /* This really shouldn't happen since we just fsck'd the commit, but
+       * deleting it makes the most sense.
+       */
+      if (opt_dry_run)
+        g_printerr (_("Commit invalid %s: %s\n"), checksum, local_error->message);
+      else
+        {
+          g_printerr (_("Deleting invalid commit %s: %s\n"), checksum, local_error->message);
+          (void) ostree_repo_delete_object (repo, OSTREE_OBJECT_TYPE_COMMIT, checksum, NULL, NULL);
+        }
+
       g_clear_error (&local_error);
       return FSCK_STATUS_HAS_INVALID_OBJECTS;
     }
@@ -240,9 +250,27 @@ fsck_commit (OstreeRepo *repo,
   dirtree_status = fsck_dirtree (repo, partial, dirtree_checksum, object_status_cache);
   status = MAX (status, dirtree_status);
 
-  /* Its ok for partial commits to have missing objects */
+  /* It's ok for partial commits to have missing objects
+   * https://github.com/flatpak/flatpak/issues/4624
+   */
   if (status == FSCK_STATUS_HAS_MISSING_OBJECTS && partial)
     status = FSCK_STATUS_OK;
+  else if (status != FSCK_STATUS_OK && !partial)
+    {
+      if (opt_dry_run)
+        g_printerr (_("Commit should be marked partial: %s\n"), checksum);
+      else
+        {
+          g_printerr (_("Marking commit as partial: %s\n"), checksum);
+          if (!ostree_repo_mark_commit_partial_reason (repo, checksum, TRUE,
+                                                       OSTREE_REPO_COMMIT_STATE_FSCK_PARTIAL,
+                                                       &local_error))
+            {
+              g_printerr ("%s\n", local_error->message);
+              g_clear_error (&local_error);
+            }
+        }
+    }
 
   return status;
 }

--- a/tests/Makefile-test-matrix.am.inc
+++ b/tests/Makefile-test-matrix.am.inc
@@ -43,6 +43,7 @@ TEST_MATRIX_DIST= \
 	tests/test-unused.sh \
 	tests/test-prune.sh \
 	tests/test-seccomp.sh \
+	tests/test-repair.sh \
 	$(NULL)
 TEST_MATRIX_EXTRA_DIST= \
 	tests/test-run.sh \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -281,6 +281,7 @@ TEST_MATRIX_SOURCE = \
 	tests/test-subset.sh{user+system} \
 	tests/test-prune.sh \
 	tests/test-seccomp.sh \
+	tests/test-repair.sh \
 	$(NULL)
 
 update-test-matrix:

--- a/tests/test-repair.sh
+++ b/tests/test-repair.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright (C) 2021 Matthew Leeds <mwleeds@protonmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..1"
+
+setup_repo
+${FLATPAK} ${U} install -y test-repo org.test.Hello
+
+# delete the object for files/bin/hello.sh
+rm ${FL_DIR}/repo/objects/0d/30582c0ac8a2f89f23c0f62e548ba7853f5285d21848dd503460a567b5d253.file
+
+# dry run repair shouldn't replace the missing file
+${FLATPAK} ${U} repair --dry-run
+assert_not_has_file ${FL_DIR}/repo/objects/0d/30582c0ac8a2f89f23c0f62e548ba7853f5285d21848dd503460a567b5d253.file
+
+# normal repair should replace the missing file
+${FLATPAK} ${U} repair
+assert_has_file ${FL_DIR}/repo/objects/0d/30582c0ac8a2f89f23c0f62e548ba7853f5285d21848dd503460a567b5d253.file
+
+# app should've been reinstalled
+${FLATPAK} ${U} list -d > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
+
+# clean up
+${FLATPAK} ${U} uninstall -y org.test.Platform org.test.Hello
+${FLATPAK} ${U} remote-delete test-repo
+
+ok "repair command handles missing files"


### PR DESCRIPTION
Commits that are found to have missing or invalid objects need to be
marked partial so that when the thing referencing them is reinstalled,
the missing objects will be pulled. libostree treats non-partial commits
as complete even if they're not, since verifying their completeness is
an expensive operation.

This exactly mirrors what the "ostree fsck" command does when it finds
corruption in a commit.

This fix is especially important because corrupt repos have been an
issue lately so we at least need repair to work properly.

Relatedly, delete invalid commit objects to ensure they are
re-downloaded, though it's not clear that code path is almost ever
reachable.

Fixes https://github.com/flatpak/flatpak/issues/4618