### PR TITLE
Add support for Wayland security context

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -200,6 +200,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   g_autofree char *runtime_extensions = NULL;
   g_autofree char *runtime_ld_path = NULL;
   g_autofree char *instance_id_host_dir = NULL;
+  g_autofree char *instance_id = NULL;
   char pid_str[64];
   g_autofree char *pid_path = NULL;
   g_autoptr(GFile) app_id_dir = NULL;
@@ -549,12 +550,13 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                       FALSE, TRUE, TRUE,
                                       &app_info_path, -1,
                                       &instance_id_host_dir,
+                                      &instance_id,
                                       error))
     return FALSE;
 
   if (!flatpak_run_add_environment_args (bwrap, app_info_path, run_flags, id,
                                          app_context, app_id_dir, NULL, -1,
-                                         NULL, cancellable, error))
+                                         instance_id, NULL, cancellable, error))
     return FALSE;
 
   for (i = 0; opt_bind_mounts != NULL && opt_bind_mounts[i] != NULL; i++)

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -69,8 +69,21 @@ common/flatpak-systemd-dbus-generated.c: data/org.freedesktop.systemd1.xml Makef
 common/%-dbus-generated.h: common/%-dbus-generated.c
 	@true # Built as a side-effect of the rules for the .c
 
+if ENABLE_WAYLAND_SECURITY_CONTEXT
+wayland_built_sources = common/security-context-v1-protocol.c common/security-context-v1-protocol.h
+endif
+
+wl_security_context_xml = $(WAYLAND_PROTOCOLS_DATADIR)/staging/security-context/security-context-v1.xml
+
+common/security-context-v1-protocol.c: $(wl_security_context_xml)
+	$(AM_V_GEN) $(WAYLAND_SCANNER) code $(wl_security_context_xml) $(builddir)/common/security-context-v1-protocol.c
+
+common/security-context-v1-protocol.h: $(wl_security_context_xml)
+	$(AM_V_GEN) $(WAYLAND_SCANNER) client-header $(wl_security_context_xml) $(builddir)/common/security-context-v1-protocol.h
+
 nodist_libflatpak_common_base_la_SOURCES = \
 	$(dbus_built_sources)		\
+	$(wayland_built_sources)	\
 	$(NULL)
 
 BUILT_SOURCES += $(nodist_libflatpak_common_base_la_SOURCES)
@@ -220,6 +233,7 @@ libflatpak_common_la_CFLAGS = \
 	$(SOUP_CFLAGS) \
 	$(SYSTEMD_CFLAGS) \
 	$(XAUTH_CFLAGS) \
+	$(WAYLAND_CLIENT_CFLAGS) \
 	$(XML_CFLAGS) \
 	$(NULL)
 libflatpak_common_la_LIBADD = \
@@ -238,6 +252,7 @@ libflatpak_common_la_LIBADD = \
 	$(SOUP_LIBS) \
 	$(SYSTEMD_LIBS) \
 	$(XAUTH_LIBS) \
+	$(WAYLAND_CLIENT_LIBS) \
 	$(XML_LIBS) \
 	$(NULL)
 

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -173,6 +173,8 @@ libflatpak_common_la_SOURCES = \
 	common/flatpak-run-pulseaudio.c \
 	common/flatpak-run-sockets-private.h \
 	common/flatpak-run-sockets.c \
+	common/flatpak-run-wayland-private.h \
+	common/flatpak-run-wayland.c \
 	common/flatpak-run-x11-private.h \
 	common/flatpak-run-x11.c \
 	common/flatpak-syscalls-private.h \

--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -28,6 +28,7 @@ typedef struct
   GArray    *fds;
   GStrv      envp;
   GPtrArray *runtime_dir_members;
+  int        sync_fds[2];
 } FlatpakBwrap;
 
 extern char *flatpak_bwrap_empty_env[1];
@@ -91,6 +92,8 @@ void          flatpak_bwrap_populate_runtime_dir (FlatpakBwrap *bwrap,
 void          flatpak_bwrap_child_setup_cb (gpointer user_data);
 void          flatpak_bwrap_child_setup (GArray *fd_array,
                                          gboolean close_fd_workaround);
+
+int           flatpak_bwrap_add_sync_fd (FlatpakBwrap *bwrap);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakBwrap, flatpak_bwrap_free)
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8352,7 +8352,7 @@ apply_extra_data (FlatpakDir   *self,
 
   if (!flatpak_run_add_environment_args (bwrap, NULL, run_flags, id,
                                          app_context, NULL, NULL, -1,
-                                         NULL, cancellable, error))
+                                         NULL, NULL, cancellable, error))
     return FALSE;
 
   flatpak_bwrap_populate_runtime_dir (bwrap, NULL);

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -52,6 +52,7 @@ gboolean flatpak_run_add_environment_args (FlatpakBwrap       *bwrap,
                                            GFile              *app_id_dir,
                                            GPtrArray          *previous_app_id_dirs,
                                            int                 per_app_dir_lock_fd,
+                                           const char         *instance_id,
                                            FlatpakExports    **exports_out,
                                            GCancellable       *cancellable,
                                            GError            **error);
@@ -95,6 +96,7 @@ gboolean flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
                                         char              **app_info_path_out,
                                         int                 instance_id_fd,
                                         char              **host_instance_id_host_dir_out,
+                                        char              **instance_id_out,
                                         GError            **error);
 
 gboolean flatpak_run_app (FlatpakDecomposed  *app_ref,

--- a/common/flatpak-run-sockets-private.h
+++ b/common/flatpak-run-sockets-private.h
@@ -30,7 +30,9 @@ G_BEGIN_DECLS
 
 void flatpak_run_add_socket_args_environment (FlatpakBwrap          *bwrap,
                                               FlatpakContextShares   shares,
-                                              FlatpakContextSockets  sockets);
+                                              FlatpakContextSockets  sockets,
+                                              const char            *app_id,
+                                              const char            *instance_id);
 void flatpak_run_add_socket_args_late        (FlatpakBwrap          *bwrap,
                                               FlatpakContextShares   shares);
 

--- a/common/flatpak-run-sockets.c
+++ b/common/flatpak-run-sockets.c
@@ -26,53 +26,9 @@
 
 #include "flatpak-run-cups-private.h"
 #include "flatpak-run-pulseaudio-private.h"
+#include "flatpak-run-wayland-private.h"
 #include "flatpak-run-x11-private.h"
 #include "flatpak-utils-private.h"
-
-/**
- * flatpak_run_add_wayland_args:
- *
- * Returns: %TRUE if a Wayland socket was found.
- */
-static gboolean
-flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
-{
-  const char *wayland_display;
-  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
-  g_autofree char *wayland_socket = NULL;
-  g_autofree char *sandbox_wayland_socket = NULL;
-  gboolean res = FALSE;
-  struct stat statbuf;
-
-  wayland_display = g_getenv ("WAYLAND_DISPLAY");
-  if (!wayland_display)
-    wayland_display = "wayland-0";
-
-  if (wayland_display[0] == '/')
-    wayland_socket = g_strdup (wayland_display);
-  else
-    wayland_socket = g_build_filename (user_runtime_dir, wayland_display, NULL);
-
-  if (!g_str_has_prefix (wayland_display, "wayland-") ||
-      strchr (wayland_display, '/') != NULL)
-    {
-      wayland_display = "wayland-0";
-      flatpak_bwrap_set_env (bwrap, "WAYLAND_DISPLAY", wayland_display, TRUE);
-    }
-
-  sandbox_wayland_socket = g_strdup_printf ("/run/flatpak/%s", wayland_display);
-
-  if (stat (wayland_socket, &statbuf) == 0 &&
-      (statbuf.st_mode & S_IFMT) == S_IFSOCK)
-    {
-      res = TRUE;
-      flatpak_bwrap_add_args (bwrap,
-                              "--ro-bind", wayland_socket, sandbox_wayland_socket,
-                              NULL);
-      flatpak_bwrap_add_runtime_dir_member (bwrap, wayland_display);
-    }
-  return res;
-}
 
 static void
 flatpak_run_add_gssproxy_args (FlatpakBwrap *bwrap)

--- a/common/flatpak-run-sockets.c
+++ b/common/flatpak-run-sockets.c
@@ -170,9 +170,11 @@ flatpak_run_add_ssh_args (FlatpakBwrap *bwrap)
  * use of a proxy.
  */
 void
-flatpak_run_add_socket_args_environment (FlatpakBwrap *bwrap,
-                                         FlatpakContextShares shares,
-                                         FlatpakContextSockets sockets)
+flatpak_run_add_socket_args_environment (FlatpakBwrap         *bwrap,
+                                         FlatpakContextShares  shares,
+                                         FlatpakContextSockets sockets,
+                                         const char           *app_id,
+                                         const char           *instance_id)
 {
   gboolean has_wayland = FALSE;
   gboolean allow_x11;
@@ -180,7 +182,8 @@ flatpak_run_add_socket_args_environment (FlatpakBwrap *bwrap,
   if (sockets & FLATPAK_CONTEXT_SOCKET_WAYLAND)
     {
       g_info ("Allowing wayland access");
-      has_wayland = flatpak_run_add_wayland_args (bwrap);
+      g_assert (app_id && instance_id);
+      has_wayland = flatpak_run_add_wayland_args (bwrap, app_id, instance_id);
     }
 
   if ((sockets & FLATPAK_CONTEXT_SOCKET_FALLBACK_X11) != 0)

--- a/common/flatpak-run-wayland-private.h
+++ b/common/flatpak-run-wayland-private.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2014 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#pragma once
+
+#include "libglnx.h"
+
+#include "flatpak-bwrap-private.h"
+#include "flatpak-common-types-private.h"
+#include "flatpak-context-private.h"
+
+G_BEGIN_DECLS
+
+gboolean
+flatpak_run_add_wayland_args (FlatpakBwrap *bwrap);
+
+G_END_DECLS

--- a/common/flatpak-run-wayland-private.h
+++ b/common/flatpak-run-wayland-private.h
@@ -29,6 +29,8 @@
 G_BEGIN_DECLS
 
 gboolean
-flatpak_run_add_wayland_args (FlatpakBwrap *bwrap);
+flatpak_run_add_wayland_args (FlatpakBwrap *bwrap,
+                              const char   *app_id,
+                              const char   *instance_id);
 
 G_END_DECLS

--- a/common/flatpak-run-wayland.c
+++ b/common/flatpak-run-wayland.c
@@ -21,7 +21,147 @@
 #include "config.h"
 #include "flatpak-run-wayland-private.h"
 
+#ifdef ENABLE_WAYLAND_SECURITY_CONTEXT
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <wayland-client.h>
+#include "security-context-v1-protocol.h"
+#endif
+
 #include "flatpak-utils-private.h"
+
+#ifdef ENABLE_WAYLAND_SECURITY_CONTEXT
+
+static void registry_handle_global (void *data, struct wl_registry *registry,
+                                    uint32_t name, const char *interface,
+                                    uint32_t version)
+{
+  struct wp_security_context_manager_v1 **out = data;
+
+  if (strcmp (interface, wp_security_context_manager_v1_interface.name) == 0)
+    {
+      *out = wl_registry_bind (registry, name,
+                               &wp_security_context_manager_v1_interface, 1);
+    }
+}
+
+static void registry_handle_global_remove (void *data,
+                                           struct wl_registry *registry,
+                                           uint32_t name)
+{
+  /* no-op */
+}
+
+static const struct wl_registry_listener registry_listener = {
+  .global = registry_handle_global,
+  .global_remove = registry_handle_global_remove,
+};
+
+static char *
+create_wl_socket (char *template)
+{
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
+  g_autofree char *proxy_socket_dir = g_build_filename (user_runtime_dir, ".flatpak/wl", NULL);
+  g_autofree char *proxy_socket = g_build_filename (proxy_socket_dir, template, NULL);
+  int fd;
+
+  if (!glnx_shutil_mkdir_p_at (AT_FDCWD, proxy_socket_dir, 0755, NULL, NULL))
+    return NULL;
+
+  fd = g_mkstemp (proxy_socket);
+  if (fd == -1)
+    return NULL;
+
+  close (fd);
+
+  return g_steal_pointer (&proxy_socket);
+}
+
+static gboolean
+flatpak_run_add_wayland_security_context_args (FlatpakBwrap *bwrap,
+                                               const char   *app_id,
+                                               const char   *instance_id,
+                                               gboolean     *available_out)
+{
+  gboolean res = FALSE;
+  struct wl_display *display;
+  struct wl_registry *registry;
+  struct wp_security_context_manager_v1 *security_context_manager = NULL;
+  struct wp_security_context_v1 *security_context;
+  struct sockaddr_un sockaddr = {0};
+  g_autofree char *socket_path = NULL;
+  int listen_fd = -1, sync_fd, ret;
+
+  *available_out = TRUE;
+
+  display = wl_display_connect (NULL);
+  if (!display)
+    return FALSE;
+
+  registry = wl_display_get_registry (display);
+  wl_registry_add_listener (registry, &registry_listener,
+                            &security_context_manager);
+  ret = wl_display_roundtrip (display);
+  wl_registry_destroy (registry);
+  if (ret < 0)
+    goto out;
+
+  if (!security_context_manager)
+    {
+      *available_out = FALSE;
+      goto out;
+    }
+
+  socket_path = create_wl_socket ("wayland-XXXXXX");
+  if (!socket_path)
+    goto out;
+
+  unlink (socket_path);
+
+  listen_fd = socket (AF_UNIX, SOCK_STREAM, 0);
+  if (listen_fd < 0)
+    goto out;
+
+  sockaddr.sun_family = AF_UNIX;
+  snprintf (sockaddr.sun_path, sizeof(sockaddr.sun_path), "%s", socket_path);
+  if (bind (listen_fd, (struct sockaddr *) &sockaddr, sizeof (sockaddr)) != 0)
+    goto out;
+
+  if (listen (listen_fd, 0) != 0)
+    goto out;
+
+  sync_fd = flatpak_bwrap_add_sync_fd (bwrap);
+  if (sync_fd < 0)
+    goto out;
+
+  security_context = wp_security_context_manager_v1_create_listener (security_context_manager,
+                                                                     listen_fd,
+                                                                     sync_fd);
+  wp_security_context_v1_set_sandbox_engine (security_context, "flatpak");
+  wp_security_context_v1_set_app_id (security_context, app_id);
+  wp_security_context_v1_set_instance_id (security_context, instance_id);
+  wp_security_context_v1_commit (security_context);
+  wp_security_context_v1_destroy (security_context);
+  if (wl_display_roundtrip (display) < 0)
+    goto out;
+
+  flatpak_bwrap_add_args (bwrap,
+                          "--ro-bind", socket_path, "/run/flatpak/wayland-0",
+                          NULL);
+  flatpak_bwrap_set_env (bwrap, "WAYLAND_DISPLAY", "/run/flatpak/wayland-0", TRUE);
+
+  res = TRUE;
+
+out:
+  if (listen_fd >= 0)
+    close (listen_fd);
+  if (security_context_manager)
+    wp_security_context_manager_v1_destroy (security_context_manager);
+  wl_display_disconnect (display);
+  return res;
+}
+
+#endif /* ENABLE_WAYLAND_SECURITY_CONTEXT */
 
 /**
  * flatpak_run_add_wayland_args:
@@ -29,7 +169,9 @@
  * Returns: %TRUE if a Wayland socket was found.
  */
 gboolean
-flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
+flatpak_run_add_wayland_args (FlatpakBwrap *bwrap,
+                              const char   *app_id,
+                              const char   *instance_id)
 {
   const char *wayland_display;
   g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
@@ -37,6 +179,16 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
   g_autofree char *sandbox_wayland_socket = NULL;
   gboolean res = FALSE;
   struct stat statbuf;
+
+#ifdef ENABLE_WAYLAND_SECURITY_CONTEXT
+  gboolean security_context_available = FALSE;
+  if (flatpak_run_add_wayland_security_context_args (bwrap, app_id, instance_id,
+                                                     &security_context_available))
+    return TRUE;
+  /* If security-context is available but we failed to set it up, bail out */
+  if (security_context_available)
+    return FALSE;
+#endif /* ENABLE_WAYLAND_SECURITY_CONTEXT */
 
   wayland_display = g_getenv ("WAYLAND_DISPLAY");
   if (!wayland_display)

--- a/common/flatpak-run-wayland.c
+++ b/common/flatpak-run-wayland.c
@@ -1,0 +1,69 @@
+/* vi:set et sw=2 sts=2 cin cino=t0,f0,(0,{s,>2s,n-s,^-s,e-s:
+ * Copyright © 2014-2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+#include "flatpak-run-wayland-private.h"
+
+#include "flatpak-utils-private.h"
+
+/**
+ * flatpak_run_add_wayland_args:
+ *
+ * Returns: %TRUE if a Wayland socket was found.
+ */
+gboolean
+flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
+{
+  const char *wayland_display;
+  g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
+  g_autofree char *wayland_socket = NULL;
+  g_autofree char *sandbox_wayland_socket = NULL;
+  gboolean res = FALSE;
+  struct stat statbuf;
+
+  wayland_display = g_getenv ("WAYLAND_DISPLAY");
+  if (!wayland_display)
+    wayland_display = "wayland-0";
+
+  if (wayland_display[0] == '/')
+    wayland_socket = g_strdup (wayland_display);
+  else
+    wayland_socket = g_build_filename (user_runtime_dir, wayland_display, NULL);
+
+  if (!g_str_has_prefix (wayland_display, "wayland-") ||
+      strchr (wayland_display, '/') != NULL)
+    {
+      wayland_display = "wayland-0";
+      flatpak_bwrap_set_env (bwrap, "WAYLAND_DISPLAY", wayland_display, TRUE);
+    }
+
+  sandbox_wayland_socket = g_strdup_printf ("/run/flatpak/%s", wayland_display);
+
+  if (stat (wayland_socket, &statbuf) == 0 &&
+      (statbuf.st_mode & S_IFMT) == S_IFSOCK)
+    {
+      res = TRUE;
+      flatpak_bwrap_add_args (bwrap,
+                              "--ro-bind", wayland_socket, sandbox_wayland_socket,
+                              NULL);
+      flatpak_bwrap_add_runtime_dir_member (bwrap, wayland_display);
+    }
+  return res;
+}

--- a/common/meson.build
+++ b/common/meson.build
@@ -100,6 +100,13 @@ flatpak_variant = custom_target(
   command : variant_schema_compiler_command,
 )
 
+libflatpak_common_base_deps = base_deps + [libglnx_dep]
+
+libflatpak_common_base_sources = [
+  'flatpak-utils-base.c',
+  'flatpak-utils-base-private.h',
+] + flatpak_gdbus + flatpak_document_gdbus
+
 built_headers = [
   enums[1],
   flatpak_version_macros,
@@ -109,16 +116,37 @@ built_headers = [
   flatpak_variant[1],
 ]
 
+if build_wayland_security_context
+  wayland_scanner_prog = find_program(wayland_scanner.get_variable(pkgconfig: 'wayland_scanner'))
+  wayland_protocols_dir = wayland_protocols.get_variable(pkgconfig: 'pkgdatadir')
+  wl_security_context_xml = wayland_protocols_dir / 'staging/security-context/security-context-v1.xml'
+  wl_security_context = [
+    custom_target(
+      'security-context-v1-protocol.c',
+      input : wl_security_context_xml,
+      output : 'security-context-v1-protocol.c',
+      command : [wayland_scanner_prog, 'code', '@INPUT@', '@OUTPUT@'],
+    ),
+    custom_target(
+      'security-context-v1-protocol.h',
+      input : wl_security_context_xml,
+      output : 'security-context-v1-protocol.h',
+      command : [wayland_scanner_prog, 'client-header', '@INPUT@', '@OUTPUT@'],
+    ),
+  ]
+
+  libflatpak_common_base_deps += [wayland_client]
+  libflatpak_common_base_sources += [wl_security_context]
+  built_headers += [wl_security_context[1]]
+endif
+
 libflatpak_common_base = static_library(
   'flatpak-common-base',
-  dependencies : base_deps + [libglnx_dep],
+  dependencies : libflatpak_common_base_deps,
   gnu_symbol_visibility : 'hidden',
   include_directories : [common_include_directories],
   install : false,
-  sources : [
-    'flatpak-utils-base.c',
-    'flatpak-utils-base-private.h',
-  ] + flatpak_gdbus + flatpak_document_gdbus,
+  sources : libflatpak_common_base_sources,
 )
 libflatpak_common_base_dep = declare_dependency(
   dependencies : base_deps + [libglnx_dep],

--- a/common/meson.build
+++ b/common/meson.build
@@ -159,6 +159,7 @@ sources = [
   'flatpak-run-dbus.c',
   'flatpak-run-pulseaudio.c',
   'flatpak-run-sockets.c',
+  'flatpak-run-wayland.c',
   'flatpak-run-x11.c',
   'flatpak-transaction.c',
   'flatpak-utils-http.c',

--- a/configure.ac
+++ b/configure.ac
@@ -342,6 +342,29 @@ if test "x$enable_xauth" = "xyes"; then
       [Define if using xauth])
 fi
 
+AC_ARG_WITH([wayland-security-context],
+            AC_HELP_STRING([--with-wayland-security-context],
+                           [Build with Wayland security context [default=auto]]),
+            [],
+            [with_wayland_security_context=auto])
+enable_wayland_security_context=no
+if test "x$with_wayland_security_context" != "xno"; then
+   PKG_CHECK_MODULES(WAYLAND_PROTOCOLS, [wayland-protocols >= 1.32],
+                     [have_wayland_protocols=yes], [have_wayland_protocols=no])
+   if test $have_wayland_protocols = yes; then
+      PKG_CHECK_MODULES(WAYLAND_CLIENT, [wayland-client])
+      PKG_CHECK_MODULES(WAYLAND_SCANNER, [wayland-scanner])
+      wayland_scanner=`$PKG_CONFIG --variable=wayland_scanner wayland-scanner`
+      AC_SUBST(WAYLAND_SCANNER, $wayland_scanner)
+      wayland_protocols_pkgdatadir=`$PKG_CONFIG --variable=pkgdatadir wayland-protocols`
+      AC_SUBST(WAYLAND_PROTOCOLS_DATADIR, $wayland_protocols_pkgdatadir)
+      AC_DEFINE([ENABLE_WAYLAND_SECURITY_CONTEXT], [1],
+         [Define if using Wayland security context])
+      enable_wayland_security_context=yes
+   fi
+fi
+AM_CONDITIONAL(ENABLE_WAYLAND_SECURITY_CONTEXT, test "x$enable_wayland_security_context" = "xyes")
+
 AC_ARG_ENABLE([gdm-env-file],
               [AC_HELP_STRING([--enable-gdm-env-file], [Install gdm env.d file (not needed if systemd generators work)])],
               install_gdm_env_file=$enableval, install_gdm_env_file=no)
@@ -626,18 +649,19 @@ echo ""
 echo "          Flatpak $FLATPAK_VERSION"
 echo "          =============="
 echo ""
-echo "          Build system helper:    $enable_system_helper"
-echo "          Build selinux module:   $enable_selinux_module"
-echo "          Build bubblewrap:       $build_bwrap"
-echo "          Build dbus-proxy:       $build_dbus_proxy"
-echo "          Use sandboxed triggers: $enable_sandboxed_triggers"
-echo "          Use seccomp:            $enable_seccomp"
-echo "          Privileged group:       $PRIVILEGED_GROUP"
-echo "          Privilege mode:         $with_priv_mode"
-echo "          Use dconf:              $have_dconf"
-echo "          Use libsystemd:         $have_libsystemd"
-echo "          Use libmalcontent:      $have_libmalcontent"
-echo "          Use libzstd:            $have_zstd"
-echo "          Use auto sideloading:   $enable_auto_sideloading"
-echo "          HTTP backend:           $http_backend"
+echo "          Build system helper:      $enable_system_helper"
+echo "          Build selinux module:     $enable_selinux_module"
+echo "          Build bubblewrap:         $build_bwrap"
+echo "          Build dbus-proxy:         $build_dbus_proxy"
+echo "          Use sandboxed triggers:   $enable_sandboxed_triggers"
+echo "          Use seccomp:              $enable_seccomp"
+echo "          Privileged group:         $PRIVILEGED_GROUP"
+echo "          Privilege mode:           $with_priv_mode"
+echo "          Use dconf:                $have_dconf"
+echo "          Use libsystemd:           $have_libsystemd"
+echo "          Use libmalcontent:        $have_libmalcontent"
+echo "          Use libzstd:              $have_zstd"
+echo "          Use auto sideloading:     $enable_auto_sideloading"
+echo "          HTTP backend:             $http_backend"
+echo "          Wayland security context: $enable_wayland_security_context"
 echo ""

--- a/meson.build
+++ b/meson.build
@@ -206,6 +206,11 @@ gir_dep = dependency('gobject-introspection-1.0', version : '>=1.40.0', required
 gtkdoc_dep = dependency('gtk-doc', required : get_option('gtkdoc'))
 build_gtk_doc = gtkdoc_dep.found()
 
+wayland_client = dependency('wayland-client', required : get_option('wayland_security_context'))
+wayland_scanner = dependency('wayland-scanner', required : get_option('wayland_security_context'))
+wayland_protocols = dependency('wayland-protocols', version : '>= 1.32', required : get_option('wayland_security_context'))
+build_wayland_security_context = wayland_client.found() and wayland_scanner.found() and wayland_protocols.found()
+
 base_deps = [glib_dep, gio_dep, gio_unix_dep]
 
 gpgme_dep = dependency('gpgme', version : '>=1.8.0')
@@ -395,6 +400,10 @@ if xau_dep.found()
   cdata.set('ENABLE_XAUTH', 1)
 endif
 
+if build_wayland_security_context
+  cdata.set('ENABLE_WAYLAND_SECURITY_CONTEXT', 1)
+endif
+
 if not get_option('sandboxed_triggers')
   cdata.set('DISABLE_SANDBOXED_TRIGGERS', 1)
 endif
@@ -432,6 +441,7 @@ summary(
     'Use libmalcontent' : malcontent_dep.found(),
     'Use libzstd' : libzstd_dep.found(),
     'Use auto sideloading' : get_option('auto_sideloading'),
+    'Wayland security context' : build_wayland_security_context,
   },
   bool_yn : true,
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -221,6 +221,12 @@ option(
   value : 'enabled',
 )
 option(
+  'wayland_security_context',
+  type : 'feature',
+  description : 'enable wayland security-context protocol support',
+  value : 'auto',
+)
+option(
   'xmlto_flags',
   type : 'array',
   description : 'options to pass to xmlto',


### PR DESCRIPTION
This exposes a reliable way for Wayland compositors to get
identifying information about a client. Compositors can then
apply security policies if desirable.

~~TODO: `bwrap --sync-fd` can only be specified once (only the last param is taken into account), but D-Bus already uses it. Any ideas how to address this?~~

References: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/68