### PR TITLE
WIP: Revert the negated home/host permissions change, add :all mode to add it back,

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -83,6 +83,17 @@ extern const char *flatpak_context_devices[];
 extern const char *flatpak_context_features[];
 extern const char *flatpak_context_shares[];
 
+typedef enum {
+  FLATPAK_CONTEXT_FILESYSTEM_FLAGS     = 0,
+} FlatpakContextFilesystemFlags;
+
+typedef struct _FlatpakContextFilesystem {
+  FlatpakFilesystemMode mode;
+  FlatpakContextFilesystemFlags flags;
+} FlatpakContextFilesystem;
+
+FlatpakContextFilesystem *flatpak_context_filesystem_dup (FlatpakContextFilesystem *data);
+
 gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
                                                  char                  **filesystem_out,
                                                  FlatpakFilesystemMode  *mode_out,

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -85,6 +85,7 @@ extern const char *flatpak_context_shares[];
 
 typedef enum {
   FLATPAK_CONTEXT_FILESYSTEM_FLAGS     = 0,
+  FLATPAK_CONTEXT_FILESYSTEM_FLAGS_ALL =  1 << 0,
 } FlatpakContextFilesystemFlags;
 
 typedef struct _FlatpakContextFilesystem {
@@ -94,10 +95,12 @@ typedef struct _FlatpakContextFilesystem {
 
 FlatpakContextFilesystem *flatpak_context_filesystem_dup (FlatpakContextFilesystem *data);
 
-gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
-                                                 char                  **filesystem_out,
-                                                 FlatpakFilesystemMode  *mode_out,
-                                                 GError                **error);
+gboolean       flatpak_context_parse_filesystem (const char                    *filesystem_and_mode,
+                                                 gboolean                       negated,
+                                                 char                         **filesystem_out,
+                                                 FlatpakFilesystemMode         *mode_out,
+                                                 FlatpakContextFilesystemFlags *flags_out,
+                                                 GError                       **error);
 
 FlatpakContext *flatpak_context_new (void);
 void           flatpak_context_free (FlatpakContext *context);

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -607,7 +607,7 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", fs->input);
-      ret = flatpak_context_parse_filesystem (fs->input, &normalized, &mode,
+      ret = flatpak_context_parse_filesystem (fs->input, FALSE, &normalized, &mode, NULL,
                                               &error);
       g_assert_no_error (error);
       g_assert_true (ret);
@@ -629,7 +629,7 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", not->input);
-      ret = flatpak_context_parse_filesystem (not->input, &normalized, &mode,
+      ret = flatpak_context_parse_filesystem (not->input, FALSE, &normalized, &mode, NULL,
                                               &error);
       g_test_message ("-> %s", error ? error->message : "(no error)");
       g_assert_error (error, G_OPTION_ERROR, not->code);


### PR DESCRIPTION
This adds a new filesystem flag "all" to mean recursive negation.   This new flag gets set for overrides with filesystems that have "!home:all" or "!host:all", or commandline args  "--nofilesystem=home:all" or "--nofilesystem=host:all". Then it changes the new recursive permission dropping to only affect filesystems with the flag set.
    
The regular !home now behaves as it did before the recent change allowing existing behaviour change. The new syntax for the overrides file is ignored (except for a warning) by older versions of flatpak.
However, even the warning is unlikely to happen because the :all overrides are really not useful in app permissions themselves but rather only in overrides (in file or cli), so they are not likely to be seen unless you update flatpak and manually use them.
    
With this change we need to change flatpak-builder to use  --nofilesystem=host:all for more recent versions of flatpak to fix the security issue.

NOTE: This is a work in progress, I have not done a lot of testing on this and it should get some tests, but I wanted to bring up the approach.
