### PR TITLE
test-history.sh: Fix flakiness by adding a sleep

### DIFF
--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -13,8 +13,8 @@ skip_revokefs_without_fuse
 
 echo "1..1"
 
-sleep 1
 HISTORY_START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
+sleep 1
 
 mkdir -p ${TEST_DATA_DIR}/system-history-installation
 mkdir -p ${FLATPAK_CONFIG_DIR}/installations.d


### PR DESCRIPTION
The history test fails sometimes in the CI due to the remote add
operating being missing from the history command's output:

+ diff history-log -
0a1
> add remote			system (history-installation)	test-repo

Presumably this is due to that operation happening in the same second
that is passed to --since, so add another sleep statement to make sure a
second passes before we do anything.