### PR TITLE
[1.12.x] Accept share/metainfo exports when installing

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7639,6 +7639,7 @@ flatpak_export_dir (GFile        *source,
     "share/dbus-1/services",               "../../..",
     "share/gnome-shell/search-providers",  "../../..",
     "share/mime/packages",                 "../../..",
+    "share/metainfo",                      "../..",
     "bin",                                 "..",
   };
   int i;

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -733,6 +733,10 @@ flatpak_get_allowed_exports (const char     *source_path,
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
     }
+  else if (strcmp (source_path, "share/metainfo") == 0)
+    {
+      g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
+    }
   else
     return FALSE;
 


### PR DESCRIPTION
This is a combination of these two commits from the main branch:

build-finish: Export appstream metainfo into a single directory
(cherry picked from commit 766bf5f08a256431cde8bca6228a4964a73ff6bc)
Export to share/metainfo not share/appdata
(cherry picked from commit 3c63cac8f9c0b45d6e6b8f4167845366a6bb34d9)

However this commit only allows the exports when deploying an
install/update, not when building a new Flatpak, so we avoid a warning
message but arguably don't add any new features to the stable branch.

Fixes https://github.com/flatpak/flatpak/issues/4800