### PR TITLE
[flatpak-1.12.x] Relax the SELinux permissions to avoid denials

### DIFF
--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -12,6 +12,8 @@ type flatpak_helper_t;
 type flatpak_helper_exec_t;
 init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
+auth_read_passwd(flatpak_helper_t)
+
 optional_policy(`
     dbus_stub()
     dbus_system_domain(flatpak_helper_t, flatpak_helper_exec_t)

--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -32,6 +32,10 @@ optional_policy(`
    policykit_dbus_chat(flatpak_helper_t)
 ')
 
+optional_policy(`
+   systemd_userdbd_stream_connect(flatpak_helper_t)
+')
+
 optional_policy(`                   
     unconfined_domain(flatpak_helper_t)
 ')

--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -14,6 +14,10 @@ init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
 auth_read_passwd(flatpak_helper_t)
 
+ifdef(`corecmd_watch_bin_dirs',`
+    corecmd_watch_bin_dirs(flatpak_helper_t)
+')
+
 optional_policy(`
     dbus_stub()
     dbus_system_domain(flatpak_helper_t, flatpak_helper_exec_t)

--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -13,6 +13,8 @@ type flatpak_helper_exec_t;
 init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
 auth_read_passwd(flatpak_helper_t)
+files_list_var_lib(flatpak_helper_t)
+files_read_var_lib_files(flatpak_helper_t)
 
 ifdef(`corecmd_watch_bin_dirs',`
     corecmd_watch_bin_dirs(flatpak_helper_t)


### PR DESCRIPTION
Since these denials were originally reported against Fedora 36, and which has `flatpak-1.12.x`, it probably makes sense to backport these.  We are carrying them downstream anyway.

---

* selinux: Let the system helper have read access to /etc/passwd
  (cherry picked from commit 002e4455d80fdf692a8feb88b563e5ab37340220)

* selinux: Let the system helper watch files inside $libexecdir
  (cherry picked from commit f8a9153d0ed464dbd1668976bf5b00edc845c80d)

* selinux: Permit read access to /var/lib/flatpak
  (cherry picked from commit 8617ab0ad0243f5ae78f505041566b16d8bb45db)

* selinux: Permit using systemd-userdbd
  (cherry picked from commit 4965e5d076b68be70bc50715e63c6fa2c678a072)