### PR TITLE
tests: Don't install tap-driver.sh in the installed-tests

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -202,7 +202,6 @@ tests/package_version.txt: Makefile
 tests/test-basic.sh: tests/package_version.txt
 
 dist_installed_test_extra_scripts += \
-	buildutil/tap-driver.sh \
 	tests/http-utils-test-server.py \
 	tests/oci-registry-server.py \
 	tests/oci-registry-client.py \


### PR DESCRIPTION
This is specifically for running build-time tests in the Autotools build
system, and is not used when running installed-tests.