### PR TITLE
app: Don't overzealously tab complete options

### DIFF
--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -339,6 +339,9 @@ flatpak_complete_options (FlatpakCompletion *completion,
   GOptionEntry *e = entries;
   int i;
 
+  if (completion->cur == NULL || completion->cur[0] != '-')
+    return;
+
   while (e->long_name != NULL)
     {
       if (e->arg_description)


### PR DESCRIPTION
If the user hasn't typed a '-', don't offer options in the tab
autocompletion. This is consistent with other linux commands, and less
messy.

Fixes https://github.com/flatpak/flatpak/issues/4753