### PR TITLE
[flatpak-1.8.x] Backport CVE-2021-43860 and CVE-2022-21682 fixes

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -83,6 +83,7 @@ extern const char *flatpak_context_features[];
 extern const char *flatpak_context_shares[];
 
 gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                                 gboolean                negated,
                                                  char                  **filesystem_out,
                                                  FlatpakFilesystemMode  *mode_out,
                                                  GError                **error);

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -82,6 +82,11 @@ extern const char *flatpak_context_devices[];
 extern const char *flatpak_context_features[];
 extern const char *flatpak_context_shares[];
 
+gboolean       flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                                 char                  **filesystem_out,
+                                                 FlatpakFilesystemMode  *mode_out,
+                                                 GError                **error);
+
 FlatpakContext *flatpak_context_new (void);
 void           flatpak_context_free (FlatpakContext *context);
 void           flatpak_context_merge (FlatpakContext *context,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -752,7 +752,7 @@ parse_filesystem_flags (const char            *filesystem,
   return g_string_free (g_steal_pointer (&s), FALSE);
 }
 
-static gboolean
+gboolean
 flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
                                   char                  **filesystem_out,
                                   FlatpakFilesystemMode  *mode_out,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -701,6 +701,10 @@ unparse_filesystem_flags (const char           *path,
     case FLATPAK_FILESYSTEM_MODE_READ_WRITE:
       break;
 
+    case FLATPAK_FILESYSTEM_MODE_NONE:
+      g_string_insert_c (s, 0, '!');
+      break;
+
     default:
       g_warning ("Unexpected filesystem mode %d", mode);
       break;
@@ -1781,10 +1785,7 @@ flatpak_context_save_metadata (FlatpakContext *context,
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-          if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
-            g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
-          else
-            g_ptr_array_add (array, g_strconcat ("!", key, NULL));
+          g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
         }
 
       g_key_file_set_string_list (metakey,

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -86,6 +86,7 @@ const char *flatpak_context_special_filesystems[] = {
   "host",
   "host-etc",
   "host-os",
+  "host-reset",
   NULL
 };
 
@@ -703,6 +704,12 @@ unparse_filesystem_flags (const char           *path,
 
     case FLATPAK_FILESYSTEM_MODE_NONE:
       g_string_insert_c (s, 0, '!');
+
+      if (g_str_has_suffix (s->str, "-reset"))
+        {
+          g_string_truncate (s, s->len - 6);
+          g_string_append (s, ":reset");
+        }
       break;
 
     default:
@@ -715,11 +722,14 @@ unparse_filesystem_flags (const char           *path,
 
 static char *
 parse_filesystem_flags (const char            *filesystem,
-                        FlatpakFilesystemMode *mode_out)
+                        gboolean               negated,
+                        FlatpakFilesystemMode *mode_out,
+                        GError               **error)
 {
   g_autoptr(GString) s = g_string_new ("");
   const char *p, *suffix;
   FlatpakFilesystemMode mode;
+  gboolean reset = FALSE;
 
   p = filesystem;
   while (*p != 0 && *p != ':')
@@ -734,7 +744,31 @@ parse_filesystem_flags (const char            *filesystem,
         g_string_append_c (s, *p++);
     }
 
-  mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
+  if (negated)
+    mode = FLATPAK_FILESYSTEM_MODE_NONE;
+  else
+    mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
+
+  if (g_str_equal (s->str, "host-reset"))
+    {
+      reset = TRUE;
+
+      if (!negated)
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                       "Filesystem token \"%s\" is only applicable for --nofilesystem",
+                       s->str);
+          return NULL;
+        }
+
+      if (*p != '\0')
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                       "Filesystem token \"%s\" cannot be used with a suffix",
+                       s->str);
+          return NULL;
+        }
+    }
 
   if (*p == ':')
     {
@@ -746,9 +780,62 @@ parse_filesystem_flags (const char            *filesystem,
         mode = FLATPAK_FILESYSTEM_MODE_READ_WRITE;
       else if (strcmp (suffix, "create") == 0)
         mode = FLATPAK_FILESYSTEM_MODE_CREATE;
+      else if (strcmp (suffix, "reset") == 0)
+        reset = TRUE;
       else if (*suffix != 0)
         g_warning ("Unexpected filesystem suffix %s, ignoring", suffix);
+
+      if (negated && mode != FLATPAK_FILESYSTEM_MODE_NONE)
+        {
+          g_warning ("Filesystem suffix \"%s\" is not applicable for --nofilesystem",
+                     suffix);
+          mode = FLATPAK_FILESYSTEM_MODE_NONE;
+        }
+
+      if (reset)
+        {
+          if (!negated)
+            {
+              g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                           "Filesystem suffix \"%s\" only applies to --nofilesystem",
+                           suffix);
+              return NULL;
+            }
+
+          if (!g_str_equal (s->str, "host"))
+            {
+              g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                           "Filesystem suffix \"%s\" can only be applied to "
+                           "--nofilesystem=host",
+                           suffix);
+              return NULL;
+            }
+
+          /* We internally handle host:reset (etc) as host-reset, only exposing it as a flag in the public
+             part to allow it to be ignored (with a warning) for old flatpak versions */
+          g_string_append (s, "-reset");
+        }
     }
+
+  /* Postcondition check: the code above should make some results
+   * impossible */
+  if (negated)
+    {
+      g_assert (mode == FLATPAK_FILESYSTEM_MODE_NONE);
+    }
+  else
+    {
+      g_assert (mode > FLATPAK_FILESYSTEM_MODE_NONE);
+      /* This flag is only applicable to --nofilesystem */
+      g_assert (!reset);
+    }
+
+  /* Postcondition check: filesystem token is host-reset iff reset flag
+   * was found */
+  if (reset)
+    g_assert (g_str_equal (s->str, "host-reset"));
+  else
+    g_assert (!g_str_equal (s->str, "host-reset"));
 
   if (mode_out)
     *mode_out = mode;
@@ -758,12 +845,17 @@ parse_filesystem_flags (const char            *filesystem,
 
 gboolean
 flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                  gboolean                negated,
                                   char                  **filesystem_out,
                                   FlatpakFilesystemMode  *mode_out,
                                   GError                **error)
 {
-  g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, mode_out);
+  g_autofree char *filesystem = NULL;
   char *slash;
+
+  filesystem = parse_filesystem_flags (filesystem_and_mode, negated, mode_out, error);
+  if (filesystem == NULL)
+    return FALSE;
 
   slash = strchr (filesystem, '/');
 
@@ -856,6 +948,14 @@ flatpak_context_take_filesystem (FlatpakContext        *context,
                                  char                  *fs,
                                  FlatpakFilesystemMode  mode)
 {
+  /* Special case: --nofilesystem=host-reset implies --nofilesystem=host.
+   * --filesystem=host-reset (or host:reset) is not allowed. */
+  if (g_str_equal (fs, "host-reset"))
+    {
+      g_return_if_fail (mode == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_hash_table_insert (context->filesystems, g_strdup ("host"), GINT_TO_POINTER (mode));
+    }
+
   g_hash_table_insert (context->filesystems, fs, GINT_TO_POINTER (mode));
 }
 
@@ -887,6 +987,14 @@ flatpak_context_merge (FlatpakContext *context,
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->persistent, g_strdup (key), value);
 
+  /* We first handle host:reset, as it overrides all other keys from the parent */
+  if (g_hash_table_lookup_extended (other->filesystems, "host-reset", NULL, &value))
+    {
+      g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_hash_table_remove_all (context->filesystems);
+    }
+
+  /* Then set the new ones, which includes propagating host:reset. */
   g_hash_table_iter_init (&iter, other->filesystems);
   while (g_hash_table_iter_next (&iter, &key, &value))
     g_hash_table_insert (context->filesystems, g_strdup (key), value);
@@ -1074,7 +1182,7 @@ option_filesystem_cb (const gchar *option_name,
   g_autofree char *fs = NULL;
   FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
+  if (!flatpak_context_parse_filesystem (value, FALSE, &fs, &mode, error))
     return FALSE;
 
   flatpak_context_take_filesystem (context, g_steal_pointer (&fs), mode);
@@ -1091,7 +1199,7 @@ option_nofilesystem_cb (const gchar *option_name,
   g_autofree char *fs = NULL;
   FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
+  if (!flatpak_context_parse_filesystem (value, TRUE, &fs, &mode, error))
     return FALSE;
 
   flatpak_context_take_filesystem (context, g_steal_pointer (&fs),
@@ -1551,15 +1659,13 @@ flatpak_context_load_metadata (FlatpakContext *context,
           g_autofree char *filesystem = NULL;
           FlatpakFilesystemMode mode;
 
-          if (!flatpak_context_parse_filesystem (fs, &filesystem, &mode, NULL))
+          if (!flatpak_context_parse_filesystem (fs, remove,
+                                                 &filesystem, &mode, NULL))
             g_debug ("Unknown filesystem type %s", filesystems[i]);
           else
             {
-              if (remove)
-                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem),
-                                                 FLATPAK_FILESYSTEM_MODE_NONE);
-              else
-                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
+              g_assert (mode == FLATPAK_FILESYSTEM_MODE_NONE || !remove);
+              flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
             }
         }
     }
@@ -1780,10 +1886,23 @@ flatpak_context_save_metadata (FlatpakContext *context,
     {
       g_autoptr(GPtrArray) array = g_ptr_array_new_with_free_func (g_free);
 
+      /* Serialize host-reset first, because order can matter in
+       * corner cases. */
+      if (g_hash_table_lookup_extended (context->filesystems, "host-reset",
+                                        NULL, &value))
+        {
+          g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+          g_ptr_array_add (array, g_strdup ("!host:reset"));
+        }
+
       g_hash_table_iter_init (&iter, context->filesystems);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
+
+          /* We already did this */
+          if (g_str_equal (key, "host-reset"))
+            continue;
 
           g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
         }
@@ -1895,7 +2014,8 @@ flatpak_context_save_metadata (FlatpakContext *context,
 void
 flatpak_context_allow_host_fs (FlatpakContext *context)
 {
-  flatpak_context_take_filesystem (context, g_strdup ("host"), FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  flatpak_context_take_filesystem (context, g_strdup ("host"),
+                                   FLATPAK_FILESYSTEM_MODE_READ_WRITE);
 }
 
 gboolean
@@ -2077,18 +2197,36 @@ flatpak_context_to_args (FlatpakContext *context,
       g_ptr_array_add (args, g_strdup_printf ("--system-%s-name=%s", flatpak_policy_to_string (policy), name));
     }
 
+  /* Serialize host-reset first, because order can matter in
+   * corner cases. */
+  if (g_hash_table_lookup_extended (context->filesystems, "host-reset",
+                                    NULL, &value))
+    {
+      g_warn_if_fail (GPOINTER_TO_INT (value) == FLATPAK_FILESYSTEM_MODE_NONE);
+      g_ptr_array_add (args, g_strdup ("--nofilesystem=host:reset"));
+    }
+
   g_hash_table_iter_init (&iter, context->filesystems);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
+      g_autofree char *fs = NULL;
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
+
+      /* We already did this */
+      if (g_str_equal (key, "host-reset"))
+        continue;
+
+      fs = unparse_filesystem_flags (key, mode);
 
       if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
         {
-          g_autofree char *fs = unparse_filesystem_flags (key, mode);
           g_ptr_array_add (args, g_strdup_printf ("--filesystem=%s", fs));
         }
       else
-        g_ptr_array_add (args, g_strdup_printf ("--nofilesystem=%s", (char *) key));
+        {
+          g_assert (fs[0] == '!');
+          g_ptr_array_add (args, g_strdup_printf ("--nofilesystem=%s", &fs[1]));
+        }
     }
 }
 

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -826,6 +826,22 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
       return TRUE;
     }
 
+  if (strcmp (filesystem, "~") == 0)
+    {
+      if (filesystem_out != NULL)
+        *filesystem_out = g_strdup ("home");
+
+      return TRUE;
+    }
+
+  if (g_str_has_prefix (filesystem, "home/"))
+    {
+      if (filesystem_out != NULL)
+        *filesystem_out = g_strconcat ("~/", filesystem + 5, NULL);
+
+      return TRUE;
+    }
+
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
                _("Unknown filesystem location %s, valid locations are: host, host-os, host-etc, home, xdg-*[/…], ~/dir, /dir"), filesystem);
   return FALSE;

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -802,6 +802,17 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
           else
             break;
         }
+
+      if (filesystem[0] == '/' && filesystem[1] == '\0')
+        {
+          /* We don't allow --filesystem=/ as equivalent to host, because
+           * it doesn't do what you'd think: --filesystem=host mounts some
+           * host directories in /run/host, not in the root. */
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                       _("--filesystem=/ is not available, "
+                         "use --filesystem=host for a similar result"));
+          return FALSE;
+        }
     }
 
   if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -759,6 +759,50 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
                                   GError                **error)
 {
   g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, mode_out);
+  char *slash;
+
+  slash = strchr (filesystem, '/');
+
+  /* Forbid /../ in paths */
+  if (slash != NULL)
+    {
+      if (g_str_has_prefix (slash + 1, "../") ||
+          g_str_has_suffix (slash + 1, "/..") ||
+          strstr (slash + 1, "/../") != NULL)
+        {
+          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                       _("Filesystem location \"%s\" contains \"..\""),
+                       filesystem);
+          return FALSE;
+        }
+
+      /* Convert "//" and "/./" to "/" */
+      for (; slash != NULL; slash = strchr (slash + 1, '/'))
+        {
+          while (TRUE)
+            {
+              if (slash[1] == '/')
+                memmove (slash + 1, slash + 2, strlen (slash + 2) + 1);
+              else if (slash[1] == '.' && slash[2] == '/')
+                memmove (slash + 1, slash + 3, strlen (slash + 3) + 1);
+              else
+                break;
+            }
+        }
+
+      /* Eliminate trailing "/." or "/". */
+      while (TRUE)
+        {
+          slash = strrchr (filesystem, '/');
+
+          if (slash != NULL &&
+              ((slash != filesystem && slash[1] == '\0') ||
+               (slash[1] == '.' && slash[2] == '\0')))
+            *slash = '\0';
+          else
+            break;
+        }
+    }
 
   if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||
       get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL) ||

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -97,6 +97,7 @@ flatpak_context_new (void)
   context = g_slice_new0 (FlatpakContext);
   context->env_vars = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   context->persistent = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  /* filename or special filesystem name => FlatpakFilesystemMode */
   context->filesystems = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   context->session_bus_policy = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   context->system_bus_policy = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
@@ -752,19 +753,23 @@ parse_filesystem_flags (const char            *filesystem,
 }
 
 static gboolean
-flatpak_context_verify_filesystem (const char *filesystem_and_mode,
-                                   GError    **error)
+flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
+                                  char                  **filesystem_out,
+                                  FlatpakFilesystemMode  *mode_out,
+                                  GError                **error)
 {
-  g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, NULL);
+  g_autofree char *filesystem = parse_filesystem_flags (filesystem_and_mode, mode_out);
 
-  if (g_strv_contains (flatpak_context_special_filesystems, filesystem))
-    return TRUE;
-  if (get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL))
-    return TRUE;
-  if (g_str_has_prefix (filesystem, "~/"))
-    return TRUE;
-  if (g_str_has_prefix (filesystem, "/"))
-    return TRUE;
+  if (g_strv_contains (flatpak_context_special_filesystems, filesystem) ||
+      get_xdg_user_dir_from_string (filesystem, NULL, NULL, NULL) ||
+      g_str_has_prefix (filesystem, "~/") ||
+      g_str_has_prefix (filesystem, "/"))
+    {
+      if (filesystem_out != NULL)
+        *filesystem_out = g_steal_pointer (&filesystem);
+
+      return TRUE;
+    }
 
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
                _("Unknown filesystem location %s, valid locations are: host, host-os, host-etc, home, xdg-*[/…], ~/dir, /dir"), filesystem);
@@ -772,22 +777,11 @@ flatpak_context_verify_filesystem (const char *filesystem_and_mode,
 }
 
 static void
-flatpak_context_add_filesystem (FlatpakContext *context,
-                                const char     *what)
+flatpak_context_take_filesystem (FlatpakContext        *context,
+                                 char                  *fs,
+                                 FlatpakFilesystemMode  mode)
 {
-  FlatpakFilesystemMode mode;
-  char *fs = parse_filesystem_flags (what, &mode);
-
   g_hash_table_insert (context->filesystems, fs, GINT_TO_POINTER (mode));
-}
-
-static void
-flatpak_context_remove_filesystem (FlatpakContext *context,
-                                   const char     *what)
-{
-  g_hash_table_insert (context->filesystems,
-                       parse_filesystem_flags (what, NULL),
-                       NULL);
 }
 
 void
@@ -1002,11 +996,13 @@ option_filesystem_cb (const gchar *option_name,
                       GError     **error)
 {
   FlatpakContext *context = data;
+  g_autofree char *fs = NULL;
+  FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_verify_filesystem (value, error))
+  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
     return FALSE;
 
-  flatpak_context_add_filesystem (context, value);
+  flatpak_context_take_filesystem (context, g_steal_pointer (&fs), mode);
   return TRUE;
 }
 
@@ -1017,11 +1013,14 @@ option_nofilesystem_cb (const gchar *option_name,
                         GError     **error)
 {
   FlatpakContext *context = data;
+  g_autofree char *fs = NULL;
+  FlatpakFilesystemMode mode;
 
-  if (!flatpak_context_verify_filesystem (value, error))
+  if (!flatpak_context_parse_filesystem (value, &fs, &mode, error))
     return FALSE;
 
-  flatpak_context_remove_filesystem (context, value);
+  flatpak_context_take_filesystem (context, g_steal_pointer (&fs),
+                                   FLATPAK_FILESYSTEM_MODE_NONE);
   return TRUE;
 }
 
@@ -1474,14 +1473,18 @@ flatpak_context_load_metadata (FlatpakContext *context,
       for (i = 0; filesystems[i] != NULL; i++)
         {
           const char *fs = parse_negated (filesystems[i], &remove);
-          if (!flatpak_context_verify_filesystem (fs, NULL))
+          g_autofree char *filesystem = NULL;
+          FlatpakFilesystemMode mode;
+
+          if (!flatpak_context_parse_filesystem (fs, &filesystem, &mode, NULL))
             g_debug ("Unknown filesystem type %s", filesystems[i]);
           else
             {
               if (remove)
-                flatpak_context_remove_filesystem (context, fs);
+                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem),
+                                                 FLATPAK_FILESYSTEM_MODE_NONE);
               else
-                flatpak_context_add_filesystem (context, fs);
+                flatpak_context_take_filesystem (context, g_steal_pointer (&filesystem), mode);
             }
         }
     }
@@ -1707,7 +1710,7 @@ flatpak_context_save_metadata (FlatpakContext *context,
         {
           FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-          if (mode != 0)
+          if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
             g_ptr_array_add (array, unparse_filesystem_flags (key, mode));
           else
             g_ptr_array_add (array, g_strconcat ("!", key, NULL));
@@ -1820,7 +1823,7 @@ flatpak_context_save_metadata (FlatpakContext *context,
 void
 flatpak_context_allow_host_fs (FlatpakContext *context)
 {
-  flatpak_context_add_filesystem (context, "host");
+  flatpak_context_take_filesystem (context, g_strdup ("host"), FLATPAK_FILESYSTEM_MODE_READ_WRITE);
 }
 
 gboolean
@@ -2007,7 +2010,7 @@ flatpak_context_to_args (FlatpakContext *context,
     {
       FlatpakFilesystemMode mode = GPOINTER_TO_INT (value);
 
-      if (mode != 0)
+      if (mode != FLATPAK_FILESYSTEM_MODE_NONE)
         {
           g_autofree char *fs = unparse_filesystem_flags (key, mode);
           g_ptr_array_add (args, g_strdup_printf ("--filesystem=%s", fs));
@@ -2126,7 +2129,7 @@ flatpak_context_export (FlatpakContext *context,
   gpointer key, value;
 
   fs_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host");
-  if (fs_mode != 0)
+  if (fs_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       DIR *dir;
       struct dirent *dirent;
@@ -2156,17 +2159,17 @@ flatpak_context_export (FlatpakContext *context,
   os_mode = MAX ((FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host-os"),
                    fs_mode);
 
-  if (os_mode != 0)
+  if (os_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_host_os_expose (exports, os_mode);
 
   etc_mode = MAX ((FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "host-etc"),
                    fs_mode);
 
-  if (etc_mode != 0)
+  if (etc_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_host_etc_expose (exports, etc_mode);
 
   home_mode = (FlatpakFilesystemMode) g_hash_table_lookup (context->filesystems, "home");
-  if (home_mode != 0)
+  if (home_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       g_debug ("Allowing homedir access");
       home_access = TRUE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8902,6 +8902,13 @@ flatpak_dir_ensure_bundle_remote (FlatpakDir   *self,
   if (metadata == NULL)
     return NULL;
 
+  /* If we rely on metadata (to e.g. print permissions), check it exists before creating the remote */
+  if (out_metadata && fp_metadata == NULL)
+    {
+      flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, "No metadata in bundler header");
+      return NULL;
+    }
+
   gpg_data = extra_gpg_data ? extra_gpg_data : included_gpg_data;
 
   parts = flatpak_decompose_ref (ref, error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1559,19 +1559,29 @@ static gboolean
 validate_commit_metadata (GVariant   *commit_data,
                           const char *ref,
                           const char *required_metadata,
+                          gsize       required_metadata_size,
                           gboolean   require_xa_metadata,
                           GError   **error)
 {
   g_autoptr(GVariant) commit_metadata = NULL;
+  g_autoptr(GVariant) xa_metadata_v = NULL;
   const char *xa_metadata = NULL;
+  gsize xa_metadata_size = 0;
 
   commit_metadata = g_variant_get_child_value (commit_data, 0);
 
   if (commit_metadata != NULL)
-    g_variant_lookup (commit_metadata, "xa.metadata", "&s", &xa_metadata);
+    {
+      xa_metadata_v = g_variant_lookup_value (commit_metadata,
+                                              "xa.metadata",
+                                              G_VARIANT_TYPE_STRING);
+      if (xa_metadata_v)
+        xa_metadata = g_variant_get_string (xa_metadata_v, &xa_metadata_size);
+    }
 
   if ((xa_metadata == NULL && require_xa_metadata) ||
-      (xa_metadata != NULL && g_strcmp0 (required_metadata, xa_metadata) != 0))
+      (xa_metadata != NULL && (xa_metadata_size != required_metadata_size ||
+                               memcmp (xa_metadata, required_metadata, xa_metadata_size) != 0)))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
                    _("Commit metadata for %s not matching expected metadata"), ref);
@@ -5449,8 +5459,13 @@ flatpak_dir_pull (FlatpakDir                           *self,
     {
       g_autoptr(GVariant) commit_data = NULL;
       if (!ostree_repo_load_commit (repo, rev, &commit_data, NULL, error) ||
-          !validate_commit_metadata (commit_data, ref, (const char *)g_bytes_get_data (require_metadata, NULL), TRUE, error))
-        return FALSE;
+          !validate_commit_metadata (commit_data,
+                                     ref,
+                                     (const char *)g_bytes_get_data (require_metadata, NULL),
+                                     g_bytes_get_size (require_metadata),
+                                     TRUE,
+                                     error))
+        goto out;
     }
 
   if (!flatpak_dir_pull_extra_data (self, repo,
@@ -7677,6 +7692,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autofree char *metadata_contents = NULL;
   g_auto(GStrv) ref_parts = NULL;
   gboolean is_app;
+  gsize metadata_size = 0;
   gboolean is_oci;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
@@ -7920,11 +7936,12 @@ flatpak_dir_deploy (FlatpakDir          *self,
   keyfile = g_key_file_new ();
   metadata_file = g_file_resolve_relative_path (checkoutdir, "metadata");
   if (g_file_load_contents (metadata_file, NULL,
-                            &metadata_contents, NULL, NULL, NULL))
+                            &metadata_contents,
+                            &metadata_size, NULL, NULL))
     {
       if (!g_key_file_load_from_data (keyfile,
                                       metadata_contents,
-                                      -1,
+                                      metadata_size,
                                       0, error))
         return FALSE;
 
@@ -7939,7 +7956,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
    * since this was lacking in fedora builds.
    */
   is_oci = flatpak_dir_get_remote_oci (self, origin);
-  if (!validate_commit_metadata (commit_data, ref, metadata_contents, !is_oci, error))
+  if (!validate_commit_metadata (commit_data, ref, metadata_contents, metadata_size, !is_oci, error))
     return FALSE;
 
   dotref = g_file_resolve_relative_path (checkoutdir, "files/.ref");

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1560,7 +1560,6 @@ validate_commit_metadata (GVariant   *commit_data,
                           const char *ref,
                           const char *required_metadata,
                           gsize       required_metadata_size,
-                          gboolean   require_xa_metadata,
                           GError   **error)
 {
   g_autoptr(GVariant) commit_metadata = NULL;
@@ -1579,9 +1578,9 @@ validate_commit_metadata (GVariant   *commit_data,
         xa_metadata = g_variant_get_string (xa_metadata_v, &xa_metadata_size);
     }
 
-  if ((xa_metadata == NULL && require_xa_metadata) ||
-      (xa_metadata != NULL && (xa_metadata_size != required_metadata_size ||
-                               memcmp (xa_metadata, required_metadata, xa_metadata_size) != 0)))
+  if (xa_metadata == NULL ||
+      xa_metadata_size != required_metadata_size ||
+      memcmp (xa_metadata, required_metadata, xa_metadata_size) != 0)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
                    _("Commit metadata for %s not matching expected metadata"), ref);
@@ -5463,7 +5462,6 @@ flatpak_dir_pull (FlatpakDir                           *self,
                                      ref,
                                      (const char *)g_bytes_get_data (require_metadata, NULL),
                                      g_bytes_get_size (require_metadata),
-                                     TRUE,
                                      error))
         goto out;
     }
@@ -7693,7 +7691,6 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_auto(GStrv) ref_parts = NULL;
   gboolean is_app;
   gsize metadata_size = 0;
-  gboolean is_oci;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -7952,11 +7949,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
   /* Check the metadata in the commit to make sure it matches the actual
    * deployed metadata, in case we relied on the one in the commit for
    * a decision
-   * Note: For historical reason we don't enforce commits to contain xa.metadata
-   * since this was lacking in fedora builds.
    */
-  is_oci = flatpak_dir_get_remote_oci (self, origin);
-  if (!validate_commit_metadata (commit_data, ref, metadata_contents, metadata_size, !is_oci, error))
+  if (!validate_commit_metadata (commit_data, ref, metadata_contents, metadata_size, error))
     return FALSE;
 
   dotref = g_file_resolve_relative_path (checkoutdir, "files/.ref");

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -30,6 +30,7 @@ typedef enum {
   FLATPAK_FILESYSTEM_MODE_READ_ONLY    = 1,
   FLATPAK_FILESYSTEM_MODE_READ_WRITE   = 2,
   FLATPAK_FILESYSTEM_MODE_CREATE       = 3,
+  FLATPAK_FILESYSTEM_MODE_LAST         = FLATPAK_FILESYSTEM_MODE_CREATE
 } FlatpakFilesystemMode;
 
 typedef struct _FlatpakExports FlatpakExports;

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -26,6 +26,7 @@
 
 /* In numerical order of more privs */
 typedef enum {
+  FLATPAK_FILESYSTEM_MODE_NONE         = 0,
   FLATPAK_FILESYSTEM_MODE_READ_ONLY    = 1,
   FLATPAK_FILESYSTEM_MODE_READ_WRITE   = 2,
   FLATPAK_FILESYSTEM_MODE_CREATE       = 3,

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -82,7 +82,7 @@ make_relative (const char *base, const char *path)
 }
 
 #define FAKE_MODE_DIR -1 /* Ensure a dir, either on tmpfs or mapped parent */
-#define FAKE_MODE_TMPFS 0
+#define FAKE_MODE_TMPFS FLATPAK_FILESYSTEM_MODE_NONE
 #define FAKE_MODE_SYMLINK G_MAXINT
 
 typedef struct
@@ -301,7 +301,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
         }
     }
 
-  if (exports->host_os != 0)
+  if (exports->host_os != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       const char *os_bind_mode = "--bind";
       int i;
@@ -355,7 +355,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
             }
         }
 
-      if (exports->host_etc == 0)
+      if (exports->host_etc == FLATPAK_FILESYSTEM_MODE_NONE)
         {
           guint i;
 
@@ -383,7 +383,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
         }
     }
 
-  if (exports->host_etc != 0)
+  if (exports->host_etc != FLATPAK_FILESYSTEM_MODE_NONE)
     {
       const char *etc_bind_mode = "--bind";
 
@@ -396,7 +396,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
     }
 }
 
-/* Returns 0 if not visible */
+/* Returns FLATPAK_FILESYSTEM_MODE_NONE if not visible */
 FlatpakFilesystemMode
 flatpak_exports_path_get_mode (FlatpakExports *exports,
                                const char     *path)
@@ -441,7 +441,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
                   break;
                 }
 
-              return 0;
+              return FLATPAK_FILESYSTEM_MODE_NONE;
             }
 
           if (S_ISLNK (st.st_mode))
@@ -451,7 +451,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
               int j;
 
               if (resolved == NULL)
-                return 0;
+                return FLATPAK_FILESYSTEM_MODE_NONE;
 
               path2_builder = g_string_new (resolved);
 
@@ -465,7 +465,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
             }
         }
       else if (parts[i + 1] == NULL)
-        return 0; /* Last part was not mapped */
+        return FLATPAK_FILESYSTEM_MODE_NONE; /* Last part was not mapped */
     }
 
   if (is_readonly)
@@ -478,7 +478,7 @@ gboolean
 flatpak_exports_path_is_visible (FlatpakExports *exports,
                                  const char     *path)
 {
-  return flatpak_exports_path_get_mode (exports, path) > 0;
+  return flatpak_exports_path_get_mode (exports, path) > FLATPAK_FILESYSTEM_MODE_NONE;
 }
 
 static gboolean
@@ -719,7 +719,7 @@ flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode,
                                          const char           *path)
 {
-  if (mode == 0)
+  if (mode == FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_path_tmpfs (exports, path);
   else
     flatpak_exports_add_path_expose (exports, mode, path);

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -85,6 +85,15 @@ make_relative (const char *base, const char *path)
 #define FAKE_MODE_TMPFS FLATPAK_FILESYSTEM_MODE_NONE
 #define FAKE_MODE_SYMLINK G_MAXINT
 
+static inline gboolean
+is_export_mode (int mode)
+{
+  return ((mode >= FLATPAK_FILESYSTEM_MODE_NONE
+           && mode <= FLATPAK_FILESYSTEM_MODE_LAST)
+          || mode == FAKE_MODE_DIR
+          || mode == FAKE_MODE_SYMLINK);
+}
+
 typedef struct
 {
   char *path;
@@ -138,6 +147,8 @@ path_parent_is_mapped (const char **keys,
       const char *mounted_path = keys[i];
       ExportedPath *ep = g_hash_table_lookup (hash_table, mounted_path);
 
+      g_assert (is_export_mode (ep->mode));
+
       if (flatpak_has_path_prefix (path, mounted_path) &&
           (strcmp (path, mounted_path) != 0))
         {
@@ -168,6 +179,8 @@ path_is_mapped (const char **keys,
     {
       const char *mounted_path = keys[i];
       ExportedPath *ep = g_hash_table_lookup (hash_table, mounted_path);
+
+      g_assert (is_export_mode (ep->mode));
 
       if (flatpak_has_path_prefix (path, mounted_path))
         {
@@ -262,6 +275,8 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
       ExportedPath *ep = l->data;
       const char *path = ep->path;
 
+      g_assert (is_export_mode (ep->mode));
+
       if (ep->mode == FAKE_MODE_SYMLINK)
         {
           if (!path_parent_is_mapped (keys, n_keys, exports->hash, path))
@@ -300,6 +315,9 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
                                   path, path, NULL);
         }
     }
+
+  g_assert (exports->host_os >= FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert (exports->host_os <= FLATPAK_FILESYSTEM_MODE_LAST);
 
   if (exports->host_os != FLATPAK_FILESYSTEM_MODE_NONE)
     {
@@ -382,6 +400,9 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
             }
         }
     }
+
+  g_assert (exports->host_etc >= FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert (exports->host_etc <= FLATPAK_FILESYSTEM_MODE_LAST);
 
   if (exports->host_etc != FLATPAK_FILESYSTEM_MODE_NONE)
     {
@@ -501,6 +522,8 @@ do_export_path (FlatpakExports *exports,
   ExportedPath *old_ep = g_hash_table_lookup (exports->hash, path);
   ExportedPath *ep;
 
+  g_return_if_fail (is_export_mode (mode));
+
   ep = g_new0 (ExportedPath, 1);
   ep->path = g_strdup (path);
 
@@ -595,6 +618,8 @@ _exports_path_expose (FlatpakExports *exports,
   char *slash;
   int i;
   glnx_autofd int o_path_fd = -1;
+
+  g_return_val_if_fail (is_export_mode (mode), FALSE);
 
   if (level > 40) /* 40 is the current kernel ELOOP check */
     {
@@ -704,6 +729,8 @@ flatpak_exports_add_path_expose (FlatpakExports       *exports,
                                  FlatpakFilesystemMode mode,
                                  const char           *path)
 {
+  g_return_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE);
+  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
   _exports_path_expose (exports, mode, path, 0);
 }
 
@@ -719,6 +746,9 @@ flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode,
                                          const char           *path)
 {
+  g_return_if_fail (mode >= FLATPAK_FILESYSTEM_MODE_NONE);
+  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
+
   if (mode == FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_path_tmpfs (exports, path);
   else
@@ -736,6 +766,9 @@ void
 flatpak_exports_add_host_etc_expose (FlatpakExports       *exports,
                                      FlatpakFilesystemMode mode)
 {
+  g_return_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE);
+  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
+
   exports->host_etc = mode;
 }
 
@@ -743,5 +776,8 @@ void
 flatpak_exports_add_host_os_expose (FlatpakExports       *exports,
                                     FlatpakFilesystemMode mode)
 {
+  g_return_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE);
+  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
+
   exports->host_os = mode;
 }

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2212,7 +2212,7 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
     return FALSE;
 
   if (external_metadata)
-    op->external_metadata = g_bytes_new (external_metadata, strlen (external_metadata) + 1);
+    op->external_metadata = g_bytes_new (external_metadata, strlen (external_metadata));
 
   return TRUE;
 }
@@ -2580,7 +2580,7 @@ load_deployed_metadata (FlatpakTransaction *self, const char *ref, char **out_co
       return NULL;
     }
 
-  return g_bytes_new_take (g_steal_pointer (&metadata_contents), metadata_contents_length + 1);
+  return g_bytes_new_take (g_steal_pointer (&metadata_contents), metadata_contents_length);
 }
 
 static void
@@ -2678,7 +2678,7 @@ resolve_op_from_commit (FlatpakTransaction *self,
   if (xa_metadata == NULL)
     g_message ("Warning: No xa.metadata in local commit %s ref %s", checksum, op->ref);
   else
-    metadata_bytes = g_bytes_new (xa_metadata, strlen (xa_metadata) + 1);
+    metadata_bytes = g_bytes_new (xa_metadata, strlen (xa_metadata));
 
   if (g_variant_lookup (commit_metadata, "xa.download-size", "t", &download_size))
     op->download_size = GUINT64_FROM_BE (download_size);
@@ -2717,7 +2717,7 @@ try_resolve_op_from_metadata (FlatpakTransaction *self,
                                           &download_size, &installed_size, &metadata, NULL))
       return FALSE;
 
-  metadata_bytes = g_bytes_new (metadata, strlen (metadata) + 1);
+  metadata_bytes = g_bytes_new (metadata, strlen (metadata));
 
   if (flatpak_remote_state_lookup_ref (state, op->ref, NULL, NULL, &info, NULL, NULL))
     op->summary_metadata = var_metadata_dup_to_gvariant (var_ref_info_get_metadata (info));

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -210,6 +210,14 @@
                                 Available since 0.3.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>home/<replaceable>path</replaceable></option></term><listitem><para>
+                                  Alias for <filename>~/path</filename>
+                                  Available since 1.8.7.
+                                  For better compatibility with older
+                                  Flatpak versions, prefer to write this
+                                  as <filename>~/path</filename>.
+                            </para></listitem></varlistentry>
+
                             <varlistentry><term><option>host</option></term>
                             <listitem><para>
                                 The entire host file system, except for
@@ -380,6 +388,15 @@
                             </term><listitem><para>
                                 An arbitrary path relative to the home
                                 directory. Available since 0.3.
+                            </para></listitem></varlistentry>
+
+                            <varlistentry><term><option>~</option></term>
+                            <listitem><para>
+                                  The same as <option>home</option>.
+                                  Available since 1.8.7.
+                                  For better compatibility with older
+                                  Flatpak versions, prefer to write this
+                                  as <option>home</option>.
                             </para></listitem></varlistentry>
 
                             <varlistentry><term>

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -244,6 +244,14 @@
                     accessing most of the home directory, but it will still
                     be allowed to access
                     <filename>$XDG_CONFIG_HOME/MyApp</filename>.
+                </para><para>
+                    As a special case,
+                    <option>--nofilesystem=host:reset</option>
+                    will ignore all <option>--filesystem</option>
+                    permissions inherited from the app manifest or a
+                    lower-precedence layer of overrides, in addition to
+                    having the behaviour of
+                    <option>--nofilesystem=host</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -219,13 +219,31 @@
                 <term><option>--nofilesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
+                    Undo the effect of a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    in the app's manifest or a lower-precedence layer of
+                    overrides, and/or remove a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    from this layer of overrides.
+                    This overrides the Context section of the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
+                    <arg choice="plain">FILESYSTEM</arg> can take the same
+                    values as for <option>--filesystem</option>, but the
+                    <arg choice="plain">:ro</arg> and
+                    <arg choice="plain">:create</arg> suffixes are not
+                    used here.
                     This option can be used multiple times.
+                </para><para>
+                    This option does not prevent access to a more
+                    narrowly-scoped <option>--filesystem</option>.
+                    For example, if an application has the equivalent of
+                    <option>--filesystem=xdg-config/MyApp</option> in
+                    its manifest or as a system-wide override, and
+                    <literal>flatpak override --user --nofilesystem=home</literal>
+                    as a per-user override, then it will be prevented from
+                    accessing most of the home directory, but it will still
+                    be allowed to access
+                    <filename>$XDG_CONFIG_HOME/MyApp</filename>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -382,6 +382,14 @@
                     accessing most of the home directory, but it will still
                     be allowed to access
                     <filename>$XDG_CONFIG_HOME/MyApp</filename>.
+                </para><para>
+                    As a special case,
+                    <option>--nofilesystem=host:reset</option>
+                    will ignore all <option>--filesystem</option>
+                    permissions inherited from the app manifest or
+                    <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+                    in addition to having the behaviour of
+                    <option>--nofilesystem=host</option>.
                 </para></listitem>
             </varlistentry>
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -359,13 +359,29 @@
                 <term><option>--nofilesystem=FILESYSTEM</option></term>
 
                 <listitem><para>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
+                    Undo the effect of a previous
+                    <option>--filesystem=</option><arg choice="plain">FILESYSTEM</arg>
+                    in the app's manifest and/or the overrides set up with
+                    <citerefentry><refentrytitle>flatpak-override</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
+                    This overrides the Context section of the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
+                    <arg choice="plain">FILESYSTEM</arg> can take the same
+                    values as for <option>--filesystem</option>, but the
+                    <arg choice="plain">:ro</arg> and
+                    <arg choice="plain">:create</arg> suffixes are not
+                    used here.
                     This option can be used multiple times.
+                </para><para>
+                    This option does not prevent access to a more
+                    narrowly-scoped <option>--filesystem</option>.
+                    For example, if an application has the equivalent of
+                    <option>--filesystem=xdg-config/MyApp</option> in
+                    its manifest or as a system-wide override, and
+                    <literal>flatpak override --user --nofilesystem=home</literal>
+                    as a per-user override, then it will be prevented from
+                    accessing most of the home directory, but it will still
+                    be allowed to access
+                    <filename>$XDG_CONFIG_HOME/MyApp</filename>.
                 </para></listitem>
             </varlistentry>
 

--- a/tests/Makefile-test-matrix.am.inc
+++ b/tests/Makefile-test-matrix.am.inc
@@ -26,6 +26,7 @@ TEST_MATRIX_DIST= \
 	tests/test-build-update-repo.sh \
 	tests/test-http-utils.sh \
 	tests/test-default-remotes.sh \
+	tests/test-metadata-validation.sh \
 	tests/test-extensions.sh \
 	tests/test-oci.sh \
 	tests/test-update-remote-configuration.sh \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -60,6 +60,10 @@ testcommon_LDADD = \
 	$(NULL)
 testcommon_SOURCES = tests/testcommon.c
 
+test_context_CFLAGS = $(testcommon_CFLAGS)
+test_context_LDADD = $(testcommon_LDADD)
+test_context_SOURCES = tests/test-context.c
+
 test_exports_CFLAGS = $(testcommon_CFLAGS)
 test_exports_LDADD = $(testcommon_LDADD)
 test_exports_SOURCES = tests/test-exports.c
@@ -235,7 +239,12 @@ test_scripts = ${TEST_MATRIX}
 dist_test_scripts = ${TEST_MATRIX_DIST}
 dist_installed_test_extra_scripts += ${TEST_MATRIX_EXTRA_DIST}
 
-test_programs = testlibrary testcommon test-exports
+test_programs = \
+	test-context \
+	test-exports \
+	testcommon \
+	testlibrary \
+	$(NULL)
 test_extra_programs = tests/httpcache tests/test-update-portal tests/test-portal-impl tests/test-authenticator
 
 @VALGRIND_CHECK_RULES@

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -199,6 +199,7 @@ TEST_MATRIX_SOURCE = \
 	tests/test-repo.sh{user+system+system-norevokefs} \
 	tests/test-sideload.sh{user+system} \
 	tests/test-default-remotes.sh \
+	tests/test-metadata-validation.sh \
 	tests/test-extensions.sh \
 	tests/test-bundle.sh{user+system+system-norevokefs} \
 	tests/test-oci.sh \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -60,6 +60,10 @@ testcommon_LDADD = \
 	$(NULL)
 testcommon_SOURCES = tests/testcommon.c
 
+test_exports_CFLAGS = $(testcommon_CFLAGS)
+test_exports_LDADD = $(testcommon_LDADD)
+test_exports_SOURCES = tests/test-exports.c
+
 tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) $(APPSTREAM_GLIB_CFLAGS) \
 	-DFLATPAK_COMPILATION \
 	-DLOCALEDIR=\"$(localedir)\"
@@ -231,7 +235,7 @@ test_scripts = ${TEST_MATRIX}
 dist_test_scripts = ${TEST_MATRIX_DIST}
 dist_installed_test_extra_scripts += ${TEST_MATRIX_EXTRA_DIST}
 
-test_programs = testlibrary testcommon
+test_programs = testlibrary testcommon test-exports
 test_extra_programs = tests/httpcache tests/test-update-portal tests/test-portal-impl tests/test-authenticator
 
 @VALGRIND_CHECK_RULES@

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -538,3 +538,27 @@ trap cleanup EXIT
 if test -n "${FLATPAK_TESTS_DEBUG:-}"; then
     set -x
 fi
+
+assert_semicolon_list_contains () {
+    list="$1"
+    member="$2"
+
+    case ";$list;" in
+        (*";$member;"*)
+            ;;
+        (*)
+            assert_not_reached "\"$list\" should contain \"$member\""
+            ;;
+    esac
+}
+
+assert_not_semicolon_list_contains () {
+    local list="$1"
+    local member="$2"
+
+    case ";$list;" in
+        (*";$member;"*)
+            assert_not_reached "\"$list\" should not contain \"$member\""
+            ;;
+    esac
+}

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -1,0 +1,343 @@
+/*
+ * Copyright © 2021 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <stdarg.h>
+
+#include <glib.h>
+#include "flatpak.h"
+#include "flatpak-context-private.h"
+#include "flatpak-run-private.h"
+#include "flatpak-utils-private.h"
+
+/* g_str_has_prefix as a GEqualFunc */
+static gboolean
+str_has_prefix (gconstpointer candidate,
+                gconstpointer pattern)
+{
+  return g_str_has_prefix (candidate, pattern);
+}
+
+static void context_parse_args (FlatpakContext *context,
+                                ...) G_GNUC_NULL_TERMINATED;
+
+static void
+context_parse_args (FlatpakContext *context,
+                    ...)
+{
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GOptionContext) oc = NULL;
+  g_autoptr(GOptionGroup) group = NULL;
+  g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func (g_free);
+  g_auto(GStrv) argv = NULL;
+  const char *arg;
+  va_list ap;
+
+  g_ptr_array_add (args, g_strdup ("argv[0]"));
+
+  va_start (ap, context);
+
+  while ((arg = va_arg (ap, const char *)) != NULL)
+    g_ptr_array_add (args, g_strdup (arg));
+
+  va_end (ap);
+
+  g_ptr_array_add (args, NULL);
+  argv = (GStrv) g_ptr_array_free (g_steal_pointer (&args), FALSE);
+
+  oc = g_option_context_new ("");
+  group = flatpak_context_get_options (context);
+  g_option_context_add_group (oc, group);
+  g_option_context_parse_strv (oc, &argv, &local_error);
+  g_assert_no_error (local_error);
+}
+
+static void
+test_context_merge_fs (void)
+{
+  /*
+   * We want to arrive at the same result regardless of whether we:
+   * - start from lowest precedence, and successively merge higher
+   *   precedences into it, discarding them when done;
+   * - successively merge highest precedence into second-highest, and
+   *   then discard highest
+   */
+  enum { LOWEST_FIRST, HIGHEST_FIRST, INVALID } merge_order;
+
+  for (merge_order = LOWEST_FIRST; merge_order < INVALID; merge_order++)
+    {
+      g_autoptr(FlatpakContext) lowest = flatpak_context_new ();
+      g_autoptr(FlatpakContext) middle = flatpak_context_new ();
+      g_autoptr(FlatpakContext) highest = flatpak_context_new ();
+      gpointer value;
+
+      context_parse_args (lowest,
+                          "--filesystem=/one",
+                          NULL);
+      context_parse_args (middle,
+                          "--nofilesystem=host:reset",
+                          "--filesystem=/two",
+                          NULL);
+      context_parse_args (highest,
+                          "--nofilesystem=host",
+                          "--filesystem=/three",
+                          NULL);
+
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (middle->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (middle->filesystems, "/three", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "host-reset", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/one", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/two", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+      if (merge_order == LOWEST_FIRST)
+        {
+          flatpak_context_merge (lowest, middle);
+
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+
+          flatpak_context_merge (lowest, highest);
+        }
+      else
+        {
+          flatpak_context_merge (middle, highest);
+
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (middle->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (middle->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+          flatpak_context_merge (lowest, middle);
+        }
+
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+    }
+
+  for (merge_order = LOWEST_FIRST; merge_order < INVALID; merge_order++)
+    {
+      g_autoptr(FlatpakContext) lowest = flatpak_context_new ();
+      g_autoptr(FlatpakContext) mid_low = flatpak_context_new ();
+      g_autoptr(FlatpakContext) mid_high = flatpak_context_new ();
+      g_autoptr(FlatpakContext) highest = flatpak_context_new ();
+      g_autoptr(GError) local_error = NULL;
+      g_autoptr(GKeyFile) metakey = g_key_file_new ();
+      g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func (g_free);
+      g_autofree char *filesystems = NULL;
+      gpointer value;
+
+      context_parse_args (lowest,
+                          "--filesystem=/one",
+                          NULL);
+      context_parse_args (mid_low,
+                          "--nofilesystem=host:reset",
+                          "--filesystem=/two",
+                          NULL);
+      context_parse_args (mid_high,
+                          "--filesystem=host",
+                          "--filesystem=/three",
+                          NULL);
+      context_parse_args (highest,
+                          "--nofilesystem=host",
+                          "--filesystem=/four",
+                          NULL);
+
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/three", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/four", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "host-reset", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/one", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/two", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/four", NULL, NULL));
+
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "host-reset", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/one", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/two", NULL, NULL));
+      g_assert_false (g_hash_table_lookup_extended (highest->filesystems, "/three", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (highest->filesystems, "/four", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+      if (merge_order == LOWEST_FIRST)
+        {
+          flatpak_context_merge (lowest, mid_low);
+
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, NULL));
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, NULL));
+
+          flatpak_context_merge (lowest, mid_high);
+
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, NULL));
+
+          flatpak_context_merge (lowest, highest);
+        }
+      else
+        {
+          flatpak_context_merge (mid_high, highest);
+
+          g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "host-reset", NULL, NULL));
+          g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/one", NULL, NULL));
+          g_assert_false (g_hash_table_lookup_extended (mid_high->filesystems, "/two", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (mid_high->filesystems, "/four", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+          flatpak_context_merge (mid_low, mid_high);
+
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "host-reset", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+          g_assert_false (g_hash_table_lookup_extended (mid_low->filesystems, "/one", NULL, NULL));
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/two", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/three", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+          g_assert_true (g_hash_table_lookup_extended (mid_low->filesystems, "/four", NULL, &value));
+          g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+          flatpak_context_merge (lowest, mid_low);
+        }
+
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "host-reset", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_NONE);
+      g_assert_false (g_hash_table_lookup_extended (lowest->filesystems, "/one", NULL, NULL));
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/two", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/three", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+      g_assert_true (g_hash_table_lookup_extended (lowest->filesystems, "/four", NULL, &value));
+      g_assert_cmpint (GPOINTER_TO_INT (value), ==, FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+      flatpak_context_save_metadata (lowest, FALSE, metakey);
+      filesystems = g_key_file_get_value (metakey,
+                                          FLATPAK_METADATA_GROUP_CONTEXT,
+                                          FLATPAK_METADATA_KEY_FILESYSTEMS,
+                                          &local_error);
+      g_assert_no_error (local_error);
+      g_test_message ("%s=%s", FLATPAK_METADATA_KEY_FILESYSTEMS, filesystems);
+      /* !host:reset is serialized first */
+      g_assert_true (g_str_has_prefix (filesystems, "!host:reset;"));
+      /* The rest are serialized in arbitrary order */
+      g_assert_nonnull (strstr (filesystems, ";!host;"));
+      g_assert_null (strstr (filesystems, "/one"));
+      g_assert_nonnull (strstr (filesystems, ";/two;"));
+      g_assert_nonnull (strstr (filesystems, ";/three;"));
+      g_assert_nonnull (strstr (filesystems, ";/four;"));
+
+      flatpak_context_to_args (lowest, args);
+      /* !host:reset is serialized first */
+      g_assert_cmpuint (args->len, >, 0);
+      g_assert_cmpstr (g_ptr_array_index (args, 0), ==,
+                       "--nofilesystem=host:reset");
+      /* The rest are serialized in arbitrary order */
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--nofilesystem=host", g_str_equal, NULL));
+      g_assert_false (g_ptr_array_find_with_equal_func (args, "--filesystem=/one", str_has_prefix, NULL));
+      g_assert_false (g_ptr_array_find_with_equal_func (args, "--nofilesystem=/one", str_has_prefix, NULL));
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--filesystem=/two", g_str_equal, NULL));
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--filesystem=/three", g_str_equal, NULL));
+      g_assert_true (g_ptr_array_find_with_equal_func (args, "--filesystem=/four", g_str_equal, NULL));
+    }
+}
+
+int
+main (int argc, char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/context/merge-fs", test_context_merge_fs);
+
+  return g_test_run ();
+}

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -241,11 +241,14 @@ typedef struct
 
 static const NotFilesystem not_filesystems[] =
 {
+  { "", G_OPTION_ERROR_FAILED },
   { "homework", G_OPTION_ERROR_FAILED },
   { "xdg-download/foo/bar/..", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-download/../foo/bar", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-download/foo/../bar", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-run", G_OPTION_ERROR_FAILED },
+  { "/", G_OPTION_ERROR_BAD_VALUE },
+  { "/////././././././//////", G_OPTION_ERROR_BAD_VALUE },
 };
 
 typedef struct

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -560,8 +560,8 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", fs->input);
-      ret = flatpak_context_parse_filesystem (fs->input, &normalized, &mode,
-                                              &error);
+      ret = flatpak_context_parse_filesystem (fs->input, FALSE,
+                                              &normalized, &mode, &error);
       g_assert_no_error (error);
       g_assert_true (ret);
 
@@ -582,8 +582,8 @@ test_filesystems (void)
       gboolean ret;
 
       g_test_message ("%s", not->input);
-      ret = flatpak_context_parse_filesystem (not->input, &normalized, &mode,
-                                              &error);
+      ret = flatpak_context_parse_filesystem (not->input, FALSE,
+                                              &normalized, &mode, &error);
       g_test_message ("-> %s", error ? error->message : "(no error)");
       g_assert_error (error, G_OPTION_ERROR, not->code);
       g_assert_false (ret);

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -132,6 +132,31 @@ assert_next_is_bind (FlatpakBwrap *bwrap,
   return i;
 }
 
+/* Assert that arguments starting from @i are --symlink @rel_target @path,
+ * where @rel_target goes up from @path to the root and back down to the
+ * target of the symlink. Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_symlink (FlatpakBwrap *bwrap,
+                      gsize i,
+                      const char *target,
+                      const char *path)
+{
+  const char *got_target;
+
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--symlink");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+
+  got_target = bwrap->argv->pdata[i++];
+  g_assert_true (g_str_has_prefix (got_target, "../../../../"));
+  g_assert_true (g_str_has_suffix (got_target, target));
+  /* TODO: Assert that it resolves to the same place as target */
+
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  return i;
+}
+
 /* Print the arguments of a call to bwrap. */
 static void
 print_bwrap (FlatpakBwrap *bwrap)
@@ -598,13 +623,34 @@ test_full (void)
   g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
   g_autofree gchar *subdir = g_build_filename (testdir, "test_full", NULL);
   g_autofree gchar *expose_rw = g_build_filename (subdir, "expose-rw", NULL);
+  g_autofree gchar *in_expose_rw = g_build_filename (subdir, "expose-rw",
+                                                     "file", NULL);
+  g_autofree gchar *dangling_link_in_expose_rw = g_build_filename (subdir,
+                                                                   "expose-rw",
+                                                                   "dangling",
+                                                                   NULL);
   g_autofree gchar *expose_ro = g_build_filename (subdir, "expose-ro", NULL);
+  g_autofree gchar *in_expose_ro = g_build_filename (subdir, "expose-ro",
+                                                     "file", NULL);
   g_autofree gchar *hide = g_build_filename (subdir, "hide", NULL);
   g_autofree gchar *dont_hide = g_build_filename (subdir, "dont-hide", NULL);
   g_autofree gchar *hide_below_expose = g_build_filename (subdir,
                                                           "expose-ro",
                                                           "hide-me",
                                                           NULL);
+  g_autofree gchar *enoent = g_build_filename (subdir, "ENOENT", NULL);
+  g_autofree gchar *one = g_build_filename (subdir, "1", NULL);
+  g_autofree gchar *rel_link = g_build_filename (subdir, "1", "rel-link", NULL);
+  g_autofree gchar *abs_link = g_build_filename (subdir, "1", "abs-link", NULL);
+  g_autofree gchar *in_abs_link = g_build_filename (subdir, "1", "abs-link",
+                                                    "file", NULL);
+  g_autofree gchar *dangling = g_build_filename (subdir, "1", "dangling", NULL);
+  g_autofree gchar *in_dangling = g_build_filename (subdir, "1", "dangling",
+                                                    "file", NULL);
+  g_autofree gchar *abs_target = g_build_filename (subdir, "2", "abs-target", NULL);
+  g_autofree gchar *target = g_build_filename (subdir, "2", "target", NULL);
+  g_autofree gchar *create_dir = g_build_filename (subdir, "create-dir", NULL);
+  g_autofree gchar *create_dir2 = g_build_filename (subdir, "create-dir2", NULL);
   gsize i;
 
   glnx_shutil_rm_rf_at (-1, subdir, NULL, &error);
@@ -630,6 +676,33 @@ test_full (void)
   if (g_mkdir_with_parents (dont_hide, S_IRWXU) != 0)
     g_error ("mkdir: %s", g_strerror (errno));
 
+  if (g_mkdir_with_parents (dont_hide, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (abs_target, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (target, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (one, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (create_dir, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (symlink (abs_target, abs_link) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
+  if (symlink ("nope", dangling) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
+  if (symlink ("nope", dangling_link_in_expose_rw) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
+  if (symlink ("../2/target", rel_link) != 0)
+    g_error ("symlink: %s", g_strerror (errno));
+
   flatpak_exports_add_host_etc_expose (exports,
                                        FLATPAK_FILESYSTEM_MODE_READ_WRITE);
   flatpak_exports_add_host_os_expose (exports,
@@ -647,6 +720,45 @@ test_full (void)
   flatpak_exports_add_path_expose_or_hide (exports,
                                            FLATPAK_FILESYSTEM_MODE_READ_ONLY,
                                            dont_hide);
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                           enoent);
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                           rel_link);
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                           abs_link);
+  flatpak_exports_add_path_dir (exports, create_dir);
+  flatpak_exports_add_path_dir (exports, create_dir2);
+
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, expose_rw), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, expose_ro), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_ONLY);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, hide_below_expose), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, hide), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, dont_hide), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_ONLY);
+  /* It knows enoent didn't really exist */
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, enoent), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, abs_link), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, rel_link), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+
+  /* Files the app would be allowed to create count as exposed */
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_expose_ro), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_expose_rw), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_abs_link), ==,
+                    FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  g_assert_cmpuint (flatpak_exports_path_get_mode (exports, in_dangling), ==,
+                    FLATPAK_FILESYSTEM_MODE_NONE);
 
   flatpak_bwrap_add_arg (bwrap, "bwrap");
   flatpak_exports_append_bwrap_args (exports, bwrap);
@@ -656,6 +768,20 @@ test_full (void)
   i = 0;
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  i = assert_next_is_symlink (bwrap, i, abs_target, abs_link);
+  i = assert_next_is_symlink (bwrap, i, "../2/target", rel_link);
+  i = assert_next_is_bind (bwrap, i, "--bind", abs_target);
+  i = assert_next_is_bind (bwrap, i, "--bind", target);
+  i = assert_next_is_dir (bwrap, i, create_dir);
+
+  /* create_dir2 is not currently created with --dir inside the container
+   * because it doesn't exist outside the container.
+   * (Is this correct? For now, tolerate either way) */
+  if (i + 2 < bwrap->argv->len &&
+      g_strcmp0 (bwrap->argv->pdata[i], "--dir") == 0 &&
+      g_strcmp0 (bwrap->argv->pdata[i + 1], create_dir2) == 0)
+    i += 2;
 
   i = assert_next_is_bind (bwrap, i, "--ro-bind", dont_hide);
   i = assert_next_is_bind (bwrap, i, "--ro-bind", expose_ro);
@@ -695,6 +821,83 @@ test_full (void)
     }
 }
 
+static void
+test_exports_ignored (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  /* These paths are chosen so that they probably exist, with the
+   * exception of /app */
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/app");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/etc");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/etc/passwd");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/usr");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/usr/bin/env");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/dev");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/dev/full");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/proc");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/proc/1");
+
+  /* These probably exist, and are merged into /usr on systems with
+   * the /usr merge */
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/bin");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/bin/sh");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib/ld-linux.so.2");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib64");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/lib64/ld-linux-x86-64.so.2");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/sbin");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/sbin/ldconfig");
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+  g_assert_cmpuint (i, ==, bwrap->argv->len - 1);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -709,6 +912,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/context/full", test_full_context);
   g_test_add_func ("/exports/empty", test_empty);
   g_test_add_func ("/exports/full", test_full);
+  g_test_add_func ("/exports/ignored", test_exports_ignored);
 
   res = g_test_run ();
 

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -298,6 +298,12 @@ static const Filesystem filesystems[] =
   { "xdg-config/././///.///././.", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
   { "xdg-config/////", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
   { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "~", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~/.", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~/", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~///././//", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "home/", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "home/Projects", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "~/Projects" },
 };
 
 static void

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -188,6 +188,9 @@ test_full_context (void)
   g_autoptr(FlatpakExports) exports = NULL;
   g_autoptr(GError) error = NULL;
   g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+  g_autofree gchar *text = NULL;
+  g_auto(GStrv) strv = NULL;
+  gsize i, n;
 
   g_key_file_set_value (keyfile,
                         FLATPAK_METADATA_GROUP_CONTEXT,
@@ -209,7 +212,7 @@ test_full_context (void)
   g_key_file_set_value (keyfile,
                         FLATPAK_METADATA_GROUP_CONTEXT,
                         FLATPAK_METADATA_KEY_FILESYSTEMS,
-                        "host;/home;");
+                        "host;/home;!/opt");
   g_key_file_set_value (keyfile,
                         FLATPAK_METADATA_GROUP_CONTEXT,
                         FLATPAK_METADATA_KEY_PERSISTENT,
@@ -277,6 +280,172 @@ test_full_context (void)
                                            &exports);
   print_bwrap (bwrap);
   g_assert_nonnull (exports);
+
+  g_clear_pointer (&keyfile, g_key_file_unref);
+  keyfile = g_key_file_new ();
+  flatpak_context_save_metadata (context, FALSE, keyfile);
+  text = g_key_file_to_data (keyfile, NULL, NULL);
+  g_test_message ("Saved:\n%s", text);
+  g_clear_pointer (&text, g_free);
+
+  /* Test that keys round-trip back into the file */
+  strv = g_key_file_get_string_list (keyfile, FLATPAK_METADATA_GROUP_CONTEXT,
+                                     FLATPAK_METADATA_KEY_FILESYSTEMS,
+                                     &n, &error);
+  g_assert_nonnull (strv);
+  /* The order is undefined, so sort them first */
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "!/opt");
+  g_assert_cmpstr (strv[i++], ==, "/home");
+  g_assert_cmpstr (strv[i++], ==, "host");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  strv = g_key_file_get_string_list (keyfile, FLATPAK_METADATA_GROUP_CONTEXT,
+                                     FLATPAK_METADATA_KEY_SHARED,
+                                     &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "ipc");
+  g_assert_cmpstr (strv[i++], ==, "network");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  strv = g_key_file_get_string_list (keyfile, FLATPAK_METADATA_GROUP_CONTEXT,
+                                     FLATPAK_METADATA_KEY_SOCKETS,
+                                     &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "cups");
+  g_assert_cmpstr (strv[i++], ==, "fallback-x11");
+  g_assert_cmpstr (strv[i++], ==, "pcsc");
+  g_assert_cmpstr (strv[i++], ==, "pulseaudio");
+  g_assert_cmpstr (strv[i++], ==, "session-bus");
+  g_assert_cmpstr (strv[i++], ==, "ssh-auth");
+  g_assert_cmpstr (strv[i++], ==, "system-bus");
+  g_assert_cmpstr (strv[i++], ==, "wayland");
+  g_assert_cmpstr (strv[i++], ==, "x11");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  strv = g_key_file_get_string_list (keyfile, FLATPAK_METADATA_GROUP_CONTEXT,
+                                     FLATPAK_METADATA_KEY_DEVICES,
+                                     &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "all");
+  g_assert_cmpstr (strv[i++], ==, "dri");
+  g_assert_cmpstr (strv[i++], ==, "kvm");
+  g_assert_cmpstr (strv[i++], ==, "shm");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  strv = g_key_file_get_string_list (keyfile, FLATPAK_METADATA_GROUP_CONTEXT,
+                                     FLATPAK_METADATA_KEY_PERSISTENT,
+                                     &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, ".openarena");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  strv = g_key_file_get_keys (keyfile, FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                              &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "org.example.SessionService");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  text = g_key_file_get_string (keyfile, FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                                "org.example.SessionService", &error);
+  g_assert_no_error (error);
+  g_assert_cmpstr (text, ==, "own");
+  g_clear_pointer (&text, g_free);
+
+  strv = g_key_file_get_keys (keyfile, FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                              &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "net.example.SystemService");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  text = g_key_file_get_string (keyfile, FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                                "net.example.SystemService", &error);
+  g_assert_no_error (error);
+  g_assert_cmpstr (text, ==, "talk");
+  g_clear_pointer (&text, g_free);
+
+  strv = g_key_file_get_keys (keyfile, FLATPAK_METADATA_GROUP_ENVIRONMENT,
+                              &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "HYPOTHETICAL_PATH");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  text = g_key_file_get_string (keyfile, FLATPAK_METADATA_GROUP_ENVIRONMENT,
+                                "HYPOTHETICAL_PATH", &error);
+  g_assert_no_error (error);
+  g_assert_cmpstr (text, ==, "/foo:/bar");
+  g_clear_pointer (&text, g_free);
+
+  strv = g_key_file_get_keys (keyfile, FLATPAK_METADATA_GROUP_PREFIX_POLICY "MyPolicy",
+                              &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "Colours");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
+
+  strv = g_key_file_get_string_list (keyfile, FLATPAK_METADATA_GROUP_PREFIX_POLICY "MyPolicy",
+                                     "Colours", &n, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (strv);
+  g_qsort_with_data (strv, n, sizeof (char *),
+                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  i = 0;
+  g_assert_cmpstr (strv[i++], ==, "blue");
+  g_assert_cmpstr (strv[i++], ==, "green");
+  g_assert_cmpstr (strv[i], ==, NULL);
+  g_assert_cmpuint (i, ==, n);
+  g_clear_pointer (&strv, g_strfreev);
 }
 
 typedef struct

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -28,17 +28,63 @@
 #include "flatpak-exports-private.h"
 #include "flatpak-run-private.h"
 
-/* This differs from g_file_test (path, G_FILE_TEST_IS_DIR) which
-   returns true if the path is a symlink to a dir */
-static gboolean
-path_is_dir (const char *path)
+static char *testdir;
+
+static void
+global_setup (void)
 {
-  struct stat s;
+  g_autofree char *cachedir = NULL;
+  g_autofree char *configdir = NULL;
+  g_autofree char *datadir = NULL;
+  g_autofree char *homedir = NULL;
+  g_autofree char *runtimedir = NULL;
 
-  if (lstat (path, &s) != 0)
-    return FALSE;
+  testdir = g_strdup ("/tmp/flatpak-test-XXXXXX");
+  g_mkdtemp (testdir);
+  g_test_message ("testdir: %s", testdir);
 
-  return S_ISDIR (s.st_mode);
+  homedir = g_strconcat (testdir, "/home", NULL);
+  g_mkdir_with_parents (homedir, S_IRWXU | S_IRWXG | S_IRWXO);
+
+  g_setenv ("HOME", homedir, TRUE);
+  g_test_message ("setting HOME=%s", homedir);
+
+  cachedir = g_strconcat (testdir, "/home/cache", NULL);
+  g_mkdir_with_parents (cachedir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_CACHE_HOME", cachedir, TRUE);
+  g_test_message ("setting XDG_CACHE_HOME=%s", cachedir);
+
+  configdir = g_strconcat (testdir, "/home/config", NULL);
+  g_mkdir_with_parents (configdir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_CONFIG_HOME", configdir, TRUE);
+  g_test_message ("setting XDG_CONFIG_HOME=%s", configdir);
+
+  datadir = g_strconcat (testdir, "/home/share", NULL);
+  g_mkdir_with_parents (datadir, S_IRWXU | S_IRWXG | S_IRWXO);
+  g_setenv ("XDG_DATA_HOME", datadir, TRUE);
+  g_test_message ("setting XDG_DATA_HOME=%s", datadir);
+
+  runtimedir = g_strconcat (testdir, "/runtime", NULL);
+  g_mkdir_with_parents (runtimedir, S_IRWXU);
+  g_setenv ("XDG_RUNTIME_DIR", runtimedir, TRUE);
+  g_test_message ("setting XDG_RUNTIME_DIR=%s", runtimedir);
+
+  g_reload_user_special_dirs_cache ();
+
+  g_assert_cmpstr (g_get_user_cache_dir (), ==, cachedir);
+  g_assert_cmpstr (g_get_user_config_dir (), ==, configdir);
+  g_assert_cmpstr (g_get_user_data_dir (), ==, datadir);
+  g_assert_cmpstr (g_get_user_runtime_dir (), ==, runtimedir);
+}
+
+static void
+global_teardown (void)
+{
+  if (g_getenv ("SKIP_TEARDOWN"))
+    return;
+
+  glnx_shutil_rm_rf_at (-1, testdir, NULL, NULL);
+  g_free (testdir);
 }
 
 /* Assert that arguments starting from @i are --dir @dir.
@@ -378,9 +424,42 @@ test_empty (void)
 static void
 test_full (void)
 {
+  g_autoptr(GError) error = NULL;
   g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
   g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  g_autofree gchar *subdir = g_build_filename (testdir, "test_full", NULL);
+  g_autofree gchar *expose_rw = g_build_filename (subdir, "expose-rw", NULL);
+  g_autofree gchar *expose_ro = g_build_filename (subdir, "expose-ro", NULL);
+  g_autofree gchar *hide = g_build_filename (subdir, "hide", NULL);
+  g_autofree gchar *dont_hide = g_build_filename (subdir, "dont-hide", NULL);
+  g_autofree gchar *hide_below_expose = g_build_filename (subdir,
+                                                          "expose-ro",
+                                                          "hide-me",
+                                                          NULL);
   gsize i;
+
+  glnx_shutil_rm_rf_at (-1, subdir, NULL, &error);
+
+  if (error != NULL)
+    {
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_clear_error (&error);
+    }
+
+  if (g_mkdir_with_parents (expose_rw, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (expose_ro, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (hide_below_expose, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (hide, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
+
+  if (g_mkdir_with_parents (dont_hide, S_IRWXU) != 0)
+    g_error ("mkdir: %s", g_strerror (errno));
 
   flatpak_exports_add_host_etc_expose (exports,
                                        FLATPAK_FILESYSTEM_MODE_READ_WRITE);
@@ -388,17 +467,17 @@ test_full (void)
                                       FLATPAK_FILESYSTEM_MODE_READ_ONLY);
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_WRITE,
-                                   "/tmp");
+                                   expose_rw);
   flatpak_exports_add_path_expose (exports,
                                    FLATPAK_FILESYSTEM_MODE_READ_ONLY,
-                                   "/var");
-  flatpak_exports_add_path_tmpfs (exports, "/var/tmp");
+                                   expose_ro);
+  flatpak_exports_add_path_tmpfs (exports, hide_below_expose);
   flatpak_exports_add_path_expose_or_hide (exports,
                                            FLATPAK_FILESYSTEM_MODE_NONE,
-                                           "/home");
+                                           hide);
   flatpak_exports_add_path_expose_or_hide (exports,
                                            FLATPAK_FILESYSTEM_MODE_READ_ONLY,
-                                           "/srv");
+                                           dont_hide);
 
   flatpak_bwrap_add_arg (bwrap, "bwrap");
   flatpak_exports_append_bwrap_args (exports, bwrap);
@@ -409,24 +488,20 @@ test_full (void)
   g_assert_cmpuint (i, <, bwrap->argv->len);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
 
-  /* Hiding /home just uses --dir because / is not exposed. */
-  if (path_is_dir ("/home"))
-    i = assert_next_is_dir (bwrap, i, "/home");
-
-  if (path_is_dir ("/srv"))
-    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/srv");
-
-  if (path_is_dir ("/tmp"))
-    i = assert_next_is_bind (bwrap, i, "--bind", "/tmp");
-
-  if (path_is_dir ("/var"))
-    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/var");
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", dont_hide);
+  i = assert_next_is_bind (bwrap, i, "--ro-bind", expose_ro);
 
   /* We don't create a FAKE_MODE_TMPFS in the container unless there is
    * a directory on the host to mount it on.
-   * Hiding /var/tmp has to use --tmpfs because /var *is* exposed. */
-  if (path_is_dir ("/var") && path_is_dir ("/var/tmp"))
-    i = assert_next_is_tmpfs (bwrap, i, "/var/tmp");
+   * Hiding $subdir/expose-ro/hide-me has to use --tmpfs because
+   * $subdir/expose-ro *is* exposed. */
+  i = assert_next_is_tmpfs (bwrap, i, hide_below_expose);
+
+  i = assert_next_is_bind (bwrap, i, "--bind", expose_rw);
+
+  /* Hiding $subdir/hide just uses --dir, because $subdir is not
+   * exposed. */
+  i = assert_next_is_dir (bwrap, i, hide);
 
   while (i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL)
     {
@@ -441,12 +516,22 @@ test_full (void)
   g_assert_cmpuint (i, ==, bwrap->argv->len - 1);
   g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
   g_assert_cmpuint (i, ==, bwrap->argv->len);
+
+  glnx_shutil_rm_rf_at (-1, subdir, NULL, &error);
+
+  if (error != NULL)
+    {
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_clear_error (&error);
+    }
 }
 
 int
 main (int argc, char *argv[])
 {
   int res;
+
+  global_setup ();
 
   g_test_init (&argc, &argv, NULL);
 
@@ -457,6 +542,8 @@ main (int argc, char *argv[])
   g_test_add_func ("/exports/full", test_full);
 
   res = g_test_run ();
+
+  global_teardown ();
 
   return res;
 }

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -242,6 +242,9 @@ typedef struct
 static const NotFilesystem not_filesystems[] =
 {
   { "homework", G_OPTION_ERROR_FAILED },
+  { "xdg-download/foo/bar/..", G_OPTION_ERROR_BAD_VALUE },
+  { "xdg-download/../foo/bar", G_OPTION_ERROR_BAD_VALUE },
+  { "xdg-download/foo/../bar", G_OPTION_ERROR_BAD_VALUE },
   { "xdg-run", G_OPTION_ERROR_FAILED },
 };
 
@@ -289,6 +292,8 @@ static const Filesystem filesystems[] =
   { "xdg-cache/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-config", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-config/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config/././///.///././.", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
+  { "xdg-config/////", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "xdg-config" },
   { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
 };
 

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1,0 +1,448 @@
+/*
+ * Copyright © 2020 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <glib.h>
+#include "flatpak.h"
+#include "flatpak-bwrap-private.h"
+#include "flatpak-context-private.h"
+#include "flatpak-exports-private.h"
+#include "flatpak-run-private.h"
+
+/* This differs from g_file_test (path, G_FILE_TEST_IS_DIR) which
+   returns true if the path is a symlink to a dir */
+static gboolean
+path_is_dir (const char *path)
+{
+  struct stat s;
+
+  if (lstat (path, &s) != 0)
+    return FALSE;
+
+  return S_ISDIR (s.st_mode);
+}
+
+/* Assert that arguments starting from @i are --dir @dir.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_dir (FlatpakBwrap *bwrap,
+                    gsize i,
+                    const char *dir)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--dir");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, dir);
+  return i;
+}
+
+/* Assert that arguments starting from @i are --tmpfs @dir.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_tmpfs (FlatpakBwrap *bwrap,
+                      gsize i,
+                      const char *dir)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "--tmpfs");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, dir);
+  return i;
+}
+
+/* Assert that arguments starting from @i are @how @path @path.
+ * Return the new @i. */
+G_GNUC_WARN_UNUSED_RESULT static gsize
+assert_next_is_bind (FlatpakBwrap *bwrap,
+                     gsize i,
+                     const char *how,
+                     const char *path)
+{
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, how);
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, path);
+  return i;
+}
+
+/* Print the arguments of a call to bwrap. */
+static void
+print_bwrap (FlatpakBwrap *bwrap)
+{
+  guint i;
+
+  for (i = 0; i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL; i++)
+    g_test_message ("%s", (const char *) bwrap->argv->pdata[i]);
+
+  g_test_message ("--");
+}
+
+static void
+test_empty_context (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(FlatpakExports) exports = NULL;
+
+  g_assert_cmpuint (g_hash_table_size (context->env_vars), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->persistent), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->filesystems), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->session_bus_policy), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->system_bus_policy), ==, 0);
+  g_assert_cmpuint (g_hash_table_size (context->generic_policy), ==, 0);
+  g_assert_cmpuint (context->shares, ==, 0);
+  g_assert_cmpuint (context->shares_valid, ==, 0);
+  g_assert_cmpuint (context->sockets, ==, 0);
+  g_assert_cmpuint (context->sockets_valid, ==, 0);
+  g_assert_cmpuint (context->devices, ==, 0);
+  g_assert_cmpuint (context->devices_valid, ==, 0);
+  g_assert_cmpuint (context->features, ==, 0);
+  g_assert_cmpuint (context->features_valid, ==, 0);
+  g_assert_cmpuint (flatpak_context_get_run_flags (context), ==, 0);
+
+  exports = flatpak_context_get_exports (context, "com.example.App");
+  g_assert_nonnull (exports);
+
+  g_clear_pointer (&exports, flatpak_exports_free);
+  flatpak_context_append_bwrap_filesystem (context, bwrap,
+                                           "com.example.App",
+                                           NULL,
+                                           NULL,
+                                           &exports);
+  print_bwrap (bwrap);
+  g_assert_nonnull (exports);
+}
+
+static void
+test_full_context (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(FlatpakExports) exports = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_SHARED,
+                        "network;ipc;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_SOCKETS,
+                        "x11;wayland;pulseaudio;session-bus;system-bus;"
+                        "fallback-x11;ssh-auth;pcsc;cups;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_DEVICES,
+                        "dri;all;kvm;shm;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_FEATURES,
+                        "devel;multiarch;bluetooth;canbus;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_FILESYSTEMS,
+                        "host;/home;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_CONTEXT,
+                        FLATPAK_METADATA_KEY_PERSISTENT,
+                        ".openarena;");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY,
+                        "org.example.SessionService",
+                        "own");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY,
+                        "net.example.SystemService",
+                        "talk");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_ENVIRONMENT,
+                        "HYPOTHETICAL_PATH", "/foo:/bar");
+  g_key_file_set_value (keyfile,
+                        FLATPAK_METADATA_GROUP_PREFIX_POLICY "MyPolicy",
+                        "Colours", "blue;green;");
+
+  flatpak_context_load_metadata (context, keyfile, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpuint (context->shares, ==,
+                    (FLATPAK_CONTEXT_SHARED_NETWORK |
+                     FLATPAK_CONTEXT_SHARED_IPC));
+  g_assert_cmpuint (context->shares_valid, ==, context->shares);
+  g_assert_cmpuint (context->devices, ==,
+                    (FLATPAK_CONTEXT_DEVICE_DRI |
+                     FLATPAK_CONTEXT_DEVICE_ALL |
+                     FLATPAK_CONTEXT_DEVICE_KVM |
+                     FLATPAK_CONTEXT_DEVICE_SHM));
+  g_assert_cmpuint (context->devices_valid, ==, context->devices);
+  g_assert_cmpuint (context->sockets, ==,
+                    (FLATPAK_CONTEXT_SOCKET_X11 |
+                     FLATPAK_CONTEXT_SOCKET_WAYLAND |
+                     FLATPAK_CONTEXT_SOCKET_PULSEAUDIO |
+                     FLATPAK_CONTEXT_SOCKET_SESSION_BUS |
+                     FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS |
+                     FLATPAK_CONTEXT_SOCKET_FALLBACK_X11 |
+                     FLATPAK_CONTEXT_SOCKET_SSH_AUTH |
+                     FLATPAK_CONTEXT_SOCKET_PCSC |
+                     FLATPAK_CONTEXT_SOCKET_CUPS));
+  g_assert_cmpuint (context->sockets_valid, ==, context->sockets);
+  g_assert_cmpuint (context->features, ==,
+                    (FLATPAK_CONTEXT_FEATURE_DEVEL |
+                     FLATPAK_CONTEXT_FEATURE_MULTIARCH |
+                     FLATPAK_CONTEXT_FEATURE_BLUETOOTH |
+                     FLATPAK_CONTEXT_FEATURE_CANBUS));
+  g_assert_cmpuint (context->features_valid, ==, context->features);
+
+  g_assert_cmpuint (flatpak_context_get_run_flags (context), ==,
+                    (FLATPAK_RUN_FLAG_DEVEL |
+                     FLATPAK_RUN_FLAG_MULTIARCH |
+                     FLATPAK_RUN_FLAG_BLUETOOTH |
+                     FLATPAK_RUN_FLAG_CANBUS));
+
+  exports = flatpak_context_get_exports (context, "com.example.App");
+  g_assert_nonnull (exports);
+
+  g_clear_pointer (&exports, flatpak_exports_free);
+  flatpak_context_append_bwrap_filesystem (context, bwrap,
+                                           "com.example.App",
+                                           NULL,
+                                           NULL,
+                                           &exports);
+  print_bwrap (bwrap);
+  g_assert_nonnull (exports);
+}
+
+typedef struct
+{
+  const char *input;
+  GOptionError code;
+} NotFilesystem;
+
+static const NotFilesystem not_filesystems[] =
+{
+  { "homework", G_OPTION_ERROR_FAILED },
+  { "xdg-run", G_OPTION_ERROR_FAILED },
+};
+
+typedef struct
+{
+  const char *input;
+  FlatpakFilesystemMode mode;
+  const char *fs;
+} Filesystem;
+
+static const Filesystem filesystems[] =
+{
+  { "home", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host-etc", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host-os", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "host:ro", FLATPAK_FILESYSTEM_MODE_READ_ONLY, "host" },
+  { "home:rw", FLATPAK_FILESYSTEM_MODE_READ_WRITE, "home" },
+  { "~/Music", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "/srv/obs/debian\\:sid\\:main:create", FLATPAK_FILESYSTEM_MODE_CREATE,
+    "/srv/obs/debian:sid:main" },
+  { "/srv/c\\:\\\\Program Files\\\\Steam", FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+    "/srv/c:\\Program Files\\Steam" },
+  { "/srv/escaped\\unnecessarily", FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+    "/srv/escapedunnecessarily" },
+  { "xdg-desktop", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-desktop/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-documents", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-documents/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-download", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-download/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-music", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-music/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-pictures", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-pictures/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-public-share", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-public-share/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-templates", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-templates/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-videos", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-videos/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-data", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-data/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-cache", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-cache/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-config/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-run/dbus", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+};
+
+static void
+test_filesystems (void)
+{
+  gsize i;
+
+  for (i = 0; i < G_N_ELEMENTS (filesystems); i++)
+    {
+      const Filesystem *fs = &filesystems[i];
+      g_autoptr(GError) error = NULL;
+      g_autofree char *normalized;
+      FlatpakFilesystemMode mode;
+      gboolean ret;
+
+      g_test_message ("%s", fs->input);
+      ret = flatpak_context_parse_filesystem (fs->input, &normalized, &mode,
+                                              &error);
+      g_assert_no_error (error);
+      g_assert_true (ret);
+
+      if (fs->fs == NULL)
+        g_assert_cmpstr (normalized, ==, fs->input);
+      else
+        g_assert_cmpstr (normalized, ==, fs->fs);
+
+      g_assert_cmpuint (mode, ==, fs->mode);
+    }
+
+  for (i = 0; i < G_N_ELEMENTS (not_filesystems); i++)
+    {
+      const NotFilesystem *not = &not_filesystems[i];
+      g_autoptr(GError) error = NULL;
+      char *normalized = NULL;
+      FlatpakFilesystemMode mode;
+      gboolean ret;
+
+      g_test_message ("%s", not->input);
+      ret = flatpak_context_parse_filesystem (not->input, &normalized, &mode,
+                                              &error);
+      g_test_message ("-> %s", error ? error->message : "(no error)");
+      g_assert_error (error, G_OPTION_ERROR, not->code);
+      g_assert_false (ret);
+      g_assert_null (normalized);
+    }
+}
+
+static void
+test_empty (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  g_assert_false (flatpak_exports_path_is_visible (exports, "/run"));
+  g_assert_cmpint (flatpak_exports_path_get_mode (exports, "/tmp"), ==,
+                   FLATPAK_FILESYSTEM_MODE_NONE);
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
+static void
+test_full (void)
+{
+  g_autoptr(FlatpakBwrap) bwrap = flatpak_bwrap_new (NULL);
+  g_autoptr(FlatpakExports) exports = flatpak_exports_new ();
+  gsize i;
+
+  flatpak_exports_add_host_etc_expose (exports,
+                                       FLATPAK_FILESYSTEM_MODE_READ_WRITE);
+  flatpak_exports_add_host_os_expose (exports,
+                                      FLATPAK_FILESYSTEM_MODE_READ_ONLY);
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                   "/tmp");
+  flatpak_exports_add_path_expose (exports,
+                                   FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                   "/var");
+  flatpak_exports_add_path_tmpfs (exports, "/var/tmp");
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_NONE,
+                                           "/home");
+  flatpak_exports_add_path_expose_or_hide (exports,
+                                           FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                           "/srv");
+
+  flatpak_bwrap_add_arg (bwrap, "bwrap");
+  flatpak_exports_append_bwrap_args (exports, bwrap);
+  flatpak_bwrap_finish (bwrap);
+  print_bwrap (bwrap);
+
+  i = 0;
+  g_assert_cmpuint (i, <, bwrap->argv->len);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "bwrap");
+
+  /* Hiding /home just uses --dir because / is not exposed. */
+  if (path_is_dir ("/home"))
+    i = assert_next_is_dir (bwrap, i, "/home");
+
+  if (path_is_dir ("/srv"))
+    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/srv");
+
+  if (path_is_dir ("/tmp"))
+    i = assert_next_is_bind (bwrap, i, "--bind", "/tmp");
+
+  if (path_is_dir ("/var"))
+    i = assert_next_is_bind (bwrap, i, "--ro-bind", "/var");
+
+  /* We don't create a FAKE_MODE_TMPFS in the container unless there is
+   * a directory on the host to mount it on.
+   * Hiding /var/tmp has to use --tmpfs because /var *is* exposed. */
+  if (path_is_dir ("/var") && path_is_dir ("/var/tmp"))
+    i = assert_next_is_tmpfs (bwrap, i, "/var/tmp");
+
+  while (i < bwrap->argv->len && bwrap->argv->pdata[i] != NULL)
+    {
+      /* An unknown number of --bind, --ro-bind and --symlink,
+       * depending how your /usr and /etc are set up.
+       * About the only thing we can say is that they are in threes. */
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+      g_assert_cmpuint (i++, <, bwrap->argv->len);
+    }
+
+  g_assert_cmpuint (i, ==, bwrap->argv->len - 1);
+  g_assert_cmpstr (bwrap->argv->pdata[i++], ==, NULL);
+  g_assert_cmpuint (i, ==, bwrap->argv->len);
+}
+
+int
+main (int argc, char *argv[])
+{
+  int res;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/context/empty", test_empty_context);
+  g_test_add_func ("/context/filesystems", test_filesystems);
+  g_test_add_func ("/context/full", test_full_context);
+  g_test_add_func ("/exports/empty", test_empty);
+  g_test_add_func ("/exports/full", test_full);
+
+  res = g_test_run ();
+
+  return res;
+}

--- a/tests/test-metadata-validation.sh
+++ b/tests/test-metadata-validation.sh
@@ -18,6 +18,8 @@ create_app () {
     local OPTIONS="$1"
     local DIR=`mktemp -d`
 
+    sleep 1
+
     mkdir ${DIR}/files
     echo $COUNTER > ${DIR}/files/counter
     let COUNTER=COUNTER+1

--- a/tests/test-metadata-validation.sh
+++ b/tests/test-metadata-validation.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# Copyright (C) 2021 Matthew Leeds <mwleeds@protonmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+echo "1..7"
+
+setup_repo
+
+COUNTER=1
+
+create_app () {
+    local OPTIONS="$1"
+    local DIR=`mktemp -d`
+
+    mkdir ${DIR}/files
+    echo $COUNTER > ${DIR}/files/counter
+    let COUNTER=COUNTER+1
+
+    local INVALID=""
+    if [[ $OPTIONS =~ "invalid" ]]; then
+        INVALID=invalidkeyfileline
+    fi
+    cat > ${DIR}/metadata <<EOF
+[Application]
+name=org.test.Malicious
+runtime=org.test.Platform/${ARCH}/master
+$INVALID
+
+[Context]
+EOF
+    if [[ $OPTIONS =~ "mismatch" ]]; then
+        echo -e "filesystems=host;" >> ${DIR}/metadata
+    fi
+    if [[ $OPTIONS =~ "hidden" ]]; then
+        echo -ne "\0" >> ${DIR}/metadata
+        echo -e "\nfilesystems=home;" >> ${DIR}/metadata
+    fi
+    local XA_METADATA=--add-metadata-string=xa.metadata="$(head -n6 ${DIR}/metadata)"$'\n'
+    if [[ $OPTIONS =~ "no-xametadata" ]]; then
+        XA_METADATA="--add-metadata-string=xa.nometadata=1"
+    fi
+    ostree commit --repo=repos/test --branch=app/org.test.Malicious/${ARCH}/master ${FL_GPGARGS} "$XA_METADATA" ${DIR}/
+    if [[ $OPTIONS =~ "no-cache-in-summary" ]]; then
+        ostree --repo=repos/test ${FL_GPGARGS} summary -u
+        # force use of legacy summary format
+        rm -rf repos/test/summary.idx repos/test/summaries
+    else
+        update_repo
+    fi
+    rm -rf ${DIR}
+}
+
+cleanup_repo () {
+    ostree refs --repo=repos/test --delete app/org.test.Malicious/${ARCH}/master
+    update_repo
+}
+
+create_app "hidden"
+
+if ${FLATPAK} ${U} install -y test-repo org.test.Malicious 2>install-error-log; then
+    assert_not_reached "Should not be able to install app with hidden permissions"
+fi
+
+assert_file_has_content install-error-log "not matching expected metadata"
+
+assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
+
+cleanup_repo
+
+ok "app with hidden permissions can't be installed (CVE-2021-43860)"
+
+create_app no-xametadata
+
+# The install will fail because the metadata in the summary doesn't match the metadata on the commit
+# The missing xa.metadata in the commit got turned into "" in the xa.cache
+if ${FLATPAK} ${U} install -y test-repo org.test.Malicious 2>install-error-log; then
+    assert_not_reached "Should not be able to install app with missing xa.metadata"
+fi
+
+assert_file_has_content install-error-log "not matching expected metadata"
+
+assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
+
+cleanup_repo
+
+ok "app with no xa.metadata can't be installed"
+
+create_app "no-xametadata no-cache-in-summary"
+
+# The install will fail because there's no metadata in the summary or on the commit
+if ${FLATPAK} ${U} install -y test-repo org.test.Malicious 2>install-error-log; then
+    assert_not_reached "Should not be able to install app with missing metadata"
+fi
+assert_file_has_content install-error-log "No xa.metadata in local commit"
+
+assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
+
+cleanup_repo
+
+ok "app with no xa.metadata and no metadata in summary can't be installed"
+
+create_app "invalid"
+
+if ${FLATPAK} ${U} install -y test-repo org.test.Malicious 2>install-error-log; then
+    assert_not_reached "Should not be able to install app with invalid metadata"
+fi
+assert_file_has_content install-error-log "Metadata for .* is invalid"
+
+assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
+
+cleanup_repo
+
+ok "app with invalid metadata (in summary) can't be installed"
+
+create_app "invalid no-cache-in-summary"
+
+if ${FLATPAK} ${U} install -y test-repo org.test.Malicious 2>install-error-log; then
+    assert_not_reached "Should not be able to install app with invalid metadata"
+fi
+assert_file_has_content install-error-log "Metadata for .* is invalid"
+
+assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
+
+cleanup_repo
+
+ok "app with invalid metadata (in commit) can't be installed"
+
+create_app "mismatch no-cache-in-summary"
+
+if ${FLATPAK} ${U} install -y test-repo org.test.Malicious 2>install-error-log; then
+    assert_not_reached "Should not be able to install app with non-matching metadata"
+fi
+assert_file_has_content install-error-log "Commit metadata for .* not matching expected metadata"
+
+assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
+
+cleanup_repo
+
+ok "app with mismatched metadata (in commit) can't be installed"
+
+create_app "mismatch"
+
+if ${FLATPAK} ${U} install -y test-repo org.test.Malicious 2>install-error-log; then
+    assert_not_reached "Should not be able to install app with non-matching metadata"
+fi
+assert_file_has_content install-error-log "Commit metadata for .* not matching expected metadata"
+
+assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
+
+cleanup_repo
+
+ok "app with mismatched metadata (in summary) can't be installed"

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -167,11 +167,19 @@ ${FLATPAK} override --user --nofilesystem=xdg-documents org.test.Hello
 ${FLATPAK} override --user --show org.test.Hello > override
 
 assert_file_has_content override "^\[Context\]$"
-assert_file_has_content override "^filesystems=.*/media;.*$"
-assert_file_has_content override "^filesystems=.*home;.*$"
-assert_file_has_content override "^filesystems=.*xdg-documents;.*$"
-assert_file_has_content override "^filesystems=.*xdg-desktop/foo:create;.*$"
-assert_file_has_content override "^filesystems=.*xdg-config:ro;.*$"
+filesystems="$(sed -ne 's/^filesystems=//p' override)"
+assert_semicolon_list_contains "$filesystems" "/media"
+assert_not_semicolon_list_contains "$filesystems" "!/media"
+assert_semicolon_list_contains "$filesystems" "home"
+assert_not_semicolon_list_contains "$filesystems" "!home"
+assert_not_semicolon_list_contains "$filesystems" "xdg-documents"
+assert_semicolon_list_contains "$filesystems" "!xdg-documents"
+assert_semicolon_list_contains "$filesystems" "xdg-desktop/foo:create"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo:create"
+assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
+assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
 ok "override --filesystem"
 

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -17,7 +17,7 @@ reset_overrides () {
     assert_file_empty info
 }
 
-echo "1..17"
+echo "1..18"
 
 setup_repo
 install_repo
@@ -180,6 +180,51 @@ assert_not_semicolon_list_contains "$filesystems" "!xdg-desktop/foo:create"
 assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
+
+${FLATPAK} override --user --nofilesystem=host:reset org.test.Hello
+${FLATPAK} override --user --show org.test.Hello > override
+filesystems="$(sed -ne 's/^filesystems=//p' override)"
+assert_not_semicolon_list_contains "$filesystems" "host"
+assert_not_semicolon_list_contains "$filesystems" "host:reset"
+assert_semicolon_list_contains "$filesystems" "!host"
+assert_semicolon_list_contains "$filesystems" "!host:reset"
+assert_not_semicolon_list_contains "$filesystems" "host-reset"
+assert_not_semicolon_list_contains "$filesystems" "!host-reset"
+
+# !host-reset is the same as !host:reset, and serializes as !host:reset
+${FLATPAK} override --user --nofilesystem=host-reset org.test.Hello
+${FLATPAK} override --user --show org.test.Hello > override
+filesystems="$(sed -ne 's/^filesystems=//p' override)"
+assert_not_semicolon_list_contains "$filesystems" "host"
+assert_not_semicolon_list_contains "$filesystems" "host:reset"
+assert_semicolon_list_contains "$filesystems" "!host"
+assert_semicolon_list_contains "$filesystems" "!host:reset"
+assert_not_semicolon_list_contains "$filesystems" "host-reset"
+assert_not_semicolon_list_contains "$filesystems" "!host-reset"
+
+# --filesystem=...:reset => error
+e=0
+${FLATPAK} override --user --filesystem=host:reset org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem suffix \"reset\" only applies to --nofilesystem"
+assert_not_streq "$e" 0
+
+# --filesystem=host-reset => error
+e=0
+${FLATPAK} override --user --filesystem=host-reset org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem token \"host-reset\" is only applicable for --nofilesystem"
+assert_not_streq "$e" 0
+
+# --filesystem=host-reset:suffix => error
+e=0
+${FLATPAK} override --user --nofilesystem=host-reset:suffix org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem token \"host-reset\" cannot be used with a suffix"
+assert_not_streq "$e" 0
+
+# --nofilesystem=/foo:reset => error
+e=0
+${FLATPAK} override --user --nofilesystem=/foo:reset org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem suffix \"reset\" can only be applied to --nofilesystem=host"
+assert_not_streq "$e" 0
 
 # --nofilesystem=...:rw => warning
 # Warnings need to be made temporarily non-fatal here.
@@ -388,4 +433,41 @@ if ! skip_one_without_bwrap "runtime override --nofilesystem=host"; then
   rm -fr "$TEST_DATA_DIR/dir2"
 
   ok "runtime override --nofilesystem=host"
+fi
+
+reset_overrides
+
+if ! skip_one_without_bwrap "runtime override --nofilesystem=host:reset"; then
+  mkdir -p "$HOME/dir"
+  mkdir -p "$TEST_DATA_DIR/dir1"
+  mkdir -p "$TEST_DATA_DIR/dir2"
+  echo "hello" > "$HOME/example"
+  echo "hello" > "$HOME/dir/example"
+  echo "hello" > "$TEST_DATA_DIR/dir1/example"
+  echo "hello" > "$TEST_DATA_DIR/dir2/example"
+
+  ${FLATPAK} override --user --filesystem=host org.test.Hello
+  ${FLATPAK} override --user --filesystem='~/dir' org.test.Hello
+  ${FLATPAK} override --user --filesystem="$TEST_DATA_DIR/dir1" org.test.Hello
+
+  ${FLATPAK} run --env=TEST_DATA_DIR="$TEST_DATA_DIR" \
+    --command=sh --nofilesystem=host:reset org.test.Hello -c '
+    echo overwritten > "$HOME/dir/example" || true
+    echo overwritten > "$HOME/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir1/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir2/example" || true
+  '
+  # --nofilesystem=host:reset cancels all --filesystem permissions from
+  # lower-precedence layers
+  assert_file_has_content "$HOME/dir/example" hello
+  assert_file_has_content "$TEST_DATA_DIR/dir1/example" hello
+  assert_file_has_content "$HOME/example" hello
+  assert_file_has_content "$TEST_DATA_DIR/dir2/example" hello
+
+  rm -fr "$HOME/dir"
+  rm -fr "$HOME/example"
+  rm -fr "$TEST_DATA_DIR/dir1"
+  rm -fr "$TEST_DATA_DIR/dir2"
+
+  ok "runtime override --nofilesystem=host:reset"
 fi

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -181,6 +181,20 @@ assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
+# --filesystem=...:bar => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --filesystem=/foo:bar org.test.Hello 2>log || e=$?
+assert_file_has_content log "Unexpected filesystem suffix bar, ignoring"
+assert_streq "$e" 0
+
+# --nofilesystem=...:bar => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --nofilesystem=/foo:bar org.test.Hello 2>log || e=$?
+assert_file_has_content log "Unexpected filesystem suffix bar, ignoring"
+assert_streq "$e" 0
+
 ok "override --filesystem"
 
 reset_overrides

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -181,6 +181,13 @@ assert_semicolon_list_contains "$filesystems" "xdg-config:ro"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config"
 assert_not_semicolon_list_contains "$filesystems" "!xdg-config:ro"
 
+# --nofilesystem=...:rw => warning
+# Warnings need to be made temporarily non-fatal here.
+e=0
+G_DEBUG= ${FLATPAK} override --user --nofilesystem=/foo:rw org.test.Hello 2>log || e=$?
+assert_file_has_content log "Filesystem suffix \"rw\" is not applicable for --nofilesystem"
+assert_streq "$e" 0
+
 # --filesystem=...:bar => warning
 # Warnings need to be made temporarily non-fatal here.
 e=0

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -17,7 +17,7 @@ reset_overrides () {
     assert_file_empty info
 }
 
-echo "1..15"
+echo "1..17"
 
 setup_repo
 install_repo
@@ -302,4 +302,83 @@ if ! skip_one_without_bwrap "persist"; then
   assert_file_has_content $HOME/.var/app/org.test.Hello/example/bye goodbye
 
   ok "persist"
+fi
+
+reset_overrides
+
+if ! skip_one_without_bwrap "runtime override --nofilesystem=home"; then
+  mkdir -p "$HOME/dir"
+  mkdir -p "$TEST_DATA_DIR/dir1"
+  mkdir -p "$TEST_DATA_DIR/dir2"
+  echo "hello" > "$HOME/example"
+  echo "hello" > "$HOME/dir/example"
+  echo "hello" > "$TEST_DATA_DIR/dir1/example"
+  echo "hello" > "$TEST_DATA_DIR/dir2/example"
+
+  ${FLATPAK} override --user --filesystem=home org.test.Hello
+  ${FLATPAK} override --user --filesystem='~/dir' org.test.Hello
+  ${FLATPAK} override --user --filesystem="$TEST_DATA_DIR/dir1" org.test.Hello
+
+  ${FLATPAK} run --env=TEST_DATA_DIR="$TEST_DATA_DIR" \
+    --command=sh --nofilesystem=home org.test.Hello -c '
+    echo overwritten > "$HOME/dir/example" || true
+    echo overwritten > "$HOME/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir1/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir2/example" || true
+  '
+  # --nofilesystem=home does not cancel a more narrowly-scoped permission
+  # such as --filesystem=~/dir
+  assert_file_has_content "$HOME/dir/example" overwritten
+  # --nofilesystem=home cancels the --filesystem=home at a lower precedence,
+  # so $HOME/example was not shared
+  assert_file_has_content "$HOME/example" hello
+  # --nofilesystem=home does not affect access to files outside $HOME
+  assert_file_has_content "$TEST_DATA_DIR/dir1/example" overwritten
+  assert_file_has_content "$TEST_DATA_DIR/dir2/example" hello
+
+  rm -fr "$HOME/dir"
+  rm -fr "$HOME/example"
+  rm -fr "$TEST_DATA_DIR/dir1"
+  rm -fr "$TEST_DATA_DIR/dir2"
+
+  ok "runtime override --nofilesystem=home"
+fi
+
+reset_overrides
+
+if ! skip_one_without_bwrap "runtime override --nofilesystem=host"; then
+  mkdir -p "$HOME/dir"
+  mkdir -p "$TEST_DATA_DIR/dir1"
+  mkdir -p "$TEST_DATA_DIR/dir2"
+  echo "hello" > "$HOME/example"
+  echo "hello" > "$HOME/dir/example"
+  echo "hello" > "$TEST_DATA_DIR/dir1/example"
+  echo "hello" > "$TEST_DATA_DIR/dir2/example"
+
+  ${FLATPAK} override --user --filesystem=host org.test.Hello
+  ${FLATPAK} override --user --filesystem='~/dir' org.test.Hello
+  ${FLATPAK} override --user --filesystem="$TEST_DATA_DIR/dir1" org.test.Hello
+
+  ${FLATPAK} run --env=TEST_DATA_DIR="$TEST_DATA_DIR" \
+    --command=sh --nofilesystem=host org.test.Hello -c '
+    echo overwritten > "$HOME/dir/example" || true
+    echo overwritten > "$HOME/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir1/example" || true
+    echo overwritten > "$TEST_DATA_DIR/dir2/example" || true
+  '
+  # --nofilesystem=host does not cancel a more narrowly-scoped permission
+  # such as --filesystem=~/dir
+  assert_file_has_content "$HOME/dir/example" overwritten
+  assert_file_has_content "$TEST_DATA_DIR/dir1/example" overwritten
+  # --nofilesystem=host cancels the --filesystem=host at a lower precedence,
+  # so $HOME/example was not shared
+  assert_file_has_content "$HOME/example" hello
+  assert_file_has_content "$TEST_DATA_DIR/dir2/example" hello
+
+  rm -fr "$HOME/dir"
+  rm -fr "$HOME/example"
+  rm -fr "$TEST_DATA_DIR/dir1"
+  rm -fr "$TEST_DATA_DIR/dir2"
+
+  ok "runtime override --nofilesystem=host"
 fi


### PR DESCRIPTION
These are the fixes for [CVE-2021-43860](https://github.com/flatpak/flatpak/security/advisories/GHSA-qpjc-vq3c-572j) and [CVE-2022-21682](https://github.com/flatpak/flatpak/security/advisories/GHSA-8ch7-5j3h-g4fx).  I am going to include them in RHEL 8.6, so I thought that I might as well submit them upstream.

---

* Fix metadata file contents after null terminators being ignored
  (backported from commit 3c3dc554e744f0ce974e2051aa8cf94f9736c785)

* Transaction: Fail the resolve if xa.metadata invalid or missing
  (backported from commit 10367bd7d2036d39bcd108d7ed81fee9c87685f3)

* Require metadata in commit also for OCI remotes
  (backported from commit bd6948c375d50860ce891ead16040faf21839fc7)

* Ensure that bundles have metadata on install
  (cherry picked from commit 574cb113720a32e60cb948495621d704fee440ad)

* Add test for metadata validation
  (cherry picked from commit ce0bb56c6fc256ee0aee5407924243f0c0f14559)

* test-metadata-validation.sh: Ensure that mtimes change between iterations
  (cherry picked from commit eb324b9d827841d101046bbf8c2976e5a8724e64)

* test-override: Assert that only the expected term is negated
  (cherry picked from commit 74f02d1e9569bde9523b9add9e7d3fb5fbfa1e63)

* test-override: Assert that unimplemented suffix is ignored with a warning
  (cherry picked from commit 97dd26c02eb759236fb5b069f9764604fc550a37)

* context: Only parse filesystem/mode strings in one place
  (cherry picked from commit 517ad25b5fe83376af258acef646551cb97af97c)

* exports: Add assertions to distinguish between mode representations
  (cherry picked from commit 115d82e6ff28375de9f5287a6d1f9fe64ce2555d)

* context: Expose flatpak_context_parse_filesystem for testing
  (cherry picked from commit 55b27b1393a3880b79dfe108b6f13f1a2fa1888b)

* tests: Add basic unit tests for FlatpakExports, FlatpakContext
  (backported from commit c0faab35fabb469e3945ad99c32f041d2d7a0dab)

* context: Do some syntactic normalization on filesystems
  (cherry picked from commit aafe1d36e0225f54db8ca2ba03d8b1981c2d09e0)

* context: Forbid --filesystem=/
  (cherry picked from commit 02094b4f39e0bcb2d2e4c82926154c584759d0e1)

* context: Normalize home/path to ~/path, and ~ to home
  (backported from commit 09424423b93e9ea263a9e3f2de1579814b941054)

* tests: Use a temporary HOME directory to test contexts and exports
  (cherry picked from commit 354b9a2257341c4b9ff313d547fe0aafc25c43f6)

* tests: Exercise flatpak_context_save_metadata
  (cherry picked from commit e55dcf5e2bc066b5c2521ad82ca65efa126040a2)

* context: Implement MODE_NONE in unparse_filesystem_flags
  (cherry picked from commit 5a83c73ed859fe3e4bd93a228a4bc8981d649c5e)

* tests: Expand exports test coverage
  (backported from commit 27870f681d7efc4ed9c8c13e190b7bc392cefb48)

* run, override: Clarify the effect of --nofilesystem
  (cherry picked from commit fe3954ff63f0cafc70fd79c8aeac24d4a7ba85e6)

* test-override: Assert pre-1.12.3 behaviour of --nofilesystem=home, host
  (cherry picked from commit 734047a1d74218ff0ed4e4667628a0ea241985ac)

* context: Introduce new --nofilesystem=host:reset
  (cherry picked from commit 92b8cfe46b3adc43c24404decff0d0c393513731)

* test-override: Assert that --nofilesystem with suffix yields a warning
  (cherry picked from commit b543933ce14ccb787de6964f52ed32fbbfce9f2d)

* test-exports: Exercise host:reset and related filesystem tokens
  (cherry picked from commit d2128c54188bcccb5e5cea59587532ad3d0295cd)

* test-context: Exercise some corner cases for merging filesystems
  (backported from commit 4206d681c5c52691dec0074e3f8c32dab1953a94)

* test-override: Exercise --nofilesystem=host:reset
  (cherry picked from commit 2c89fc3ef340cf0d762b225a4f0578797e992003)