### PR TITLE
Cope better with /var/lib/flatpak existing but being empty

### DIFF
--- a/app/flatpak-builtins.h
+++ b/app/flatpak-builtins.h
@@ -39,10 +39,12 @@ G_BEGIN_DECLS
  * @FLATPAK_BUILTIN_FLAG_ONE_DIR: Allow a single --user/--system/--installation option
  *    and return a single dir. If no option is specified, default to --system
  * @FLATPAK_BUILTIN_FLAG_STANDARD_DIRS: Allow repeated use of --user/--system/--installation
- *    and return multiple dirs. If no option is specified return system(default)+user
+ *    and return multiple dirs. If no option is specified return system(default)+user.
+ *    Implies %FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO.
  * @FLATPAK_BUILTIN_FLAG_ALL_DIRS: Allow repeated use of --user/--system/--installation
  *    and return multiple dirs. If no option is specified, return all installations,
- *    starting with system(default)+user
+ *    starting with system(default)+user.
+ *    Implies %FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO.
  *
  * Flags affecting the behavior of flatpak_option_context_parse().
  *

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -470,7 +470,9 @@ flatpak_option_context_parse (GOptionContext     *context,
         {
           FlatpakDir *dir = g_ptr_array_index (dirs, i);
 
-          if (flags & FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO)
+          if (flags & (FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO |
+                       FLATPAK_BUILTIN_FLAG_ALL_DIRS |
+                       FLATPAK_BUILTIN_FLAG_STANDARD_DIRS))
             {
               if (!flatpak_dir_maybe_ensure_repo (dir, cancellable, error))
                 return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3945,7 +3945,7 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
           if (!flatpak_dir_system_helper_call_ensure_repo (self,
                                                            FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
                                                            installation ? installation : "",
-                                                           NULL, &local_error))
+                                                           cancellable, &local_error))
             {
               if (allow_empty)
                 return TRUE;
@@ -4089,7 +4089,7 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
           if (!flatpak_dir_system_helper_call_ensure_repo (self,
                                                            FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
                                                            installation ? installation : "",
-                                                           NULL, &my_error))
+                                                           cancellable, &my_error))
             {
               if (allow_empty)
                 return TRUE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4007,22 +4007,33 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
          that still user bare-user */
       OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER_ONLY;
 
-      if (!ostree_repo_create (repo, mode, cancellable, &my_error))
+      if (flatpak_dir_use_system_helper (self, NULL))
         {
-          flatpak_rm_rf (repodir, cancellable, NULL);
+          if (!system_helper_maybe_ensure_repo (self, allow_empty, cancellable, error))
+            return FALSE;
 
-          if (allow_empty)
-            return TRUE;
-
-          g_propagate_error (error, g_steal_pointer (&my_error));
-          return FALSE;
+          if (!ensure_repo_opened (repo, cancellable, error))
+            return FALSE;
         }
-
-      /* Create .changed file early to avoid polling non-existing file in monitor */
-      if (!flatpak_dir_mark_changed (self, &my_error))
+      else
         {
-          g_warning ("Error marking directory as changed: %s", my_error->message);
-          g_clear_error (&my_error);
+          if (!ostree_repo_create (repo, mode, cancellable, &my_error))
+            {
+              flatpak_rm_rf (repodir, cancellable, NULL);
+
+              if (allow_empty)
+                return TRUE;
+
+              g_propagate_error (error, g_steal_pointer (&my_error));
+              return FALSE;
+            }
+
+          /* Create .changed file early to avoid polling non-existing file in monitor */
+          if (!flatpak_dir_mark_changed (self, &my_error))
+            {
+              g_warning ("Error marking directory as changed: %s", my_error->message);
+              g_clear_error (&my_error);
+            }
         }
     }
   else

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3921,6 +3921,30 @@ apply_new_flatpakrepo (const char *remote_name,
 }
 
 static gboolean
+system_helper_maybe_ensure_repo (FlatpakDir *self,
+                                 gboolean allow_empty,
+                                 GCancellable *cancellable,
+                                 GError **error)
+{
+  g_autoptr(GError) local_error = NULL;
+  const char *installation = flatpak_dir_get_id (self);
+
+  if (!flatpak_dir_system_helper_call_ensure_repo (self,
+                                                   FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
+                                                   installation ? installation : "",
+                                                   cancellable, &local_error))
+    {
+      if (allow_empty)
+        return TRUE;
+
+      g_propagate_error (error, g_steal_pointer (&local_error));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
 _flatpak_dir_ensure_repo (FlatpakDir   *self,
                           gboolean      allow_empty,
                           GCancellable *cancellable,
@@ -3939,20 +3963,8 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
     {
       if (flatpak_dir_use_system_helper (self, NULL))
         {
-          g_autoptr(GError) local_error = NULL;
-          const char *installation = flatpak_dir_get_id (self);
-
-          if (!flatpak_dir_system_helper_call_ensure_repo (self,
-                                                           FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
-                                                           installation ? installation : "",
-                                                           cancellable, &local_error))
-            {
-              if (allow_empty)
-                return TRUE;
-
-              g_propagate_error (error, g_steal_pointer (&local_error));
-              return FALSE;
-            }
+          if (!system_helper_maybe_ensure_repo (self, allow_empty, cancellable, error))
+            return FALSE;
         }
       else
         {
@@ -4085,18 +4097,8 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
     {
       if (flatpak_dir_use_system_helper (self, NULL))
         {
-          const char *installation = flatpak_dir_get_id (self);
-          if (!flatpak_dir_system_helper_call_ensure_repo (self,
-                                                           FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
-                                                           installation ? installation : "",
-                                                           cancellable, &my_error))
-            {
-              if (allow_empty)
-                return TRUE;
-
-              g_propagate_error (error, g_steal_pointer (&my_error));
-              return FALSE;
-            }
+          if (!system_helper_maybe_ensure_repo (self, allow_empty, cancellable, error))
+            return FALSE;
 
           if (!ostree_repo_reload_config (repo, cancellable, error))
             return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4025,12 +4025,24 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
         {
           if (!ostree_repo_create (repo, mode, cancellable, &my_error))
             {
+              const char *repo_path = flatpak_file_get_path_cached (repodir);
+
               flatpak_rm_rf (repodir, cancellable, NULL);
 
               if (allow_empty)
                 return TRUE;
 
-              g_propagate_error (error, g_steal_pointer (&my_error));
+              /* As of 2022, the error message from libostree is not the most helpful:
+               * Creating repo: mkdirat: Permission denied
+               * If the repository path is in the error message, assume this
+               * has been fixed. If not, add it. */
+              if (strstr (my_error->message, repo_path) != NULL)
+                g_propagate_error (error, g_steal_pointer (&my_error));
+              else
+                g_set_error (error, my_error->domain, my_error->code,
+                             "Unable to create repository at %s (%s)",
+                             repo_path, my_error->message);
+
               return FALSE;
             }
 


### PR DESCRIPTION
As noted in #4111, the Flatpak CLI is currently not very good at dealing with a `/var/lib/flatpak` that has been provisioned as an empty directory - perhaps by `systemd-tmpfiles` or equivalent, or while offloading `/var/lib/flatpak` from a small root filesystem to a larger "bulk data" partition using bind-mounts.

---

* dir: Pass cancellable through to remote EnsureRepo call

* dir: Factor out common code to call EnsureRepo on system helper

* dir: Factor out function to open the libostree repository
    
    I'm about to add another caller for this.

* dir: Use system helper to create system repo if necessary
    
    Previously, if /var/lib/flatpak didn't exist then we would use the
    system helper to create and populate it, but if it existed and was empty,
    we could only populate it if we had privileges. This led to errors from
    libostree:
    
        Creating repo: mkdirat: Permission denied
    
    The EnsureRepo method call is allowed by default for active local users,
    so do this even if allow_empty is true: this will incorporate
    /etc/flatpak/remotes.d into the repository, whether it is newly-created
    or not. This makes a `flatpak search` work immediately, without having
    to fetch metadata explicitly.

* dir: Avoid polkit prompts for EnsureRepo in most CLI commands
    
    If we are running a CLI command in the background, then EnsureRepo
    might require authorization. Silently skip it if allow_empty was true,
    as it is for commands that iterate through all repositories.

* dir: Include repo path in error message if unable to create it
    
    libostree makes heavy use of fd-based I/O, which has the disadvantage
    that it is rarely obvious what path an error message is referring to.

* app: Make ALL_DIRS and STANDARD_DIRS imply OPTIONAL_REPO
    
    It is already the case that when we are using ALL_DIRS, we always
    combine it with OPTIONAL_REPO, meaning no need to populate empty
    installations. ALL_DIRS is used for commands that iterate through all
    known installations to enumerate apps/runtimes, such as `flatpak run`
    and `flatpak list`; for these commands, it's reasonable to say that
    if the installation does not have a libostree repository, then that's
    equivalent to it having a libostree repository with no apps and no
    runtimes. Make this happen automatically if forgotten.
    
    For STANDARD_DIRS, we were inconsistent about this: `flatpak remote-list`
    had OPTIONAL_REPO, but the other commands did not.
    STANDARD_DIRS is used for `flatpak create-usb`, and for all the commands
    that manipulate remotes.
    
    For the commands that manipulate remotes, it seems reasonable to say
    that if an installation has no libostree repository and we are unable
    to create one, then that's equivalent to an installation with a
    libostree repository but no remotes.
    
    Similarly, for create-usb, an installation where we are unable to create
    a libostree repository seems like it should be equivalent to an
    installation whose libostree repository does not contain any of the
    refs we are interested in.
    
    Resolves: https://github.com/flatpak/flatpak/issues/4111