### PR TITLE
run: Avoid execve() when measuring test coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -210,7 +210,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS =		\
 
 coverage:
 	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) lcov-clean
-	$(AM_V_GEN) $(MAKE) check
+	$(AM_V_GEN) FLATPAK_TEST_COVERAGE=1 $(MAKE) check
 	$(AM_V_GEN) $(MAKE) $(AM_MAKEFLAGS) genlcov
 
 lcov-clean:


### PR DESCRIPTION
Normally, we want to save a process and get better signal handling
by replacing the `flatpak run` process with bubblewrap.

However, when we're doing profiling or measuring coverage, we want to
exit cleanly so that profiling data can be recorded, which is done in
an atexit() hook. In this situation, bypass the execve() optimization;
instead, start bubblewrap in the background, immediately wait for it,
and propagate its exit status.

---

This was useful when checking coverage for the new code in #4678.