### PR TITLE
build-update: Only add the specified summary-arches to the compat sum…

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4349,11 +4349,8 @@ generate_summary (OstreeRepo   *repo,
       for (int i = 0; summary_arches[i] != NULL; i++)
         {
           const char *arch = summary_arches[i];
-          const char *compat_arch = flatpak_get_compat_arch (arch);
 
           g_hash_table_add (summary_arches_ht, (char *)arch);
-          if (compat_arch)
-            g_hash_table_add (summary_arches_ht, (char *)compat_arch);
         }
     }
 


### PR DESCRIPTION
…mary

We support the "summary-arches" variable to limit which arches goes
into the compat summary file. However, its currently always adding in
the compat arches of whatever arches you list. This means we can't
e.g. keep compat summary support for aarch64, but not for armv7, which
is a problem as we're nearing the 10MB summary size limit of ostree
for old clients.

So, just keep the exact arches listed. If you want to keep compat
arches, you need to explicitly list them.