### PR TITLE
dir: Use SHA256, not SHA1, to name the cache for a filtered remote

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10923,7 +10923,7 @@ remote_filter_load (GFile *path, GError **error)
     }
 
   filter = g_new0 (RemoteFilter, 1);
-  filter->checksum = g_compute_checksum_for_data (G_CHECKSUM_SHA1, (guchar *)data, data_size);
+  filter->checksum = g_compute_checksum_for_data (G_CHECKSUM_SHA256, (guchar *)data, data_size);
   filter->path = g_object_ref (path);
   filter->mtime = mtime;
   filter->last_mtime_check = g_get_monotonic_time ();


### PR DESCRIPTION
SHA1 hashes are considered weak these days. Some distributions have
static analysis tools to detect the use of such weak hashes, and they
get triggered by flatpak. While this particular use of SHA1 in flatpak
is likely not security sensitive, it's also easy to move to SHA256 to
avoid any debate.

Here, the SHA1 hash of a named remote's filter file is used to generate
the name of the directory where the refs from that remote are cached.
One can reasonably assume that the cache is frequently invalidated
because the list of refs on the remote changes all the time. Hence,
it's not big problem if it gets invalidated once more because of this
change.