### PR TITLE
run: Don't propagate GStreamer variables to the sandbox

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1699,6 +1699,18 @@ static const ExportData default_exports[] = {
   {"PERLLIB", NULL},
   {"PERL5LIB", NULL},
   {"XCURSOR_PATH", NULL},
+  {"GST_PLUGIN_PATH_1_0", NULL},
+  {"GST_REGISTRY", NULL},
+  {"GST_REGISTRY_1_0", NULL},
+  {"GST_PLUGIN_PATH", NULL},
+  {"GST_PLUGIN_SYSTEM_PATH", NULL},
+  {"GST_PLUGIN_SCANNER", NULL},
+  {"GST_PLUGIN_SCANNER_1_0", NULL},
+  {"GST_PLUGIN_SYSTEM_PATH_1_0", NULL},
+  {"GST_PRESET_PATH", NULL},
+  {"GST_PTP_HELPER", NULL},
+  {"GST_PTP_HELPER_1_0", NULL},
+  {"GST_INSTALL_PLUGINS_HELPER", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {


### PR DESCRIPTION
Trying to run sandboxed GStreamer applications from within jhbuild, for
example, would make those applications fail to find their plugins.

```
$ LANG=C flatpak run org.gnome.Totem.Devel
** (totem:2): WARNING **: 19:32:06.406: Element 'gtkglsink' is missing, verify your installation
** (totem:2): WARNING **: 19:32:06.406: Element 'glsinkbin' is missing, verify your installation
```

Don't propagate those GStreamer environment variables to within the
sandbox to avoid that problem.

See https://gitlab.gnome.org/GNOME/totem/-/issues/504