### PR TITLE
[1.12] Cope better with /var/lib/flatpak existing but being empty

### DIFF
--- a/app/flatpak-builtins.h
+++ b/app/flatpak-builtins.h
@@ -39,10 +39,12 @@ G_BEGIN_DECLS
  * @FLATPAK_BUILTIN_FLAG_ONE_DIR: Allow a single --user/--system/--installation option
  *    and return a single dir. If no option is specified, default to --system
  * @FLATPAK_BUILTIN_FLAG_STANDARD_DIRS: Allow repeated use of --user/--system/--installation
- *    and return multiple dirs. If no option is specified return system(default)+user
+ *    and return multiple dirs. If no option is specified return system(default)+user.
+ *    Implies %FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO.
  * @FLATPAK_BUILTIN_FLAG_ALL_DIRS: Allow repeated use of --user/--system/--installation
  *    and return multiple dirs. If no option is specified, return all installations,
- *    starting with system(default)+user
+ *    starting with system(default)+user.
+ *    Implies %FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO.
  *
  * Flags affecting the behavior of flatpak_option_context_parse().
  *

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -460,7 +460,9 @@ flatpak_option_context_parse (GOptionContext     *context,
         {
           FlatpakDir *dir = g_ptr_array_index (dirs, i);
 
-          if (flags & FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO)
+          if (flags & (FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO |
+                       FLATPAK_BUILTIN_FLAG_ALL_DIRS |
+                       FLATPAK_BUILTIN_FLAG_STANDARD_DIRS))
             {
               if (!flatpak_dir_maybe_ensure_repo (dir, cancellable, error))
                 return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3943,7 +3943,7 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
           if (!flatpak_dir_system_helper_call_ensure_repo (self,
                                                            FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
                                                            installation ? installation : "",
-                                                           NULL, &local_error))
+                                                           cancellable, &local_error))
             {
               if (allow_empty)
                 return TRUE;
@@ -4087,7 +4087,7 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
           if (!flatpak_dir_system_helper_call_ensure_repo (self,
                                                            FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
                                                            installation ? installation : "",
-                                                           NULL, &my_error))
+                                                           cancellable, &my_error))
             {
               if (allow_empty)
                 return TRUE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3943,6 +3943,23 @@ system_helper_maybe_ensure_repo (FlatpakDir *self,
 }
 
 static gboolean
+ensure_repo_opened (OstreeRepo *repo,
+                    GCancellable *cancellable,
+                    GError **error)
+{
+  if (!ostree_repo_open (repo, cancellable, error))
+    {
+      g_autofree char *repopath = NULL;
+
+      repopath = g_file_get_path (ostree_repo_get_path (repo));
+      g_prefix_error (error, _("While opening repository %s: "), repopath);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
 _flatpak_dir_ensure_repo (FlatpakDir   *self,
                           gboolean      allow_empty,
                           GCancellable *cancellable,
@@ -4008,14 +4025,8 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
     }
   else
     {
-      if (!ostree_repo_open (repo, cancellable, error))
-        {
-          g_autofree char *repopath = NULL;
-
-          repopath = g_file_get_path (repodir);
-          g_prefix_error (error, _("While opening repository %s: "), repopath);
-          return FALSE;
-        }
+      if (!ensure_repo_opened (repo, cancellable, error))
+        return FALSE;
     }
 
   /* In the system-helper case we're directly using the global repo, and we can't write any

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3920,6 +3920,7 @@ apply_new_flatpakrepo (const char *remote_name,
 
 static gboolean
 system_helper_maybe_ensure_repo (FlatpakDir *self,
+                                 FlatpakHelperEnsureRepoFlags flags,
                                  gboolean allow_empty,
                                  GCancellable *cancellable,
                                  GError **error)
@@ -3928,7 +3929,7 @@ system_helper_maybe_ensure_repo (FlatpakDir *self,
   const char *installation = flatpak_dir_get_id (self);
 
   if (!flatpak_dir_system_helper_call_ensure_repo (self,
-                                                   FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
+                                                   flags,
                                                    installation ? installation : "",
                                                    cancellable, &local_error))
     {
@@ -3970,15 +3971,20 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
   g_autoptr(GError) my_error = NULL;
   g_autoptr(GFile) cache_dir = NULL;
   g_autoptr(GHashTable) flatpakrepos = NULL;
+  FlatpakHelperEnsureRepoFlags ensure_flags = FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE;
 
   if (self->repo != NULL)
     return TRUE;
+
+  /* Don't trigger polkit prompts if we are just doing this opportunistically */
+  if (allow_empty)
+    ensure_flags |= FLATPAK_HELPER_ENSURE_REPO_FLAGS_NO_INTERACTION;
 
   if (!g_file_query_exists (self->basedir, cancellable))
     {
       if (flatpak_dir_use_system_helper (self, NULL))
         {
-          if (!system_helper_maybe_ensure_repo (self, allow_empty, cancellable, error))
+          if (!system_helper_maybe_ensure_repo (self, ensure_flags, allow_empty, cancellable, error))
             return FALSE;
         }
       else
@@ -4007,7 +4013,7 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
 
       if (flatpak_dir_use_system_helper (self, NULL))
         {
-          if (!system_helper_maybe_ensure_repo (self, allow_empty, cancellable, error))
+          if (!system_helper_maybe_ensure_repo (self, ensure_flags, allow_empty, cancellable, error))
             return FALSE;
 
           if (!ensure_repo_opened (repo, cancellable, error))
@@ -4117,7 +4123,7 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
     {
       if (flatpak_dir_use_system_helper (self, NULL))
         {
-          if (!system_helper_maybe_ensure_repo (self, allow_empty, cancellable, error))
+          if (!system_helper_maybe_ensure_repo (self, ensure_flags, allow_empty, cancellable, error))
             return FALSE;
 
           if (!ostree_repo_reload_config (repo, cancellable, error))


### PR DESCRIPTION
Backport of #4732. This is complicated enough that it should have some testing in 1.13.x first, but I think it would be worth having in 1.12.x, since it removes a semi-frequently-fired footgun.