### PR TITLE
[flatpak-1.8.x] tests: Fix test-sideload.sh if ostree is built with curl backend

### DIFF
--- a/tests/test-sideload.sh
+++ b/tests/test-sideload.sh
@@ -112,10 +112,8 @@ httpd_clear_log
 if ${FLATPAK} ${U} install -y test-repo org.test.Hello &> install-error-log; then
     assert_not_reached "Disabled online install broken"
 fi
-assert_file_has_content install-error-log "Server returned status 404: Not Found"
+assert_file_has_content install-error-log "Server returned .*404.*"
 assert_file_has_content httpd-log "GET .*commit .*404"
-
-assert_file_has_content install-error-log "Server returned status 404: Not Found"
 
 ln -s $SIDELOAD_REPO $SIDELOAD_REPO_LINK
 


### PR DESCRIPTION
This fixes the test on Fedora 35, which I noticed when trying to help @alexlarsson [release 1.8.6](https://github.com/flatpak/flatpak/pull/4474).

Is it possible that the test suite was always broken when run on Fedora against the distribution's `ostree` RPM?  Fedora has been building OSTree against `libcurl` for a very long time (ie., from Fedora 26/27).