### PR TITLE
Revise solution to CVE-2022-21682 to avoid behaviour changes

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -84,6 +84,7 @@ extern const char *flatpak_context_features[];
 extern const char *flatpak_context_shares[];
 
 gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                                 gboolean                negated,
                                                  char                  **filesystem_out,
                                                  FlatpakFilesystemMode  *mode_out,
                                                  GError                **error);

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -87,6 +87,7 @@ const char *flatpak_context_special_filesystems[] = {
   "host",
   "host-etc",
   "host-os",
+  "host-reset",
   NULL
 };
 
@@ -704,6 +705,12 @@ unparse_filesystem_flags (const char           *path,
 
     case FLATPAK_FILESYSTEM_MODE_NONE:
       g_string_insert_c (s, 0, '!');
+
+      if (g_str_has_suffix (s->str, "-reset"))
+        {
+          g_string_truncate (s, s->len - 6);
+          g_string_append (s, ":reset");
+        }
       break;
 
     default:
@@ -716,11 +723,14 @@ unparse_filesystem_flags (const char           *path,
 
 static char *
 parse_filesystem_flags (const char            *filesystem,
-                        FlatpakFilesystemMode *mode_out)
+                        gboolean               negated,
+                        FlatpakFilesystemMode *mode_out,
+                        GError               **error)
 {
   g_autoptr(GString) s = g_string_new ("");
   const char *p, *suffix;
   FlatpakFilesystemMode mode;
+  gboolean reset = FALSE;
 
   p = filesystem;
   while (*p != 0 && *p != ':')
@@ -735,7 +745,31 @@ parse_filesystem_flags (const char            *filesystem,
         g_string_append_c (s, *p++);
     }
 
-  mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
+  if (negated)
+    mode = FLATPAK_FILESYSTEM_MODE_NONE;
+  else
+    mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
+
+  if (g_str_equal (s->str, "host-reset"))
+    {
+      reset = TRUE;
+
+      if (!negated)
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                       "Filesystem token \"%s\" is only applicable for --nofilesystem",
+                       s->str);
+          return NULL;
+        }
+
+      if (*p != '\0')
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                       "Filesystem token \"%s\" cannot be used with a suffix",
+                       s->str);
+          return NULL;
+        }
+    }
 
   if (*p == ':')
     {
@@ -747,9 +781,62 @@ parse_filesystem_flags (const char            *filesystem,
         mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
       else if (strcmp (suffix, "create") == 0)
         mode = FLATPAK_FILESYSTEM_MODE_CREATE;
+      else if (strcmp (suffix, "reset") == 0)
+        reset = TRUE;
       else if (*suffix != 0)
         g_warning ("Unexpected filesystem suffix %s, ignoring", suffix);
+
+      if (negated && mode != FLATPAK_FILESYSTEM_MODE_NONE)
+        {
+          g_warning ("Filesystem suffix \"%s\" is not applicable for --nofilesystem",
+                     suffix);
+          mode = FLATPAK_FILESYSTEM_MODE_NONE;
+        }
+
+      if (reset)
+        {
+          if (!negated)
+            {
+              g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                           "Filesystem suffix \"%s\" only applies to --nofilesystem",
+                           suffix);
+              return NULL;
+            }
+
+          if (!g_str_equal (s->str, "host"))
+            {
+              g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                           "Filesystem suffix \"%s\" can only be applied to "
+                           "--nofilesystem=host",
+                           suffix);
+              return NULL;
+            }
+
+          /* We internally handle host:reset (etc) as host-reset, only exposing it as a flag in the public
+             part to allow it to be ignored (with a warning) for old flatpak versions */
+          g_string_append (s, "-reset");
+        }
     }
+
+  /* Postcondition check: the code above should make some results
+   * impossible */
+  if (negated)
+    {
+      g_assert (mode == FLATPAK_FILESYSTEM_MODE_NONE);
+    }
+  else
+    {
+      g_assert (mode > FLATPAK_FILESYSTEM_MODE_NONE);
+      /* This flag is only applicable to --nofilesystem */
+      g_assert (!reset);
+    }
+
+  /* Postcondition check: filesystem token is host-reset iff reset flag
+   * was found */
+  if (reset)
+    g_assert (g_str_equal (s->str, "host-reset"));
+  else
+    g_assert (!g_str_equal (s->str, "host-reset"));
 
   if (mode_out)
     *mode_out = mode;
@@ -759,12 +846,17 @@ parse_filesystem_flags (const char            *filesystem,
 
 gboolean
 flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                  gboolean                negated,
                                   char                  **filesystem_out,
                                   FlatpakFilesystemMode  *mode_out,
                                   GError                **error)
 {
-  g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, mode_out);
+  g_autofree char *filesystem = NULL;
   char *slash;
+
+  filesystem = parse_filesystem_flags (filesystem_and_mode, negated, mode_out, error);
+  if (filesystem == NULL)
+    return FALSE;
 
   slash = strchr (filesystem, '/');
 
@@ -857,6 +949,14 @@ flatpak_context_take_filesystem (FlatpakContext        *context,
                                  char                  *fs,
                                  FlatpakFilesystemMode  mode)
 {
+  /* Special case: --nofilesystem=host-reset implies --nofilesystem=host.
+   * --filesystem=host-reset (or host:reset) is not allowed. */
+  if (g_str_equal (fs, "host-reset"))
+    {
+      g_return_if_fail (mode == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_hash_table_insert (context->filesystems, g_strdup ("host"), GINT_TO_POINTER (mode));
+    }
+
   g_hash_table_insert (context->filesystems, fs, GINT_TO_POINTER (mode));
 }
 
@@ -888,6 +988,14 @@ flatpak_context_merge (FlatpakContext *context,
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->persistent, g_strdup (key), value);
 
+  /* We first handle host:reset, as it overrides all other keys from the parent */
+  if (g_hash_table_lookup_extended (other->filesystems, "host-reset", NULL, &value))
+    {
+      g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_hash_table_remove_all (context->filesystems);
+    }
+
+  /* Then set the new ones, which includes propagating host:reset. */
   g_hash_table_iter_init (&iter, other->filesystems);
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->filesystems, g_strdup (key), value);
@@ -1075,7 +1183,7 @@ option_filesystem_cb (const gchar *option_name,
   g_autofree char *fs = NULL;
   FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
+  if (!flatpak_context_parse_filesystem (value, FALSE, &fs, &mode, error))
     return FALSE;
 
   flatpak_context_take_filesystem (context, g_steal_pointer (&fs), mode);
@@ -1092,7 +1200,7 @@ option_nofilesystem_cb (const gchar *option_name,
   g_autofree char *fs = NULL;
   FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
+  if (!flatpak_context_parse_filesystem (value, TRUE, &fs, &mode, error))
     return FALSE;
 
   flatpak_context_take_filesystem (context, g_steal_pointer (&fs),
@@ -1597,15 +1705,13 @@ flatpak_context_load_metadata (FlatpakContext *context,
           g_autofree char *filesystem = NULL;
           FlatpakFilesystemMode mode;
 
-          if (!flatpak_context_parse_filesystem (fs, &filesystem, &mode, NULL))
+          if (!flatpak_context_parse_filesystem (fs, remove,
+                                                 &filesystem, &mode, NULL))
             g_debug ("Unknown filesystem type %s", filesystems[i]);
           else
             {
-              if (remove)
-                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem),
-                                                 FLATPAK_FILESYSTEM_MODE_NONE);
-              else
-                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
+              g_assert (mode == FLATPAK_FILESYSTEM_MODE_NONE || !remove);
+              flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
             }
         }
     }
@@ -1851,10 +1957,23 @@ flatpak_context_save_metadata (FlatpakContext *context,
     {
       g_autoptr(GPtrArray) array = g_ptr_array_new_with_free_func (g_free);
 
+      /* Serialize host-reset first, because order can matter in
+       * corner cases. */
+      if (g_hash_table_lookup_extended (context->filesystems, "host-reset",
+                                        NULL, &value))
+        {
+          g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+          g_ptr_array_add (array, g_strdup ("!host:reset"));
+        }
+
       g_hash_table_iter_init (&iter, context->filesystems);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
+
+          /* We already did this */
+          if (g_str_equal (key, "host-reset"))
+            continue;
 
           g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
         }
@@ -1994,7 +2113,8 @@ flatpak_context_save_metadata (FlatpakContext *context,
 void
 flatpak_context_allow_host_fs (FlatpakContext *context)
 {
-  flatpak_context_take_filesystem (context, g_strdup ("host"), FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  flatpak_context_take_filesystem (context, g_strdup ("host"),
+                                   FLATPAK_FILESYSTEM_MODE_READ_WRITE);
 }
 
 gboolean
@@ -2185,18 +2305,36 @@ flatpak_context_to_args (FlatpakContext *context,
       g_ptr_array_add (args, g_strdup_printf ("--system-%s-name=%s", flatpak_policy_to_string (policy), name));
     }
 
+  /* Serialize host-reset first, because order can matter in
+   * corner cases. */
+  if (g_hash_table_lookup_extended (context->filesystems, "host-reset",
+                                    NULL, &value))
+    {
+      g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_ptr_array_add (args, g_strdup ("--nofilesystem=host:reset"));
+    }
+
   g_hash_table_iter_init (&iter, context->filesystems);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
+      g_autofree char *fs = NULL;
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
+
+      /* We already did this */
+      if (g_str_equal (key, "host-reset"))
+        continue;
+
+      fs = unparse_filesystem_flags (key, mode);
 
       if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
         {
-          g_autofree char *fs = unparse_filesystem_flags (key, mode);
           g_ptr_array_add (args, g_strdup_printf ("--filesystem=%s", fs));
         }
       else
-        g_ptr_array_add (args, g_strdup_printf ("--nofilesystem=%s", (char *) key));
+        {
+          g_assert (fs[0] == '!');
+          g_ptr_array_add (args, g_strdup_printf ("--nofilesystem=%s", &fs[1]));
+        }
     }
 }
 

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -852,31 +852,6 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
   return FALSE;
 }
 
-/* Note: This only works with valid keys, i.e. they passed flatpak_context_parse_filesystem */
-static gboolean
-flatpak_filesystem_key_in_home (const char *filesystem)
-{
-  /* "home" is definitely in home */
-  if (strcmp (filesystem, "home") == 0)
-    return TRUE;
-
-  /* All the other special fs:es are non-home.
-   * Note: This considers absolute paths that are in the homedir as non-home.
-   */
-  if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||
-      g_str_has_prefix (filesystem, "/"))
-    return FALSE;
-
-  /* Files in xdg-run are not in home */
-  if (g_str_has_prefix (filesystem, "xdg-run"))
-    return FALSE;
-
-  /* All remaining keys (~/, xdg-data, etc) are considered in home,
-   * Note: technically $XDG_HOME_DATA could point outside the homedir, but we ignore that.
-   */
-  return TRUE;
-}
-
 static void
 flatpak_context_take_filesystem (FlatpakContext        *context,
                                  char                  *fs,
@@ -891,8 +866,6 @@ flatpak_context_merge (FlatpakContext *context,
 {
   GHashTableIter iter;
   gpointer key, value;
-  gboolean no_home = FALSE;
-  gboolean no_host = FALSE;
 
   context->shares &= ~other->shares_valid;
   context->shares |= other->shares;
@@ -915,41 +888,6 @@ flatpak_context_merge (FlatpakContext *context,
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->persistent, g_strdup (key), value);
 
-  /* We first handle all negative home and host as they override other
-     keys than themselves from the parent */
-  if (g_hash_table_lookup_extended (other->filesystems,
-                                    "host",
-                                    NULL, &value))
-    {
-      FlatpakFilesystemMode host_mode = GPOINTER_TO_INT (value);
-      if (host_mode == FLATPAK_FILESYSTEM_MODE_NONE)
-        no_host = TRUE;
-    }
-
-  if (g_hash_table_lookup_extended (other->filesystems,
-                                    "home",
-                                    NULL, &value))
-    {
-      FlatpakFilesystemMode home_mode = GPOINTER_TO_INT (value);
-      if (home_mode == FLATPAK_FILESYSTEM_MODE_NONE)
-        no_home = TRUE;
-    }
-
-  if (no_host)
-    {
-      g_hash_table_remove_all (context->filesystems);
-    }
-  else if (no_home)
-    {
-      g_hash_table_iter_init (&iter, context->filesystems);
-      while (g_hash_table_iter_next (&iter, &key, &value))
-        {
-          if (flatpak_filesystem_key_in_home ((const char *)key))
-            g_hash_table_iter_remove (&iter);
-        }
-    }
-
-  /* Then set the new ones, which includes propagating the nohost and nohome ones. */
   g_hash_table_iter_init (&iter, other->filesystems);
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->filesystems, g_strdup (key), value);

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -258,13 +258,6 @@
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
-                </para><para>
-                    In general, "--nofilesystem=PATH" will remove access to a specific path if exactly that path
-                    was previously granted. However, as a special case, "--nofilesystem=home"  will remove access to all
-                    previously granted locations inside the homedir as well, such as "home/some-dir", or "xdg-download",
-                    and "--nofilesystem=host" will remove access to all previously granted locations.
-                    Note: absolute paths that happen to be inside the current users home directory are not considered for
-                    this special case.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -247,13 +247,6 @@
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
-                </para><para>
-                    In general, "--nofilesystem=PATH" will remove access to a specific path if exactly that path
-                    was previously granted. However, as a special case, "--nofilesystem=home" will remove access to all
-                    previously granted locations inside the homedir as well, such as "home/some-dir", or "xdg-download",
-                    and "--nofilesystem=host" will remove access to all previously granted locations.
-                    Note: absolute paths that happen to be inside the current users home directory are not considered for
-                    this special case.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -223,13 +223,31 @@
                 <term><option>--nofilesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
+                    Undo the effect of a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    in the app's manifest or a lower-precedence layer of
+                    overrides, and/or remove a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    from this layer of overrides.
+                    This overrides the Context section of the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
+                    <arg choice="plain">FILESYSTEM</arg> can take the same
+                    values as for <option>--filesystem</option>, but the
+                    <arg choice="plain">:ro</arg> and
+                    <arg choice="plain">:create</arg> suffixes are not
+                    used here.
                     This option can be used multiple times.
+                </para><para>
+                    This option does not prevent access to a more
+                    narrowly-scoped <option>--filesystem</option>.
+                    For example, if an application has the equivalent of
+                    <option>--filesystem=xdg-config/MyApp</option> in
+                    its manifest or as a system-wide override, and
+                    <literal>flatpak override --user --nofilesystem=home</literal>
+                    as a per-user override, then it will be prevented from
+                    accessing most of the home directory, but it will still
+                    be allowed to access
+                    <filename>$XDG_CONFIG_HOME/MyApp</filename>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -248,6 +248,14 @@
                     accessing most of the home directory, but it will still
                     be allowed to access
                     <filename>$XDG_CONFIG_HOME/MyApp</filename>.
+                </para><para>
+                    As a special case,
+                    <option>--nofilesystem=host:reset</option>
+                    will ignore all <option>--filesystem</option>
+                    permissions inherited from the app manifest or a
+                    lower-precedence layer of overrides, in addition to
+                    having the behaviour of
+                    <option>--nofilesystem=host</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -230,13 +230,6 @@
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
-                </para><para>
-                    In general, "--nofilesystem=PATH" will remove access to a specific path if exactly that path
-                    was previously granted. However, as a special case, "--nofilesystem=home" will remove access to all
-                    previously granted locations inside the homedir as well, such as "home/some-dir", or "xdg-download",
-                    and "--nofilesystem=host" will remove access to all previously granted locations.
-                    Note: absolute paths that happen to be inside the current users home directory are not considered for
-                    this special case.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -381,15 +381,7 @@
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
-                </para><para>
-                    In general, "--nofilesystem=PATH" will remove access to a specific path if exactly that path
-                    was previously granted. However, as a special case, "--nofilesystem=home" will remove access to all
-                    previously granted locations inside the homedir as well, such as "home/some-dir", or "xdg-download",
-                    and "--nofilesystem=host" will remove access to all previously granted locations.
-                    Note: absolute paths that happen to be inside the current users home directory are not considered for
-                    this special case.
                 </para></listitem>
-
             </varlistentry>
 
             <varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -374,13 +374,29 @@
                 <term><option>--nofilesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
+                    Undo the effect of a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    in the app's manifest and/or the overrides set up with
+                    <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+                    This overrides the Context section of the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
+                    <arg choice="plain">FILESYSTEM</arg> can take the same
+                    values as for <option>--filesystem</option>, but the
+                    <arg choice="plain">:ro</arg> and
+                    <arg choice="plain">:create</arg> suffixes are not
+                    used here.
                     This option can be used multiple times.
+                </para><para>
+                    This option does not prevent access to a more
+                    narrowly-scoped <option>--filesystem</option>.
+                    For example, if an application has the equivalent of
+                    <option>--filesystem=xdg-config/MyApp</option> in
+                    its manifest or as a system-wide override, and
+                    <literal>flatpak override --user --nofilesystem=home</literal>
+                    as a per-user override, then it will be prevented from
+                    accessing most of the home directory, but it will still
+                    be allowed to access
+                    <filename>$XDG_CONFIG_HOME/MyApp</filename>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -397,6 +397,14 @@
                     accessing most of the home directory, but it will still
                     be allowed to access
                     <filename>$XDG_CONFIG_HOME/MyApp</filename>.
+                </para><para>
+                    As a special case,
+                    <option>--nofilesystem=host:reset</option>
+                    will ignore all <option>--filesystem</option>
+                    permissions inherited from the app manifest or
+                    <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+                    in addition to having the behaviour of
+                    <option>--nofilesystem=host</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -17,11 +17,23 @@
 
 #include "config.h"
 
+#include <stdarg.h>
+
 #include <glib.h>
 #include "flatpak.h"
 #include "flatpak-context-private.h"
+#include "flatpak-run-private.h"
+#include "flatpak-utils-private.h"
 
 #include "tests/testlib.h"
+
+/* g_str_has_prefix as a GEqualFunc */
+static gboolean
+str_has_prefix (gconstpointer candidate,
+                gconstpointer pattern)
+{
+  return g_str_has_prefix (candidate, pattern);
+}
 
 static void
 test_context_env (void)
@@ -116,6 +128,305 @@ test_context_env_fd (void)
   g_clear_error (&error);
 }
 
+static void context_parse_args (FlatpakContext *context,
+                                ...) G_GNUC_NULL_TERMINATED;
+
+static void
+context_parse_args (FlatpakContext *context,
+                    ...)
+{
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GOptionContext) oc = NULL;
+  g_autoptr(GOptionGroup) group = NULL;
+  g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func (g_free);
+  g_auto(GStrv) argv = NULL;
+  const char *arg;
+  va_list ap;
+
+  g_ptr_array_add (args, g_strdup ("argv[0]"));
+
+  va_start (ap, context);
+
+  while ((arg = va_arg (ap, const char *)) != NULL)
+    g_ptr_array_add (args, g_strdup (arg));
+
+  va_end (ap);
+
+  g_ptr_array_add (args, NULL);
+  argv = (GStrv) g_ptr_array_free (g_steal_pointer (&args), FALSE);
+
+  oc = g_option_context_new ("");
+  group = flatpak_context_get_options (context);
+  g_option_context_add_group (oc, group);
+  g_option_context_parse_strv (oc, &argv, &local_error);
+  g_assert_no_error (local_error);
+}
+
+static void
+test_context_merge_fs (void)
+{
+  /*
+   * We want to arrive at the same result regardless of whether we:
+   * - start from lowest precedence, and successively merge higher
+   *   precedences into it, discarding them when done;
+   * - successively merge highest precedence into second-highest, and
+   *   then discard highest
+   */
+  enum { LOWEST_FIRST, HIGHEST_FIRST, INVALID } merge_order;
+
+  for (merge_order = LOWEST_FIRST; merge_order < INVALID; merge_order++)
+    {
+      g_autoptr(FlatpakContext) lowest = flatpak_context_new ();
+      g_autoptr(FlatpakContext) middle = flatpak_context_new ();
+      g_autoptr(FlatpakContext) highest = flatpak_context_new ();
+      gpointer value;
+
+      context_parse_args (lowest,
+                          "--filesystem=/one",
+                          NULL);
+      context_parse_args (middle,
+                          "--nofilesystem=host:reset",
+                          "--filesystem=/two",
+                          NULL);
+      context_parse_args (highest,
+                          "--nofilesystem=host",
+                          "--filesystem=/three",
+                          NULL);
+
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (middle->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (middle->filesystems, "/three", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "host-reset", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/one", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/two", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+      if (merge_order == LOWEST_FIRST)
+        {
+          flatpak_context_merge (lowest, middle);
+
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+
+          flatpak_context_merge (lowest, highest);
+        }
+      else
+        {
+          flatpak_context_merge (middle, highest);
+
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (middle->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+          flatpak_context_merge (lowest, middle);
+        }
+
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+    }
+
+  for (merge_order = LOWEST_FIRST; merge_order < INVALID; merge_order++)
+    {
+      g_autoptr(FlatpakContext) lowest = flatpak_context_new ();
+      g_autoptr(FlatpakContext) mid_low = flatpak_context_new ();
+      g_autoptr(FlatpakContext) mid_high = flatpak_context_new ();
+      g_autoptr(FlatpakContext) highest = flatpak_context_new ();
+      g_autoptr(GError) local_error = NULL;
+      g_autoptr(GKeyFile) metakey = g_key_file_new ();
+      g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func (g_free);
+      g_autofree char *filesystems = NULL;
+      gpointer value;
+
+      context_parse_args (lowest,
+                          "--filesystem=/one",
+                          NULL);
+      context_parse_args (mid_low,
+                          "--nofilesystem=host:reset",
+                          "--filesystem=/two",
+                          NULL);
+      context_parse_args (mid_high,
+                          "--filesystem=host",
+                          "--filesystem=/three",
+                          NULL);
+      context_parse_args (highest,
+                          "--nofilesystem=host",
+                          "--filesystem=/four",
+                          NULL);
+
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/three", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/four", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "host-reset", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/one", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/two", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/four", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "host-reset", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/one", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/two", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/three", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "/four", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+      if (merge_order == LOWEST_FIRST)
+        {
+          flatpak_context_merge (lowest, mid_low);
+
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, NULL));
+
+          flatpak_context_merge (lowest, mid_high);
+
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, NULL));
+
+          flatpak_context_merge (lowest, highest);
+        }
+      else
+        {
+          flatpak_context_merge (mid_high, highest);
+
+          g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "host-reset", NULL, NULL));
+          g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/one", NULL, NULL));
+          g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/two", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "/four", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+          flatpak_context_merge (mid_low, mid_high);
+
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/four", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+          flatpak_context_merge (lowest, mid_low);
+        }
+
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+      flatpak_context_save_metadata (lowest, FALSE, metakey);
+      filesystems = g_key_file_get_value (metakey,
+                                          FLATPAK_METADATA_GROUP_CONTEXT,
+                                          FLATPAK_METADATA_KEY_FILESYSTEMS,
+                                          &local_error);
+      g_assert_no_error (local_error);
+      g_test_message ("%s=%s", FLATPAK_METADATA_KEY_FILESYSTEMS, filesystems);
+      /* !host:reset is serialized first */
+      g_assert_true (g_str_has_prefix (filesystems, "!host:reset;"));
+      /* The rest are serialized in arbitrary order */
+      g_assert_nonnull (strstr (filesystems, ";!host;"));
+      g_assert_null (strstr (filesystems, "/one"));
+      g_assert_nonnull (strstr (filesystems, ";/two;"));
+      g_assert_nonnull (strstr (filesystems, ";/three;"));
+      g_assert_nonnull (strstr (filesystems, ";/four;"));
+
+      flatpak_context_to_args (lowest, args);
+      /* !host:reset is serialized first */
+      g_assert_cmpuint (args->len, >, 0);
+      g_assert_cmpstr (g_ptr_array_index (args, 0), ==,
+                       "--nofilesystem=host:reset");
+      /* The rest are serialized in arbitrary order */
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--nofilesystem=host", g_str_equal, NULL));
+      g_assert_false (g_ptr_array_find_with_equal_func (args, "--filesystem=/one", str_has_prefix, NULL));
+      g_assert_false (g_ptr_array_find_with_equal_func (args, "--nofilesystem=/one", str_has_prefix, NULL));
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--filesystem=/two", g_str_equal, NULL));
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--filesystem=/three", g_str_equal, NULL));
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--filesystem=/four", g_str_equal, NULL));
+    }
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -123,6 +434,7 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/context/env", test_context_env);
   g_test_add_func ("/context/env-fd", test_context_env_fd);
+  g_test_add_func ("/context/merge-fs", test_context_merge_fs);
 
   return g_test_run ();
 }

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -536,6 +536,13 @@ static const NotFilesystem not_filesystems[] =
   { "xdg-run", G_OPTION_ERROR_FAILED },
   { "/", G_OPTION_ERROR_BAD_VALUE },
   { "/////././././././//////", G_OPTION_ERROR_BAD_VALUE },
+  { "host:reset", G_OPTION_ERROR_FAILED },
+  { "host-reset", G_OPTION_ERROR_FAILED },
+  { "host-reset:rw", G_OPTION_ERROR_FAILED },
+  { "host-reset:reset", G_OPTION_ERROR_FAILED },
+  { "!host-reset:reset", G_OPTION_ERROR_FAILED },
+  { "/foo:reset", G_OPTION_ERROR_FAILED },
+  { "!/foo:reset", G_OPTION_ERROR_FAILED },
 };
 
 typedef struct
@@ -591,6 +598,9 @@ static const Filesystem filesystems[] =
   { "~///././//", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
   { "home/", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
   { "home/Projects", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "~/Projects" },
+  { "!home", FLATPAK_FILESYSTEM_MODE_NONE, "home" },
+  { "!host:reset", FLATPAK_FILESYSTEM_MODE_NONE, "host-reset" },
+  { "!host-reset", FLATPAK_FILESYSTEM_MODE_NONE, "host-reset" },
 };
 
 static void
@@ -601,19 +611,32 @@ test_filesystems (void)
   for (i = 0; i < G_N_ELEMENTS (filesystems); i++)
     {
       const Filesystem *fs = &filesystems[i];
+      const char *input = fs->input;
+      gboolean negated = FALSE;
       g_autoptr(GError) error = NULL;
       g_autofree char *normalized;
       FlatpakFilesystemMode mode;
       gboolean ret;
 
       g_test_message ("%s", fs->input);
-      ret = flatpak_context_parse_filesystem (fs->input, FALSE,
+
+      if (input[0] == '!')
+        {
+          g_test_message ("-> input is negated");
+          negated = TRUE;
+          input++;
+        }
+
+      ret = flatpak_context_parse_filesystem (input, negated,
                                               &normalized, &mode, &error);
       g_assert_no_error (error);
       g_assert_true (ret);
 
+      g_test_message ("-> mode: %u", mode);
+      g_test_message ("-> normalized filesystem: %s", normalized);
+
       if (fs->fs == NULL)
-        g_assert_cmpstr (normalized, ==, fs->input);
+        g_assert_cmpstr (normalized, ==, input);
       else
         g_assert_cmpstr (normalized, ==, fs->fs);
 
@@ -623,13 +646,22 @@ test_filesystems (void)
   for (i = 0; i < G_N_ELEMENTS (not_filesystems); i++)
     {
       const NotFilesystem *not = &not_filesystems[i];
+      const char *input = not->input;
+      gboolean negated = FALSE;
       g_autoptr(GError) error = NULL;
       char *normalized = NULL;
       FlatpakFilesystemMode mode;
       gboolean ret;
 
       g_test_message ("%s", not->input);
-      ret = flatpak_context_parse_filesystem (not->input, FALSE,
+
+      if (input[0] == '!')
+        {
+          negated = TRUE;
+          input++;
+        }
+
+      ret = flatpak_context_parse_filesystem (input, negated,
                                               &normalized, &mode, &error);
       g_test_message ("-> %s", error ? error->message : "(no error)");
       g_assert_error (error, G_OPTION_ERROR, not->code);

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -607,8 +607,8 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", fs->input);
-      ret = flatpak_context_parse_filesystem (fs->input, &normalized, &mode,
-                                              &error);
+      ret = flatpak_context_parse_filesystem (fs->input, FALSE,
+                                              &normalized, &mode, &error);
       g_assert_no_error (error);
       g_assert_true (ret);
 
@@ -629,8 +629,8 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", not->input);
-      ret = flatpak_context_parse_filesystem (not->input, &normalized, &mode,
-                                              &error);
+      ret = flatpak_context_parse_filesystem (not->input, FALSE,
+                                              &normalized, &mode, &error);
       g_test_message ("-> %s", error ? error->message : "(no error)");
       g_assert_error (error, G_OPTION_ERROR, not->code);
       g_assert_false (ret);

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -17,7 +17,7 @@ reset_overrides () {
     assert_file_empty info
 }
 
-echo "1..17"
+echo "1..18"
 
 setup_repo
 install_repo
@@ -186,6 +186,51 @@ assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo:create"
 assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
+
+${FLATPAK} override --user --nofilesystem=host:reset org.test.Hello
+${FLATPAK} override --user --show org.test.Hello > override
+filesystems="$(sed -ne 's/^filesystems=//p' override)"
+assert_not_semicolon_list_contains "$filesystems" "host"
+assert_not_semicolon_list_contains "$filesystems" "host:reset"
+assert_semicolon_list_contains "$filesystems" "!host"
+assert_semicolon_list_contains "$filesystems" "!host:reset"
+assert_not_semicolon_list_contains "$filesystems" "host-reset"
+assert_not_semicolon_list_contains "$filesystems" "!host-reset"
+
+# !host-reset is the same as !host:reset, and serializes as !host:reset
+${FLATPAK} override --user --nofilesystem=host-reset org.test.Hello
+${FLATPAK} override --user --show org.test.Hello > override
+filesystems="$(sed -ne 's/^filesystems=//p' override)"
+assert_not_semicolon_list_contains "$filesystems" "host"
+assert_not_semicolon_list_contains "$filesystems" "host:reset"
+assert_semicolon_list_contains "$filesystems" "!host"
+assert_semicolon_list_contains "$filesystems" "!host:reset"
+assert_not_semicolon_list_contains "$filesystems" "host-reset"
+assert_not_semicolon_list_contains "$filesystems" "!host-reset"
+
+# --filesystem=...:reset => error
+e=0
+${FLATPAK} override --user --filesystem=host:reset org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem suffix \"reset\" only applies to --nofilesystem"
+assert_not_streq "$e" 0
+
+# --filesystem=host-reset => error
+e=0
+${FLATPAK} override --user --filesystem=host-reset org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem token \"host-reset\" is only applicable for --nofilesystem"
+assert_not_streq "$e" 0
+
+# --filesystem=host-reset:suffix => error
+e=0
+${FLATPAK} override --user --nofilesystem=host-reset:suffix org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem token \"host-reset\" cannot be used with a suffix"
+assert_not_streq "$e" 0
+
+# --nofilesystem=/foo:reset => error
+e=0
+${FLATPAK} override --user --nofilesystem=/foo:reset org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem suffix \"reset\" can only be applied to --nofilesystem=host"
+assert_not_streq "$e" 0
 
 # --nofilesystem=...:rw => warning
 # Warnings need to be made temporarily non-fatal here.
@@ -394,4 +439,41 @@ if ! skip_one_without_bwrap "runtime override --nofilesystem=host"; then
   rm -fr "$TEST_DATA_DIR/dir2"
 
   ok "runtime override --nofilesystem=host"
+fi
+
+reset_overrides
+
+if ! skip_one_without_bwrap "runtime override --nofilesystem=host:reset"; then
+  mkdir -p "$HOME/dir"
+  mkdir -p "$TEST_DATA_DIR/dir1"
+  mkdir -p "$TEST_DATA_DIR/dir2"
+  echo "hello" > "$HOME/example"
+  echo "hello" > "$HOME/dir/example"
+  echo "hello" > "$TEST_DATA_DIR/dir1/example"
+  echo "hello" > "$TEST_DATA_DIR/dir2/example"
+
+  ${FLATPAK} override --user --filesystem=host org.test.Hello
+  ${FLATPAK} override --user --filesystem='~/dir' org.test.Hello
+  ${FLATPAK} override --user --filesystem="$TEST_DATA_DIR/dir1" org.test.Hello
+
+  ${FLATPAK} run --env=TEST_DATA_DIR="$TEST_DATA_DIR" \
+    --command=sh --nofilesystem=host:reset org.test.Hello -c '
+    echo overwritten > "$HOME/dir/example" || true
+    echo overwritten > "$HOME/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir1/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir2/example" || true
+  '
+  # --nofilesystem=host:reset cancels all --filesystem permissions from
+  # lower-precedence layers
+  assert_file_has_content "$HOME/dir/example" hello
+  assert_file_has_content "$TEST_DATA_DIR/dir1/example" hello
+  assert_file_has_content "$HOME/example" hello
+  assert_file_has_content "$TEST_DATA_DIR/dir2/example" hello
+
+  rm -fr "$HOME/dir"
+  rm -fr "$HOME/example"
+  rm -fr "$TEST_DATA_DIR/dir1"
+  rm -fr "$TEST_DATA_DIR/dir2"
+
+  ok "runtime override --nofilesystem=host:reset"
 fi

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -187,6 +187,13 @@ assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
+# --nofilesystem=...:rw => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --nofilesystem=/foo:rw org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem suffix \"rw\" is not applicable for --nofilesystem"
+assert_streq "$e" 0
+
 # --filesystem=...:bar => warning
 # Warnings need to be made temporarily non-fatal here.
 e=0

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -17,7 +17,7 @@ reset_overrides () {
     assert_file_empty info
 }
 
-echo "1..15"
+echo "1..17"
 
 setup_repo
 install_repo
@@ -308,4 +308,83 @@ if ! skip_one_without_bwrap "persist"; then
   assert_file_has_content $HOME/.var/app/org.test.Hello/example/bye goodbye
 
   ok "persist"
+fi
+
+reset_overrides
+
+if ! skip_one_without_bwrap "runtime override --nofilesystem=home"; then
+  mkdir -p "$HOME/dir"
+  mkdir -p "$TEST_DATA_DIR/dir1"
+  mkdir -p "$TEST_DATA_DIR/dir2"
+  echo "hello" > "$HOME/example"
+  echo "hello" > "$HOME/dir/example"
+  echo "hello" > "$TEST_DATA_DIR/dir1/example"
+  echo "hello" > "$TEST_DATA_DIR/dir2/example"
+
+  ${FLATPAK} override --user --filesystem=home org.test.Hello
+  ${FLATPAK} override --user --filesystem='~/dir' org.test.Hello
+  ${FLATPAK} override --user --filesystem="$TEST_DATA_DIR/dir1" org.test.Hello
+
+  ${FLATPAK} run --env=TEST_DATA_DIR="$TEST_DATA_DIR" \
+    --command=sh --nofilesystem=home org.test.Hello -c '
+    echo overwritten > "$HOME/dir/example" || true
+    echo overwritten > "$HOME/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir1/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir2/example" || true
+  '
+  # --nofilesystem=home does not cancel a more narrowly-scoped permission
+  # such as --filesystem=~/dir
+  assert_file_has_content "$HOME/dir/example" overwritten
+  # --nofilesystem=home cancels the --filesystem=home at a lower precedence,
+  # so $HOME/example was not shared
+  assert_file_has_content "$HOME/example" hello
+  # --nofilesystem=home does not affect access to files outside $HOME
+  assert_file_has_content "$TEST_DATA_DIR/dir1/example" overwritten
+  assert_file_has_content "$TEST_DATA_DIR/dir2/example" hello
+
+  rm -fr "$HOME/dir"
+  rm -fr "$HOME/example"
+  rm -fr "$TEST_DATA_DIR/dir1"
+  rm -fr "$TEST_DATA_DIR/dir2"
+
+  ok "runtime override --nofilesystem=home"
+fi
+
+reset_overrides
+
+if ! skip_one_without_bwrap "runtime override --nofilesystem=host"; then
+  mkdir -p "$HOME/dir"
+  mkdir -p "$TEST_DATA_DIR/dir1"
+  mkdir -p "$TEST_DATA_DIR/dir2"
+  echo "hello" > "$HOME/example"
+  echo "hello" > "$HOME/dir/example"
+  echo "hello" > "$TEST_DATA_DIR/dir1/example"
+  echo "hello" > "$TEST_DATA_DIR/dir2/example"
+
+  ${FLATPAK} override --user --filesystem=host org.test.Hello
+  ${FLATPAK} override --user --filesystem='~/dir' org.test.Hello
+  ${FLATPAK} override --user --filesystem="$TEST_DATA_DIR/dir1" org.test.Hello
+
+  ${FLATPAK} run --env=TEST_DATA_DIR="$TEST_DATA_DIR" \
+    --command=sh --nofilesystem=host org.test.Hello -c '
+    echo overwritten > "$HOME/dir/example" || true
+    echo overwritten > "$HOME/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir1/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir2/example" || true
+  '
+  # --nofilesystem=host does not cancel a more narrowly-scoped permission
+  # such as --filesystem=~/dir
+  assert_file_has_content "$HOME/dir/example" overwritten
+  assert_file_has_content "$TEST_DATA_DIR/dir1/example" overwritten
+  # --nofilesystem=host cancels the --filesystem=host at a lower precedence,
+  # so $HOME/example was not shared
+  assert_file_has_content "$HOME/example" hello
+  assert_file_has_content "$TEST_DATA_DIR/dir2/example" hello
+
+  rm -fr "$HOME/dir"
+  rm -fr "$HOME/example"
+  rm -fr "$TEST_DATA_DIR/dir1"
+  rm -fr "$TEST_DATA_DIR/dir2"
+
+  ok "runtime override --nofilesystem=host"
 fi


### PR DESCRIPTION
This is an alternative to #4675, with a similar practical result, but resolving some of my comments on #4675, and hopefully structured in a way that is going to be easier to backport. I think this ends up looking better: @alexlarsson, WDYT?

I've also added some test coverage here, which I think is something this feature needs.

If @alexlarsson agrees with this approach, then we can either close #4675 in favour of this PR, or replace `new-home-host-all-perms` with my branch from this PR (so that it becomes the new implementation of #4675) and close this PR.

---

* Revert "manpages: Document the new details of --nofilesystem behaviour."
    
    The new behaviour caused regressions in some situations that previously
    worked, and will be reverted.
    
    This reverts commit 4d11f77aa7fd3e64cfa80af89d92567ab9e8e6fa.

* Revert "Make --nofilesystem=host/home remove access to subdirs of those"
    
    This caused regressions for some previously-working use cases. For
    example, some Flatpak users previously used a global
    `flatpak override --nofilesystem=home` or
    `flatpak override --nofilesystem=host`, but expected that individual apps
    would still be able to have finer-grained filesystem access granted by the
    app manifest, such as Zoom's `--filesystem=~/Documents/Zoom:create`. With
    the changes in 1.12.3, this no longer has the desired result, because
    `--nofilesystem=home` was special-cased to disallow inheriting the
    finer-grained `--filesystem`.
    
    This reverts commit 445bddeee657fdc8d2a0a1f0de12975400d4fc1a.
    
    This reverts the initial solution to CVE-2022-21682, which we intend to
    resolve differently, by introducing a new feature in Flatpak and making
    use of it in a new flatpak-builder version.

* run, override: Clarify the effect of --nofilesystem
    
    There are two reasonable interpretations for --nofilesystem=home:
    either it revokes a previous --filesystem=home (as in Flatpak 1.12.2 and
    older versions), or it completely forbids access to the home directory
    (as in Flatpak 1.12.3). Clarify the man pages to indicate that it only
    revokes a previous --filesystem=home. This will hopefully reduce
    mismatches between the design and what users expect to happen, as
    in flatpak#4654.
    
    A subsequent commit will introduce a way to get the Flatpak 1.12.3
    behaviour in a way that is more backwards-compatible with Flatpak 1.12.2
    and older versions.

* test-override: Assert that only the expected term is negated
    
    We weren't distinguishing here between overrides that should have been
    negated (xdg-documents) and overrides that should not have been negated
    (everything else).

* test-override: Assert pre-1.12.3 behaviour of --nofilesystem=home, host

* test-override: Assert that unimplemented suffix is ignored with a warning

* context: Introduce new --nofilesystem=host:reset, home:reset
    
    This reintroduces the special case that existed in Flatpak 1.12.3, but
    under a different name, so that it will be backwards-compatible. With
    this change, flatpak-builder will be able to resolve CVE-2022-21682 by
    using --filesystem=host:reset.
    
    We want to implement this as a suffix rather than as a new keyword,
    because unknown suffixes are ignored with a warning, rather than causing
    a fatal error. This means that the new version of flatpak-builder will
    be able to run against older versions of flatpak: it will still be
    vulnerable to CVE-2022-21682 in that situation, but at least it will run.
    
    Based on a previous patch by Alexander Larsson.

* test-override: Assert that --nofilesystem with suffix yields a warning
    
    This was added as part of implementing the :reset suffix.

* test-override: Exercise --nofilesystem=host:reset, home:reset