### PR TITLE
Improve flatpak_run_parse_pulse_server

### DIFF
--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -207,4 +207,7 @@ gboolean flatpak_run_parse_x11_display (const char  *display,
                                         char       **original_display_nr,
                                         GError     **error);
 
+char * flatpak_run_parse_pulse_server (const char *value,
+                                       gboolean   *remote);
+
 #endif /* __FLATPAK_RUN_H__ */

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -704,7 +704,7 @@ flatpak_run_get_pulseaudio_server (void)
  * Returns the first supported server address, or NULL if none are supported,
  * or NULL with @remote set if @value points to a remote server.
  */
-static char *
+char *
 flatpak_run_parse_pulse_server (const char *value,
                                 gboolean   *remote)
 {
@@ -731,11 +731,13 @@ flatpak_run_parse_pulse_server (const char *value,
       if (server[0] == '/')
         return g_strdup (server);
 
-      if (g_str_has_prefix (server, "tcp:"))
-        {
-          *remote = TRUE;
-          return NULL;
-        }
+      /*
+       * Handle:
+       *   - the "tcp:", "tcp4:", "tcp6:" prefixes
+       *   - a hostname or IP
+       */
+      *remote = TRUE;
+      return NULL;
     }
 
   return NULL;


### PR DESCRIPTION
Add support for:
- "tcp4:" and "tcp6:" prefixes;
- a hostname or IP without any prefix.

See
https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/ServerStrings/.
