### PR TITLE
Avoid using which(1)

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,8 +7,7 @@ test -n "$srcdir" || srcdir=.
 olddir=$(pwd)
 cd "$srcdir"
 
-AUTORECONF=$(which autoreconf)
-if test -z "$AUTORECONF"; then
+if ! command -v autoreconf >/dev/null; then
     echo "*** No autoreconf found, please install it ***"
     exit 1
 fi
@@ -25,8 +24,7 @@ fi
 sed -e 's,$(libglnx_srcpath),subprojects/libglnx,g' < subprojects/libglnx/Makefile-libglnx.am > subprojects/Makefile-libglnx.am.inc
 sed -e 's,$(bwrap_srcpath),subprojects/bubblewrap,g' < subprojects/bubblewrap/Makefile-bwrap.am > subprojects/Makefile-bwrap.am.inc
 
-GTKDOCIZE=$(which gtkdocize 2>/dev/null)
-if test -z "$GTKDOCIZE"; then
+if ! command -v gtkdocize >/dev/null; then
     echo "*** You don't have gtk-doc installed, and thus won't be able to generate the documentation. ***"
     rm -f gtk-doc.make
     cat > gtk-doc.make <<EOF

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -38,7 +38,7 @@ ln -s ../lib ${DIR}/usr/lib32
 if test -f /sbin/ldconfig.real; then
     cp /sbin/ldconfig.real ${DIR}/usr/bin/ldconfig
 else
-    cp `which ldconfig` ${DIR}/usr/bin
+    cp "$(type -P ldconfig)" "${DIR}/usr/bin"
 fi
 LIBS=`mktemp`
 BINS=`mktemp`
@@ -64,8 +64,8 @@ add_bin() {
 }
 
 for i in $@ bash ls cat echo readlink socat; do
-    I=`which $i`
-    add_bin $I
+    I=$(type -P "$i")
+    add_bin "$I"
 done
 for i in `cat $BINS`; do
     #echo Adding binary $i 1>&2

--- a/triggers/desktop-database.trigger
+++ b/triggers/desktop-database.trigger
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if test \( -x "$(which update-desktop-database 2>/dev/null)" \) -a \( -d $1/exports/share/applications \); then
-    exec update-desktop-database -q $1/exports/share/applications
+if test \( -x "$(which update-desktop-database 2>/dev/null)" \) -a \( -d "$1/exports/share/applications" \); then
+    exec update-desktop-database -q "$1/exports/share/applications"
 fi

--- a/triggers/desktop-database.trigger
+++ b/triggers/desktop-database.trigger
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if test \( -x "$(which update-desktop-database 2>/dev/null)" \) -a \( -d "$1/exports/share/applications" \); then
+if command -v update-desktop-database >/dev/null && test -d "$1/exports/share/applications"; then
     exec update-desktop-database -q "$1/exports/share/applications"
 fi

--- a/triggers/gtk-icon-cache.trigger
+++ b/triggers/gtk-icon-cache.trigger
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-if test \( -x "$(which gtk-update-icon-cache 2>/dev/null)" \) -a \( -d $1/exports/share/icons/hicolor \); then
-    cp /usr/share/icons/hicolor/index.theme $1/exports/share/icons/hicolor/
-    for dir in $1/exports/share/icons/*; do
-        if test -f $dir/index.theme; then
-            if ! gtk-update-icon-cache --quiet $dir; then
+if test \( -x "$(which gtk-update-icon-cache 2>/dev/null)" \) -a \( -d "$1/exports/share/icons/hicolor" \); then
+    cp /usr/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
+    for dir in "$1"/exports/share/icons/*; do
+        if test -f "$dir/index.theme"; then
+            if ! gtk-update-icon-cache --quiet "$dir"; then
                 echo "Failed to run gtk-update-icon-cache for $dir"
                 exit 1
             fi

--- a/triggers/gtk-icon-cache.trigger
+++ b/triggers/gtk-icon-cache.trigger
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if test \( -x "$(which gtk-update-icon-cache 2>/dev/null)" \) -a \( -d "$1/exports/share/icons/hicolor" \); then
+if command -v gtk-update-icon-cache >/dev/null && test -d "$1/exports/share/icons/hicolor"; then
     cp /usr/share/icons/hicolor/index.theme "$1/exports/share/icons/hicolor/"
     for dir in "$1"/exports/share/icons/*; do
         if test -f "$dir/index.theme"; then

--- a/triggers/mime-database.trigger
+++ b/triggers/mime-database.trigger
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if test \( -x "$(which update-mime-database 2>/dev/null)" \) -a \( -d $1/exports/share/mime/packages \); then
-    exec update-mime-database $1/exports/share/mime
+if test \( -x "$(which update-mime-database 2>/dev/null)" \) -a \( -d "$1/exports/share/mime/packages" \); then
+    exec update-mime-database "$1/exports/share/mime"
 fi

--- a/triggers/mime-database.trigger
+++ b/triggers/mime-database.trigger
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if test \( -x "$(which update-mime-database 2>/dev/null)" \) -a \( -d "$1/exports/share/mime/packages" \); then
+if command -v update-mime-database >/dev/null && test -d "$1/exports/share/mime/packages"; then
     exec update-mime-database "$1/exports/share/mime"
 fi


### PR DESCRIPTION
which(1) is not standardized by POSIX, has different implementations and behaviour on different distributions, and isn't a shell builtin. Replace it with `command -v` and `type -P` as appropriate.

* autogen.sh: Use command -v to check whether commands exist
    
    which(1) is not standardized by POSIX, and has different implementations
    and behaviour on different distributions. The behaviour and exit status
    of command -v is standardized by POSIX.

* triggers: Quote more defensively
    
    In the unlikely event that one of these paths contains spaces or other
    special characters, we don't want to field splitting to take place.

* triggers: Use command -v in preference to which
    
    which(1) is not standardized by POSIX, and has different implementations
    and behaviour on different distributions. The behaviour and exit status
    of command -v is standardized by POSIX, and in particular, checking its
    exit status is an appropriate way to ask: if I called this command,
    would it be found?

* tests: Use type -P in preference to which
    
    which(1) is neither standardized by POSIX nor built-in to bash, and has
    different implementations and behaviour on different distributions.
    command -v is standardized by POSIX, but it won't return the path to an
    executable if the same command is available as a shell builtin, so it
    isn't necessarily suitable here either.
    
    The Flatpak test suite uses bash scripts rather than POSIX shell scripts,
    so we can safely make use of bash-specific options for builtins, and
    in particular type -P, which has the semantics we want here: search PATH,
    even if there is a shell builtin of the same name.