### PR TITLE
run: Fix session-bus and a11y-bus args being incorrect

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -278,7 +278,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
   if (opt_a11y_bus == -1)
     opt_a11y_bus = !opt_sandbox;
   if (opt_session_bus == -1)
-    opt_a11y_bus = !opt_sandbox;
+    opt_session_bus = !opt_sandbox;
 
   if (opt_sandbox)
     flags |= FLATPAK_RUN_FLAG_SANDBOX | FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY;


### PR DESCRIPTION
This would incorrectly overwrite the a11y-bus option and not set the default session-bus options.

This change has a security implication that `--sandbox` will now disable session-bus access.
