### PR TITLE
[1.12] wayland: allow absolute path in WAYLAND_DISPLAY

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -308,7 +308,10 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
   if (!wayland_display)
     wayland_display = "wayland-0";
 
-  wayland_socket = g_build_filename (user_runtime_dir, wayland_display, NULL);
+  if (wayland_display[0] == '/')
+    wayland_socket = g_strdup (wayland_display);
+  else
+    wayland_socket = g_build_filename (user_runtime_dir, wayland_display, NULL);
 
   if (!g_str_has_prefix (wayland_display, "wayland-") ||
       strchr (wayland_display, '/') != NULL)


### PR DESCRIPTION
If WAYLAND_DISPLAY starts with a '/', use it for the socket path as-is.
See [1].

[1]: https://gitlab.freedesktop.org/wayland/wayland/-/blob/d690712b7b83faeb8fca4015b296aece2fb30c65/src/wayland-client.c#L1064-1095

Signed-off-by: Julian Orth <ju.orth@gmail.com>
(cherry picked from commit aac1205d66e03facc965279d5825272597b305d0)

---

Backport of #4752 to 1.12.x