### PR TITLE
build: Consistently include libglnx header as "libglnx.h"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,6 @@ AM_CPPFLAGS =							\
 	-DSYSTEM_HELPER_USER=\"$(SYSTEM_HELPER_USER)\"          \
 	-DSYSTEM_FONT_CACHE_DIRS=\"$(SYSTEM_FONT_CACHE_DIRS)\"		\
 	-DG_LOG_DOMAIN=\"flatpak\"				\
-	-I$(srcdir)/subprojects					\
 	-I$(srcdir)/subprojects/libglnx				\
 	-I$(srcdir)/common					\
 	-I$(builddir)/common					\

--- a/app/flatpak-builtins-build-bundle.c
+++ b/app/flatpak-builtins-build-bundle.c
@@ -31,7 +31,7 @@
 
 #include <gio/gunixinputstream.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-context-private.h"

--- a/app/flatpak-builtins-build-import-bundle.c
+++ b/app/flatpak-builtins-build-import-bundle.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-build-sign.c
+++ b/app/flatpak-builtins-build-sign.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-build-update-repo.c
+++ b/app/flatpak-builtins-build-update-repo.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-base-private.h"

--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-config.c
+++ b/app/flatpak-builtins-config.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "common/flatpak-dir-private.h"

--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-document-export.c
+++ b/app/flatpak-builtins-document-export.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-document-dbus-generated.h"
 
 #include <gio/gunixfdlist.h>

--- a/app/flatpak-builtins-document-info.c
+++ b/app/flatpak-builtins-document-info.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-document-dbus-generated.h"
 
 #include <gio/gunixfdlist.h>

--- a/app/flatpak-builtins-document-list.c
+++ b/app/flatpak-builtins-document-list.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-document-dbus-generated.h"
 
 #include "flatpak-builtins.h"

--- a/app/flatpak-builtins-document-unexport.c
+++ b/app/flatpak-builtins-document-unexport.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-document-dbus-generated.h"
 
 #include <gio/gunixfdlist.h>

--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -29,7 +29,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-history.c
+++ b/app/flatpak-builtins-history.c
@@ -29,7 +29,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-journal.h>

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -29,7 +29,7 @@
 
 #include <gio/gunixinputstream.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-kill.c
+++ b/app/flatpak-builtins-kill.c
@@ -31,7 +31,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-instance.h"

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-make-current.c
+++ b/app/flatpak-builtins-make-current.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-mask.c
+++ b/app/flatpak-builtins-mask.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -29,7 +29,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-permission-list.c
+++ b/app/flatpak-builtins-permission-list.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"

--- a/app/flatpak-builtins-permission-remove.c
+++ b/app/flatpak-builtins-permission-remove.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"

--- a/app/flatpak-builtins-permission-reset.c
+++ b/app/flatpak-builtins-permission-reset.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"

--- a/app/flatpak-builtins-permission-set.c
+++ b/app/flatpak-builtins-permission-set.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"

--- a/app/flatpak-builtins-permission-show.c
+++ b/app/flatpak-builtins-permission-show.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-permission-dbus-generated.h"
 
 #include "flatpak-builtins.h"

--- a/app/flatpak-builtins-pin.c
+++ b/app/flatpak-builtins-pin.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-ps.c
+++ b/app/flatpak-builtins-ps.c
@@ -29,7 +29,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-remote-delete.c
+++ b/app/flatpak-builtins-remote-delete.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-remote-list.c
+++ b/app/flatpak-builtins-remote-list.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-remote-modify.c
+++ b/app/flatpak-builtins-remote-modify.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-repo.c
+++ b/app/flatpak-builtins-repo.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -29,7 +29,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-utils-private.h"

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -23,7 +23,7 @@
 
 #include <glib.h>
 #include <appstream.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-dir-private.h"
 #include "flatpak-permission-dbus-generated.h"

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -28,7 +28,7 @@
 
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #ifdef USE_SYSTEM_HELPER
 #include <polkit/polkit.h>

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -185,7 +185,6 @@ endif
 libflatpak_common_la_CFLAGS = \
 	-DFLATPAK_COMPILATION \
 	-DLIBEXECDIR=\"$(libexecdir)\" \
-	-I$(srcdir)/subprojects/dbus-proxy \
 	$(AM_CFLAGS) \
 	$(ARCHIVE_CFLAGS) \
 	$(ZSTD_CFLAGS) \

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -35,7 +35,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-bwrap-private.h"
 #include "flatpak-utils-private.h"

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -21,7 +21,7 @@
 #ifndef __FLATPAK_CONTEXT_H__
 #define __FLATPAK_CONTEXT_H__
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "dbus-proxy/flatpak-proxy.h"
 #include <flatpak-common-types-private.h>
 #include "flatpak-exports-private.h"

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -22,9 +22,15 @@
 #define __FLATPAK_CONTEXT_H__
 
 #include "libglnx.h"
-#include "dbus-proxy/flatpak-proxy.h"
 #include <flatpak-common-types-private.h>
 #include "flatpak-exports-private.h"
+
+typedef enum {
+  FLATPAK_POLICY_NONE,
+  FLATPAK_POLICY_SEE,
+  FLATPAK_POLICY_TALK,
+  FLATPAK_POLICY_OWN
+} FlatpakPolicy;
 
 typedef struct FlatpakContext FlatpakContext;
 

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -35,7 +35,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-run-private.h"
 #include "flatpak-proxy.h"

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -38,7 +38,6 @@
 #include "libglnx.h"
 
 #include "flatpak-run-private.h"
-#include "flatpak-proxy.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-dir-private.h"
 #include "flatpak-systemd-dbus-generated.h"

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -28,7 +28,7 @@
 #include "flatpak-progress-private.h"
 #include "flatpak-variant-private.h"
 #include "flatpak-ref-utils-private.h"
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 /* Version history:
  * The version field was added in flatpak 1.2, anything before is 0.

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -55,7 +55,7 @@
 #include "flatpak-utils-base-private.h"
 #include "flatpak-variant-private.h"
 #include "flatpak-variant-impl-private.h"
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "system-helper/flatpak-system-helper.h"
 
 #ifdef HAVE_LIBMALCONTENT

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -21,7 +21,7 @@
 #ifndef __FLATPAK_EXPORTS_H__
 #define __FLATPAK_EXPORTS_H__
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-bwrap-private.h"
 
 /* In numerical order of more privs */

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -42,7 +42,6 @@
 
 #include "flatpak-exports-private.h"
 #include "flatpak-run-private.h"
-#include "flatpak-proxy.h"
 #include "flatpak-utils-base-private.h"
 #include "flatpak-dir-private.h"
 #include "flatpak-systemd-dbus-generated.h"

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -38,7 +38,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-exports-private.h"
 #include "flatpak-run-private.h"

--- a/common/flatpak-oci-registry-private.h
+++ b/common/flatpak-oci-registry-private.h
@@ -21,7 +21,7 @@
 #ifndef __FLATPAK_OCI_REGISTRY_H__
 #define __FLATPAK_OCI_REGISTRY_H__
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include <glib.h>
 #include <gio/gio.h>

--- a/common/flatpak-prune.c
+++ b/common/flatpak-prune.c
@@ -35,7 +35,7 @@
 #include "flatpak-error.h"
 #include "flatpak-prune-private.h"
 #include "flatpak-variant-impl-private.h"
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "valgrind-private.h"
 
 /* This is a custom implementation of ostree-prune that caches the

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -21,7 +21,7 @@
 #ifndef __FLATPAK_RUN_H__
 #define __FLATPAK_RUN_H__
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-common-types-private.h"
 #include "flatpak-context-private.h"
 #include "flatpak-bwrap-private.h"

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -55,7 +55,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "flatpak-run-private.h"
 #include "flatpak-proxy.h"

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -58,7 +58,6 @@
 #include "libglnx.h"
 
 #include "flatpak-run-private.h"
-#include "flatpak-proxy.h"
 #include "flatpak-utils-base-private.h"
 #include "flatpak-dir-private.h"
 #include "flatpak-instance-private.h"

--- a/common/flatpak-utils-base.c
+++ b/common/flatpak-utils-base.c
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 char *
 flatpak_get_timezone (void)

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -23,7 +23,7 @@
 
 #include <gio/gunixoutputstream.h>
 #include <libsoup/soup.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include <sys/types.h>
 #include <sys/xattr.h>

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -23,7 +23,7 @@
 
 #include <string.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include <flatpak-common-types-private.h>
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -51,7 +51,7 @@
 #include "flatpak-utils-base-private.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-variant-impl-private.h"
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "valgrind-private.h"
 
 /* This is also here so the common code can report these errors to the lib */

--- a/common/test-lib.c
+++ b/common/test-lib.c
@@ -1,6 +1,6 @@
 #include "config.h"
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include <flatpak.h>
 #include <gio/gunixoutputstream.h>

--- a/portal/flatpak-portal-app-info.c
+++ b/portal/flatpak-portal-app-info.c
@@ -21,7 +21,7 @@
 #include "config.h"
 
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak-portal-app-info.h"
 #include "flatpak-portal-error.h"
 

--- a/tests/can-use-fuse.c
+++ b/tests/can-use-fuse.c
@@ -11,7 +11,7 @@
 
 #include <glib/gstdio.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #define FUSE_USE_VERSION 26
 #include <fuse_lowlevel.h>

--- a/tests/hold-lock.c
+++ b/tests/hold-lock.c
@@ -30,7 +30,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 static GArray *global_locks = NULL;
 static gboolean opt_wait = FALSE;

--- a/tests/test-instance.c
+++ b/tests/test-instance.c
@@ -32,8 +32,8 @@
 #include "flatpak-instance-private.h"
 #include "flatpak-run-private.h"
 
-#include "libglnx/libglnx.h"
-#include "libglnx/tests/libglnx-testlib.h"
+#include "libglnx.h"
+#include "tests/libglnx-testlib.h"
 
 #include "testlib.h"
 

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -21,7 +21,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 char *
 assert_mkdtemp (char *tmpl)

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -7,7 +7,7 @@
 #include <glib.h>
 #include <ostree.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include "flatpak.h"
 
 #include "can-use-fuse.h"


### PR DESCRIPTION
* build: Consistently include libglnx header as "libglnx.h"
    
    Recent Meson versions have warnings if you add the subprojects
    directory as an include path, because the way Meson wants to consume
    subprojects is by the subproject's build system producing a Meson
    dependency object that encapsulates its include directory. Flatpak
    doesn't have a Meson build system yet, but I'm working on that.
    
    libglnx seems to be set up to have the libglnx directory be its include
    path instead: for example, ostree (by the author of libglnx) already
    uses "libglnx.h" or <libglnx.h> everywhere. Do the same here.

* common: Decouple flatpak-context-private.h from xdg-dbus-proxy
    
    If we're using a system copy of xdg-dbus-proxy, it's not really correct
    to include a header from our subproject (which we are otherwise not
    going to be compiling), and Meson is stricter about this than Autotools.
    Instead, duplicate the FlatpakPolicy enum, which is the only part we
    actually need.