### PR TITLE
Support non-filesystem-based X11 sockets

### DIFF
--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -201,7 +201,9 @@ gboolean flatpak_run_app (FlatpakDecomposed  *app_ref,
 extern const char * const *flatpak_abs_usrmerged_dirs;
 
 gboolean flatpak_run_parse_x11_display (const char  *display,
+                                        int         *family,
                                         char       **x11_socket,
+                                        char       **remote_host,
                                         char       **original_display_nr,
                                         GError     **error);
 

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -200,4 +200,9 @@ gboolean flatpak_run_app (FlatpakDecomposed  *app_ref,
 
 extern const char * const *flatpak_abs_usrmerged_dirs;
 
+gboolean flatpak_run_parse_x11_display (const char  *display,
+                                        char       **x11_socket,
+                                        char       **original_display_nr,
+                                        GError     **error);
+
 #endif /* __FLATPAK_RUN_H__ */

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -177,7 +177,7 @@ write_xauth (char *number, FILE *output)
           local_xa = *xa;
           if (local_xa.number)
             {
-              local_xa.number = "99";
+              local_xa.number = (char *) "99";
               local_xa.number_length = 2;
             }
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -116,15 +116,24 @@ auth_streq (const char *str,
 
 static gboolean
 xauth_entry_should_propagate (const Xauth *xa,
-                              const char  *hostname,
+                              int          family,
+                              const char  *remote_hostname,
+                              const char  *local_hostname,
                               const char  *number)
 {
-  /* ensure entry isn't for remote access */
-  if (xa->family != FamilyLocal && xa->family != FamilyWild)
+  /* ensure entry isn't for a different type of access */
+  if (family != FamilyWild && xa->family != family && xa->family != FamilyWild)
+    return FALSE;
+
+  /* ensure entry isn't for remote access, except that if remote_hostname
+   * is specified, then remote access to that hostname is OK */
+  if (xa->family != FamilyWild && xa->family != FamilyLocal &&
+      (remote_hostname == NULL ||
+       !auth_streq (remote_hostname, xa->address, xa->address_length)))
     return FALSE;
 
   /* ensure entry is for this machine */
-  if (xa->family == FamilyLocal && !auth_streq (hostname, xa->address, xa->address_length))
+  if (xa->family == FamilyLocal && !auth_streq (local_hostname, xa->address, xa->address_length))
     {
       /* OpenSUSE inherits the hostname value from DHCP without updating
        * its X11 authentication cookie. The old hostname value can still
@@ -152,7 +161,9 @@ xauth_entry_should_propagate (const Xauth *xa,
 }
 
 static void
-write_xauth (const char *number,
+write_xauth (int family,
+             const char *remote_host,
+             const char *number,
              const char *replace_number,
              FILE       *output)
 {
@@ -177,7 +188,8 @@ write_xauth (const char *number,
       xa = XauReadAuth (f);
       if (xa == NULL)
         break;
-      if (xauth_entry_should_propagate (xa, unames.nodename, number))
+      if (xauth_entry_should_propagate (xa, family, remote_host,
+                                        unames.nodename, number))
         {
           local_xa = *xa;
           if (local_xa.number != NULL && replace_number != NULL)
@@ -330,16 +342,8 @@ flatpak_run_add_x11_args (FlatpakBwrap         *bwrap,
 
       g_assert (original_display_nr != NULL);
 
-      if (family != FamilyLocal)
-        {
-          g_warning ("Non-local X11 address DISPLAY=%s", display);
-          flatpak_bwrap_unset_env (bwrap, "DISPLAY");
-          return;
-        }
-
-      g_assert (x11_socket != NULL);
-
-      if (g_file_test (x11_socket, G_FILE_TEST_EXISTS))
+      if (x11_socket != NULL
+          && g_file_test (x11_socket, G_FILE_TEST_EXISTS))
         {
           flatpak_bwrap_add_args (bwrap,
                                   "--ro-bind", x11_socket, "/tmp/.X11-unix/X99",
@@ -353,9 +357,16 @@ flatpak_run_add_x11_args (FlatpakBwrap         *bwrap,
            * doesn't exist, then the only way this is going to work
            * is if the app can connect to abstract socket
            * @/tmp/.X11-unix/X42 or to TCP port localhost:6042,
-           * either of which requires a shared network namespace. */
-          g_warning ("X11 socket %s does not exist in filesystem.",
-                     x11_socket);
+           * either of which requires a shared network namespace.
+           *
+           * Alternatively, if DISPLAY is othermachine:23, then we
+           * definitely need access to TCP port othermachine:6023. */
+          if (x11_socket != NULL)
+            g_warning ("X11 socket %s does not exist in filesystem.",
+                       x11_socket);
+          else
+            g_warning ("Remote X11 display detected.");
+
           g_warning ("X11 access will require --share=network permission.");
         }
       else if (x11_socket != NULL)
@@ -383,7 +394,8 @@ flatpak_run_add_x11_args (FlatpakBwrap         *bwrap,
                 {
                   static const char dest[] = "/run/flatpak/Xauthority";
 
-                  write_xauth (original_display_nr, replace_display_nr, output);
+                  write_xauth (family, remote_host, original_display_nr,
+                               replace_display_nr, output);
                   flatpak_bwrap_add_args_data_fd (bwrap, "--ro-bind-data", tmp_fd, dest);
 
                   flatpak_bwrap_set_env (bwrap, "XAUTHORITY", dest, TRUE);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -102,6 +102,9 @@ extract_unix_path_from_dbus_address (const char *address)
   return g_strndup (path, path_end - path);
 }
 
+/* This is part of the X11 protocol, so we can safely hard-code it here */
+#define FamilyInternet6 (6)
+
 #ifdef ENABLE_XAUTH
 static gboolean
 auth_streq (const char *str,
@@ -202,15 +205,25 @@ write_xauth (const char *number,
 
   fclose (f);
 }
-#endif /* ENABLE_XAUTH */
+#else /* !ENABLE_XAUTH */
+
+/* When not doing Xauth, any distinct values will do, but use the same
+ * ones Xauth does so that we can refer to them in our unit test. */
+#define FamilyLocal (256)
+#define FamilyWild (65535)
+
+#endif /* !ENABLE_XAUTH */
 
 /*
+ * @family: (out) (not optional):
  * @x11_socket: (out) (not optional):
  * @display_nr_out: (out) (not optional):
  */
 gboolean
 flatpak_run_parse_x11_display (const char  *display,
+                               int         *family,
                                char       **x11_socket,
+                               char       **remote_host,
                                char       **display_nr_out,
                                GError     **error)
 {
@@ -218,7 +231,8 @@ flatpak_run_parse_x11_display (const char  *display,
   const char *display_nr;
   const char *display_nr_end;
 
-  colon = strchr (display, ':');
+  /* Use the last ':', not the first, to cope with [::1]:0 */
+  colon = strrchr (display, ':');
 
   if (colon == NULL)
     return glnx_throw (error, "No colon found in DISPLAY=%s", display);
@@ -232,14 +246,22 @@ flatpak_run_parse_x11_display (const char  *display,
   while (g_ascii_isdigit (*display_nr_end))
     display_nr_end++;
 
+  *display_nr_out = g_strndup (display_nr, display_nr_end - display_nr);
+
   if (display == colon || g_str_has_prefix (display, "unix:"))
     {
-      *display_nr_out = g_strndup (display_nr, display_nr_end - display_nr);
+      *family = FamilyLocal;
       *x11_socket = g_strdup_printf ("/tmp/.X11-unix/X%s", *display_nr_out);
+    }
+  else if (display[0] == '[' && display[colon - display - 1] == ']')
+    {
+      *family = FamilyInternet6;
+      *remote_host = g_strndup (display + 1, colon - display - 2);
     }
   else
     {
-      return glnx_throw (error, "Non-local X11 address DISPLAY=%s", display);
+      *family = FamilyWild;
+      *remote_host = g_strndup (display, colon - display);
     }
 
   return TRUE;
@@ -290,9 +312,12 @@ flatpak_run_add_x11_args (FlatpakBwrap *bwrap,
 
   if (display != NULL)
     {
+      g_autofree char *remote_host = NULL;
       g_autofree char *original_display_nr = NULL;
+      int family = -1;
 
-      if (!flatpak_run_parse_x11_display (display, &x11_socket, &original_display_nr,
+      if (!flatpak_run_parse_x11_display (display, &family, &x11_socket,
+                                          &remote_host, &original_display_nr,
                                           &local_error))
         {
           g_warning ("%s", local_error->message);
@@ -301,6 +326,14 @@ flatpak_run_add_x11_args (FlatpakBwrap *bwrap,
         }
 
       g_assert (original_display_nr != NULL);
+
+      if (family != FamilyLocal)
+        {
+          g_warning ("Non-local X11 address DISPLAY=%s", display);
+          flatpak_bwrap_unset_env (bwrap, "DISPLAY");
+          return;
+        }
+
       g_assert (x11_socket != NULL);
 
       flatpak_bwrap_add_args (bwrap,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -104,17 +104,17 @@ extract_unix_path_from_dbus_address (const char *address)
 
 #ifdef ENABLE_XAUTH
 static gboolean
-auth_streq (char *str,
-            char *au_str,
-            int   au_len)
+auth_streq (const char *str,
+            const char *au_str,
+            int         au_len)
 {
   return au_len == strlen (str) && memcmp (str, au_str, au_len) == 0;
 }
 
 static gboolean
-xauth_entry_should_propagate (Xauth *xa,
-                              char  *hostname,
-                              char  *number)
+xauth_entry_should_propagate (const Xauth *xa,
+                              const char  *hostname,
+                              const char  *number)
 {
   /* ensure entry isn't for remote access */
   if (xa->family != FamilyLocal && xa->family != FamilyWild)
@@ -149,7 +149,8 @@ xauth_entry_should_propagate (Xauth *xa,
 }
 
 static void
-write_xauth (char *number, FILE *output)
+write_xauth (const char *number,
+             FILE       *output)
 {
   Xauth *xa, local_xa;
   char *filename;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -106,7 +106,7 @@ extract_unix_path_from_dbus_address (const char *address)
 static gboolean
 auth_streq (const char *str,
             const char *au_str,
-            int         au_len)
+            size_t      au_len)
 {
   return au_len == strlen (str) && memcmp (str, au_str, au_len) == 0;
 }

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -232,7 +232,7 @@ flatpak_run_parse_x11_display (const char  *display,
   while (g_ascii_isdigit (*display_nr_end))
     display_nr_end++;
 
-  if (display == colon)
+  if (display == colon || g_str_has_prefix (display, "unix:"))
     {
       *display_nr_out = g_strndup (display_nr, display_nr_end - display_nr);
       *x11_socket = g_strdup_printf ("/tmp/.X11-unix/X%s", *display_nr_out);

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1779,6 +1779,7 @@ static const DisplayTest x11_display_tests[] =
   { ":0", FamilyLocal, "/tmp/.X11-unix/X0", NULL, "0" },
   { ":0.0", FamilyLocal, "/tmp/.X11-unix/X0", NULL, "0" },
   { ":42.0", FamilyLocal, "/tmp/.X11-unix/X42", NULL, "42" },
+  { "unix:42", FamilyLocal, "/tmp/.X11-unix/X42", NULL, "42" },
   { "othermachine:23", FamilyWild, NULL, "othermachine", "23" },
   { "bees.example.com:23", FamilyWild, NULL, "bees.example.com", "23" },
   { "[::1]:0", FamilyInternet6, NULL, "::1", "0" },

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1799,6 +1799,7 @@ test_parse_x11_display (void)
   for (i = 0; i < G_N_ELEMENTS (x11_display_tests); i++)
     {
       const DisplayTest *test = &x11_display_tests[i];
+      int family = -1;
       g_autofree char *x11_socket = NULL;
       g_autofree char *remote_host = NULL;
       g_autofree char *display_number = NULL;
@@ -1808,12 +1809,13 @@ test_parse_x11_display (void)
       g_test_message ("%s", test->display);
 
       ok = flatpak_run_parse_x11_display (test->display,
+                                          &family,
                                           &x11_socket,
+                                          &remote_host,
                                           &display_number,
                                           &error);
 
-      /* TODO: should be able to parse non-local addresses, too */
-      if (test->family != FamilyLocal)
+      if (test->family == 0)
         {
           g_assert_nonnull (error);
           g_assert_false (ok);
@@ -1826,6 +1828,7 @@ test_parse_x11_display (void)
         {
           g_assert_no_error (error);
           g_assert_true (ok);
+          g_assert_cmpint (family, ==, test->family);
           g_assert_cmpstr (x11_socket, ==, test->x11_socket);
           g_assert_cmpstr (remote_host, ==, test->remote_host);
           g_assert_cmpstr (display_number, ==, test->display_number);


### PR DESCRIPTION
This PR generalizes our support for parsing and remapping the X11 `DISPLAY` and `XAUTHORITY`, so that we can cope with two situations we previously didn't:

* Local connections where the path-based `AF_UNIX` socket has somehow been deleted: #4702 
* X11-over-ssh forwarding, traditional (insecure) remote X11 and other use-cases involving TCP: #397 

I had to do some refactoring to enable this, so it's probably easiest to review commit-by-commit.

---

* run: Avoid cast warning when built with -Wwrite-strings
    
    We're not going to call XauDisposeAuth on local_xa, so it's OK to put
    a "borrowed" constant string here.

* run: Improve const-correctness of Xauth code

* run: Avoid signed/unsigned comparison in Xauth handling
    
    In practice, au_len comes from one of the length fields in an Xauth
    struct, which are all of type unsigned short, so it cannot really be
    negative; but if we passed a negative argument here, the comparisons
    would not behave as intended. Use the more correct size_t.

* run: Factor out parsing X11 displays into a helper function
    
    This allows it to be unit-tested.

* run: Treat DISPLAY=unix:42 the same as :42
    
    xauth and xcb both treat this as a request to use AF_UNIX.

* run: Support parsing non-local X11 addresses
    
    We still don't support rewriting XAUTHORITY for these, but at least we
    understand them now.

* run: Handle X11 over local abstract or TCP sockets
    
    If the filesystem-backed Unix socket (G_UNIX_SOCKET_ADDRESS_PATH) does
    not exist, X11 clients can also use a Linux abstract Unix socket
    (G_UNIX_SOCKET_ADDRESS_ABSTRACT), or even a TCP socket.
    
    Both of these are going to require --share=network to be enabled, so
    print a warning if it isn't. We don't automatically enable
    --share=network, because that elevates the privileges of apps that would
    otherwise have entered a new network namespace, but users can make it
    work with `flatpak run --share=network` or
    `flatpak override --share=network`.
    
    When falling back to an abstract Unix socket or to a TCP socket, we
    can't remap the display number to the fixed :99.0 that we normally use,
    so adjust write_xauth() to be able to avoid doing that.
    
    Resolves: https://github.com/flatpak/flatpak/issues/4702

* run: Allow remapping Xauthority entries for remote or forwarded X11
    
    As with non-path-based AF_UNIX sockets, both of these are going to
    require --share=network to be enabled, so print a warning if it isn't.
    We don't automatically enable --share=network, because that elevates
    the privileges of apps that would otherwise have entered a new network
    namespace, but regular users of remote X11 can choose to enable it with
    `flatpak run --share=network` or `flatpak override --share=network`.
    
    Resolves: https://github.com/flatpak/flatpak/issues/397