### PR TITLE
Fixes for Coverity warnings

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -189,7 +189,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   FlatpakRunFlags run_flags;
   const char *group = NULL;
   const char *runtime_key = NULL;
-  const char *dest = NULL;
+  g_autofree char *dest = NULL;
   gboolean is_app = FALSE;
   gboolean is_extension = FALSE;
   gboolean is_app_extension = FALSE;
@@ -487,7 +487,7 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   /* We add the actual bind below so that we're not shadowed by other extensions or their tmpfs */
 
   if (extension_point)
-    dest = extension_point;
+    dest = g_strdup (extension_point);
   else if (is_app)
     dest = g_strdup ("/app");
   else

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2538,7 +2538,10 @@ flatpak_context_export (FlatpakContext *context,
           subpath = g_build_filename (path, rest, NULL);
 
           if (mode == FLATPAK_FILESYSTEM_MODE_CREATE && do_create)
-            g_mkdir_with_parents (subpath, 0755);
+            {
+              if (g_mkdir_with_parents (subpath, 0755) != 0)
+                g_debug ("Unable to create directory %s", subpath);
+            }
 
           if (g_file_test (subpath, G_FILE_TEST_EXISTS))
             {
@@ -2556,7 +2559,10 @@ flatpak_context_export (FlatpakContext *context,
           path = g_build_filename (g_get_home_dir (), filesystem + 2, NULL);
 
           if (mode == FLATPAK_FILESYSTEM_MODE_CREATE && do_create)
-            g_mkdir_with_parents (path, 0755);
+            {
+              if (g_mkdir_with_parents (path, 0755) != 0)
+                g_debug ("Unable to create directory %s", path);
+            }
 
           if (g_file_test (path, G_FILE_TEST_EXISTS))
             flatpak_exports_add_path_expose_or_hide (exports, mode, path);
@@ -2564,7 +2570,10 @@ flatpak_context_export (FlatpakContext *context,
       else if (g_str_has_prefix (filesystem, "/"))
         {
           if (mode == FLATPAK_FILESYSTEM_MODE_CREATE && do_create)
-            g_mkdir_with_parents (filesystem, 0755);
+            {
+              if (g_mkdir_with_parents (filesystem, 0755) != 0)
+                g_debug ("Unable to create directory %s", filesystem);
+            }
 
           if (g_file_test (filesystem, G_FILE_TEST_EXISTS))
             flatpak_exports_add_path_expose_or_hide (exports, mode, filesystem);
@@ -2693,7 +2702,8 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
           g_autofree char *src = g_build_filename (g_get_home_dir (), ".var/app", app_id, persist, NULL);
           g_autofree char *dest = g_build_filename (g_get_home_dir (), persist, NULL);
 
-          g_mkdir_with_parents (src, 0755);
+          if (g_mkdir_with_parents (src, 0755) != 0)
+            g_debug ("Unable to create directory %s", src);
 
           flatpak_bwrap_add_bind_arg (bwrap, "--bind", src, dest);
         }

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -730,7 +730,8 @@ flatpak_instance_allocate_id (char **host_dir_out,
   g_return_val_if_fail (lock_fd_out != NULL, NULL);
   g_return_val_if_fail (*lock_fd_out == -1, NULL);
 
-  g_mkdir_with_parents (base_dir, 0755);
+  if (g_mkdir_with_parents (base_dir, 0755) != 0)
+    return NULL;
 
   flatpak_instance_iterate_all_and_gc (NULL);
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -6750,7 +6750,8 @@ flatpak_pull_from_bundle (OstreeRepo   *repo,
   if (metadata == NULL)
     return FALSE;
 
-  metadata_size = strlen (metadata_contents);
+  if (metadata_contents != NULL)
+    metadata_size = strlen (metadata_contents);
 
   if (!ostree_repo_get_remote_option (repo, remote, "collection-id", NULL,
                                       &remote_collection_id, NULL))


### PR DESCRIPTION
Going through my downstream Coverity reports, I see that these are relevant for `main` as it stands today.

---

* utils: Avoid passing a potentially NULL pointer to strlen(3)

* dir: Don't ignore errors when deleting a file

* context, instance: Don't ignore errors when creating directories

* build: Don't leak the destination prefix