### PR TITLE
Some backports to 1.12.x

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4360,6 +4360,73 @@ flatpak_dir_remove_appstream (FlatpakDir   *self,
   return TRUE;
 }
 
+#define SECS_PER_MINUTE (60)
+#define SECS_PER_HOUR   (60 * SECS_PER_MINUTE)
+#define SECS_PER_DAY    (24 * SECS_PER_HOUR)
+
+/* This looks for old temporary files created by previous versions of
+   flatpak_dir_deploy_appstream(). These are all either directories
+   starting with a dot, or symlinks starting with a dot. Such temp
+   files if found can be from a concurrent deploy, so we only remove
+   any such files older than a day to avoid races.
+*/
+static void
+remove_old_appstream_tmpdirs (GFile *dir)
+{
+  g_auto(GLnxDirFdIterator) dir_iter = { 0 };
+  time_t now = time (NULL);
+
+  if (!glnx_dirfd_iterator_init_at (AT_FDCWD, flatpak_file_get_path_cached (dir),
+                                    FALSE, &dir_iter, NULL))
+    return;
+
+  while (TRUE)
+    {
+      struct stat stbuf;
+      struct dirent *dent;
+      g_autoptr(GFile) tmp = NULL;
+
+      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dir_iter, &dent, NULL, NULL))
+        break;
+
+      if (dent == NULL)
+        break;
+
+      /* We ignore non-dotfiles and .timestamps as they are not tempfiles */
+      if (dent->d_name[0] != '.' ||
+          strcmp (dent->d_name, ".timestamp") == 0)
+        continue;
+
+      /* Check for right types and names */
+      if (dent->d_type == DT_DIR)
+        {
+          if (strlen (dent->d_name) != 72 ||
+              dent->d_name[65] != '-')
+            continue;
+        }
+      else if (dent->d_type == DT_LNK)
+        {
+          if (!g_str_has_prefix (dent->d_name, ".active-"))
+            continue;
+        }
+      else
+        continue;
+
+      /* Check that the file is at least a day old to avoid races */
+      if (!glnx_fstatat (dir_iter.fd, dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW, NULL))
+        continue;
+
+      if (stbuf.st_mtime >= now ||
+          now - stbuf.st_mtime < SECS_PER_DAY)
+        continue;
+
+      tmp = g_file_get_child (dir, dent->d_name);
+
+      /* We ignore errors here, no need to worry anyone */
+      (void)flatpak_rm_rf (tmp, NULL, NULL);
+    }
+}
+
 gboolean
 flatpak_dir_deploy_appstream (FlatpakDir   *self,
                               const char   *remote,
@@ -4645,6 +4712,10 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
       g_autofree char *appstream_dir_path = g_file_get_path (appstream_dir);
       utime (appstream_dir_path, NULL);
     }
+
+  /* There used to be an bug here where temporary files where not removed, which could use
+   * quite a lot of space over time, so we check for these and remove them. */
+  remove_old_appstream_tmpdirs (arch_dir);
 
   if (out_changed)
     *out_changed = TRUE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4384,7 +4384,6 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
   g_autoptr(GFile) active_tmp_link = NULL;
   g_autoptr(GError) tmp_error = NULL;
   g_autofree char *new_dir = NULL;
-  g_autofree char *checkout_dir_path = NULL;
   OstreeRepoCheckoutAtOptions options = { 0, };
   glnx_autofd int dfd = -1;
   g_autoptr(GFileInfo) file_info = NULL;
@@ -4396,6 +4395,8 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
   g_autoptr(GRegex) allow_refs = NULL;
   g_autoptr(GRegex) deny_refs = NULL;
   g_autofree char *subset = NULL;
+  g_auto(GLnxTmpDir) tmpdir = { 0, };
+  g_autoptr(FlatpakTempDir) tmplink = NULL;
 
   /* Keep a shared repo lock to avoid prunes removing objects we're relying on
    * while we do the checkout. This could happen if the ref changes after we
@@ -4485,15 +4486,13 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
   {
     g_autofree char *template = g_strdup_printf (".%s-XXXXXX", new_dir);
     g_autoptr(GFile) tmp_dir_template = g_file_get_child (arch_dir, template);
-    checkout_dir_path = g_file_get_path (tmp_dir_template);
-    if (g_mkdtemp_full (checkout_dir_path, 0755) == NULL)
-      {
-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                     _("Can't create deploy directory"));
-        return FALSE;
-      }
+
+    if (!glnx_mkdtempat (AT_FDCWD, flatpak_file_get_path_cached (tmp_dir_template), 0755,
+                         &tmpdir, error))
+      return FALSE;
   }
-  checkout_dir = g_file_new_for_path (checkout_dir_path);
+
+  checkout_dir = g_file_new_for_path (tmpdir.path);
 
   options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
   options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
@@ -4501,7 +4500,7 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
   options.bareuseronly_dirs = TRUE; /* https://github.com/ostreedev/ostree/pull/927 */
 
   if (!ostree_repo_checkout_at (self->repo, &options,
-                                AT_FDCWD, checkout_dir_path, new_checksum,
+                                AT_FDCWD, tmpdir.path, new_checksum,
                                 cancellable, error))
     return FALSE;
 
@@ -4594,6 +4593,9 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
   if (!g_file_make_symbolic_link (active_tmp_link, new_dir, cancellable, error))
     return FALSE;
 
+   /* This is a link, not a dir, but it will remove the same way on destroy */
+  tmplink = g_object_ref (active_tmp_link);
+
   if (syncfs (dfd) != 0)
     {
       glnx_set_error_from_errno (error);
@@ -4607,6 +4609,9 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
                     cancellable, NULL, NULL, error))
     return FALSE;
 
+  /* Don't delete tmpdir now that it's moved */
+  glnx_tmpdir_unset (&tmpdir);
+
   if (syncfs (dfd) != 0)
     {
       glnx_set_error_from_errno (error);
@@ -4617,6 +4622,9 @@ flatpak_dir_deploy_appstream (FlatpakDir   *self,
                             active_link,
                             cancellable, error))
     return FALSE;
+
+  /* Don't delete tmplink now that it's moved */
+  g_object_unref (g_steal_pointer (&tmplink));
 
   if (old_dir != NULL &&
       g_strcmp0 (old_dir, new_dir) != 0)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1698,6 +1698,18 @@ static const ExportData default_exports[] = {
   {"PERLLIB", NULL},
   {"PERL5LIB", NULL},
   {"XCURSOR_PATH", NULL},
+  {"GST_PLUGIN_PATH_1_0", NULL},
+  {"GST_REGISTRY", NULL},
+  {"GST_REGISTRY_1_0", NULL},
+  {"GST_PLUGIN_PATH", NULL},
+  {"GST_PLUGIN_SYSTEM_PATH", NULL},
+  {"GST_PLUGIN_SCANNER", NULL},
+  {"GST_PLUGIN_SCANNER_1_0", NULL},
+  {"GST_PLUGIN_SYSTEM_PATH_1_0", NULL},
+  {"GST_PRESET_PATH", NULL},
+  {"GST_PTP_HELPER", NULL},
+  {"GST_PTP_HELPER_1_0", NULL},
+  {"GST_INSTALL_PLUGINS_HELPER", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {


### PR DESCRIPTION
The main fixes is the appstream deploy tmpdata leak, but I added the gstreamer env var propagation change too, as that seems useful and not very risky.

Do we need anything else?