### PR TITLE
[flatpak-1.12.x] 1.12.6 backports

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5222,7 +5222,7 @@ repo_pull (OstreeRepo                           *self,
            FlatpakRemoteState                   *state,
            const char                          **dirs_to_pull,
            const char                           *ref_to_fetch,
-           const char                           *rev_to_fetch, /* (nullable) */
+           const char                           *rev_to_fetch,
            GFile                                *sideload_repo,
            const char                           *token,
            FlatpakPullFlags                      flatpak_flags,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -5242,6 +5242,9 @@ repo_pull (OstreeRepo                           *self,
   const char *refs_to_fetch[2];
   g_autofree char *sideload_url = NULL;
 
+  g_return_val_if_fail (ref_to_fetch != NULL, FALSE);
+  g_return_val_if_fail (rev_to_fetch != NULL, FALSE);
+
   /* The ostree fetcher asserts if error is NULL */
   if (error == NULL)
     error = &dummy_error;

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -632,7 +632,7 @@ flatpak_get_gtk_theme (void)
       else
         {
           schema = g_settings_schema_source_lookup (source,
-                                                    "org.gnome.desktop.interface", FALSE);
+                                                    "org.gnome.desktop.interface", TRUE);
 
           if (schema == NULL)
             g_once_init_leave (&gtk_theme, g_strdup (""));

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -11,10 +11,20 @@ USE_SYSTEMDIR=yes
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..1"
-
 HISTORY_START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
 sleep 1
+
+if ! logger "Checking whether Flatpak can use the journal..."; then
+    skip "Cannot write to Journal with logger"
+fi
+
+messages="$(journalctl --user --since="${HISTORY_START_TIME}" || true)"
+
+if [ -z "$messages" ]; then
+    skip "Cannot read back from Journal with journalctl"
+fi
+
+echo "1..1"
 
 mkdir -p ${TEST_DATA_DIR}/system-history-installation
 mkdir -p ${FLATPAK_CONFIG_DIR}/installations.d


### PR DESCRIPTION
These are all clean cherry-picks of important patches so I don't think there's much to debate here. There are some other patches on the development branch such as https://github.com/flatpak/flatpak/pull/4752 that it might make sense to backport but I decided to be conservative here.