### PR TITLE
[1.2.x] Use system copy of xdg-dbus-proxy for build-time tests if configured

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -2,11 +2,16 @@ AM_TESTS_ENVIRONMENT = FLATPAK_TESTS_DEBUG=1 \
 	FLATPAK_CONFIG_DIR=/dev/null \
 	FLATPAK_TRIGGERSDIR=$$(cd $(top_srcdir) && pwd)/triggers \
 	FLATPAK_VALIDATE_ICON=$$(cd $(top_builddir) && pwd)/flatpak-validate-icon \
-	FLATPAK_DBUSPROXY=$$(cd $(top_builddir) && pwd)/flatpak-dbus-proxy \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
 	LD_LIBRARY_PATH=$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH} \
 	PATH=$$(cd $(top_builddir) && pwd):$${PATH} \
 	$(NULL)
+
+if WITH_SYSTEM_DBUS_PROXY
+AM_TESTS_ENVIRONMENT += FLATPAK_DBUSPROXY=$(DBUS_PROXY)
+else
+AM_TESTS_ENVIRONMENT += FLATPAK_DBUSPROXY=$$(cd $(top_builddir) && pwd)/flatpak-dbus-proxy
+endif
 
 if WITH_SYSTEM_BWRAP
 AM_TESTS_ENVIRONMENT += FLATPAK_BWRAP=$(BWRAP)


### PR DESCRIPTION
This follows the same logic as the system bwrap.

Otherwise, build-time tests will fail when we are using a system
xdg-dbus-proxy and not compiling our own (the symptom is that testlibrary
hangs).

Closes: #2823
Approved by: matthiasclasen

(cherry picked from commit 8115489116aa85ec848318782cdb6c49400aaaf9)

---

This is not *strictly* needed for backports of security fixes to 1.2.x for Debian 10, but it would make my life a lot easier, by letting me bisect builds in the configuration used in Debian.