### PR TITLE
dir: Use an a relative path to checkout the metadata directory

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8266,7 +8266,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
       if (!g_file_make_directory_with_parents (files, cancellable, error))
         return FALSE;
 
-      options.subpath = "/metadata";
+      options.subpath = "metadata";
 
       if (!ostree_repo_checkout_at (self->repo, &options,
                                     AT_FDCWD, checkoutdirpath,


### PR DESCRIPTION
ostree_repo_checkout_at is using g_file_get_child internally which is expecting
a relative path to the subdirectory and returns early when an absolute path is
given.