### PR TITLE
main: Don't install polkit agent when running in tests, fixing slowness.

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -601,6 +601,11 @@ install_polkit_agent (void)
   PolkitAgentListener *listener = NULL;
   g_autoptr(GError) local_error = NULL;
   g_autoptr(GDBusConnection) bus = NULL;
+  const char *on_session;
+
+  on_session = g_getenv ("FLATPAK_SYSTEM_HELPER_ON_SESSION");
+  if (on_session != NULL)
+    return NULL;
 
   bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &local_error);
 


### PR DESCRIPTION
In the tests we don't use a systemwide helper anyway, so the polkit
stuff is unnecessary. Also, for some reason this was taking a very
long time for me, causing the tests to be super slow.