### PR TITLE
Improve overrides unit test

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -609,3 +609,27 @@ trap cleanup EXIT
 if test -n "${FLATPAK_TESTS_DEBUG:-}"; then
     set -x
 fi
+
+assert_semicolon_list_contains () {
+    list="$1"
+    member="$2"
+
+    case ";$list;" in
+        (*";$member;"*)
+            ;;
+        (*)
+            assert_not_reached "\"$list\" should contain \"$member\""
+            ;;
+    esac
+}
+
+assert_not_semicolon_list_contains () {
+    local list="$1"
+    local member="$2"
+
+    case ";$list;" in
+        (*";$member;"*)
+            assert_not_reached "\"$list\" should not contain \"$member\""
+            ;;
+    esac
+}

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -173,11 +173,19 @@ ${FLATPAK} override --user --nofilesystem=xdg-documents org.test.Hello
 ${FLATPAK} override --user --show org.test.Hello > override
 
 assert_file_has_content override "^\[Context\]$"
-assert_file_has_content override "^filesystems=.*/media;.*$"
-assert_file_has_content override "^filesystems=.*home;.*$"
-assert_file_has_content override "^filesystems=.*xdg-documents;.*$"
-assert_file_has_content override "^filesystems=.*xdg-desktop/foo:create;.*$"
-assert_file_has_content override "^filesystems=.*xdg-config:ro;.*$"
+filesystems="$(sed -ne 's/^filesystems=//p' override)"
+assert_semicolon_list_contains "$filesystems" "/media"
+assert_not_semicolon_list_contains "$filesystems" "!/media"
+assert_semicolon_list_contains "$filesystems" "home"
+assert_not_semicolon_list_contains "$filesystems" "!home"
+assert_not_semicolon_list_contains "$filesystems" "xdg-documents"
+assert_semicolon_list_contains "$filesystems" "!xdg-documents"
+assert_semicolon_list_contains "$filesystems" "xdg-desktop/foo:create"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo:create"
+assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
 ok "override --filesystem"
 

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -187,6 +187,20 @@ assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
+# --filesystem=...:bar => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --filesystem=/foo:bar org.test.Hello 2>log || e=$?
+assert_file_has_content log "Unexpected filesystem suffix bar, ignoring"
+assert_streq "$e" 0
+
+# --nofilesystem=...:bar => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --nofilesystem=/foo:bar org.test.Hello 2>log || e=$?
+assert_file_has_content log "Unexpected filesystem suffix bar, ignoring"
+assert_streq "$e" 0
+
 ok "override --filesystem"
 
 reset_overrides


### PR DESCRIPTION
This is an enabler for the extra test coverage in #4678.

* test-override: Assert that only the expected term is negated
    
    We weren't distinguishing here between overrides that should have been
    negated (xdg-documents) and overrides that should not have been negated
    (everything else).

* test-override: Assert that unimplemented suffix is ignored with a warning