### PR TITLE
app: Refuse to work with sudo and --user

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -369,6 +369,16 @@ flatpak_option_context_parse (GOptionContext     *context,
         flatpak_disable_fancy_output ();
     }
 
+  /* sudo flatpak --user ... would operate on the root user's installation,
+   * which is almost certainly not what the user intended so just consider it
+   * an error.
+   */
+  if (opt_user && running_under_sudo ())
+    return flatpak_fail_error (error, FLATPAK_ERROR,
+                               _("Refusing to operate under sudo with --user. "
+                                 "Omit sudo to operate on the user installation, "
+                                 "or use a root shell to operate on the root user's installation."));
+
   if (!(flags & FLATPAK_BUILTIN_FLAG_NO_DIR))
     {
       dirs = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -916,6 +916,8 @@ gboolean flatpak_str_is_integer (const char *s);
 gboolean flatpak_uri_equal (const char *uri1,
                             const char *uri2);
 
+gboolean running_under_sudo (void);
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 #endif /* __FLATPAK_UTILS_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -9076,3 +9076,20 @@ flatpak_uri_equal (const char *uri1,
 
   return g_strcmp0 (uri1_norm, uri2_norm) == 0;
 }
+
+gboolean
+running_under_sudo (void)
+{
+  const char *sudo_command_env = g_getenv ("SUDO_COMMAND");
+  g_auto(GStrv) split_command = NULL;
+
+  if (!sudo_command_env)
+    return FALSE;
+
+  /* SUDO_COMMAND could be a value like `/usr/bin/flatpak run foo` */
+  split_command = g_strsplit (sudo_command_env, " ", 2);
+  if (g_str_has_suffix (split_command[0], "flatpak"))
+    return TRUE;
+
+  return FALSE;
+}


### PR DESCRIPTION
Have heard of people running Flatpak commands with both sudo and --user,
and not expecting it work on the root user's installation. Let's just
not allow it since it's not something people ever do intentionally.