### PR TITLE
WIP: history: Allow showing appstream pulls

### DIFF
--- a/app/flatpak-builtins-history.c
+++ b/app/flatpak-builtins-history.c
@@ -44,12 +44,14 @@ static char *opt_since;
 static char *opt_until;
 static gboolean opt_reverse;
 static const char **opt_cols;
+static gboolean opt_show_appstream_pulls;
 
 static GOptionEntry options[] = {
   { "since", 0, 0, G_OPTION_ARG_STRING, &opt_since, N_("Only show changes after TIME"), N_("TIME") },
   { "until", 0, 0, G_OPTION_ARG_STRING, &opt_until, N_("Only show changes before TIME"), N_("TIME") },
   { "reverse", 0, 0, G_OPTION_ARG_NONE, &opt_reverse, N_("Show newest entries first"), NULL },
   { "columns", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_cols, N_("What information to show"), N_("FIELD,…") },
+  { "show-appstream-pulls", 0, 0, G_OPTION_ARG_NONE, &opt_show_appstream_pulls, N_("Show appstream pulls"), NULL },
   { NULL }
 };
 
@@ -121,6 +123,7 @@ print_history (GPtrArray    *dirs,
                GDateTime    *since,
                GDateTime    *until,
                gboolean      reverse,
+               gboolean      show_appstream_pulls,
                GCancellable *cancellable,
                GError      **error)
 {
@@ -169,10 +172,11 @@ print_history (GPtrArray    *dirs,
         if (*error)
           return FALSE;
 
+
         /* Appstream pulls are probably not interesting, and they are confusing
          * since by default we include the Application column which shows up blank.
          */
-        if (ref_str && ref_str[0] && g_str_has_prefix (ref_str, "appstream"))
+        if (!show_appstream_pulls && ref_str && ref_str[0] && g_str_has_prefix (ref_str, "appstream"))
           continue;
 
         remote = get_field (j, "REMOTE", error);
@@ -504,7 +508,7 @@ flatpak_builtin_history (int argc, char **argv, GCancellable *cancellable, GErro
   if (columns == NULL)
     return FALSE;
 
-  if (!print_history (dirs, columns, since, until, opt_reverse, cancellable, error))
+  if (!print_history (dirs, columns, since, until, opt_reverse, opt_show_appstream_pulls, cancellable, error))
     return FALSE;
 
   return TRUE;


### PR DESCRIPTION
Currently, 'flatpak history' unconditionally hides any entries for refs
beginning 'appstream/', with two reasons given in the code:

1. Appstream pulls are probably not interesting
2. they are confusing since by default we include the Application column
   which shows up blank.

The first is true in most cases, but today I really did want to see
appstream pulls in the history to validate my hunch that gnome-software
is downloading the same appstream repeatedly.

The second is one reason this patch is WIP. With this patch and passing
--show-appstream-pulls, the output begins (on my system):

    Time            Change         Application                                Branch Installation Remote
    May 13 13:03:38 pull                                                             user         flathub
    May 13 13:03:43 pull                                                             user         gnome-nightly
    May 16 09:31:11 pull                                                             user         flathub
    May 16 09:31:17 pull                                                             user         gnome-nightly

The problem is that if you pass '--columns=all', you still don't get the
Ref column, because it is marked to be skipped when showing all columns.
(A new meaning of 'all' to me!) So you have to spell out all the columns
you want, just to add 'ref'.

Some ideas:

a. Support '--columns=+ref' to mean "default columns, plus ref"
b. Support '--columns=all,ref' to mean "'all' columns, but also ref even
   though it is maked to be not considered part of 'all'"
c. Change the defaults so that when --show-appstream-pulls is set,
   application, arch and branch are NOT default and ref is.