### PR TITLE
selinux: Let system helper have read access to /etc/passwd

### DIFF
--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -12,6 +12,8 @@ type flatpak_helper_t;
 type flatpak_helper_exec_t;
 init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
+auth_read_passwd(flatpak_helper_t)
+
 optional_policy(`
     dbus_stub()
     dbus_system_domain(flatpak_helper_t, flatpak_helper_exec_t)


### PR DESCRIPTION
The system-helper (ie., the `flatpak-system-helper` process) is
labelled with flatpak_helper_exec_t and runs in the flatpak_helper_t
domain, and needs to be able to read /etc/passwd.  This explicitly
permits it to do so to avoid running into SELinux denials.

https://bugzilla.redhat.com/show_bug.cgi?id=2070350