### PR TITLE
Delete some unreachable ref-not-found code

### DIFF
--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -149,17 +149,11 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
     {
       if (opt_commit)
         commit = g_strdup (opt_commit);
-      else
+      else if (!flatpak_remote_state_lookup_ref (state, flatpak_decomposed_get_ref (ref),
+                                                 &commit, NULL, NULL, NULL, error))
         {
-          flatpak_remote_state_lookup_ref (state, flatpak_decomposed_get_ref (ref), &commit, NULL, NULL, NULL, error);
-          if (commit == NULL)
-            {
-              if (error != NULL && *error == NULL)
-                flatpak_fail_error (error, FLATPAK_ERROR_REF_NOT_FOUND,
-                                    _("Couldn't find latest checksum for ref %s in remote %s"),
-                                    flatpak_decomposed_get_ref (ref), remote);
-              return FALSE;
-            }
+          g_assert (error == NULL || *error != NULL);
+          return FALSE;
         }
     }
   else

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5896,18 +5896,10 @@ flatpak_dir_pull (FlatpakDir                           *self,
     {
       rev = g_strdup (opt_rev);
     }
-  else
+  else if (!flatpak_remote_state_lookup_ref (state, ref, &rev, NULL, NULL, NULL, error))
     {
-      flatpak_remote_state_lookup_ref (state, ref, &rev, NULL, NULL, NULL, error);
-      if (rev == NULL && error != NULL && *error == NULL)
-        flatpak_fail_error (error, FLATPAK_ERROR_REF_NOT_FOUND, _("Couldn't find latest checksum for ref %s in remote %s"),
-                            ref, state->remote_name);
-
-      if (rev == NULL)
-        {
-          g_assert (error == NULL || *error != NULL);
-          return FALSE;
-        }
+      g_assert (error == NULL || *error != NULL);
+      return FALSE;
     }
 
   g_debug ("%s: Using commit %s for pull of ref %s from remote %s%s%s",


### PR DESCRIPTION
flatpak_remote_state_lookup_ref() always sets the error to
FLATPAK_ERROR_REF_NOT_FOUND when it returns FALSE.

Found by coverity CID 1514265