### PR TITLE
Fix "Failed to read commit" error messages on install/update operations

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5266,7 +5266,7 @@ repo_pull (OstreeRepo                           *self,
            FlatpakRemoteState                   *state,
            const char                          **dirs_to_pull,
            const char                           *ref_to_fetch,
-           const char                           *rev_to_fetch, /* (nullable) */
+           const char                           *rev_to_fetch,
            GFile                                *sideload_repo,
            const char                           *token,
            FlatpakPullFlags                      flatpak_flags,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5286,6 +5286,9 @@ repo_pull (OstreeRepo                           *self,
   const char *refs_to_fetch[2];
   g_autofree char *sideload_url = NULL;
 
+  g_return_val_if_fail (ref_to_fetch != NULL, FALSE);
+  g_return_val_if_fail (rev_to_fetch != NULL, FALSE);
+
   /* The ostree fetcher asserts if error is NULL */
   if (error == NULL)
     error = &dummy_error;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5857,6 +5857,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
                   GError                              **error)
 {
   gboolean ret = FALSE;
+  gboolean have_commit = FALSE;
   g_autofree char *rev = NULL;
   g_autofree char *url = NULL;
   g_autoptr(GPtrArray) subdirs_arg = NULL;
@@ -5934,6 +5935,23 @@ flatpak_dir_pull (FlatpakDir                           *self,
                                      cancellable,
                                      error))
     goto out;
+
+  /* Work around a libostree bug where the pull may succeed but the pulled
+   * commit will be incomplete by preemptively marking the commit partial.
+   * Note this has to be done before ostree_repo_prepare_transaction() so we
+   * aren't checking the staging dir for the commit.
+   * https://github.com/flatpak/flatpak/issues/3479
+   * https://github.com/ostreedev/ostree/pull/2549
+   */
+  {
+    g_autoptr(GError) local_error = NULL;
+
+    if (!ostree_repo_has_object (repo, OSTREE_OBJECT_TYPE_COMMIT, rev, &have_commit, NULL, &local_error))
+      g_warning ("Encountered error checking for commit object %s: %s", rev, local_error->message);
+    else if (!have_commit &&
+             !ostree_repo_mark_commit_partial (repo, rev, TRUE, &local_error))
+      g_warning ("Encountered error marking commit partial: %s: %s", rev, local_error->message);
+  }
 
   if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
     goto out;


### PR DESCRIPTION
All the details of the bug are in:
https://github.com/ostreedev/ostree/pull/2549
https://github.com/flatpak/flatpak/issues/3479

This patch works around it by marking the commit we're about to pull
partial, so that if the .commit object exists in a staging directory
from a previous failed pull, it will not be erroneously considered a
complete commit, even by affected versions of libostree that don't have
the above patch. If for some reason the commit in the staging dir is
complete, libostree should harmlessly verify that and pull it in.

Usually the commit we are pulling does not already exist in the local
repo, but add a check anyway so we don't risk marking a complete commit
as partial, and so this works on the code path from
"flatpak install --reinstall ..."

Fixes #3479