### PR TITLE
tests: Make grep assertions more specific

### DIFF
--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -137,8 +137,8 @@ ${FLATPAK} ${U} uninstall -y org.test.Hello
 ${FLATPAK} ${U} install -y test-repo org.test.Hllo >install-log
 assert_file_has_content install-log "org\.test\.Hello"
 
-${FLATPAK} ${U} list -d > list-log
-assert_file_has_content list-log "org\.test\.Hello"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
 
 ok "typo correction works for install"
 
@@ -157,8 +157,8 @@ fi
 ${FLATPAK} ${U} install -y org.test.Hello |& tee install-log
 assert_file_has_content install-log "org\.test\.Hello"
 
-${FLATPAK} ${U} list -d > list-log
-assert_file_has_content list-log "org\.test\.Hello"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
 
 ${FLATPAK} ${U} remote-modify --enable test-missing-gpg-repo
 ${FLATPAK} ${U} remote-modify --enable test-wrong-gpg-repo
@@ -361,10 +361,10 @@ ${FLATPAK} repo --branches repos/test > branches-log
 assert_file_has_content branches-log "^app/org\.test\.Hello/.*eol=Reason2"
 
 # eol only visible in remote-ls if -a:
-${FLATPAK} ${U} remote-ls -d test-repo > remote-ls-log
-assert_not_file_has_content remote-ls-log "app/org\.test\.Hello"
+${FLATPAK} ${U} remote-ls --columns=ref test-repo > remote-ls-log
+assert_not_file_has_content remote-ls-log "app/org\.test\.Hello/"
 
-${FLATPAK} ${U} remote-ls -d -a test-repo > remote-ls-log
+${FLATPAK} ${U} remote-ls --columns=ref,options -a test-repo > remote-ls-log
 assert_file_has_content remote-ls-log "app/org\.test\.Hello/.*eol=Reason2"
 
 ${FLATPAK} ${U} update -y org.test.Hello > update-log
@@ -374,7 +374,7 @@ assert_file_has_content update-log "Reason2"
 ${FLATPAK} ${U} info org.test.Hello > info-log
 assert_file_has_content info-log "End-of-life: Reason2"
 
-${FLATPAK} ${U} list -d > list-log
+${FLATPAK} ${U} list --columns=ref,options > list-log
 assert_file_has_content list-log "org\.test\.Hello/.*eol=Reason2"
 
 ${FLATPAK} ${U} uninstall -y org.test.Hello
@@ -437,16 +437,16 @@ ${FLATPAK} ${U} pin --remove runtime/org.test.Platform/$ARCH/master 2>/dev/null 
 EXPORT_ARGS="--end-of-life=Reason3" make_updated_runtime
 
 ${FLATPAK} ${U} install -y test-repo org.test.Hello
-${FLATPAK} ${U} list -d > list-log
-assert_file_has_content list-log "org\.test\.Hello"
-assert_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
+assert_file_has_content list-log "org\.test\.Platform/"
 
 ${FLATPAK} ${U} uninstall -y org.test.Hello
 
-${FLATPAK} ${U} list -d -a > list-log
-assert_not_file_has_content list-log "org\.test\.Hello"
-assert_not_file_has_content list-log "org\.test\.Platform"
-assert_not_file_has_content list-log "org\.test\.Platform.Locale"
+${FLATPAK} ${U} list --columns=ref -a > list-log
+assert_not_file_has_content list-log "org\.test\.Hello/"
+assert_not_file_has_content list-log "org\.test\.Platform/"
+assert_not_file_has_content list-log "org\.test\.Platform.Locale/"
 
 ok "eol runtime uninstalled with app"
 
@@ -538,8 +538,8 @@ assert_has_file $FL_DIR/repo/refs/remotes/test-repo/app/org.test.Hello/$ARCH/mas
 ok "mirror ref deletion on update"
 
 ${FLATPAK} ${U} list --arch=$ARCH --columns=ref > list-log
-assert_file_has_content list-log "org\.test\.Hello"
-assert_file_has_content list-log "org\.test\.Platform"
+assert_file_has_content list-log "org\.test\.Hello/"
+assert_file_has_content list-log "org\.test\.Platform/"
 
 ok "flatpak list --arch --columns works"
 
@@ -550,17 +550,17 @@ fi
 # Test that unspecified --user/--system finds the right one, so no ${U}
 ${FLATPAK} uninstall -y org.test.Platform org.test.Hello
 
-${FLATPAK} ${U} list -d > list-log
-assert_not_file_has_content list-log "org\.test\.Hello"
-assert_not_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Hello/"
+assert_not_file_has_content list-log "org\.test\.Platform/"
 
 ok "uninstall vs installations"
 
 ${FLATPAK} ${U} install -y test-repo org.test.Hello
 
-${FLATPAK} ${U} list -d > list-log
-assert_file_has_content list-log "org\.test\.Hello"
-assert_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
+assert_file_has_content list-log "org\.test\.Platform/"
 
 if ${FLATPAK} ${U} uninstall -y org.test.Platform; then
     assert_not_reached "Should not be able to uninstall ${U} when there is a dependency installed"
@@ -569,9 +569,9 @@ fi
 ${FLATPAK} ${U} uninstall -y org.test.Hello
 ${FLATPAK} ${U} uninstall -y org.test.Platform
 
-${FLATPAK} ${U} list -d > list-log
-assert_not_file_has_content list-log "org\.test\.Hello"
-assert_not_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Hello/"
+assert_not_file_has_content list-log "org\.test\.Platform/"
 
 ok "uninstall dependencies"
 
@@ -592,9 +592,9 @@ ok "install and uninstall support 'NAME BRANCH' syntax"
 
 ${FLATPAK} ${U} install -y --no-deploy test-repo org.test.Hello
 
-${FLATPAK} ${U} list -d > list-log
-assert_not_file_has_content list-log "org\.test\.Hello"
-assert_not_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Hello/"
+assert_not_file_has_content list-log "org\.test\.Platform/"
 
 # Disable the remote to make sure we don't do i/o
 port=$(cat httpd-port)
@@ -605,9 +605,9 @@ ${FLATPAK} ${U} install -y --no-pull test-repo org.test.Hello
 # re-enable remote
 ${FLATPAK} ${U} remote-modify --url="http://127.0.0.1:${port}/test" test-repo
 
-${FLATPAK} ${U} list -d > list-log
-assert_file_has_content list-log "org\.test\.Hello"
-assert_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
+assert_file_has_content list-log "org\.test\.Platform/"
 
 ok "install with --no-deploy and then --no-pull"
 
@@ -615,9 +615,9 @@ ${FLATPAK} ${U} uninstall -y org.test.Hello org.test.Platform
 
 ${FLATPAK} ${U} install -y --no-deploy --app test-repo hello
 
-${FLATPAK} ${U} list -d > list-log
-assert_not_file_has_content list-log "org\.test\.Hello"
-assert_not_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Hello/"
+assert_not_file_has_content list-log "org\.test\.Platform/"
 
 # Disable the remote to make sure we don't do i/o
 port=$(cat httpd-port)
@@ -629,32 +629,32 @@ ${FLATPAK} ${U} install -y --no-pull --app test-repo hello
 # re-enable remote
 ${FLATPAK} ${U} remote-modify --url="http://127.0.0.1:${port}/test" test-repo
 
-${FLATPAK} ${U} list -d > list-log
-assert_file_has_content list-log "org\.test\.Hello"
-assert_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
+assert_file_has_content list-log "org\.test\.Platform/"
 
 ok "install with --no-deploy and then --no-pull works with typo correction"
 
 ${FLATPAK} uninstall -y --all
 
-${FLATPAK} ${U} list -d > list-log
-assert_not_file_has_content list-log "org\.test\.Hello"
-assert_not_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Hello/"
+assert_not_file_has_content list-log "org\.test\.Platform/"
 
 ok "uninstall --all"
 
 ${FLATPAK} ${U} install -y test-repo org.test.Hello
 
-${FLATPAK} ${U} list -a --columns=application > list-log
-assert_file_has_content list-log "org\.test\.Hello"
-assert_file_has_content list-log "org\.test\.Hello\.Locale"
+${FLATPAK} ${U} list -a --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Hello/"
+assert_file_has_content list-log "org\.test\.Hello\.Locale/"
 
 ${FLATPAK} ${U} remote-delete --force test-repo
 ${FLATPAK} ${U} uninstall -y org.test.Hello
 
-${FLATPAK} ${U} list -a --columns=application > list-log
-assert_not_file_has_content list-log "org\.test\.Hello"
-assert_not_file_has_content list-log "org\.test\.Hello\.Locale"
+${FLATPAK} ${U} list -a --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Hello/"
+assert_not_file_has_content list-log "org\.test\.Hello\.Locale/"
 
 setup_repo
 
@@ -663,20 +663,20 @@ ok "uninstall with missing remote"
 # Remove any pin of the runtime from an earlier test
 ${FLATPAK} ${U} pin --remove runtime/org.test.Platform/$ARCH/master 2>/dev/null || true
 
-${FLATPAK} ${U} list -a --columns=application > list-log
-assert_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list -a --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Platform/"
 
 ${FLATPAK} ${U} uninstall -y --unused
 
-${FLATPAK} ${U} list -a --columns=application > list-log
-assert_not_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list -a --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Platform/"
 
 ok "uninstall --unused"
 
 ${FLATPAK} ${U} install -y test-repo org.test.Platform
 
-${FLATPAK} ${U} list -a --columns=application > list-log
-assert_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list -a --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Platform/"
 
 # Check that the runtime won't be removed if it's pinned
 # (which happens during the install above)
@@ -690,14 +690,14 @@ rm pins
 
 ${FLATPAK} ${U} uninstall -y --unused
 
-${FLATPAK} ${U} list -a --columns=application > list-log
-assert_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list -a --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.Platform/"
 
 # Remove the pin and try again
 ${FLATPAK} ${U} pin --remove "runtime/org.test.Platform/$ARCH/master"
 ${FLATPAK} ${U} uninstall -y --unused
-${FLATPAK} ${U} list -a --columns=application > list-log
-assert_not_file_has_content list-log "org\.test\.Platform"
+${FLATPAK} ${U} list -a --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.Platform/"
 
 ok "uninstall --unused ignores pinned runtimes"
 
@@ -710,22 +710,22 @@ ok "uninstall --unused ignores pinned runtimes"
 # * system remote, and --user is used
 # * user remote, and --system is used
 if [ x${USE_SYSTEMDIR-} == xyes ]; then
-    ${FLATPAK} --system remote-ls test-repo > repo-list
-    assert_file_has_content repo-list "org\.test\.Hello"
+    ${FLATPAK} --system remote-ls --columns=ref test-repo > repo-list
+    assert_file_has_content repo-list "org\.test\.Hello/"
 
-    ${FLATPAK} remote-ls test-repo > repo-list
-    assert_file_has_content repo-list "org\.test\.Hello"
+    ${FLATPAK} remote-ls --columns=ref test-repo > repo-list
+    assert_file_has_content repo-list "org\.test\.Hello/"
 
     if ${FLATPAK} --user remote-ls test-repo 2> remote-ls-error-log; then
         assert_not_reached "flatpak --user remote-ls should not work for system remotes"
     fi
     assert_file_has_content remote-ls-error-log "Remote \"test-repo\" not found"
 else
-    ${FLATPAK} --user remote-ls test-repo > repo-list
-    assert_file_has_content repo-list "org\.test\.Hello"
+    ${FLATPAK} --user remote-ls --columns=ref test-repo > repo-list
+    assert_file_has_content repo-list "org\.test\.Hello/"
 
-    ${FLATPAK} remote-ls test-repo > repo-list
-    assert_file_has_content repo-list "org\.test\.Hello"
+    ${FLATPAK} remote-ls --columns=ref test-repo > repo-list
+    assert_file_has_content repo-list "org\.test\.Hello/"
 
     if ${FLATPAK} --system remote-ls test-repo 2> remote-ls-error-log; then
         assert_not_reached "flatpak --system remote-ls should not work for user remotes"
@@ -737,8 +737,8 @@ ok "remote-ls"
 
 # Test that remote-ls can take a file:// URI
 ${FLATPAK} build-update-repo  ${BUILD_UPDATE_REPO_FLAGS-} --no-update-appstream repos/test
-${FLATPAK} remote-ls file://`pwd`/repos/test > repo-list
-assert_file_has_content repo-list "org\.test\.Hello"
+${FLATPAK} remote-ls --columns=ref file://`pwd`/repos/test > repo-list
+assert_file_has_content repo-list "org\.test\.Hello/"
 
 ok "remote-ls URI"
 
@@ -836,10 +836,10 @@ ok "remote-delete"
 # * user remote, and --system is used
 if [ x${USE_SYSTEMDIR-} == xyes ]; then
     ${FLATPAK} --system remote-info test-repo org.test.Hello > remote-ref-info
-    assert_file_has_content remote-ref-info "ID: org\.test\.Hello"
+    assert_file_has_content remote-ref-info "ID: org\.test\.Hello$"
 
     ${FLATPAK} remote-info test-repo org.test.Hello > remote-ref-info
-    assert_file_has_content remote-ref-info "ID: org\.test\.Hello"
+    assert_file_has_content remote-ref-info "ID: org\.test\.Hello$"
 
     if ${FLATPAK} --user remote-info test-repo org.test.Hello 2> remote-info-error-log; then
         assert_not_reached "flatpak --user remote-info should not work for system remotes"
@@ -847,10 +847,10 @@ if [ x${USE_SYSTEMDIR-} == xyes ]; then
     assert_file_has_content remote-info-error-log "Remote \"test-repo\" not found"
 else
     ${FLATPAK} --user remote-info test-repo org.test.Hello > remote-ref-info
-    assert_file_has_content remote-ref-info "ID: org\.test\.Hello"
+    assert_file_has_content remote-ref-info "ID: org\.test\.Hello$"
 
     ${FLATPAK} remote-info test-repo org.test.Hello > remote-ref-info
-    assert_file_has_content remote-ref-info "ID: org\.test\.Hello"
+    assert_file_has_content remote-ref-info "ID: org\.test\.Hello$"
 
     if ${FLATPAK} --system remote-info test-repo org.test.Hello 2> remote-info-error-log; then
         assert_not_reached "flatpak --system remote-info should not work for user remotes"
@@ -860,26 +860,26 @@ fi
 
 ok "remote-info"
 
-${FLATPAK} ${U} remote-ls -d -a test-repo > remote-ls-log
-assert_file_has_content remote-ls-log "app/org\.test\.Hello"
-assert_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale"
-assert_file_has_content remote-ls-log "runtime/org\.test\.Platform"
+${FLATPAK} ${U} remote-ls --columns=ref -a test-repo > remote-ls-log
+assert_file_has_content remote-ls-log "app/org\.test\.Hello/"
+assert_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale/"
+assert_file_has_content remote-ls-log "runtime/org\.test\.Platform/"
 
 ${FLATPAK}  ${U} remote-info test-repo org.test.Hello > remote-ref-info
-assert_file_has_content remote-ref-info "ID: org\.test\.Hello"
+assert_file_has_content remote-ref-info "ID: org\.test\.Hello$"
 
 ${FLATPAK} ${U} update --appstream test-repo
-assert_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml "app/org\.test\.Hello"
+assert_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml "app/org\.test\.Hello/"
 
 # Make a copy so we can remove it later
 cp ${test_srcdir}/test.filter test.filter
 ${FLATPAK} ${U} remote-modify test-repo --filter $(pwd)/test.filter
 
-${FLATPAK} ${U} remote-ls -d -a test-repo > remote-ls-log
+${FLATPAK} ${U} remote-ls --columns=ref -a test-repo > remote-ls-log
 
-assert_not_file_has_content remote-ls-log "app/org\.test\.Hello"
-assert_not_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale"
-assert_file_has_content remote-ls-log "runtime/org\.test\.Platform"
+assert_not_file_has_content remote-ls-log "app/org\.test\.Hello/"
+assert_not_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale/"
+assert_file_has_content remote-ls-log "runtime/org\.test\.Platform/"
 
 if ${FLATPAK}  ${U} remote-info test-repo org.test.Hello > remote-ref-info 2> /dev/null; then
     assert_not_reached "flatpak remote-info test-repo org.test.Hello should fail due to filter"
@@ -890,14 +890,14 @@ if ${FLATPAK} ${U} install -y test-repo org.test.Hello 2> /dev/null; then
 fi
 
 ${FLATPAK} ${U} update --appstream test-repo
-assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml "app/org\.test\.Hello"
+assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml "app/org\.test\.Hello/"
 
 # Ensure that filter works even when the filter file is removed (uses the backup)
 rm -f test.filter
-${FLATPAK} ${U} remote-ls -d -a test-repo > remote-ls-log
-assert_not_file_has_content remote-ls-log "app/org\.test\.Hello"
-assert_not_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale"
-assert_file_has_content remote-ls-log "runtime/org\.test\.Platform"
+${FLATPAK} ${U} remote-ls --columns=ref -a test-repo > remote-ls-log
+assert_not_file_has_content remote-ls-log "app/org\.test\.Hello/"
+assert_not_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale/"
+assert_file_has_content remote-ls-log "runtime/org\.test\.Platform/"
 if ${FLATPAK}  ${U} remote-info test-repo org.test.Hello > remote-ref-info; then
     assert_not_reached "flatpak remote-info test-repo org.test.Hello should fail due to filter"
 fi
@@ -906,16 +906,16 @@ if ${FLATPAK} ${U} install -y test-repo org.test.Hello; then
 fi
 
 ${FLATPAK} ${U} update --appstream test-repo
-assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml "app/org\.test\.Hello"
+assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml "app/org\.test\.Hello/"
 
 # Remove filter
 
 ${FLATPAK} ${U} remote-modify test-repo --no-filter
 
-${FLATPAK} ${U} remote-ls -d -a test-repo > remote-ls-log
-assert_file_has_content remote-ls-log "app/org\.test\.Hello"
-assert_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale"
-assert_file_has_content remote-ls-log "runtime/org\.test\.Platform"
+${FLATPAK} ${U} remote-ls --columns=ref -a test-repo > remote-ls-log
+assert_file_has_content remote-ls-log "app/org\.test\.Hello/"
+assert_file_has_content remote-ls-log "runtime/org\.test\.Hello\.Locale/"
+assert_file_has_content remote-ls-log "runtime/org\.test\.Platform/"
 
 ok "filter"
 

--- a/tests/test-subset.sh
+++ b/tests/test-subset.sh
@@ -33,8 +33,8 @@ assert_file_has_content repo-info.txt "Subsummaries: .*subset1-$ARCH.*"
 assert_file_has_content repo-info.txt "Subsummaries: .*subset2-$ARCH.*"
 
 $FLATPAK repo --branches repos/test > repo-all.txt
-assert_file_has_content repo-all.txt "app/org.test.Hello/$ARCH/master"
-assert_file_has_content repo-all.txt "runtime/org.test.Platform/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org\.test\.Hello/$ARCH/master"
+assert_file_has_content repo-all.txt "runtime/org\.test\.Platform/$ARCH/master"
 
 EXPORT_ARGS="--subset=subset1 " GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test org.test.SubsetOne master ""
 EXPORT_ARGS="--subset=subset2 " GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test org.test.SubsetTwo master ""
@@ -46,36 +46,36 @@ assert_file_has_content repo-info.txt "Subsummaries: .*subset1-$ARCH.*"
 assert_file_has_content repo-info.txt "Subsummaries: .*subset2-$ARCH.*"
 
 $FLATPAK repo --branches repos/test > repo-all.txt
-assert_file_has_content repo-all.txt "app/org.test.Hello/$ARCH/master"
-assert_file_has_content repo-all.txt "app/org.test.SubsetOne/$ARCH/master"
-assert_file_has_content repo-all.txt "app/org.test.SubsetTwo/$ARCH/master"
-assert_file_has_content repo-all.txt "app/org.test.NoSubset/$ARCH/master"
-assert_file_has_content repo-all.txt "runtime/org.test.Platform/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org\.test\.Hello/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org\.test\.SubsetOne/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org\.test\.SubsetTwo/$ARCH/master"
+assert_file_has_content repo-all.txt "app/org\.test\.NoSubset/$ARCH/master"
+assert_file_has_content repo-all.txt "runtime/org\.test\.Platform/$ARCH/master"
 
 $FLATPAK repo --branches repos/test --subset=subset1 > repo-subset1.txt
-assert_file_has_content repo-subset1.txt "app/org.test.Hello/$ARCH/master"
-assert_file_has_content repo-subset1.txt "app/org.test.SubsetOne/$ARCH/master"
-assert_not_file_has_content repo-subset1.txt "app/org.test.SubsetTwo/$ARCH/master"
-assert_not_file_has_content repo-subset1.txt "app/org.test.NoSubset/$ARCH/master"
-assert_file_has_content repo-subset1.txt "runtime/org.test.Platform/$ARCH/master"
+assert_file_has_content repo-subset1.txt "app/org\.test\.Hello/$ARCH/master"
+assert_file_has_content repo-subset1.txt "app/org\.test\.SubsetOne/$ARCH/master"
+assert_not_file_has_content repo-subset1.txt "app/org\.test\.SubsetTwo/$ARCH/master"
+assert_not_file_has_content repo-subset1.txt "app/org\.test\.NoSubset/$ARCH/master"
+assert_file_has_content repo-subset1.txt "runtime/org\.test\.Platform/$ARCH/master"
 
 $FLATPAK repo --branches repos/test --subset=subset2 > repo-subset2.txt
-assert_file_has_content repo-subset2.txt "app/org.test.Hello/$ARCH/master"
-assert_not_file_has_content repo-subset2.txt "app/org.test.SubsetOne/$ARCH/master"
-assert_file_has_content repo-subset2.txt "app/org.test.SubsetTwo/$ARCH/master"
-assert_not_file_has_content repo-subset2.txt "app/org.test.NoSubset/$ARCH/master"
-assert_file_has_content repo-subset2.txt "runtime/org.test.Platform/$ARCH/master"
+assert_file_has_content repo-subset2.txt "app/org\.test\.Hello/$ARCH/master"
+assert_not_file_has_content repo-subset2.txt "app/org\.test\.SubsetOne/$ARCH/master"
+assert_file_has_content repo-subset2.txt "app/org\.test\.SubsetTwo/$ARCH/master"
+assert_not_file_has_content repo-subset2.txt "app/org\.test\.NoSubset/$ARCH/master"
+assert_file_has_content repo-subset2.txt "runtime/org\.test\.Platform/$ARCH/master"
 
 ok "repo has right refs in right subset"
 
 ${FLATPAK} ${U} remote-modify --subset=subset1 test-repo
 
-${FLATPAK} ${U} remote-ls test-repo > remote-subset1.txt
-assert_file_has_content remote-subset1.txt "org.test.Hello"
-assert_file_has_content remote-subset1.txt "org.test.SubsetOne"
-assert_not_file_has_content remote-subset1.txt "org.test.SubsetTwo"
-assert_not_file_has_content remote-subset1.txt "org.test.NoSubset"
-assert_file_has_content remote-subset1.txt "org.test.Platform"
+${FLATPAK} ${U} remote-ls --columns=ref test-repo > remote-subset1.txt
+assert_file_has_content remote-subset1.txt "org\.test\.Hello/"
+assert_file_has_content remote-subset1.txt "org\.test\.SubsetOne/"
+assert_not_file_has_content remote-subset1.txt "org\.test\.SubsetTwo/"
+assert_not_file_has_content remote-subset1.txt "org\.test\.NoSubset/"
+assert_file_has_content remote-subset1.txt "org\.test\.Platform/"
 
 ${FLATPAK} ${U} install -y org.test.Hello &> /dev/null
 ${FLATPAK} ${U} install -y org.test.SubsetOne &> /dev/null
@@ -95,12 +95,12 @@ ok "remote subset handling works"
 
 ${FLATPAK} ${U} remote-modify --subset=subset2 test-repo
 
-${FLATPAK} ${U} remote-ls test-repo > remote-subset2.txt
-assert_file_has_content remote-subset2.txt "org.test.Hello"
-assert_not_file_has_content remote-subset2.txt "org.test.SubsetOne"
-assert_file_has_content remote-subset2.txt "org.test.SubsetTwo"
-assert_not_file_has_content remote-subset1.txt "org.test.NoSubset"
-assert_file_has_content remote-subset2.txt "org.test.Platform"
+${FLATPAK} ${U} remote-ls --columns=ref test-repo > remote-subset2.txt
+assert_file_has_content remote-subset2.txt "org\.test\.Hello/"
+assert_not_file_has_content remote-subset2.txt "org\.test\.SubsetOne/"
+assert_file_has_content remote-subset2.txt "org\.test\.SubsetTwo/"
+assert_not_file_has_content remote-subset1.txt "org\.test\.NoSubset/"
+assert_file_has_content remote-subset2.txt "org\.test\.Platform/"
 
 ${FLATPAK} ${U} install -y org.test.SubsetTwo &> /dev/null
 


### PR DESCRIPTION
Maybe it's a bit pedantic but we shouldn't be matching
"org.test.Hello.Plugin.fun" when we're trying to match "org.test.Hello",
so add some trailing slashes to prevent that, and change the options on
a few commands so we're only parsing the columns we care about.