### PR TITLE
[1.2.x] Fix build with GCC 11

### DIFF
--- a/common/flatpak-enum-types.c.template
+++ b/common/flatpak-enum-types.c.template
@@ -15,9 +15,9 @@
 GType
 @enum_name@_get_type (void)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
+  static gsize static_g_@type@_type_id = 0;
 
-  if (g_once_init_enter (&g_define_type_id__volatile))
+  if (g_once_init_enter (&static_g_@type@_type_id))
     {
       static const G@Type@Value values[] = {
 /*** END value-header ***/
@@ -31,10 +31,10 @@ GType
       };
       GType g_define_type_id =
         g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
-      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
+      g_once_init_leave (&static_g_@type@_type_id, g_define_type_id);
     }
 
-  return g_define_type_id__volatile;
+  return static_g_@type@_type_id;
 }
 
 /*** END value-tail ***/


### PR DESCRIPTION
* Fix build with GCC 11

    From: @mcatanzaro 

    See:
https://gitlab.gnome.org/GNOME/glib/-/commit/fab561f8d05794329184cd81f9ab9d9d77dcc22a
(cherry picked from commit 9b34768fa7fa24243439a815ece671a0b2b020dc)
(cherry picked from commit d5bca23eaa93209cd9e2a53cf7384bb983573242)

---

This would make it easier to do initial testing of backports for Debian 10 on a modern system, rather than having to use a Debian 10 VM for all development.

The 1.2.x branch is unmaintained upstream and will not have further releases, but I have to maintain it for Debian 10 (until its EOL date in August 2022) *anyway*, so it might as well be buildable.