### PR TITLE
Add --include-sdk/debug to install SDK/debuginfo along with a ref

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -51,6 +51,8 @@ static gboolean opt_no_deps;
 static gboolean opt_no_static_deltas;
 static gboolean opt_runtime;
 static gboolean opt_app;
+static gboolean opt_include_sdk;
+static gboolean opt_include_debug;
 static gboolean opt_bundle;
 static gboolean opt_from;
 static gboolean opt_yes;
@@ -69,6 +71,8 @@ static GOptionEntry options[] = {
   { "no-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_no_static_deltas, N_("Don't use static deltas"), NULL },
   { "runtime", 0, 0, G_OPTION_ARG_NONE, &opt_runtime, N_("Look for runtime with the specified name"), NULL },
   { "app", 0, 0, G_OPTION_ARG_NONE, &opt_app, N_("Look for app with the specified name"), NULL },
+  { "include-sdk", 0, 0, G_OPTION_ARG_NONE, &opt_include_sdk, N_("Additionally install the SDK used to build the given refs") },
+  { "include-debug", 0, 0, G_OPTION_ARG_NONE, &opt_include_debug, N_("Additionally install the debug info for the given refs and their dependencies") },
   { "bundle", 0, 0, G_OPTION_ARG_NONE, &opt_bundle, N_("Assume LOCATION is a .flatpak single-file bundle"), NULL },
   { "from", 0, 0, G_OPTION_ARG_NONE, &opt_from, N_("Assume LOCATION is a .flatpakref application description"), NULL },
   { "gpg-file", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_gpg_file, N_("Check bundle signatures with GPG key from FILE (- for stdin)"), N_("FILE") },
@@ -171,6 +175,8 @@ install_bundle (FlatpakDir *dir,
   flatpak_transaction_set_disable_related (transaction, opt_no_related);
   flatpak_transaction_set_disable_auto_pin (transaction, opt_no_auto_pin);
   flatpak_transaction_set_reinstall (transaction, opt_reinstall);
+  flatpak_transaction_set_auto_install_sdk (transaction, opt_include_sdk);
+  flatpak_transaction_set_auto_install_debug (transaction, opt_include_debug);
 
   for (int i = 0; opt_sideload_repos != NULL && opt_sideload_repos[i] != NULL; i++)
     flatpak_transaction_add_sideload_repo (transaction, opt_sideload_repos[i]);
@@ -249,6 +255,8 @@ install_from (FlatpakDir *dir,
   flatpak_transaction_set_disable_auto_pin (transaction, opt_no_auto_pin);
   flatpak_transaction_set_reinstall (transaction, opt_reinstall);
   flatpak_transaction_set_default_arch (transaction, opt_arch);
+  flatpak_transaction_set_auto_install_sdk (transaction, opt_include_sdk);
+  flatpak_transaction_set_auto_install_debug (transaction, opt_include_debug);
 
   for (int i = 0; opt_sideload_repos != NULL && opt_sideload_repos[i] != NULL; i++)
     flatpak_transaction_add_sideload_repo (transaction, opt_sideload_repos[i]);
@@ -317,6 +325,9 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
 
   if (opt_noninteractive)
     opt_yes = TRUE; /* Implied */
+
+  if (opt_include_sdk || opt_include_debug)
+    opt_or_update = TRUE;
 
   kinds = flatpak_kinds_from_bools (opt_app, opt_runtime);
 
@@ -481,6 +492,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
   flatpak_transaction_set_disable_related (transaction, opt_no_related);
   flatpak_transaction_set_disable_auto_pin (transaction, opt_no_auto_pin);
   flatpak_transaction_set_reinstall (transaction, opt_reinstall);
+  flatpak_transaction_set_auto_install_sdk (transaction, opt_include_sdk);
+  flatpak_transaction_set_auto_install_debug (transaction, opt_include_debug);
 
   for (i = 0; opt_sideload_repos != NULL && opt_sideload_repos[i] != NULL; i++)
     flatpak_transaction_add_sideload_repo (transaction, opt_sideload_repos[i]);

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -256,6 +256,16 @@ void                flatpak_transaction_set_include_unused_uninstall_ops (Flatpa
 FLATPAK_EXTERN
 gboolean            flatpak_transaction_get_include_unused_uninstall_ops (FlatpakTransaction *self);
 FLATPAK_EXTERN
+void                flatpak_transaction_set_auto_install_sdk (FlatpakTransaction *self,
+                                                              gboolean            auto_install_sdk);
+FLATPAK_EXTERN
+gboolean            flatpak_transaction_get_auto_install_sdk (FlatpakTransaction *self);
+FLATPAK_EXTERN
+void                flatpak_transaction_set_auto_install_debug (FlatpakTransaction *self,
+                                                                gboolean            auto_install_debug);
+FLATPAK_EXTERN
+gboolean            flatpak_transaction_get_auto_install_debug (FlatpakTransaction *self);
+FLATPAK_EXTERN
 void                flatpak_transaction_add_dependency_source (FlatpakTransaction  *self,
                                                                FlatpakInstallation *installation);
 FLATPAK_EXTERN

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -270,6 +270,25 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--include-sdk</option></term>
+
+                <listitem><para>
+                  For each app being installed, also installs the SDK that was used to build it.
+                  Implies <option>--or-update</option>; incompatible with <option>--no-deps</option>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--include-debug</option></term>
+
+                <listitem><para>
+                  For each ref being installed, as well as all dependencies, also installs its
+                  debug info. Implies <option>--or-update</option>; incompatible with
+                  <option>--no-deps</option>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-y</option></term>
                 <term><option>--assumeyes</option></term>
                 <listitem><para>


### PR DESCRIPTION
This makes it a lot easier to give guidance on using `flatpak run -d` or
`flatpak-coredumpctl`, because there's an easy way to install the
relevant refs.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>