### PR TITLE
[1.10] test-metadata-validation.sh: Ensure that mtimes change between iterations

### DIFF
--- a/tests/test-metadata-validation.sh
+++ b/tests/test-metadata-validation.sh
@@ -18,6 +18,8 @@ create_app () {
     local OPTIONS="$1"
     local DIR=`mktemp -d`
 
+    sleep 1
+
     mkdir ${DIR}/files
     echo $COUNTER > ${DIR}/files/counter
     let COUNTER=COUNTER+1


### PR DESCRIPTION
Our old adversary, 1-second timestamp resolution, strikes again!

---

This caused a test failure when I tried packaging flatpak 1.10.6 as a Debian security update: the test sometimes operated on a version of the test fixture (a mockup of a malicious app) from a previous iteration, and got the wrong error message as a result.

I'm *hoping* that changes elsewhere in Flatpak, or in some other component, make this unnecessary in newer branches... 1.12.3 passed tests on all of Debian 12, Debian 11, Ubuntu 20.04, Ubuntu 18.04 and Ubuntu 16.04.