### PR TITLE
[1.2.x] Backport fix for CVE-2022-21682

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -79,6 +79,11 @@ extern const char *flatpak_context_devices[];
 extern const char *flatpak_context_features[];
 extern const char *flatpak_context_shares[];
 
+gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                                 char                  **filesystem_out,
+                                                 FlatpakFilesystemMode  *mode_out,
+                                                 GError                **error);
+
 FlatpakContext *flatpak_context_new (void);
 void           flatpak_context_free (FlatpakContext *context);
 void           flatpak_context_merge (FlatpakContext *context,

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -80,6 +80,7 @@ extern const char *flatpak_context_features[];
 extern const char *flatpak_context_shares[];
 
 gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                                 gboolean                negated,
                                                  char                  **filesystem_out,
                                                  FlatpakFilesystemMode  *mode_out,
                                                  GError                **error);

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -92,6 +92,7 @@ flatpak_context_new (void)
   context = g_slice_new0 (FlatpakContext);
   context->env_vars = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   context->persistent = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  /* filename or special filesystem name => FlatpakFilesystemMode */
   context->filesystems = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   context->session_bus_policy = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   context->system_bus_policy = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
@@ -748,19 +749,23 @@ parse_filesystem_flags (const char            *filesystem,
 }
 
 static gboolean
-flatpak_context_verify_filesystem (const char *filesystem_and_mode,
-                                   GError    **error)
+flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                  char                  **filesystem_out,
+                                  FlatpakFilesystemMode  *mode_out,
+                                  GError                **error)
 {
-  g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, NULL);
+  g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, mode_out);
 
-  if (g_strv_contains (flatpak_context_special_filesystems, filesystem))
-    return TRUE;
-  if (get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL))
-    return TRUE;
-  if (g_str_has_prefix (filesystem, "~/"))
-    return TRUE;
-  if (g_str_has_prefix (filesystem, "/"))
-    return TRUE;
+  if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||
+      get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL) ||
+      g_str_has_prefix (filesystem, "~/") ||
+      g_str_has_prefix (filesystem, "/"))
+    {
+      if (filesystem_out != NULL)
+        *filesystem_out = g_steal_pointer (&filesystem);
+
+      return TRUE;
+    }
 
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
                _("Unknown filesystem location %s, valid locations are: host, home, xdg-*[/…], ~/dir, /dir"), filesystem);
@@ -768,22 +773,11 @@ flatpak_context_verify_filesystem (const char *filesystem_and_mode,
 }
 
 static void
-flatpak_context_add_filesystem (FlatpakContext *context,
-                                const char     *what)
+flatpak_context_take_filesystem (FlatpakContext        *context,
+                                 char                  *fs,
+                                 FlatpakFilesystemMode  mode)
 {
-  FlatpakFilesystemMode mode;
-  char *fs = parse_filesystem_flags (what, &mode);
-
   g_hash_table_insert (context->filesystems, fs, GINT_TO_POINTER (mode));
-}
-
-static void
-flatpak_context_remove_filesystem (FlatpakContext *context,
-                                   const char     *what)
-{
-  g_hash_table_insert (context->filesystems,
-                       parse_filesystem_flags (what, NULL),
-                       NULL);
 }
 
 void
@@ -999,11 +993,13 @@ option_filesystem_cb (const gchar *option_name,
                       GError     **error)
 {
   FlatpakContext *context = data;
+  g_autofree char *fs = NULL;
+  FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_verify_filesystem (value, error))
+  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
     return FALSE;
 
-  flatpak_context_add_filesystem (context, value);
+  flatpak_context_take_filesystem (context, g_steal_pointer (&fs), mode);
   return TRUE;
 }
 
@@ -1014,11 +1010,14 @@ option_nofilesystem_cb (const gchar *option_name,
                         GError     **error)
 {
   FlatpakContext *context = data;
+  g_autofree char *fs = NULL;
+  FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_verify_filesystem (value, error))
+  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
     return FALSE;
 
-  flatpak_context_remove_filesystem (context, value);
+  flatpak_context_take_filesystem (context, g_steal_pointer (&fs),
+                                   FLATPAK_FILESYSTEM_MODE_NONE);
   return TRUE;
 }
 
@@ -1441,14 +1440,18 @@ flatpak_context_load_metadata (FlatpakContext *context,
       for (i = 0; filesystems[i] != NULL; i++)
         {
           const char *fs = parse_negated (filesystems[i], &remove);
-          if (!flatpak_context_verify_filesystem (fs, NULL))
+          g_autofree char *filesystem = NULL;
+          FlatpakFilesystemMode mode;
+
+          if (!flatpak_context_parse_filesystem (fs, &filesystem, &mode, NULL))
             g_debug ("Unknown filesystem type %s", filesystems[i]);
           else
             {
               if (remove)
-                flatpak_context_remove_filesystem (context, fs);
+                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem),
+                                                 FLATPAK_FILESYSTEM_MODE_NONE);
               else
-                flatpak_context_add_filesystem (context, fs);
+                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
             }
         }
     }
@@ -1674,7 +1677,7 @@ flatpak_context_save_metadata (FlatpakContext *context,
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-          if (mode != 0)
+          if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
             g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
           else
             g_ptr_array_add (array, g_strconcat ("!", key, NULL));
@@ -1781,7 +1784,7 @@ flatpak_context_save_metadata (FlatpakContext *context,
 void
 flatpak_context_allow_host_fs (FlatpakContext *context)
 {
-  flatpak_context_add_filesystem (context, "host");
+  flatpak_context_take_filesystem (context, g_strdup ("host"), FLATPAK_FILESYSTEM_MODE_READ_WRITE);
 }
 
 gboolean
@@ -1846,7 +1849,7 @@ flatpak_context_to_args (FlatpakContext *context,
     {
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-      if (mode != 0)
+      if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
         {
           g_autofree char *fs = unparse_filesystem_flags (key, mode);
           g_ptr_array_add (args, g_strdup_printf ("--filesystem=%s", fs));
@@ -1958,7 +1961,7 @@ flatpak_context_export (FlatpakContext *context,
   gpointer key, value;
 
   fs_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host");
-  if (fs_mode != 0)
+  if (fs_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       DIR *dir;
       struct dirent *dirent;
@@ -1987,7 +1990,7 @@ flatpak_context_export (FlatpakContext *context,
     }
 
   home_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "home");
-  if (home_mode != 0)
+  if (home_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       g_debug ("Allowing homedir access");
       home_access = TRUE;

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -697,6 +697,10 @@ unparse_filesystem_flags (const char           *path,
     case FLATPAK_FILESYSTEM_MODE_READ_WRITE:
       break;
 
+    case FLATPAK_FILESYSTEM_MODE_NONE:
+      g_string_insert_c (s, 0, '!');
+      break;
+
     default:
       g_warning ("Unexpected filesystem mode %d", mode);
       break;
@@ -1677,10 +1681,7 @@ flatpak_context_save_metadata (FlatpakContext *context,
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-          if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
-            g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
-          else
-            g_ptr_array_add (array, g_strconcat ("!", key, NULL));
+          g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
         }
 
       g_key_file_set_string_list (metakey,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -748,7 +748,7 @@ parse_filesystem_flags (const char            *filesystem,
   return g_string_free (g_steal_pointer (&s), FALSE);
 }
 
-static gboolean
+gboolean
 flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
                                   char                  **filesystem_out,
                                   FlatpakFilesystemMode  *mode_out,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -81,6 +81,7 @@ const char *flatpak_context_features[] = {
 const char *flatpak_context_special_filesystems[] = {
   "home",
   "host",
+  "host-reset",
   NULL
 };
 
@@ -699,6 +700,12 @@ unparse_filesystem_flags (const char           *path,
 
     case FLATPAK_FILESYSTEM_MODE_NONE:
       g_string_insert_c (s, 0, '!');
+
+      if (g_str_has_suffix (s->str, "-reset"))
+        {
+          g_string_truncate (s, s->len - 6);
+          g_string_append (s, ":reset");
+        }
       break;
 
     default:
@@ -711,11 +718,14 @@ unparse_filesystem_flags (const char           *path,
 
 static char *
 parse_filesystem_flags (const char            *filesystem,
-                        FlatpakFilesystemMode *mode_out)
+                        gboolean               negated,
+                        FlatpakFilesystemMode *mode_out,
+                        GError               **error)
 {
   g_autoptr(GString) s = g_string_new ("");
   const char *p, *suffix;
   FlatpakFilesystemMode mode;
+  gboolean reset = FALSE;
 
   p = filesystem;
   while (*p != 0 && *p != ':')
@@ -730,7 +740,31 @@ parse_filesystem_flags (const char            *filesystem,
         g_string_append_c (s, *p++);
     }
 
-  mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
+  if (negated)
+    mode = FLATPAK_FILESYSTEM_MODE_NONE;
+  else
+    mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
+
+  if (g_str_equal (s->str, "host-reset"))
+    {
+      reset = TRUE;
+
+      if (!negated)
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                       "Filesystem token \"%s\" is only applicable for --nofilesystem",
+                       s->str);
+          return NULL;
+        }
+
+      if (*p != '\0')
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                       "Filesystem token \"%s\" cannot be used with a suffix",
+                       s->str);
+          return NULL;
+        }
+    }
 
   if (*p == ':')
     {
@@ -742,9 +776,62 @@ parse_filesystem_flags (const char            *filesystem,
         mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
       else if (strcmp (suffix, "create") == 0)
         mode = FLATPAK_FILESYSTEM_MODE_CREATE;
+      else if (strcmp (suffix, "reset") == 0)
+        reset = TRUE;
       else if (*suffix != 0)
         g_warning ("Unexpected filesystem suffix %s, ignoring", suffix);
+
+      if (negated && mode != FLATPAK_FILESYSTEM_MODE_NONE)
+        {
+          g_warning ("Filesystem suffix \"%s\" is not applicable for --nofilesystem",
+                     suffix);
+          mode = FLATPAK_FILESYSTEM_MODE_NONE;
+        }
+
+      if (reset)
+        {
+          if (!negated)
+            {
+              g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                           "Filesystem suffix \"%s\" only applies to --nofilesystem",
+                           suffix);
+              return NULL;
+            }
+
+          if (!g_str_equal (s->str, "host"))
+            {
+              g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                           "Filesystem suffix \"%s\" can only be applied to "
+                           "--nofilesystem=host",
+                           suffix);
+              return NULL;
+            }
+
+          /* We internally handle host:reset (etc) as host-reset, only exposing it as a flag in the public
+             part to allow it to be ignored (with a warning) for old flatpak versions */
+          g_string_append (s, "-reset");
+        }
     }
+
+  /* Postcondition check: the code above should make some results
+   * impossible */
+  if (negated)
+    {
+      g_assert (mode == FLATPAK_FILESYSTEM_MODE_NONE);
+    }
+  else
+    {
+      g_assert (mode > FLATPAK_FILESYSTEM_MODE_NONE);
+      /* This flag is only applicable to --nofilesystem */
+      g_assert (!reset);
+    }
+
+  /* Postcondition check: filesystem token is host-reset iff reset flag
+   * was found */
+  if (reset)
+    g_assert (g_str_equal (s->str, "host-reset"));
+  else
+    g_assert (!g_str_equal (s->str, "host-reset"));
 
   if (mode_out)
     *mode_out = mode;
@@ -754,11 +841,16 @@ parse_filesystem_flags (const char            *filesystem,
 
 gboolean
 flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                  gboolean                negated,
                                   char                  **filesystem_out,
                                   FlatpakFilesystemMode  *mode_out,
                                   GError                **error)
 {
-  g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, mode_out);
+  g_autofree char *filesystem = NULL;
+
+  filesystem = parse_filesystem_flags (filesystem_and_mode, negated, mode_out, error);
+  if (filesystem == NULL)
+    return FALSE;
 
   if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||
       get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL) ||
@@ -781,6 +873,14 @@ flatpak_context_take_filesystem (FlatpakContext        *context,
                                  char                  *fs,
                                  FlatpakFilesystemMode  mode)
 {
+  /* Special case: --nofilesystem=host-reset implies --nofilesystem=host.
+   * --filesystem=host-reset (or host:reset) is not allowed. */
+  if (g_str_equal (fs, "host-reset"))
+    {
+      g_return_if_fail (mode == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_hash_table_insert (context->filesystems, g_strdup ("host"), GINT_TO_POINTER (mode));
+    }
+
   g_hash_table_insert (context->filesystems, fs, GINT_TO_POINTER (mode));
 }
 
@@ -812,6 +912,14 @@ flatpak_context_merge (FlatpakContext *context,
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->persistent, g_strdup (key), value);
 
+  /* We first handle host:reset, as it overrides all other keys from the parent */
+  if (g_hash_table_lookup_extended (other->filesystems, "host-reset", NULL, &value))
+    {
+      g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_hash_table_remove_all (context->filesystems);
+    }
+
+  /* Then set the new ones, which includes propagating host:reset. */
   g_hash_table_iter_init (&iter, other->filesystems);
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->filesystems, g_strdup (key), value);
@@ -1000,7 +1108,7 @@ option_filesystem_cb (const gchar *option_name,
   g_autofree char *fs = NULL;
   FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
+  if (!flatpak_context_parse_filesystem (value, FALSE, &fs, &mode, error))
     return FALSE;
 
   flatpak_context_take_filesystem (context, g_steal_pointer (&fs), mode);
@@ -1017,7 +1125,7 @@ option_nofilesystem_cb (const gchar *option_name,
   g_autofree char *fs = NULL;
   FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
+  if (!flatpak_context_parse_filesystem (value, TRUE, &fs, &mode, error))
     return FALSE;
 
   flatpak_context_take_filesystem (context, g_steal_pointer (&fs),
@@ -1447,15 +1555,13 @@ flatpak_context_load_metadata (FlatpakContext *context,
           g_autofree char *filesystem = NULL;
           FlatpakFilesystemMode mode;
 
-          if (!flatpak_context_parse_filesystem (fs, &filesystem, &mode, NULL))
+          if (!flatpak_context_parse_filesystem (fs, remove,
+                                                 &filesystem, &mode, NULL))
             g_debug ("Unknown filesystem type %s", filesystems[i]);
           else
             {
-              if (remove)
-                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem),
-                                                 FLATPAK_FILESYSTEM_MODE_NONE);
-              else
-                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
+              g_assert (mode == FLATPAK_FILESYSTEM_MODE_NONE || !remove);
+              flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
             }
         }
     }
@@ -1676,10 +1782,23 @@ flatpak_context_save_metadata (FlatpakContext *context,
     {
       g_autoptr(GPtrArray) array = g_ptr_array_new_with_free_func (g_free);
 
+      /* Serialize host-reset first, because order can matter in
+       * corner cases. */
+      if (g_hash_table_lookup_extended (context->filesystems, "host-reset",
+                                        NULL, &value))
+        {
+          g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+          g_ptr_array_add (array, g_strdup ("!host:reset"));
+        }
+
       g_hash_table_iter_init (&iter, context->filesystems);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
+
+          /* We already did this */
+          if (g_str_equal (key, "host-reset"))
+            continue;
 
           g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
         }
@@ -1845,18 +1964,36 @@ flatpak_context_to_args (FlatpakContext *context,
       g_ptr_array_add (args, g_strdup_printf ("--system-%s-name=%s", flatpak_policy_to_string (policy), name));
     }
 
+  /* Serialize host-reset first, because order can matter in
+   * corner cases. */
+  if (g_hash_table_lookup_extended (context->filesystems, "host-reset",
+                                    NULL, &value))
+    {
+      g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_ptr_array_add (args, g_strdup ("--nofilesystem=host:reset"));
+    }
+
   g_hash_table_iter_init (&iter, context->filesystems);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
+      g_autofree char *fs = NULL;
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
+
+      /* We already did this */
+      if (g_str_equal (key, "host-reset"))
+        continue;
+
+      fs = unparse_filesystem_flags (key, mode);
 
       if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
         {
-          g_autofree char *fs = unparse_filesystem_flags (key, mode);
           g_ptr_array_add (args, g_strdup_printf ("--filesystem=%s", fs));
         }
       else
-        g_ptr_array_add (args, g_strdup_printf ("--nofilesystem=%s", (char *) key));
+        {
+          g_assert (fs[0] == '!');
+          g_ptr_array_add (args, g_strdup_printf ("--nofilesystem=%s", &fs[1]));
+        }
     }
 }
 

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -78,6 +78,12 @@ const char *flatpak_context_features[] = {
   NULL
 };
 
+const char *flatpak_context_special_filesystems[] = {
+  "home",
+  "host",
+  NULL
+};
+
 FlatpakContext *
 flatpak_context_new (void)
 {
@@ -747,9 +753,7 @@ flatpak_context_verify_filesystem (const char *filesystem_and_mode,
 {
   g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, NULL);
 
-  if (strcmp (filesystem, "host") == 0)
-    return TRUE;
-  if (strcmp (filesystem, "home") == 0)
+  if (g_strv_contains (flatpak_context_special_filesystems, filesystem))
     return TRUE;
   if (get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL))
     return TRUE;
@@ -1997,8 +2001,7 @@ flatpak_context_export (FlatpakContext *context,
       const char *filesystem = key;
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-      if (strcmp (filesystem, "host") == 0 ||
-          strcmp (filesystem, "home") == 0)
+      if (g_strv_contains (flatpak_context_special_filesystems, filesystem))
         continue;
 
       if (g_str_has_prefix (filesystem, "xdg-"))

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -26,6 +26,7 @@
 
 /* In numerical order of more privs */
 typedef enum {
+  FLATPAK_FILESYSTEM_MODE_NONE         = 0,
   FLATPAK_FILESYSTEM_MODE_READ_ONLY    = 1,
   FLATPAK_FILESYSTEM_MODE_READ_WRITE   = 2,
   FLATPAK_FILESYSTEM_MODE_CREATE       = 3,

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -80,7 +80,7 @@ make_relative (const char *base, const char *path)
 }
 
 #define FAKE_MODE_DIR -1 /* Ensure a dir, either on tmpfs or mapped parent */
-#define FAKE_MODE_TMPFS 0
+#define FAKE_MODE_TMPFS FLATPAK_FILESYSTEM_MODE_NONE
 #define FAKE_MODE_SYMLINK G_MAXINT
 
 typedef struct
@@ -278,7 +278,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
         }
     }
 
-  if (exports->host_fs != 0)
+  if (exports->host_fs != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       if (g_file_test ("/usr", G_FILE_TEST_IS_DIR))
         flatpak_bwrap_add_args (bwrap,
@@ -291,7 +291,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
     }
 }
 
-/* Returns 0 if not visible */
+/* Returns FLATPAK_FILESYSTEM_MODE_NONE if not visible */
 FlatpakFilesystemMode
 flatpak_exports_path_get_mode (FlatpakExports *exports,
                                const char     *path)
@@ -337,7 +337,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
                   break;
                 }
 
-              return 0;
+              return FLATPAK_FILESYSTEM_MODE_NONE;
             }
 
           if (S_ISLNK (st.st_mode))
@@ -347,7 +347,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
               int j;
 
               if (resolved == NULL)
-                return 0;
+                return FLATPAK_FILESYSTEM_MODE_NONE;
 
               path2_builder = g_string_new (resolved);
 
@@ -361,7 +361,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
             }
         }
       else if (parts[i + 1] == NULL)
-        return 0; /* Last part was not mapped */
+        return FLATPAK_FILESYSTEM_MODE_NONE; /* Last part was not mapped */
     }
 
   if (is_readonly)
@@ -374,7 +374,7 @@ gboolean
 flatpak_exports_path_is_visible (FlatpakExports *exports,
                                  const char     *path)
 {
-  return flatpak_exports_path_get_mode (exports, path) > 0;
+  return flatpak_exports_path_get_mode (exports, path) > FLATPAK_FILESYSTEM_MODE_NONE;
 }
 
 static gboolean
@@ -605,7 +605,7 @@ flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode,
                                          const char           *path)
 {
-  if (mode == 0)
+  if (mode == FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_path_tmpfs (exports, path);
   else
     flatpak_exports_add_path_expose (exports, mode, path);

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -239,6 +239,14 @@
                     accessing most of the home directory, but it will still
                     be allowed to access
                     <filename>$XDG_CONFIG_HOME/MyApp</filename>.
+                </para><para>
+                    As a special case,
+                    <option>--nofilesystem=host:reset</option>
+                    will ignore all <option>--filesystem</option>
+                    permissions inherited from the app manifest or a
+                    lower-precedence layer of overrides, in addition to
+                    having the behaviour of
+                    <option>--nofilesystem=host</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -214,13 +214,31 @@
                 <term><option>--nofilesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
+                    Undo the effect of a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    in the app's manifest or a lower-precedence layer of
+                    overrides, and/or remove a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    from this layer of overrides.
+                    This overrides the Context section of the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
+                    <arg choice="plain">FILESYSTEM</arg> can take the same
+                    values as for <option>--filesystem</option>, but the
+                    <arg choice="plain">:ro</arg> and
+                    <arg choice="plain">:create</arg> suffixes are not
+                    used here.
                     This option can be used multiple times.
+                </para><para>
+                    This option does not prevent access to a more
+                    narrowly-scoped <option>--filesystem</option>.
+                    For example, if an application has the equivalent of
+                    <option>--filesystem=xdg-config/MyApp</option> in
+                    its manifest or as a system-wide override, and
+                    <literal>flatpak override --user --nofilesystem=home</literal>
+                    as a per-user override, then it will be prevented from
+                    accessing most of the home directory, but it will still
+                    be allowed to access
+                    <filename>$XDG_CONFIG_HOME/MyApp</filename>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -371,6 +371,14 @@
                     accessing most of the home directory, but it will still
                     be allowed to access
                     <filename>$XDG_CONFIG_HOME/MyApp</filename>.
+                </para><para>
+                    As a special case,
+                    <option>--nofilesystem=host:reset</option>
+                    will ignore all <option>--filesystem</option>
+                    permissions inherited from the app manifest or
+                    <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+                    in addition to having the behaviour of
+                    <option>--nofilesystem=host</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -348,13 +348,29 @@
                 <term><option>--nofilesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
+                    Undo the effect of a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    in the app's manifest and/or the overrides set up with
+                    <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+                    This overrides the Context section of the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
+                    <arg choice="plain">FILESYSTEM</arg> can take the same
+                    values as for <option>--filesystem</option>, but the
+                    <arg choice="plain">:ro</arg> and
+                    <arg choice="plain">:create</arg> suffixes are not
+                    used here.
                     This option can be used multiple times.
+                </para><para>
+                    This option does not prevent access to a more
+                    narrowly-scoped <option>--filesystem</option>.
+                    For example, if an application has the equivalent of
+                    <option>--filesystem=xdg-config/MyApp</option> in
+                    its manifest or as a system-wide override, and
+                    <literal>flatpak override --user --nofilesystem=home</literal>
+                    as a per-user override, then it will be prevented from
+                    accessing most of the home directory, but it will still
+                    be allowed to access
+                    <filename>$XDG_CONFIG_HOME/MyApp</filename>.
                 </para></listitem>
             </varlistentry>
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -58,6 +58,10 @@ testcommon_LDADD = \
 	$(NULL)
 testcommon_SOURCES = tests/testcommon.c
 
+test_exports_CFLAGS = $(testcommon_CFLAGS)
+test_exports_LDADD = $(testcommon_LDADD)
+test_exports_SOURCES = tests/test-exports.c
+
 tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
         -DLOCALEDIR=\"$(localedir)\"
@@ -177,7 +181,7 @@ test_scripts = ${TEST_MATRIX}
 dist_test_scripts = ${TEST_MATRIX_DIST}
 dist_installed_test_extra_scripts += ${TEST_MATRIX_EXTRA_DIST}
 
-test_programs = testlibrary testcommon
+test_programs = testlibrary testcommon test-exports
 test_extra_programs = tests/httpcache
 
 @VALGRIND_CHECK_RULES@

--- a/tests/http-utils-test-server.py
+++ b/tests/http-utils-test-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from wsgiref.handlers import format_date_time
 from email.utils import parsedate
@@ -13,9 +13,9 @@ if sys.version_info[0] >= 3:
     import http.server as http_server
     from io import BytesIO
 else:
-    from urlparse import parse_qs
-    import BaseHTTPServer as http_server
-    from StringIO import StringIO as BytesIO
+    from urllib.parse import parse_qs
+    import http.server as http_server
+    from io import StringIO as BytesIO
 
 server_start_time = int(time.time())
 
@@ -54,7 +54,7 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             add_headers['Etag'] = etag
 
         self.send_response(response)
-        for k, v in add_headers.items():
+        for k, v in list(add_headers.items()):
             self.send_header(k, v)
 
         if 'max-age' in query:

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -278,6 +278,10 @@ update_repo () {
         collection_args=
     fi
 
+    if test -f repos/${REPONAME}/summary; then
+        sleep 1 # ensure we get a new timestamp on the summary files
+    fi
+
     ${FLATPAK} build-update-repo ${collection_args} ${GPGARGS:-${FL_GPGARGS}} ${UPDATE_REPO_ARGS-} repos/${REPONAME}
 }
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -382,3 +382,27 @@ cleanup () {
     fi
 }
 trap cleanup EXIT
+
+assert_semicolon_list_contains () {
+    list="$1"
+    member="$2"
+
+    case ";$list;" in
+        (*";$member;"*)
+            ;;
+        (*)
+            assert_not_reached "\"$list\" should contain \"$member\""
+            ;;
+    esac
+}
+
+assert_not_semicolon_list_contains () {
+    local list="$1"
+    local member="$2"
+
+    case ";$list;" in
+        (*";$member;"*)
+            assert_not_reached "\"$list\" should not contain \"$member\""
+            ;;
+    esac
+}

--- a/tests/oci-registry-client.py
+++ b/tests/oci-registry-client.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-from __future__ import print_function
+#!/usr/bin/python3
 
 import sys
 
@@ -8,7 +6,7 @@ if sys.version_info[0] >= 3:
     import http.client as http_client
     import urllib.parse as urllib_parse
 else:
-    import httplib as http_client
+    import http.client as http_client
     import urllib as urllib_parse
 
 if sys.argv[2] == 'add':

--- a/tests/oci-registry-server.py
+++ b/tests/oci-registry-server.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-
-from __future__ import print_function
+#!/usr/bin/python3
 
 import base64
 import hashlib
@@ -13,8 +11,8 @@ if sys.version_info[0] >= 3:
     from urllib.parse import parse_qs
     import http.server as http_server
 else:
-    from urlparse import parse_qs
-    import BaseHTTPServer as http_server
+    from urllib.parse import parse_qs
+    import http.server as http_server
 
 repositories = {}
 icons = {}
@@ -120,7 +118,7 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             response = 404
 
         self.send_response(response)
-        for k, v in add_headers.items():
+        for k, v in list(add_headers.items()):
             self.send_header(k, v)
 
         if response == 200:

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1,0 +1,438 @@
+/*
+ * Copyright © 2020 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <glib.h>
+#include "flatpak.h"
+#include "flatpak-bwrap-private.h"
+#include "flatpak-context-private.h"
+#include "flatpak-exports-private.h"
+#include "flatpak-run-private.h"
+
+/* This differs from g_file_test (path, G_FILE_TEST_IS_DIR) which
+   returns true if the path is a symlink to a dir */
+static gboolean
+path_is_dir (const char *path)
+{
+  struct stat s;
+
+  if (lstat (path, &s) != 0)
+    return FALSE;
+
+  return S_ISDIR (s.st_mode);
+}
+
+/* Assert that arguments starting from @i are --dir @dir.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_dir (FlatpakBwrap *bwrap,
+                    gsize i,
+                    const char *dir)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--dir");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, dir);
+  return i;
+}
+
+/* Assert that arguments starting from @i are --tmpfs @dir.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_tmpfs (FlatpakBwrap *bwrap,
+                      gsize i,
+                      const char *dir)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--tmpfs");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, dir);
+  return i;
+}
+
+/* Assert that arguments starting from @i are @how @path @path.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_bind (FlatpakBwrap *bwrap,
+                     gsize i,
+                     const char *how,
+                     const char *path)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, how);
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  return i;
+}
+
+/* Print the arguments of a call to bwrap. */
+static void
+print_bwrap (FlatpakBwrap *bwrap)
+{
+  guint i;
+
+  for (i = 0; i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL; i++)
+    g_test_message ("%s", (const char *) bwrap->argv->pdata[i]);
+
+  g_test_message ("--");
+}
+
+static void
+test_empty_context (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(FlatpakExports) exports = NULL;
+
+  g_assert_cmpuint (g_hash_table_size (context->env_vars), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->persistent), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->filesystems), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->session_bus_policy), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->system_bus_policy), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->generic_policy), ==, 0);
+  g_assert_cmpuint (context->shares, ==, 0);
+  g_assert_cmpuint (context->shares_valid, ==, 0);
+  g_assert_cmpuint (context->sockets, ==, 0);
+  g_assert_cmpuint (context->sockets_valid, ==, 0);
+  g_assert_cmpuint (context->devices, ==, 0);
+  g_assert_cmpuint (context->devices_valid, ==, 0);
+  g_assert_cmpuint (context->features, ==, 0);
+  g_assert_cmpuint (context->features_valid, ==, 0);
+  g_assert_cmpuint (flatpak_context_get_run_flags (context), ==, 0);
+
+  exports = flatpak_context_get_exports (context, "com.example.App");
+  g_assert_nonnull (exports);
+
+  g_clear_pointer (&exports, flatpak_exports_free);
+  flatpak_context_append_bwrap_filesystem (context, bwrap,
+                                           "com.example.App",
+                                           NULL,
+                                           &exports);
+  print_bwrap (bwrap);
+  g_assert_nonnull (exports);
+}
+
+static void
+test_full_context (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(FlatpakExports) exports = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_SHARED,
+                        "network;ipc;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_SOCKETS,
+                        "x11;wayland;pulseaudio;session-bus;system-bus;"
+                        "fallback-x11;ssh-auth;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_DEVICES,
+                        "dri;all;kvm;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_FEATURES,
+                        "devel;multiarch;bluetooth;canbus;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_FILESYSTEMS,
+                        "host;/home;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_PERSISTENT,
+                        ".openarena;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                        "org.example.SessionService",
+                        "own");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                        "net.example.SystemService",
+                        "talk");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_ENVIRONMENT,
+                        "HYPOTHETICAL_PATH", "/foo:/bar");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_PREFIX_POLICY "MyPolicy",
+                        "Colours", "blue;green;");
+
+  flatpak_context_load_metadata (context, keyfile, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpuint (context->shares, ==,
+                    (FLATPAK_CONTEXT_SHARED_NETWORK |
+                     FLATPAK_CONTEXT_SHARED_IPC));
+  g_assert_cmpuint (context->shares_valid, ==, context->shares);
+  g_assert_cmpuint (context->devices, ==,
+                    (FLATPAK_CONTEXT_DEVICE_DRI |
+                     FLATPAK_CONTEXT_DEVICE_ALL |
+                     FLATPAK_CONTEXT_DEVICE_KVM));
+  g_assert_cmpuint (context->devices_valid, ==, context->devices);
+  g_assert_cmpuint (context->sockets, ==,
+                    (FLATPAK_CONTEXT_SOCKET_X11 |
+                     FLATPAK_CONTEXT_SOCKET_WAYLAND |
+                     FLATPAK_CONTEXT_SOCKET_PULSEAUDIO |
+                     FLATPAK_CONTEXT_SOCKET_SESSION_BUS |
+                     FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS |
+                     FLATPAK_CONTEXT_SOCKET_FALLBACK_X11 |
+                     FLATPAK_CONTEXT_SOCKET_SSH_AUTH));
+  g_assert_cmpuint (context->sockets_valid, ==, context->sockets);
+  g_assert_cmpuint (context->features, ==,
+                    (FLATPAK_CONTEXT_FEATURE_DEVEL |
+                     FLATPAK_CONTEXT_FEATURE_MULTIARCH |
+                     FLATPAK_CONTEXT_FEATURE_BLUETOOTH |
+                     FLATPAK_CONTEXT_FEATURE_CANBUS));
+  g_assert_cmpuint (context->features_valid, ==, context->features);
+
+  g_assert_cmpuint (flatpak_context_get_run_flags (context), ==,
+                    (FLATPAK_RUN_FLAG_DEVEL |
+                     FLATPAK_RUN_FLAG_MULTIARCH |
+                     FLATPAK_RUN_FLAG_BLUETOOTH |
+                     FLATPAK_RUN_FLAG_CANBUS));
+
+  exports = flatpak_context_get_exports (context, "com.example.App");
+  g_assert_nonnull (exports);
+
+  g_clear_pointer (&exports, flatpak_exports_free);
+  flatpak_context_append_bwrap_filesystem (context, bwrap,
+                                           "com.example.App",
+                                           NULL,
+                                           &exports);
+  print_bwrap (bwrap);
+  g_assert_nonnull (exports);
+}
+
+typedef struct
+{
+  const char *input;
+  GOptionError code;
+} NotFilesystem;
+
+static const NotFilesystem not_filesystems[] =
+{
+  { "homework", G_OPTION_ERROR_FAILED },
+  { "xdg-run", G_OPTION_ERROR_FAILED },
+};
+
+typedef struct
+{
+  const char *input;
+  FlatpakFilesystemMode mode;
+  const char *fs;
+} Filesystem;
+
+static const Filesystem filesystems[] =
+{
+  { "home", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host:ro", FLATPAK_FILESYSTEM_MODE_READ_ONLY, "host" },
+  { "home:rw", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~/Music", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "/srv/obs/debian\\:sid\\:main:create", FLATPAK_FILESYSTEM_MODE_CREATE,
+    "/srv/obs/debian:sid:main" },
+  { "/srv/c\\:\\\\Program Files\\\\Steam", FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+    "/srv/c:\\Program Files\\Steam" },
+  { "/srv/escaped\\unnecessarily", FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+    "/srv/escapedunnecessarily" },
+  { "xdg-desktop", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-desktop/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-documents", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-documents/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-download", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-download/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-music", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-music/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-pictures", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-pictures/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-public-share", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-public-share/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-templates", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-templates/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-videos", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-videos/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-data", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-data/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-cache", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-cache/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+};
+
+static void
+test_filesystems (void)
+{
+  gsize i;
+
+  for (i = 0; i < G_N_ELEMENTS (filesystems); i++)
+    {
+      const Filesystem *fs = &filesystems[i];
+      g_autoptr(GError) error = NULL;
+      g_autofree char *normalized;
+      FlatpakFilesystemMode mode;
+      gboolean ret;
+
+      g_test_message ("%s", fs->input);
+      ret = flatpak_context_parse_filesystem (fs->input, &normalized, &mode,
+                                              &error);
+      g_assert_no_error (error);
+      g_assert_true (ret);
+
+      if (fs->fs == NULL)
+        g_assert_cmpstr (normalized, ==, fs->input);
+      else
+        g_assert_cmpstr (normalized, ==, fs->fs);
+
+      g_assert_cmpuint (mode, ==, fs->mode);
+    }
+
+  for (i = 0; i < G_N_ELEMENTS (not_filesystems); i++)
+    {
+      const NotFilesystem *not = &not_filesystems[i];
+      g_autoptr(GError) error = NULL;
+      char *normalized = NULL;
+      FlatpakFilesystemMode mode;
+      gboolean ret;
+
+      g_test_message ("%s", not->input);
+      ret = flatpak_context_parse_filesystem (not->input, &normalized, &mode,
+                                              &error);
+      g_test_message ("-> %s", error ? error->message : "(no error)");
+      g_assert_error (error, G_OPTION_ERROR, not->code);
+      g_assert_false (ret);
+      g_assert_null (normalized);
+    }
+}
+
+static void
+test_empty (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  g_assert_false (flatpak_exports_path_is_visible (exports, "/run"));
+  g_assert_cmpint (flatpak_exports_path_get_mode (exports, "/tmp"), ==,
+                   FLATPAK_FILESYSTEM_MODE_NONE);
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
+static void
+test_full (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                   "/tmp");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/var");
+  flatpak_exports_add_path_tmpfs (exports, "/var/tmp");
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_NONE,
+                                           "/home");
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                           "/srv");
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  /* Hiding /home just uses --dir because / is not exposed. */
+  if (path_is_dir ("/home"))
+    i = assert_next_is_dir (bwrap, i, "/home");
+
+  if (path_is_dir ("/srv"))
+    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/srv");
+
+  if (path_is_dir ("/tmp"))
+    i = assert_next_is_bind (bwrap, i, "--bind", "/tmp");
+
+  if (path_is_dir ("/var"))
+    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/var");
+
+  /* We don't create a FAKE_MODE_TMPFS in the container unless there is
+   * a directory on the host to mount it on.
+   * Hiding /var/tmp has to use --tmpfs because /var *is* exposed. */
+  if (path_is_dir ("/var") && path_is_dir ("/var/tmp"))
+    i = assert_next_is_tmpfs (bwrap, i, "/var/tmp");
+
+  while (i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL)
+    {
+      /* An unknown number of --bind, --ro-bind and --symlink,
+       * depending how your /usr and /etc are set up.
+       * About the only thing we can say is that they are in threes. */
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+    }
+
+  g_assert_cmpuint (i, ==, bwrap->argv->len - 1);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
+int
+main (int argc, char *argv[])
+{
+  int res;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/context/empty", test_empty_context);
+  g_test_add_func ("/context/filesystems", test_filesystems);
+  g_test_add_func ("/context/full", test_full_context);
+  g_test_add_func ("/exports/empty", test_empty);
+  g_test_add_func ("/exports/full", test_full);
+
+  res = g_test_run ();
+
+  return res;
+}

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -475,6 +475,13 @@ static const NotFilesystem not_filesystems[] =
 {
   { "homework", G_OPTION_ERROR_FAILED },
   { "xdg-run", G_OPTION_ERROR_FAILED },
+  { "host:reset", G_OPTION_ERROR_FAILED },
+  { "host-reset", G_OPTION_ERROR_FAILED },
+  { "host-reset:rw", G_OPTION_ERROR_FAILED },
+  { "host-reset:reset", G_OPTION_ERROR_FAILED },
+  { "!host-reset:reset", G_OPTION_ERROR_FAILED },
+  { "/foo:reset", G_OPTION_ERROR_FAILED },
+  { "!/foo:reset", G_OPTION_ERROR_FAILED },
 };
 
 typedef struct
@@ -520,6 +527,9 @@ static const Filesystem filesystems[] =
   { "xdg-config", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-config/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "!home", FLATPAK_FILESYSTEM_MODE_NONE, "home" },
+  { "!host:reset", FLATPAK_FILESYSTEM_MODE_NONE, "host-reset" },
+  { "!host-reset", FLATPAK_FILESYSTEM_MODE_NONE, "host-reset" },
 };
 
 static void
@@ -530,19 +540,32 @@ test_filesystems (void)
   for (i = 0; i < G_N_ELEMENTS (filesystems); i++)
     {
       const Filesystem *fs = &filesystems[i];
+      const char *input = fs->input;
+      gboolean negated = FALSE;
       g_autoptr(GError) error = NULL;
       g_autofree char *normalized;
       FlatpakFilesystemMode mode;
       gboolean ret;
 
       g_test_message ("%s", fs->input);
-      ret = flatpak_context_parse_filesystem (fs->input, FALSE,
+
+      if (input[0] == '!')
+        {
+          g_test_message ("-> input is negated");
+          negated = TRUE;
+          input++;
+        }
+
+      ret = flatpak_context_parse_filesystem (input, negated,
                                               &normalized, &mode, &error);
       g_assert_no_error (error);
       g_assert_true (ret);
 
+      g_test_message ("-> mode: %u", mode);
+      g_test_message ("-> normalized filesystem: %s", normalized);
+
       if (fs->fs == NULL)
-        g_assert_cmpstr (normalized, ==, fs->input);
+        g_assert_cmpstr (normalized, ==, input);
       else
         g_assert_cmpstr (normalized, ==, fs->fs);
 
@@ -552,13 +575,22 @@ test_filesystems (void)
   for (i = 0; i < G_N_ELEMENTS (not_filesystems); i++)
     {
       const NotFilesystem *not = &not_filesystems[i];
+      const char *input = not->input;
+      gboolean negated = FALSE;
       g_autoptr(GError) error = NULL;
       char *normalized = NULL;
       FlatpakFilesystemMode mode;
       gboolean ret;
 
       g_test_message ("%s", not->input);
-      ret = flatpak_context_parse_filesystem (not->input, FALSE,
+
+      if (input[0] == '!')
+        {
+          negated = TRUE;
+          input++;
+        }
+
+      ret = flatpak_context_parse_filesystem (input, negated,
                                               &normalized, &mode, &error);
       g_test_message ("-> %s", error ? error->message : "(no error)");
       g_assert_error (error, G_OPTION_ERROR, not->code);

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -536,8 +536,8 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", fs->input);
-      ret = flatpak_context_parse_filesystem (fs->input, &normalized, &mode,
-                                              &error);
+      ret = flatpak_context_parse_filesystem (fs->input, FALSE,
+                                              &normalized, &mode, &error);
       g_assert_no_error (error);
       g_assert_true (ret);
 
@@ -558,8 +558,8 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", not->input);
-      ret = flatpak_context_parse_filesystem (not->input, &normalized, &mode,
-                                              &error);
+      ret = flatpak_context_parse_filesystem (not->input, FALSE,
+                                              &normalized, &mode, &error);
       g_test_message ("-> %s", error ? error->message : "(no error)");
       g_assert_error (error, G_OPTION_ERROR, not->code);
       g_assert_false (ret);

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -132,6 +132,31 @@ assert_next_is_bind (FlatpakBwrap *bwrap,
   return i;
 }
 
+/* Assert that arguments starting from @i are --symlink @rel_target @path,
+ * where @rel_target goes up from @path to the root and back down to the
+ * target of the symlink. Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_symlink (FlatpakBwrap *bwrap,
+                      gsize i,
+                      const char *target,
+                      const char *path)
+{
+  const char *got_target;
+
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--symlink");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+
+  got_target = bwrap->argv->pdata[i++];
+  g_assert_true (g_str_has_prefix (got_target, "../../../../"));
+  g_assert_true (g_str_has_suffix (got_target, target));
+  /* TODO: Assert that it resolves to the same place as target */
+
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  return i;
+}
+
 /* Print the arguments of a call to bwrap. */
 static void
 print_bwrap (FlatpakBwrap *bwrap)
@@ -575,13 +600,34 @@ test_full (void)
   g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
   g_autofree gchar *subdir = g_build_filename (testdir, "test_full", NULL);
   g_autofree gchar *expose_rw = g_build_filename (subdir, "expose-rw", NULL);
+  g_autofree gchar *in_expose_rw = g_build_filename (subdir, "expose-rw",
+                                                     "file", NULL);
+  g_autofree gchar *dangling_link_in_expose_rw = g_build_filename (subdir,
+                                                                   "expose-rw",
+                                                                   "dangling",
+                                                                   NULL);
   g_autofree gchar *expose_ro = g_build_filename (subdir, "expose-ro", NULL);
+  g_autofree gchar *in_expose_ro = g_build_filename (subdir, "expose-ro",
+                                                     "file", NULL);
   g_autofree gchar *hide = g_build_filename (subdir, "hide", NULL);
   g_autofree gchar *dont_hide = g_build_filename (subdir, "dont-hide", NULL);
   g_autofree gchar *hide_below_expose = g_build_filename (subdir,
                                                           "expose-ro",
                                                           "hide-me",
                                                           NULL);
+  g_autofree gchar *enoent = g_build_filename (subdir, "ENOENT", NULL);
+  g_autofree gchar *one = g_build_filename (subdir, "1", NULL);
+  g_autofree gchar *rel_link = g_build_filename (subdir, "1", "rel-link", NULL);
+  g_autofree gchar *abs_link = g_build_filename (subdir, "1", "abs-link", NULL);
+  g_autofree gchar *in_abs_link = g_build_filename (subdir, "1", "abs-link",
+                                                    "file", NULL);
+  g_autofree gchar *dangling = g_build_filename (subdir, "1", "dangling", NULL);
+  g_autofree gchar *in_dangling = g_build_filename (subdir, "1", "dangling",
+                                                    "file", NULL);
+  g_autofree gchar *abs_target = g_build_filename (subdir, "2", "abs-target", NULL);
+  g_autofree gchar *target = g_build_filename (subdir, "2", "target", NULL);
+  g_autofree gchar *create_dir = g_build_filename (subdir, "create-dir", NULL);
+  g_autofree gchar *create_dir2 = g_build_filename (subdir, "create-dir2", NULL);
   gsize i;
 
   glnx_shutil_rm_rf_at (-1, subdir, NULL, &error);
@@ -607,6 +653,33 @@ test_full (void)
   if (g_mkdir_with_parents (dont_hide, S_IRWXU) != 0)
     g_error ("mkdir: %s", g_strerror (errno));
 
+  if (g_mkdir_with_parents (dont_hide, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (abs_target, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (target, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (one, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (create_dir, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (symlink (abs_target, abs_link) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
+  if (symlink ("nope", dangling) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
+  if (symlink ("nope", dangling_link_in_expose_rw) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
+  if (symlink ("../2/target", rel_link) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_WRITE,
                                    expose_rw);
@@ -620,6 +693,45 @@ test_full (void)
   flatpak_exports_add_path_expose_or_hide (exports,
                                            FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                            dont_hide);
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                           enoent);
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                           rel_link);
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                           abs_link);
+  flatpak_exports_add_path_dir (exports, create_dir);
+  flatpak_exports_add_path_dir (exports, create_dir2);
+
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, expose_rw), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, expose_ro), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_ONLY);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, hide_below_expose), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, hide), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, dont_hide), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_ONLY);
+  /* It knows enoent didn't really exist */
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, enoent), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, abs_link), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, rel_link), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+  /* Files the app would be allowed to create count as exposed */
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_expose_ro), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_expose_rw), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_abs_link), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_dangling), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
 
   flatpak_bwrap_add_arg (bwrap, "bwrap");
   flatpak_exports_append_bwrap_args (exports, bwrap);
@@ -629,6 +741,20 @@ test_full (void)
   i = 0;
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  i = assert_next_is_symlink (bwrap, i, abs_target, abs_link);
+  i = assert_next_is_symlink (bwrap, i, "../2/target", rel_link);
+  i = assert_next_is_bind (bwrap, i, "--bind", abs_target);
+  i = assert_next_is_bind (bwrap, i, "--bind", target);
+  i = assert_next_is_dir (bwrap, i, create_dir);
+
+  /* create_dir2 is not currently created with --dir inside the container
+   * because it doesn't exist outside the container.
+   * (Is this correct? For now, tolerate either way) */
+  if (i + 2 < bwrap->argv->len &&
+      g_strcmp0 (bwrap->argv->pdata[i], "--dir") == 0 &&
+      g_strcmp0 (bwrap->argv->pdata[i + 1], create_dir2) == 0)
+    i += 2;
 
   i = assert_next_is_bind (bwrap, i, "--ro-bind", dont_hide);
   i = assert_next_is_bind (bwrap, i, "--ro-bind", expose_ro);
@@ -668,6 +794,84 @@ test_full (void)
     }
 }
 
+static void
+test_exports_ignored (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  /* These paths are chosen so that they probably exist, with the
+   * exception of /app */
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/app");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/etc");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/etc/passwd");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/usr");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/usr/bin/env");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/dev");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/dev/full");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/proc");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/proc/1");
+
+  /* These probably exist, and are merged into /usr on systems with
+   * the /usr merge */
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/bin");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/bin/sh");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib/ld-linux.so.2");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib64");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib64/ld-linux-x86-64.so.2");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/sbin");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/sbin/ldconfig");
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  g_assert_cmpuint (i, ==, bwrap->argv->len - 1);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -682,6 +886,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/context/full", test_full_context);
   g_test_add_func ("/exports/empty", test_empty);
   g_test_add_func ("/exports/full", test_full);
+  g_test_add_func ("/exports/ignored", test_exports_ignored);
 
   res = g_test_run ();
 

--- a/tests/test-http-utils.sh
+++ b/tests/test-http-utils.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-$(dirname $0)/test-webserver.sh "" "python $test_srcdir/http-utils-test-server.py 0"
+$(dirname $0)/test-webserver.sh "" "python3 $test_srcdir/http-utils-test-server.py 0"
 FLATPAK_HTTP_PID=$(cat httpd-pid)
 mv httpd-port httpd-port-main
 port=$(cat httpd-port-main)

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -27,11 +27,11 @@ echo "1..13"
 
 # Start the fake registry server
 
-$(dirname $0)/test-webserver.sh "" "python $test_srcdir/oci-registry-server.py 0"
+$(dirname $0)/test-webserver.sh "" "python3 $test_srcdir/oci-registry-server.py 0"
 FLATPAK_HTTP_PID=$(cat httpd-pid)
 mv httpd-port httpd-port-main
 port=$(cat httpd-port-main)
-client="python $test_srcdir/oci-registry-client.py 127.0.0.1:$port"
+client="python3 $test_srcdir/oci-registry-client.py 127.0.0.1:$port"
 
 setup_repo_no_add oci
 

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -165,11 +165,19 @@ ${FLATPAK} override --user --nofilesystem=xdg-documents org.test.Hello
 ${FLATPAK} override --user --show org.test.Hello > override
 
 assert_file_has_content override "^\[Context\]$"
-assert_file_has_content override "^filesystems=.*/media;.*$"
-assert_file_has_content override "^filesystems=.*home;.*$"
-assert_file_has_content override "^filesystems=.*xdg-documents;.*$"
-assert_file_has_content override "^filesystems=.*xdg-desktop/foo:create;.*$"
-assert_file_has_content override "^filesystems=.*xdg-config:ro;.*$"
+filesystems="$(sed -ne 's/^filesystems=//p' override)"
+assert_semicolon_list_contains "$filesystems" "/media"
+assert_not_semicolon_list_contains "$filesystems" "!/media"
+assert_semicolon_list_contains "$filesystems" "home"
+assert_not_semicolon_list_contains "$filesystems" "!home"
+assert_not_semicolon_list_contains "$filesystems" "xdg-documents"
+assert_semicolon_list_contains "$filesystems" "!xdg-documents"
+assert_semicolon_list_contains "$filesystems" "xdg-desktop/foo:create"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo:create"
+assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
 echo "ok override --filesystem"
 

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -179,6 +179,13 @@ assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
+# --nofilesystem=...:rw => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --nofilesystem=/foo:rw org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem suffix \"rw\" is not applicable for --nofilesystem"
+assert_streq "$e" 0
+
 # --filesystem=...:bar => warning
 # Warnings need to be made temporarily non-fatal here.
 e=0

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -179,7 +179,21 @@ assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
-echo "ok override --filesystem"
+# --filesystem=...:bar => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --filesystem=/foo:bar org.test.Hello 2>log || e=$?
+assert_file_has_content log "Unexpected filesystem suffix bar, ignoring"
+assert_streq "$e" 0
+
+# --nofilesystem=...:bar => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --nofilesystem=/foo:bar org.test.Hello 2>log || e=$?
+assert_file_has_content log "Unexpected filesystem suffix bar, ignoring"
+assert_streq "$e" 0
+
+ok "override --filesystem"
 
 reset_overrides
 

--- a/tests/test-webserver.sh
+++ b/tests/test-webserver.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 dir=$1
-cmd=${2:-python -m SimpleHTTPServer 0}
+cmd=${2:-python3 -m http.server 0}
 test_tmpdir=$(pwd)
 
 [ "$dir" != "" ] && cd ${dir}
@@ -21,7 +21,7 @@ for x in $(seq 300); do
     echo >&2
     # If it's non-empty, see whether it matches our regexp
     if test -s ${test_tmpdir}/httpd-output.tmp; then
-        sed -e 's,Serving HTTP on 0.0.0.0 port \([0-9]*\) \.\.\.,\1,' < ${test_tmpdir}/httpd-output.tmp > ${test_tmpdir}/httpd-port
+        sed -e 's,Serving HTTP on 0.0.0.0 port \([0-9]*\) (http://0.0.0.0:[0-9]*/) \.\.\.,\1,' < ${test_tmpdir}/httpd-output.tmp > ${test_tmpdir}/httpd-port
         if ! cmp ${test_tmpdir}/httpd-output.tmp ${test_tmpdir}/httpd-port 1>/dev/null; then
             # If so, we've successfully extracted the port
             break


### PR DESCRIPTION
As with #4672, the Debian security team wants me to fix both Debian 11 (Flatpak 1.10.x) and Debian 10 (Flatpak 1.2.x), so I've tried to backport the changes to the 1.2.x branch.

This version is in sync with 1.12.4 and 1.10.7, not the original 1.12.3 and 1.10.6. In particular, I didn't apply the original (behaviour-changing) solution and then immediately revert it, but instead went directly to the #4678 solution, which reduces merge conflicts.

This might also help distros that want to backport this stuff to 1.6 or 1.8 to work out what they need to backport, although I don't intend to do that myself (I'm already covering more branches than I really have the bandwidth for).

The diffstat is bigger than I'd like for a security update, but this is what happens when we try to go back to a branch from 3 years ago, and in any case a lot of it is tests.

## Preparation: FlatpakContext refactoring, more test coverage

The changes that resolve CVE-2022-21682 rely on some infrastructure that didn't exist in this branch. I think the only way we're realistically going to get `--nofilesystem=host:reset` in 1.2.x is to backport that first.

* context: Generalize handling of special filesystems a bit
    
    The original version of this commit, in Flatpak 1.7.x, was preparation
    for adding more special filesystem keywords; but the infrastructure
    added there was later used to solve CVE-2022-21682.
    
    (cherry picked from commit 949a3ec479d5ca0c962cf12adec70aea30bf0186)
    [smcv: Re-word commit message to reflect why this was backported]

* tests: Convert all tests to python3

    From: @alexlarsson 

    Python2 is pretty much dead, lets make us only use python3.
    
    (cherry picked from commit 2b6641575db75d8af8228749798f4ea635797577)

* tests: Work around summary mtime cache issue (for 1.8 branch)

    From: @alexlarsson 
    
    This adds a sleep(1) before each summary update (if there is a
    pre-existing summary file). This avoids issues where a new summary
    file get the same mtime (in seconds precision).
    
    This is kind of a hacky work around, but it is good enought to get
    the flatpak-1.8 branch working with latest ostree, and master has a better
    fix already.

* context: Only parse filesystem/mode strings in one place
    
    This gives us the ability for the parse function (the former verify
    function) to carry out a normalization step as well.
    
    (cherry picked from commit 517ad25b5fe83376af258acef646551cb97af97c)
    [smcv: Backport to 1.2.x as part of resolving CVE-2022-21682]

* context: Expose flatpak_context_parse_filesystem for testing
    
    (cherry picked from commit 55b27b1393a3880b79dfe108b6f13f1a2fa1888b)

* tests: Add basic unit tests for FlatpakExports, FlatpakContext
    
    There's a limit to how many assertions we can make here right now,
    because what we do here is very dependent on the "shape" of the host
    filesystem. This could be extended in future by using a mock home
    directory whose contents we control.
    
    (cherry picked from commit c0faab35fabb469e3945ad99c32f041d2d7a0dab)
    [smcv: Adjust for 1.2.x]

* tests: Use a temporary HOME directory to test contexts and exports
    
    This gives us control over the paths that get shared (or not) and
    whether they are symlinks, so that we can expand coverage later.
    
    (cherry picked from commit 354b9a2257341c4b9ff313d547fe0aafc25c43f6)

* tests: Exercise flatpak_context_save_metadata
    
    (cherry picked from commit e55dcf5e2bc066b5c2521ad82ca65efa126040a2)

* context: Implement MODE_NONE in unparse_filesystem_flags
    
    flatpak doesn't yet use -Wswitch-enum, but perhaps it should at some
    point. Now that FLATPAK_FILESYSTEM_MODE_NONE is a member of the enum,
    it should be handled; and if we're doing that, we might as well make
    the same function fully responsible for it.
    
    (cherry picked from commit 5a83c73ed859fe3e4bd93a228a4bc8981d649c5e)

* tests: Expand exports test coverage
    
    (cherry picked from commit 27870f681d7efc4ed9c8c13e190b7bc392cefb48)

## Actually dealing with CVE-2022-21682

This is basically #4680 and #4678.

* run, override: Clarify the effect of --nofilesystem
    
    There are two reasonable interpretations for --nofilesystem=home:
    either it revokes a previous --filesystem=home (as in Flatpak 1.12.2 and
    older versions), or it completely forbids access to the home directory
    (as in Flatpak 1.12.3). Clarify the man pages to indicate that it only
    revokes a previous --filesystem=home. This will hopefully reduce
    mismatches between the design and what users expect to happen, as
    in flatpak#4654.
    
    A subsequent commit will introduce a way to get the Flatpak 1.12.3
    behaviour in a way that is more backwards-compatible with Flatpak 1.12.2
    and older versions.
    
    (cherry picked from commit 7bbeed2b87b84d6d94006e25418b7f89a7784fdb)

* test-override: Assert pre-1.12.3 behaviour of --nofilesystem=home, host
    
    (cherry picked from commit 813e1f0b3bef788553b9d37d1ec89c1124491a65)

* test-override: Assert that only the expected term is negated
    
    We weren't distinguishing here between overrides that should have been
    negated (xdg-documents) and overrides that should not have been negated
    (everything else).
    
    (cherry picked from commit 4e3d1d8b7bbd4c0611b6bb44f67c6ad1734d6b7d)

* test-override: Assert that unimplemented suffix is ignored with a warning
    
    (cherry picked from commit 8a44df04c88491c9e694d4a31f968b81805c2c44)

* context: Introduce new --nofilesystem=host:reset
    
    This reintroduces the special case that existed in Flatpak 1.12.3, but
    under a different name, so that it will be backwards-compatible. With
    this change, flatpak-builder will be able to resolve CVE-2022-21682 by
    using --filesystem=host:reset.
    
    We want to implement this as a suffix rather than as a new keyword,
    because unknown suffixes are ignored with a warning, rather than causing
    a fatal error. This means that the new version of flatpak-builder will
    be able to run against older versions of flatpak: it will still be
    vulnerable to CVE-2022-21682 in that situation, but at least it will run.
    
    Co-authored-by: @alexlarsson 
    (cherry picked from commit 5709f1aaed6579f0136976e14e7f3cae399134ca)

* test-override: Assert that --nofilesystem with suffix yields a warning
    
    This was added as part of implementing the :reset suffix.
    
    (cherry picked from commit ab0169ee39fe72eb0cd6544e10e094cfe8cd0466)

* test-exports: Exercise host:reset and related filesystem tokens
    
    Co-authored-by: @alexlarsson 
    (cherry picked from commit f3d12dc7930334d42cfa96a57fd68de9919f1537)

* test-override: Exercise --nofilesystem=host:reset
    
    Co-authored-by: @alexlarsson 
    (cherry picked from commit 4aa70d2d7201e44c7259bf5aeae90beb733e331f)
