### PR TITLE
dir: Consistently use relative paths for libostree subpaths

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8400,7 +8400,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
       if (!g_file_make_directory_with_parents (files, cancellable, error))
         return FALSE;
 
-      options.subpath = "/metadata";
+      options.subpath = "metadata";
 
       if (!ostree_repo_checkout_at (self->repo, &options,
                                     AT_FDCWD, checkoutdirpath,
@@ -8413,7 +8413,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
 
       for (i = 0; subpaths[i] != NULL; i++)
         {
-          g_autofree char *subpath = g_build_filename ("/files", subpaths[i], NULL);
+          g_autofree char *subpath = g_build_filename ("files", subpaths[i], NULL);
           g_autofree char *dstpath = g_build_filename (checkoutdirpath, "/files", subpaths[i], NULL);
           g_autofree char *dstpath_parent = g_path_get_dirname (dstpath);
           g_autoptr(GFile) child = NULL;


### PR DESCRIPTION
The subpath is resolved relative to the root of the commit, so we can
use either an absolute or a relative path interchangeably. When using
libostree < 2021.6 with GLib >= 2.71, absolute paths cause an assertion
failure here; that was a libostree bug and was fixed in 2021.6, but we
can interoperate with more versions by sticking to relative paths, and
there's no real reason to prefer absolute.

Resolves: https://github.com/flatpak/flatpak/issues/4805

---

This is a more complete version of #4707. We don't really *need* this change, but it makes it more likely that people with a random assortment of Flatpak, libostree and GLib versions will avoid the bug.