### PR TITLE
flatpak-context: Properly flatten filesystem permissions

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1963,13 +1963,17 @@ flatpak_context_save_metadata (FlatpakContext *context,
                                         NULL, &value))
         {
           g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
-          g_ptr_array_add (array, g_strdup ("!host:reset"));
+          if (!flatten)
+            g_ptr_array_add (array, g_strdup ("!host:reset"));
         }
 
       g_hash_table_iter_init (&iter, context->filesystems);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
+
+          if (flatten && mode == FLATPAK_FILESYSTEM_MODE_NONE)
+            continue;
 
           /* We already did this */
           if (g_str_equal (key, "host-reset"))


### PR DESCRIPTION
When generating flattened permissions (i.e. for --show-permissions or
for the /.flatpak-info file) we're currently flattening the permissions
(i.e. don't show things that would only affect layering the permissions).

However, the code doesn't currently do this for the filesystem key, so
implement that.