### PR TITLE
selinux: Permit read access to /var/lib/flatpak

### DIFF
--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -14,6 +14,10 @@ init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
 auth_read_passwd(flatpak_helper_t)
 
+ifdef(`corecmd_watch_bin_dirs',`
+    corecmd_watch_bin_dirs(flatpak_helper_t)
+')
+
 optional_policy(`
     dbus_stub()
     dbus_system_domain(flatpak_helper_t, flatpak_helper_exec_t)

--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -13,6 +13,8 @@ type flatpak_helper_exec_t;
 init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
 auth_read_passwd(flatpak_helper_t)
+files_list_var_lib(flatpak_helper_t)
+files_read_var_lib_files(flatpak_helper_t)
 
 ifdef(`corecmd_watch_bin_dirs',`
     corecmd_watch_bin_dirs(flatpak_helper_t)


### PR DESCRIPTION
It's clearly quite important to have read access to /var/lib/flatpak
and it's contents.  This explicitly permits that to avoid running
into SELinux denials.

https://bugzilla.redhat.com/show_bug.cgi?id=2070741

This goes on top of https://github.com/flatpak/flatpak/pull/4852 and https://github.com/flatpak/flatpak/pull/4853