### PR TITLE
[1.12.x] Cherry-pick misc bug fixes from master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ document-portal/xdp-resources.[ch]
 test-suite*.log
 common/flatpak-version-macros.h
 flatpak.pc
+flatpak.pp.bz2
 common/flatpak-enum-types.c
 common/flatpak-enum-types.h
 test-libflatpak
@@ -104,6 +105,18 @@ Flatpak-1.0.*
 /testcommon
 /testcommon.log
 /testcommon.trs
+/test-context
+/test-context.log
+/test-context.trs
+/test-exports
+/test-exports.log
+/test-exports.trs
+/test-instance
+/test-instance.log
+/test-instance.trs
+/test-portal
+/test-portal.log
+/test-portal.trs
 /tests/test-keyring/.gpg-v21-migrated
 /tests/test-keyring/private-keys-v1.d/
 /tests/test-keyring/trustdb.gpg
@@ -118,6 +131,9 @@ Flatpak-1.0.*
 /tests/test-authenticator
 /tests/test-update-portal
 /tests/test-portal-impl
+/tests/hold-lock
+/tests/list-unused
+/tests/mock-flatpak
 *.test
 /tests/*.sh.log
 /tests/*.sh.test

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ Flatpak-1.0.*
 /tests/hold-lock
 /tests/list-unused
 /tests/mock-flatpak
+/tests/try-syscall
 *.test
 /tests/*.sh.log
 /tests/*.sh.test

--- a/app/flatpak-builtins-build-update-repo.c
+++ b/app/flatpak-builtins-build-update-repo.c
@@ -395,7 +395,7 @@ generate_all_deltas (OstreeRepo   *repo,
       else
         {
           /* Ignore unknown ref types */
-          ignore_ref = FALSE;
+          ignore_ref = TRUE;
         }
 
       if (ignore_ref)

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -194,30 +194,42 @@ as_app_equal (AsApp *app1, AsApp *app2)
 }
 #endif
 
-/* This returns the app ID with the ".desktop" suffix stripped. In most cases
- * that is what as_app_get_id_filename() does, but if the ID actually ends in
- * .desktop it is stripped anyway and e.g.  "org.telegram" is returned instead
- * of "org.telegram.desktop" (which is a bug in appstream-glib). See
- * https://github.com/hughsie/appstream-glib/issues/420 and
- * https://github.com/flatpak/flatpak/issues/4535
- */
-static const char *
+static char *
 _app_get_id_no_suffix (AsApp *app)
 {
-  const gchar *id_with_suffix = NULL;
-  const gchar *id_stripped = NULL;
-  id_with_suffix = as_app_get_id_no_prefix (app);
+  const char *id_stripped = NULL;
+  GPtrArray *bundles = NULL;
+
+  /* First try using the <bundle> ID which is unambiguously the flatpak ref */
+  bundles = as_app_get_bundles (app);
+  for (guint i = 0; i < bundles->len; i++)
+    {
+      g_autoptr(FlatpakDecomposed) decomposed = NULL;
+      AsBundle *bundle = g_ptr_array_index (bundles, i);
+      if (as_bundle_get_kind (bundle) != AS_BUNDLE_KIND_FLATPAK)
+        continue;
+
+      decomposed = flatpak_decomposed_new_from_ref (as_bundle_get_id (bundle), NULL);
+      if (decomposed != NULL)
+        return flatpak_decomposed_dup_id (decomposed);
+    }
+
+  /* Fall back to using the <id> field, which is required by appstream spec,
+   * but make sure the .desktop suffix isn't stripped overzealously
+   * https://github.com/hughsie/appstream-glib/issues/420
+   */
   id_stripped = as_app_get_id_filename (app);
   if (flatpak_is_valid_name (id_stripped, -1, NULL))
-    return id_stripped;
+    return g_strdup (id_stripped);
   else
     {
       g_autofree char *id_with_desktop = g_strconcat (id_stripped, ".desktop", NULL);
+      const char *id_with_suffix = as_app_get_id_no_prefix (app);
       if (flatpak_is_valid_name (id_with_desktop, -1, NULL) &&
           g_strcmp0 (id_with_suffix, id_with_desktop) == 0)
-        return id_with_suffix;
+        return g_strdup (id_with_suffix);
       else
-        return id_stripped;
+        return g_strdup (id_stripped);
     }
 }
 
@@ -237,7 +249,7 @@ static void
 print_app (Column *columns, MatchResult *res, FlatpakTablePrinter *printer)
 {
   const char *version = as_app_get_version (res->app);
-  const char *id = _app_get_id_no_suffix (res->app);
+  g_autofree char *id = _app_get_id_no_suffix (res->app);
   const char *name = as_app_get_localized_name (res->app);
   const char *comment = as_app_get_localized_comment (res->app);
   guint i;
@@ -334,7 +346,7 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
           guint score = as_app_search_matches (app, search_text);
           if (score == 0)
             {
-              const char *app_id = _app_get_id_no_suffix (app);
+              g_autofree char *app_id = _app_get_id_no_suffix (app);
               if (strcasestr (app_id, search_text) != NULL)
                 score = 50;
               else

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -194,6 +194,33 @@ as_app_equal (AsApp *app1, AsApp *app2)
 }
 #endif
 
+/* This returns the app ID with the ".desktop" suffix stripped. In most cases
+ * that is what as_app_get_id_filename() does, but if the ID actually ends in
+ * .desktop it is stripped anyway and e.g.  "org.telegram" is returned instead
+ * of "org.telegram.desktop" (which is a bug in appstream-glib). See
+ * https://github.com/hughsie/appstream-glib/issues/420 and
+ * https://github.com/flatpak/flatpak/issues/4535
+ */
+static const char *
+_app_get_id_no_suffix (AsApp *app)
+{
+  const gchar *id_with_suffix = NULL;
+  const gchar *id_stripped = NULL;
+  id_with_suffix = as_app_get_id_no_prefix (app);
+  id_stripped = as_app_get_id_filename (app);
+  if (flatpak_is_valid_name (id_stripped, -1, NULL))
+    return id_stripped;
+  else
+    {
+      g_autofree char *id_with_desktop = g_strconcat (id_stripped, ".desktop", NULL);
+      if (flatpak_is_valid_name (id_with_desktop, -1, NULL) &&
+          g_strcmp0 (id_with_suffix, id_with_desktop) == 0)
+        return id_with_suffix;
+      else
+        return id_stripped;
+    }
+}
+
 static int
 compare_apps (MatchResult *a, AsApp *b)
 {
@@ -210,7 +237,7 @@ static void
 print_app (Column *columns, MatchResult *res, FlatpakTablePrinter *printer)
 {
   const char *version = as_app_get_version (res->app);
-  const char *id = as_app_get_id_filename (res->app);
+  const char *id = _app_get_id_no_suffix (res->app);
   const char *name = as_app_get_localized_name (res->app);
   const char *comment = as_app_get_localized_comment (res->app);
   guint i;
@@ -307,7 +334,7 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
           guint score = as_app_search_matches (app, search_text);
           if (score == 0)
             {
-              const char *app_id = as_app_get_id_filename (app);
+              const char *app_id = _app_get_id_no_suffix (app);
               if (strcasestr (app_id, search_text) != NULL)
                 score = 50;
               else

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -124,7 +124,7 @@ add_new_remote (FlatpakTransaction            *transaction,
 
   if (self->disable_interaction)
     {
-      g_print (_("Configuring %s as new remote '%s'"), url, remote_name);
+      g_print (_("Configuring %s as new remote '%s'\n"), url, remote_name);
       return TRUE;
     }
 
@@ -397,7 +397,7 @@ progress_changed_cb (FlatpakTransactionProgress *progress,
         g_print ("\r%s", str->str); /* redraw failed, just update the progress */
     }
   else
-    g_print ("\n%s", str->str);
+    g_print ("%s\n", str->str);
 }
 
 static void
@@ -455,7 +455,7 @@ new_operation (FlatpakTransaction          *transaction,
       redraw (self);
     }
   else
-    g_print ("\n%-*s", self->table_width, text);
+    g_print ("%s\n", text);
 
   g_free (self->progress_msg);
   self->progress_msg = g_steal_pointer (&text);
@@ -509,7 +509,7 @@ operation_error (FlatpakTransaction            *transaction,
           redraw (self);
         }
       else
-        g_print ("\n%-*s\n", self->table_width, msg); /* override progress, and go to next line */
+        g_print ("%s\n", msg);
 
       return TRUE;
     }
@@ -548,7 +548,7 @@ operation_error (FlatpakTransaction            *transaction,
       redraw (self);
     }
   else
-    g_printerr ("\n%-*s\n", self->table_width, text);
+    g_printerr ("%s\n", text);
 
   if (!non_fatal && self->stop_on_first_error)
     return FALSE;
@@ -1052,7 +1052,7 @@ message_handler (const gchar   *log_domain,
       redraw (self);
     }
   else
-    g_print ("\n%-*s\n", self->table_width, text);
+    g_print ("%s\n", text);
 }
 
 static gboolean
@@ -1414,7 +1414,7 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
           redraw (self);
         }
       else
-        g_print ("\n%-*s", self->table_width, text);
+        g_print ("%s", text);
 
       g_print ("\n");
     }

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -455,7 +455,7 @@ new_operation (FlatpakTransaction          *transaction,
       redraw (self);
     }
   else
-    g_print ("\r%-*s", self->table_width, text);
+    g_print ("\n%-*s", self->table_width, text);
 
   g_free (self->progress_msg);
   self->progress_msg = g_steal_pointer (&text);
@@ -509,7 +509,7 @@ operation_error (FlatpakTransaction            *transaction,
           redraw (self);
         }
       else
-        g_print ("\r%-*s\n", self->table_width, msg); /* override progress, and go to next line */
+        g_print ("\n%-*s\n", self->table_width, msg); /* override progress, and go to next line */
 
       return TRUE;
     }
@@ -548,7 +548,7 @@ operation_error (FlatpakTransaction            *transaction,
       redraw (self);
     }
   else
-    g_printerr ("\r%-*s\n", self->table_width, text);
+    g_printerr ("\n%-*s\n", self->table_width, text);
 
   if (!non_fatal && self->stop_on_first_error)
     return FALSE;
@@ -1052,7 +1052,7 @@ message_handler (const gchar   *log_domain,
       redraw (self);
     }
   else
-    g_print ("\r%-*s\n", self->table_width, text);
+    g_print ("\n%-*s\n", self->table_width, text);
 }
 
 static gboolean
@@ -1414,7 +1414,7 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
           redraw (self);
         }
       else
-        g_print ("\r%-*s", self->table_width, text);
+        g_print ("\n%-*s", self->table_width, text);
 
       g_print ("\n");
     }

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -876,7 +876,7 @@ complete (int    argc,
       FlatpakCommand *c = commands;
       while (c->name)
         {
-          if (c->fn != NULL)
+          if (c->fn != NULL && !c->deprecated)
             flatpak_complete_word (completion, "%s ", c->name);
           c++;
         }

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -591,6 +591,10 @@ flatpak_run_parse_pulse_server (const char *value)
       const char *server = servers[i];
       if (g_str_has_prefix (server, "{"))
         {
+          /*
+           * TODO: compare the value within {} to the local hostname and D-Bus machine ID,
+           * and skip if it matches neither.
+           */
           const char * closing = strstr (server, "}");
           if (closing == NULL)
             continue;
@@ -601,6 +605,8 @@ flatpak_run_parse_pulse_server (const char *value)
         return g_strdup (server + 5);
       if (server[0] == '/')
         return g_strdup (server);
+
+      /* TODO: Support TCP connections? */
     }
 
   return NULL;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -575,6 +575,11 @@ flatpak_run_get_pulseaudio_server (void)
   return NULL;
 }
 
+/*
+ * Parse a PulseAudio server string, as documented on
+ * https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/ServerStrings/.
+ * Returns the first supported server address, or NULL if none are supported.
+ */
 static char *
 flatpak_run_parse_pulse_server (const char *value)
 {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -591,8 +591,11 @@ flatpak_run_parse_pulse_server (const char *value)
             continue;
           server = closing + 1;
         }
+
       if (g_str_has_prefix (server, "unix:"))
         return g_strdup (server + 5);
+      if (server[0] == '/')
+        return g_strdup (server);
     }
 
   return NULL;

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -503,7 +503,10 @@ load_uri_callback (GObject      *source_object,
       if (!glnx_open_tmpfile_linkable_at (data->out_tmpfile_parent_dfd, ".",
                                           O_WRONLY, data->out_tmpfile,
                                           &data->error))
-        return;
+        {
+          g_main_context_wakeup (data->context);
+          return;
+        }
 
       g_assert (data->out == NULL);
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5200,7 +5200,7 @@ msgstr "Skipping %s due to previous error"
 #: common/flatpak-transaction.c:4815
 #, fuzzy, c-format
 msgid "Aborted due to failure (%s)"
-msgstr "Aborted due to failure"
+msgstr "Aborted due to failure (%s)"
 
 #: common/flatpak-utils.c:793
 msgid "Glob can't match apps"

--- a/tests/Makefile-test-matrix.am.inc
+++ b/tests/Makefile-test-matrix.am.inc
@@ -42,6 +42,7 @@ TEST_MATRIX_DIST= \
 	tests/test-auth.sh \
 	tests/test-unused.sh \
 	tests/test-prune.sh \
+	tests/test-seccomp.sh \
 	$(NULL)
 TEST_MATRIX_EXTRA_DIST= \
 	tests/test-run.sh \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -279,7 +279,7 @@ TEST_MATRIX_SOURCE = \
 	$(NULL)
 
 update-test-matrix:
-	$(srcdir)/tests/expand-test-matrix.sh "$(TEST_MATRIX_SOURCE)" > tests/Makefile-test-matrix.am.inc
+	$(srcdir)/tests/expand-test-matrix.sh "$(TEST_MATRIX_SOURCE)" > $(srcdir)/tests/Makefile-test-matrix.am.inc
 
 tests/test-%.wrap:
 	@true

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -280,6 +280,7 @@ TEST_MATRIX_SOURCE = \
 	tests/test-summaries.sh{user+system} \
 	tests/test-subset.sh{user+system} \
 	tests/test-prune.sh \
+	tests/test-seccomp.sh \
 	$(NULL)
 
 update-test-matrix:

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -143,6 +143,10 @@ tests_test_authenticator_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) \
 tests_test_authenticator_LDADD = $(AM_LDADD) $(BASE_LIBS) libflatpak-common.la libflatpak-common-base.la libglnx.la
 tests_test_authenticator_SOURCES = tests/test-authenticator.c
 
+tests_try_syscall_CFLAGS = $(AM_CFLAGS)
+tests_try_syscall_LDADD = $(AM_LDADD)
+tests_try_syscall_SOURCES = tests/try-syscall.c
+
 tests_list_unused_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
 	-DLOCALEDIR=\"$(localedir)\"
@@ -317,6 +321,7 @@ test_extra_programs = \
 	tests/test-authenticator \
 	tests/test-portal-impl \
 	tests/test-update-portal \
+	tests/try-syscall \
 	$(NULL)
 
 @VALGRIND_CHECK_RULES@

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -18,7 +18,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-# redirect stdout to stderr, otherwise the log will have command output out of
+# redirect stderr to stdout, otherwise the log will have command output out of
 # order with xtrace output
 exec 2>&1
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -18,6 +18,10 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
+# redirect stdout to stderr, otherwise the log will have command output out of
+# order with xtrace output
+exec 2>&1
+
 if [ -n "${G_TEST_SRCDIR:-}" ]; then
     test_srcdir="${G_TEST_SRCDIR}"
 else

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -67,7 +67,7 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/files
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
 # Ensure Exec key is rewritten
-assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=master --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
+assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*flatpak run --branch=master --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
 assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png
 assert_has_file $FL_DIR/exports/share/icons/HighContrast/64x64/apps/org.test.Hello.png
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -51,12 +51,12 @@ elif [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
     # Set a collection ID and GPG on the server, but not in the client configuration
     setup_repo_no_add test-no-gpg org.test.Collection.NoGpg
     port=$(cat httpd-port)
-    flatpak remote-add ${U} --no-gpg-verify test-no-gpg-repo "http://127.0.0.1:${port}/test-no-gpg"
+    ${FLATPAK} remote-add ${U} --no-gpg-verify test-no-gpg-repo "http://127.0.0.1:${port}/test-no-gpg"
 else
     GPGPUBKEY="" GPGARGS="" setup_repo test-no-gpg
 fi
 
-flatpak remote-add ${U} --no-gpg-verify local-test-no-gpg-repo `pwd`/repos/test-no-gpg
+${FLATPAK} remote-add ${U} --no-gpg-verify local-test-no-gpg-repo `pwd`/repos/test-no-gpg
 
 #alternative gpg key repo
 GPGPUBKEY="${FL_GPG_HOMEDIR2}/pubring.gpg" GPGARGS="${FL_GPGARGS2}" setup_repo test-gpg2 org.test.Collection.Gpg2
@@ -65,13 +65,13 @@ GPGPUBKEY="${FL_GPG_HOMEDIR2}/pubring.gpg" GPGARGS="${FL_GPGARGS2}" setup_repo t
 # Don’t use --collection-id= here, or the collections code will grab the appropriate
 # GPG key from one of the previously-configured remotes with the same collection ID.
 port=$(cat httpd-port)
-if flatpak remote-add ${U} test-missing-gpg-repo "http://127.0.0.1:${port}/test"; then
+if ${FLATPAK} remote-add ${U} test-missing-gpg-repo "http://127.0.0.1:${port}/test"; then
     assert_not_reached "Should fail metadata-update due to missing gpg key"
 fi
 
 #remote with wrong GPG key
 port=$(cat httpd-port)
-if flatpak remote-add ${U} --gpg-import=${FL_GPG_HOMEDIR2}/pubring.gpg test-wrong-gpg-repo "http://127.0.0.1:${port}/test"; then
+if ${FLATPAK} remote-add ${U} --gpg-import=${FL_GPG_HOMEDIR2}/pubring.gpg test-wrong-gpg-repo "http://127.0.0.1:${port}/test"; then
     assert_not_reached "Should fail metadata-update due to wrong gpg key"
 fi
 
@@ -79,7 +79,7 @@ fi
 rm -rf repos/test/refs/heads/appstream2
 ${FLATPAK} build-update-repo ${BUILD_UPDATE_REPO_FLAGS-} --no-update-appstream ${FL_GPGARGS} repos/test
 
-flatpak ${U} --appstream update test-repo
+${FLATPAK} ${U} --appstream update test-repo
 
 assert_has_file $FL_DIR/repo/refs/remotes/test-repo/appstream/$ARCH
 assert_not_has_file $FL_DIR/repo/refs/remotes/test-repo/appstream2/$ARCH
@@ -94,7 +94,7 @@ ok "update compat appstream"
 # Then regenerate new appstream branch and verify that we update to it
 update_repo
 
-flatpak ${U} --appstream update test-repo
+${FLATPAK} ${U} --appstream update test-repo
 
 assert_has_file $FL_DIR/repo/refs/remotes/test-repo/appstream2/$ARCH
 
@@ -391,12 +391,12 @@ ostree init --repo=repos/test-rebase --mode=archive-z2 ${rebase_collection_args}
 ${FLATPAK} build-commit-from --no-update-summary --src-repo=repos/test ${FL_GPGARGS} repos/test-rebase app/org.test.Hello/$ARCH/master runtime/org.test.Hello.Locale/$ARCH/master
 update_repo test-rebase ${REBASE_COLLECTION_ID}
 
-flatpak remote-add ${U} --gpg-import=${FL_GPG_HOMEDIR}/pubring.gpg test-rebase "http://127.0.0.1:${port}/test-rebase"
+${FLATPAK} remote-add ${U} --gpg-import=${FL_GPG_HOMEDIR}/pubring.gpg test-rebase "http://127.0.0.1:${port}/test-rebase"
 
 ${FLATPAK} ${U} install -y test-rebase org.test.Hello
 
 assert_not_has_dir $HOME/.var/app/org.test.Hello
-${CMD_PREFIX} flatpak run --command=bash org.test.Hello -c 'echo foo > $XDG_DATA_HOME/a-file'
+${FLATPAK} run --command=bash org.test.Hello -c 'echo foo > $XDG_DATA_HOME/a-file'
 assert_has_dir $HOME/.var/app/org.test.Hello
 assert_has_file $HOME/.var/app/org.test.Hello/data/a-file
 
@@ -410,7 +410,7 @@ ${FLATPAK} ${U} update -y org.test.Hello
 assert_has_dir $FL_DIR/app/org.test.NewHello/$ARCH/master/active/files
 assert_not_has_file $FL_DIR/app/org.test.NewHello/$ARCH/master/active/files
 
-${CMD_PREFIX} flatpak run --command=bash org.test.NewHello -c 'echo foo > $XDG_DATA_HOME/another-file'
+${FLATPAK} run --command=bash org.test.NewHello -c 'echo foo > $XDG_DATA_HOME/another-file'
 
 # Ensure we migrated the app data
 assert_has_dir $HOME/.var/app/org.test.NewHello

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -453,10 +453,10 @@ assert_has_file $FL_DIR/app/org.test.OldVersion/$ARCH/stable/active/files/update
 ok "version checks"
 
 rm -rf app
-flatpak build-init app org.test.Writable org.test.Platform org.test.Platform stable
+${FLATPAK} build-init app org.test.Writable org.test.Platform org.test.Platform stable
 mkdir -p app/files/a-dir
 chmod a+rwx app/files/a-dir
-flatpak build-finish --command=hello.sh app
+${FLATPAK} build-finish --command=hello.sh app
 # Note: not --canonical-permissions
 ${FLATPAK} build-export -vv  --no-update-summary --disable-sandbox --files=files repos/test app stable
 ostree --repo=repos/test commit  --keep-metadata=xa.metadata --owner-uid=0 --owner-gid=0  --no-xattrs  ${FL_GPGARGS} --branch=app/org.test.Writable/$ARCH/stable app
@@ -472,11 +472,11 @@ fi
 ok "no world writable dir"
 
 rm -rf app
-flatpak build-init app org.test.Setuid org.test.Platform org.test.Platform stable
+${FLATPAK} build-init app org.test.Setuid org.test.Platform org.test.Platform stable
 mkdir -p app/files/
 touch app/files/exe
 chmod u+s app/files/exe
-flatpak build-finish --command=hello.sh app
+${FLATPAK} build-finish --command=hello.sh app
 # Note: not --canonical-permissions
 ${FLATPAK} build-export -vv  --no-update-summary --disable-sandbox --files=files repos/test app stable
 ostree -v --repo=repos/test commit --keep-metadata=xa.metadata --owner-uid=0 --owner-gid=0 --no-xattrs  ${FL_GPGARGS} --branch=app/org.test.Setuid/$ARCH/stable app
@@ -490,10 +490,10 @@ assert_file_has_content err2.txt [Ii]nvalid
 ok "no setuid"
 
 rm -rf app
-flatpak build-init app org.test.App org.test.Platform org.test.Platform stable
+${FLATPAK} build-init app org.test.App org.test.Platform org.test.Platform stable
 mkdir -p app/files/
 touch app/files/exe
-flatpak build-finish --command=hello.sh --sdk=org.test.Sdk app
+${FLATPAK} build-finish --command=hello.sh --sdk=org.test.Sdk app
 ${FLATPAK} build-export  --no-update-summary ${FL_GPGARGS} repos/test app stable
 update_repo
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -45,7 +45,7 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/files
 assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/stable/active/export
 assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
 # Ensure Exec key is rewritten
-assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
+assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*flatpak run --branch=stable --arch=$ARCH --command=hello\.sh org\.test\.Hello$"
 assert_has_file $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini
 assert_file_has_content $FL_DIR/exports/share/gnome-shell/search-providers/org.test.Hello.search-provider.ini "^DefaultDisabled=true$"
 assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png

--- a/tests/test-seccomp.sh
+++ b/tests/test-seccomp.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Copyright 2021 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+
+echo "1..16"
+
+setup_repo
+install_repo
+
+cp -a "$G_TEST_BUILDDIR/try-syscall" "$test_tmpdir/try-syscall"
+
+# How this works:
+# try-syscall tries to make various syscalls, some benign, some not.
+#
+# The parameters are chosen to make them fail with EBADF or EFAULT if
+# not blocked. If they are blocked, we get ENOSYS or EPERM. If the syscall
+# is impossible for a particular architecture, we get ENOENT.
+#
+# The exit status is an errno value, which we can compare with the expected
+# errno value.
+
+eval "$("$test_tmpdir/try-syscall" print-errno-values)"
+
+try_syscall () {
+  ${FLATPAK} run \
+    --filesystem="$test_tmpdir" \
+    --command="$test_tmpdir/try-syscall" \
+    $extra_argv \
+    org.test.Hello "$@"
+}
+
+for extra_argv in "" "--allow=multiarch"; do
+  echo "# testing with extra argv: '$extra_argv'"
+
+  echo "# chmod (benign)"
+  e=0
+  try_syscall chmod || e="$?"
+  assert_streq "$e" "$EFAULT"
+  ok "chmod not blocked"
+
+  echo "# chroot (harmful)"
+  e=0
+  try_syscall chroot || e="$?"
+  assert_streq "$e" "$EPERM"
+  ok "chroot blocked with EPERM"
+
+  echo "# clone3 (harmful)"
+  e=0
+  try_syscall clone3 || e="$?"
+  # This is either ENOSYS because the kernel genuinely doesn't implement it,
+  # or because we successfully blocked it. We can't tell which.
+  assert_streq "$e" "$ENOSYS"
+  ok "clone3 blocked with ENOSYS (CVE-2021-41133)"
+
+  echo "# ioctl TIOCNOTTY (benign)"
+  e=0
+  try_syscall "ioctl TIOCNOTTY" || e="$?"
+  assert_streq "$e" "$EBADF"
+  ok "ioctl TIOCNOTTY not blocked"
+
+  echo "# ioctl TIOCSTI (CVE-2017-5226)"
+  e=0
+  try_syscall "ioctl TIOCSTI" || e="$?"
+  assert_streq "$e" "$EPERM"
+  ok "ioctl TIOCSTI blocked (CVE-2017-5226)"
+
+  echo "# ioctl TIOCSTI (trying to repeat CVE-2019-10063)"
+  e=0
+  try_syscall "ioctl TIOCSTI CVE-2019-10063" || e="$?"
+  if test "$e" = "$ENOENT"; then
+    echo "ok # SKIP Cannot replicate CVE-2019-10063 on 32-bit architecture"
+  else
+    assert_streq "$e" "$EPERM"
+    ok "ioctl TIOCSTI with high bits blocked (CVE-2019-10063)"
+  fi
+
+  echo "# listen (benign)"
+  e=0
+  try_syscall "listen" || e="$?"
+  assert_streq "$e" "$EBADF"
+  ok "listen not blocked"
+
+  echo "# prctl (benign)"
+  e=0
+  try_syscall "prctl" || e="$?"
+  assert_streq "$e" "$EFAULT"
+  ok "prctl not blocked"
+done

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -84,7 +84,7 @@ assert_file_has_content ${FL_DIR}/repo/config '^collection-id=org\.test\.Collect
 sed -i "s/deploy-collection-id=true//" repos/test/config
 assert_not_file_has_content repos/test/config '^deploy-collection-id=true$'
 
-flatpak remote-modify --collection-id= test-repo
+${FLATPAK} remote-modify --collection-id= test-repo
 assert_not_file_has_content ${FL_DIR}/repo/config '^collection-id=org\.test\.Collection$'
 
 UPDATE_REPO_ARGS="--collection-id=org.test.Collection --deploy-sideload-collection-id" update_repo

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -984,7 +984,7 @@ test_list_refs_in_remotes (void)
       const char *collection_id = flatpak_ref_get_collection_id (ref);
 
       /* There is no collection ref defined for the remote, so collection id is NULL */
-      g_assert (collection_id == NULL);
+      g_assert_null (collection_id);
 
       g_hash_table_add (ref_specs, (char *)ref_spec);
     }

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -809,6 +809,30 @@ test_remote_new (void)
 }
 
 static void
+_remove_remote (const char *remote_name,
+                gboolean    system)
+{
+  char *argv[] = { "flatpak", "remote-delete", NULL, "name", NULL };
+
+  argv[2] = system ? "--system" : "--user";
+  argv[3] = (char *)remote_name;
+
+  run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
+}
+
+static void
+remove_remote_system (const char *remote_name)
+{
+  _remove_remote (remote_name, TRUE);
+}
+
+static void
+remove_remote_user (const char *remote_name)
+{
+  _remove_remote (remote_name, FALSE);
+}
+
+static void
 test_remote_new_from_file (void)
 {
   g_autoptr(FlatpakInstallation) inst = NULL;
@@ -905,6 +929,8 @@ test_remote_new_from_file (void)
   g_assert_cmpstr (flatpak_remote_get_filter (remote), ==, NULL);
 
   g_clear_object (&remote);
+
+  remove_remote_user ("file-remote");
 }
 
 static void
@@ -1012,6 +1038,8 @@ test_list_refs_in_remotes (void)
       else
         g_assert_null (g_hash_table_lookup (ref_specs, ref_spec));
     }
+
+  remove_remote_user ("multi-refs-repo");
 }
 
 static void
@@ -2485,30 +2513,6 @@ add_remote_user (const char *remote_repo_name,
 }
 
 static void
-_remove_remote (const char *remote_name,
-                gboolean    system)
-{
-  char *argv[] = { "flatpak", "remote-delete", NULL, "name", NULL };
-
-  argv[2] = system ? "--system" : "--user";
-  argv[3] = (char *)remote_name;
-
-  run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);
-}
-
-static void
-remove_remote_system (const char *remote_name)
-{
-  _remove_remote (remote_name, TRUE);
-}
-
-static void
-remove_remote_user (const char *remote_name)
-{
-  _remove_remote (remote_name, FALSE);
-}
-
-static void
 add_flatpakrepo (const char *flatpakrepo_repo_name)
 {
   g_autofree char *data = NULL;
@@ -3419,6 +3423,8 @@ test_transaction_install_flatpakref (void)
   res = flatpak_transaction_run (transaction, NULL, &error);
   g_assert_no_error (error);
   g_assert_true (res);
+
+  remove_remote_user ("my-little-repo");
 }
 
 static gboolean
@@ -4626,6 +4632,10 @@ test_installation_unused_refs_across_installations (void)
   g_assert_nonnull (refs);
   g_assert_no_error (error);
   g_assert_cmpint (refs->len, ==, 0);
+
+  empty_installation (user_inst);
+  empty_installation (system_inst);
+  remove_remote_system ("test-runtime-only-repo");
 }
 
 int

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -3448,19 +3448,21 @@ _is_remote_in_installation (FlatpakInstallation *installation,
   return FALSE;
 }
 
-static void
-assert_remote_in_installation (FlatpakInstallation *installation,
-                               const char          *remote_name)
-{
-  g_assert_true (_is_remote_in_installation (installation, remote_name));
-}
+#define assert_remote_in_installation(inst, remote)        \
+  G_STMT_START {                                           \
+    if (!_is_remote_in_installation (inst, remote))        \
+      g_assertion_message (G_LOG_DOMAIN,                   \
+                           __FILE__, __LINE__, G_STRFUNC,  \
+                           "remote " remote " not found"); \
+  } G_STMT_END
 
-static void
-assert_remote_not_in_installation (FlatpakInstallation *installation,
-                                   const char          *remote_name)
-{
-  g_assert_true (!_is_remote_in_installation (installation, remote_name));
-}
+#define assert_remote_not_in_installation(inst, remote)    \
+  G_STMT_START {                                           \
+    if (_is_remote_in_installation (inst, remote))         \
+      g_assertion_message (G_LOG_DOMAIN,                   \
+                           __FILE__, __LINE__, G_STRFUNC,  \
+                           "remote " remote " was found"); \
+  } G_STMT_END
 
 static gboolean
 add_new_remote3 (FlatpakTransaction             *transaction,

--- a/tests/try-syscall.c
+++ b/tests/try-syscall.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2021 Simon McVittie
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * Try one or more system calls that might have been blocked by a
+ * seccomp filter. Return the last value of errno seen.
+ *
+ * In general, we pass a bad fd or pointer to each syscall that will
+ * accept one, so that it will fail with EBADF or EFAULT without side-effects.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/prctl.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#if defined(_MIPS_SIM)
+# if _MIPS_SIM == _MIPS_SIM_ABI32
+#   define MISSING_SYSCALL_BASE 4000
+# elif _MIPS_SIM == _MIPS_SIM_ABI64
+#   define MISSING_SYSCALL_BASE 5000
+# elif _MIPS_SIM == _MIPS_SIM_NABI32
+#   define MISSING_SYSCALL_BASE 6000
+# else
+#   error "Unknown MIPS ABI"
+# endif
+#endif
+
+#if defined(__ia64__)
+# define MISSING_SYSCALL_BASE 1024
+#endif
+
+#if defined(__alpha__)
+# define MISSING_SYSCALL_BASE 110
+#endif
+
+#if defined(__x86_64__) && defined(__ILP32__)
+# define MISSING_SYSCALL_BASE 0x40000000
+#endif
+
+/*
+ * MISSING_SYSCALL_BASE:
+ *
+ * Number to add to the syscall numbers of recently-added syscalls
+ * to get the appropriate syscall for the current ABI.
+ */
+#ifndef MISSING_SYSCALL_BASE
+# define MISSING_SYSCALL_BASE 0
+#endif
+
+#ifndef __NR_clone3
+# define __NR_clone3 (MISSING_SYSCALL_BASE + 435)
+#endif
+
+/*
+ * The size of clone3's parameter (as of 2021)
+ */
+#define SIZEOF_STRUCT_CLONE_ARGS ((size_t) 88)
+
+/*
+ * An invalid pointer that will cause syscalls to fail with EFAULT
+ */
+#define WRONG_POINTER ((char *) 1)
+
+int
+main (int argc, char **argv)
+{
+  int errsv = 0;
+  int i;
+
+  for (i = 1; i < argc; i++)
+    {
+      const char *arg = argv[i];
+
+      if (strcmp (arg, "print-errno-values") == 0)
+        {
+          printf ("EBADF=%d\n", EBADF);
+          printf ("EFAULT=%d\n", EFAULT);
+          printf ("ENOENT=%d\n", ENOENT);
+          printf ("ENOSYS=%d\n", ENOSYS);
+          printf ("EPERM=%d\n", EPERM);
+        }
+      else if (strcmp (arg, "chmod") == 0)
+        {
+          /* If not blocked by seccomp, this will fail with EFAULT */
+          if (chmod (WRONG_POINTER, 0700) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+      else if (strcmp (arg, "chroot") == 0)
+        {
+          /* If not blocked by seccomp, this will fail with EFAULT */
+          if (chroot (WRONG_POINTER) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+      else if (strcmp (arg, "clone3") == 0)
+        {
+          /* If not blocked by seccomp, this will fail with EFAULT */
+          if (syscall (__NR_clone3, WRONG_POINTER, SIZEOF_STRUCT_CLONE_ARGS) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+      else if (strcmp (arg, "ioctl TIOCNOTTY") == 0)
+        {
+          /* If not blocked by seccomp, this will fail with EBADF */
+          if (ioctl (-1, TIOCNOTTY) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+      else if (strcmp (arg, "ioctl TIOCSTI") == 0)
+        {
+          /* If not blocked by seccomp, this will fail with EBADF */
+          if (ioctl (-1, TIOCSTI, WRONG_POINTER) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+#ifdef __LP64__
+      else if (strcmp (arg, "ioctl TIOCSTI CVE-2019-10063") == 0)
+        {
+          unsigned long not_TIOCSTI = (0x123UL << 32) | (unsigned long) TIOCSTI;
+
+          /* If not blocked by seccomp, this will fail with EBADF */
+          if (syscall (__NR_ioctl, -1, not_TIOCSTI, WRONG_POINTER) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+#endif
+     else if (strcmp (arg, "listen") == 0)
+        {
+          /* If not blocked by seccomp, this will fail with EBADF */
+          if (listen (-1, 42) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+     else if (strcmp (arg, "prctl") == 0)
+        {
+          /* If not blocked by seccomp, this will fail with EFAULT */
+          if (prctl (PR_GET_CHILD_SUBREAPER, WRONG_POINTER, 0, 0, 0) != 0)
+            {
+              errsv = errno;
+              perror (arg);
+            }
+        }
+      else
+        {
+          fprintf (stderr, "Unsupported syscall \"%s\"\n", arg);
+          errsv = ENOENT;
+        }
+   }
+
+  return errsv;
+}


### PR DESCRIPTION
* tests: Allow FLATPAK_BINARY=flatpak for exports

    Author: @jtojnar, via #4496 

    (cherry picked from commit 96dbe28cfa96e80b23fa1d8072eb36edad41279c)

* tests: Generate Makefile-test-matrix.am.inc in $(srcdir)

    Author: me, via #4504

    (cherry picked from commit 647c51380c13b72adbd67e0aa83b3a2979f5c6a8)

* testlibrary: Don't use g_assert()

    Author: @mwleeds, via #4489  

    (cherry picked from commit 0258fc82bb8eac176d45781b54920f0a27613890)

* .gitignore: Update for recent changes

    Author: @mwleeds 
    
    (cherry picked from commit 2181f4f171abf824d8e3c754e9e7415813460856)

* tests: Add try-syscall helper

    Author: me, via #4505 

    (cherry picked from commit 4ce251882c488953ca6e3734f00c5dbe2e1e3e7a)

* tests: Add basic test coverage for our seccomp filters

    Author: me, via #4505 

    (cherry picked from commit 7c5aec474caef7aa004286cc9359611ad21d227b)

* flatpak-utils-http: Ensure to wake up the main context on error

    Author: @pwithnall, via #4518 

* run: Support PulseAudio socket path without unix: prefix

    Author: @wjt, via #4564 

    (cherry picked from commit 7534a970a5535d57d5fa07bd5ed9eb3647cbb7dc)

* run: Add link to PulseAudio server string documentation

    Author: @wjt, via #4564 

    (cherry picked from commit bcc114383b744e3dc32c0b859fc900f9793ce6c7)

* run: Document shortcomings of PulseAudio server string parsing

    Author: @wjt, via #4564 

    (cherry picked from commit eabbff6fefb879d6726a31afa8ae17ee144855a7)

* search: Don't strip .desktop suffix overzealously

    Author: @mwleeds, via #4536 

    (cherry picked from commit 62e09b406b8a7fb517c294d2c0b149a83f2cc64b)

* search: Use <bundle> ID to determine flatpak app ID

    Author: @mwleeds, via #4536 

    (cherry picked from commit 39de0ef280a98f67d639444cc6ea3bcfa61c0eec)

* app: Don't use carriage return for non-fancy output

    Author: @mwleeds, via #4532

    (cherry picked from commit 86d6918a1186467fb4e26408ec1bb947dcf7ba28)

* build-update-repo: Don't try to generate deltas of unknown refs

    Author: @mwleeds, via #4522

    (cherry picked from commit 17fbe516c4251c08a648f5e938af3af78fbd4ab4)

* tests: Use ${FLATPAK} not flatpak

    Author: @mwleeds, via #4580

    (cherry picked from commit d23793294d59125e645273d8b3518a9c19b597eb)

* Make test suite logs prettier

    Author: @mwleeds, via #4583

    (cherry picked from commit 388c23cfc51b6b9f03dcdf87b11c0078f11227ea)

* tests: Fix a comment

    Author: @mwleeds 
    
    (cherry picked from commit dfde010a49ed02c966ee9050e8ea4dc75033bdb6)

* app: Don't tab-complete on aliases

    Author: @mwleeds, via #4587 
    Fixes: #4036

    (cherry picked from commit 2c4c84ffee1a7b0c73f5af9dec02f63e6e1ef2ca)

* dir: Verify subsummary checksum from disk cache

    Author: @mwleeds, via #4568 
    Fixes: #4127

    (cherry picked from commit 6d74eec0a97171ef46fac7aa4017c235758a1f3d)

* Fix en_GB localization: Do not forget to pass the actual error message

    Author: @aleixpol, via #4606 

    (cherry picked from commit e28b1f31584a6fae71f51985187bc8f1755e9bd1)

* testlibrary: Tweak some helper functions

    Author: @mwleeds, via #4489 

    (cherry picked from commit 8f85f77ff9c1b1dea02ab96771a764ff86e7c024)

* testlibrary: Add missing cleanup

    Author: @mwleeds, via #4489 

    (cherry picked from commit f753dd214c9a44f462ca013e7357ead8f35538aa)

* testlibrary: Make remote existence assertions more friendly

    Author: @mwleeds, via #4489 

    (cherry picked from commit dd48e78652079556bebfe930caad2efa09656584)