### PR TITLE
selinux: Let the system helper watch files inside $libexecdir

### DIFF
--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -12,6 +12,8 @@ type flatpak_helper_t;
 type flatpak_helper_exec_t;
 init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
+auth_read_passwd(flatpak_helper_t)
+
 optional_policy(`
     dbus_stub()
     dbus_system_domain(flatpak_helper_t, flatpak_helper_exec_t)

--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -14,6 +14,10 @@ init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
 auth_read_passwd(flatpak_helper_t)
 
+ifdef(`corecmd_watch_bin_dirs',`
+    corecmd_watch_bin_dirs(flatpak_helper_t)
+')
+
 optional_policy(`
     dbus_stub()
     dbus_system_domain(flatpak_helper_t, flatpak_helper_exec_t)


### PR DESCRIPTION
The system-helper (ie., the `flatpak-system-helper` process) is
labelled with flatpak_helper_exec_t and runs in the flatpak_helper_t
domain, and tries to set up an inotify(7) watch on it's own binary so
that it can exit when the binary is replaced.  This explicitly permits
it to do so to avoid running into SELinux denials.

The corecmd_watch_bin_dirs SELinux interface is a recent addition [1],
and is therefore used conditionally when defined.

[1] https://github.com/fedora-selinux/selinux-policy/commit/88072fd293
    https://github.com/fedora-selinux/selinux-policy/pull/1133

https://bugzilla.redhat.com/show_bug.cgi?id=2053634

This goes on top of https://github.com/flatpak/flatpak/pull/4852