### PR TITLE
Github workflow improvements

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,10 +65,12 @@ jobs:
     - name: autogen.sh
       run: NOCONFIGURE=1 ./autogen.sh
     - name: configure
+      # We don't do gtk-doc or GObject-Introspection here, because they can
+      # clash with AddressSanitizer. Instead, the clang build enables those.
       run: |
         mkdir _build
         pushd _build
-        ../configure  --enable-internal-checks --enable-asan
+        ../configure  --enable-internal-checks --enable-asan --disable-introspection
         popd
       env:
         CFLAGS: -O2 -Wp,-D_FORTIFY_SOURCE=2
@@ -172,7 +174,7 @@ jobs:
       run: |
         mkdir _build
         pushd _build
-        ../configure --enable-gtk-doc --enable-gtk-doc-html
+        ../configure --enable-gtk-doc --enable-gtk-doc-html --enable-introspection
         popd
       env:
         CFLAGS: -O2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -146,6 +146,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
+        sudo add-apt-repository ppa:flatpak/stable
         sudo apt-get update
         sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-focal main' # Needed for updates to work
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
@@ -158,14 +159,6 @@ jobs:
       uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Build ostree dependency
-      run: |
-        git clone --branch v2020.8 --depth 1 --no-tags https://github.com/ostreedev/ostree.git ./ostree
-        pushd ./ostree
-        ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --sysconfdir=/etc --localstatedir=/var
-        make -j $(getconf _NPROCESSORS_ONLN)
-        sudo make install
-        popd
     - name: Create logs dir
       run: mkdir test-logs
     - name: autogen.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -128,7 +128,7 @@ jobs:
       with:
         submodules: true
     - name: configure
-      run: ./autogen.sh  --enable-gtk-doc --enable-gtk-doc-html
+      run: ./autogen.sh
       env:
         CC: clang
         CFLAGS: -Werror=unused-variable
@@ -172,7 +172,7 @@ jobs:
       run: |
         mkdir _build
         pushd _build
-        ../configure
+        ../configure --enable-gtk-doc --enable-gtk-doc-html
         popd
       env:
         CFLAGS: -O2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -180,7 +180,9 @@ jobs:
         CFLAGS: -O2
     - name: Build flatpak
       run: make -C _build -j $(getconf _NPROCESSORS_ONLN)
-    - name: Run tests
+    - name: Distcheck
+      run: make -C _build distcheck
+    - name: Run tests under valgrind
       run: make -C _build check
       env:
         FLATPAK_TESTS_VALGRIND: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        sudo add-apt-repository ppa:alexlarsson/flatpak
+        sudo add-apt-repository ppa:flatpak/stable
         sudo add-apt-repository ppa:alexlarsson/glib260
         sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update
@@ -116,7 +116,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Install Dependencies
       run: |
-        sudo add-apt-repository ppa:alexlarsson/flatpak
+        sudo add-apt-repository ppa:flatpak/stable
         sudo add-apt-repository ppa:alexlarsson/glib260
         sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,7 +65,6 @@ jobs:
     - name: autogen.sh
       run: NOCONFIGURE=1 ./autogen.sh
     - name: configure
-      # TODO: Enable gtk-doc builds
       run: |
         mkdir _build
         pushd _build
@@ -170,7 +169,6 @@ jobs:
     - name: autogen.sh
       run: NOCONFIGURE=1 ./autogen.sh
     - name: configure
-      # TODO: Enable gtk-doc builds
       run: |
         mkdir _build
         pushd _build


### PR DESCRIPTION
* workflows: Remove a TODO
    
    We explicitly enable gtk-doc for one of our builds (the one that uses
    clang on Ubuntu 18.04). There's no real need to enable it for more than
    one build.

* workflows: Move gtk-doc enablement from clang to valgrind build
    
    We want to have gtk-doc enabled in the build that will run
    `make distcheck`, but the clang/CodeQL build seems like a poor fit for
    that, since it runs twice (for C and Python) and has extra
    instrumentation. Move it to the build where we will run tests under
    valgrind, which is already somewhat slow.

* workflows: Explicitly enable/disable GObject-Introspection
    
    For the build that uses --enable-asan, explicitly disable introspection,
    since the GObject-Introspection scanner works poorly with libtool
    and AddressSanitizer (see #4844); the only reason this worked until
    now is that --enable-asan doesn't currently do anything (again,
    see #4844).
    
    For the build that runs tests under valgrind, we already can't use
    AddressSanitizer, making this a good place to explicitly enable
    introspection, so that we have at least one build with it enabled.

* workflows: Run distcheck
    
    This lets us verify that our ability to do releases hasn't regressed.
    
    Run this as part of the "valgrind" build, since we want to enable
    gtk-doc for distcheck, and it's this build that already enables gtk-doc.
    We don't want to do this in the main Autotools build, since
    that enables AddressSanitizer, which often works badly with the
    "scanner" tools in gtk-doc and GObject-Introspection - although this
    is currently mitigated by --enable-asan not actually working as
    intended (see #4844).