### PR TITLE
selinux: Permit using systemd-userdbd

### DIFF
--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -32,6 +32,10 @@ optional_policy(`
    policykit_dbus_chat(flatpak_helper_t)
 ')
 
+optional_policy(`
+   systemd_userdbd_stream_connect(flatpak_helper_t)
+')
+
 optional_policy(`                   
     unconfined_domain(flatpak_helper_t)
 ')


### PR DESCRIPTION
The systemd-userdbd service was added in systemd 245, which was
released in March 2020 and is available in RHEL 9.  Therefore, it's
safe to assume that the systemd_userdbd_stream_connect() SELinux
interface is also available on all relevant operating systems, unless
there's reason to believe otherwise.

https://bugzilla.redhat.com/show_bug.cgi?id=2071217