### PR TITLE
Improve --sideload-repo option to take create-usb dirs

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1358,7 +1358,7 @@ get_remote_state (FlatpakDir   *dir,
   for (int i = 0; opt_sideload_repos != NULL && opt_sideload_repos[i] != NULL; i++)
      {
       g_autoptr(GFile) f = g_file_new_for_path (opt_sideload_repos[i]);
-      flatpak_remote_state_add_sideload_repo (state, f);
+      flatpak_remote_state_add_sideload_dir (state, f);
      }
 
   return state;

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -198,8 +198,8 @@ GVariant *flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
                                                 char              **out_commit,
                                                 GCancellable       *cancellable,
                                                 GError            **error);
-void flatpak_remote_state_add_sideload_repo (FlatpakRemoteState *self,
-                                             GFile               *path);
+void flatpak_remote_state_add_sideload_dir (FlatpakRemoteState *self,
+                                            GFile              *path);
 
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDir, g_object_unref)

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1981,7 +1981,7 @@ flatpak_transaction_ensure_remote_state (FlatpakTransaction             *self,
         {
           const char *path = g_ptr_array_index (priv->extra_sideload_repos, i);
           g_autoptr(GFile) f = g_file_new_for_path (path);
-          flatpak_remote_state_add_sideload_repo (state, f);
+          flatpak_remote_state_add_sideload_dir (state, f);
         }
     }
 


### PR DESCRIPTION
Currently, when using the sideloading support for offline updates, there
are two types of directories that are interesting: an ostree repo
directory on a directory that was passed to `flatpak create-usb`. By
default the latter has a repo at the subpath ".ostree/repo", and if a
custom destination was specified with "--destination-repo", a symlink is
created pointing to it in ".ostree/repos.d".

Currently Flatpak supports either repos or create-usb dirs in the
`sideload-repos` directory in either the Flatpak installation or
`/run/flatpak` (see flatpak(1)), but only supports repo directories
being passed to "--sideload-repo" for the install and update commands.

This is pretty confusing and actually made me think the sideload support
was broken because I forgot about this limitation. So change things so
we can accept either type of directory specified either way: via option
or via the "sideload-repos" directories.

I've tested all of the following cases:
- pointing to a repo with --sideload-repo
- pointing to a create-usb dir with --sideload-repo
- linking to a repo in ~/.local/share/flatpak/sideload-repos
- linking to a create-usb dir in ~/.local/share/flatpak/sideload-repos
- pulling from a sideload repo when online as a performance improvement