### PR TITLE
Initial work to support multiple http libraries

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-        libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
+        libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
@@ -123,7 +123,7 @@ jobs:
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-        libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
+        libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang e2fslibs-dev
     - name: Check out flatpak
       uses: actions/checkout@v1
@@ -152,7 +152,7 @@ jobs:
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-        libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
+        libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev \
         valgrind e2fslibs-dev
     - name: Check out flatpak

--- a/app/Makefile.am.inc
+++ b/app/Makefile.am.inc
@@ -44,7 +44,6 @@ libflatpak_app_la_LIBADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
 	$(OSTREE_LIBS) \
-	$(SOUP_LIBS) \
 	$(JSON_LIBS) \
 	$(APPSTREAM_LIBS) \
 	$(SYSTEMD_LIBS) \
@@ -55,7 +54,6 @@ libflatpak_app_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
 	$(OSTREE_CFLAGS) \
-	$(SOUP_CFLAGS) \
 	$(JSON_CFLAGS) \
 	$(APPSTREAM_CFLAGS) \
 	 $(SYSTEMD_CFLAGS) \
@@ -136,7 +134,6 @@ flatpak_LDADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
 	$(OSTREE_LIBS) \
-	$(SOUP_LIBS) \
 	$(JSON_LIBS) \
 	$(APPSTREAM_LIBS) \
 	$(SYSTEMD_LIBS) \
@@ -151,7 +148,6 @@ flatpak_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
 	$(OSTREE_CFLAGS) \
-	$(SOUP_CFLAGS) \
 	$(JSON_CFLAGS) \
 	$(APPSTREAM_CFLAGS) \
 	$(SYSTEMD_CFLAGS) \

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -221,9 +221,9 @@ install_from (FlatpakDir *dir,
   if (g_str_has_prefix (filename, "http:") ||
       g_str_has_prefix (filename, "https:"))
     {
-      g_autoptr(SoupSession) soup_session = NULL;
-      soup_session = flatpak_create_soup_session (PACKAGE_STRING);
-      file_data = flatpak_load_uri (soup_session, filename, 0, NULL, NULL, NULL, NULL, cancellable, error);
+      g_autoptr(FlatpakHttpSession) http_session = NULL;
+      http_session = flatpak_create_http_session (PACKAGE_STRING);
+      file_data = flatpak_load_uri (http_session, filename, 0, NULL, NULL, NULL, NULL, cancellable, error);
       if (file_data == NULL)
         {
           g_prefix_error (error, "Can't load uri %s: ", filename);

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -244,10 +244,10 @@ load_options (const char *remote_name,
     {
       const char *options_data;
       gsize options_size;
-      g_autoptr(SoupSession) soup_session = NULL;
+      g_autoptr(FlatpakHttpSession) http_session = NULL;
 
-      soup_session = flatpak_create_soup_session (PACKAGE_STRING);
-      bytes = flatpak_load_uri (soup_session, filename, 0, NULL, NULL, NULL, NULL, NULL, &local_error);
+      http_session = flatpak_create_http_session (PACKAGE_STRING);
+      bytes = flatpak_load_uri (http_session, filename, 0, NULL, NULL, NULL, NULL, NULL, &local_error);
 
       if (bytes == NULL)
         {

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -168,6 +168,8 @@ libflatpak_common_la_SOURCES = \
 	common/flatpak-utils-http.c \
 	common/flatpak-utils-private.h \
 	common/flatpak-utils.c \
+	common/flatpak-uri-private.h \
+	common/flatpak-uri.c \
 	common/flatpak-prune.c \
 	common/flatpak-prune-private.h \
 	common/flatpak-zstd-decompressor.c \

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -199,6 +199,7 @@ libflatpak_common_la_CFLAGS = \
 	$(MALCONTENT_CFLAGS) \
 	$(OSTREE_CFLAGS) \
 	$(POLKIT_CFLAGS) \
+	$(CURL_CFLAGS) \
 	$(SOUP_CFLAGS) \
 	$(SYSTEMD_CFLAGS) \
 	$(XAUTH_CFLAGS) \
@@ -216,6 +217,7 @@ libflatpak_common_la_LIBADD = \
 	$(MALCONTENT_LIBS) \
 	$(OSTREE_LIBS) \
 	$(POLKIT_LIBS) \
+	$(CURL_LIBS) \
 	$(SOUP_LIBS) \
 	$(SYSTEMD_LIBS) \
 	$(XAUTH_LIBS) \
@@ -235,6 +237,7 @@ libflatpak_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
 	$(OSTREE_CFLAGS) \
+	$(CURL_CFLAGS) \
 	$(SOUP_CFLAGS) \
 	$(JSON_CFLAGS) \
 	$(NULL)
@@ -253,6 +256,7 @@ libflatpak_la_LIBADD = \
 	libglnx.la \
 	$(BASE_LIBS)	\
 	$(OSTREE_LIBS)	\
+	$(CURL_LIBS)	\
 	$(SOUP_LIBS)	\
 	$(JSON_LIBS)    \
 	$(NULL)

--- a/common/flatpak-oci-registry-private.h
+++ b/common/flatpak-oci-registry-private.h
@@ -160,24 +160,24 @@ FlatpakOciSignature *flatpak_oci_verify_signature (OstreeRepo *repo,
                                                    GBytes     *signature,
                                                    GError    **error);
 
-gboolean flatpak_oci_index_ensure_cached (SoupSession  *soup_session,
-                                          const char   *uri,
-                                          GFile        *index,
-                                          char        **index_uri_out,
-                                          GCancellable *cancellable,
-                                          GError      **error);
+gboolean flatpak_oci_index_ensure_cached (FlatpakHttpSession  *http_session,
+                                          const char          *uri,
+                                          GFile               *index,
+                                          char               **index_uri_out,
+                                          GCancellable        *cancellable,
+                                          GError             **error);
 
 GVariant *flatpak_oci_index_make_summary (GFile        *index,
                                           const char   *index_uri,
                                           GCancellable *cancellable,
                                           GError      **error);
 
-GBytes *flatpak_oci_index_make_appstream (SoupSession  *soup_session,
-                                          GFile        *index,
-                                          const char   *index_uri,
-                                          const char   *arch,
-                                          int           icons_dfd,
-                                          GCancellable *cancellable,
-                                          GError      **error);
+GBytes *flatpak_oci_index_make_appstream (FlatpakHttpSession  *http_session,
+                                          GFile               *index,
+                                          const char          *index_uri,
+                                          const char          *arch,
+                                          int                  icons_dfd,
+                                          GCancellable        *cancellable,
+                                          GError             **error);
 
 #endif /* __FLATPAK_OCI_REGISTRY_H__ */

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -1002,7 +1002,7 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
       return NULL;
     }
 
-  params = soup_header_parse_param_list (www_authenticate + strlen ("Bearer "));
+  params = flatpak_parse_http_header_param_list (www_authenticate + strlen ("Bearer "));
 
   realm = g_hash_table_lookup (params, "realm");
   if (realm == NULL)

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -22,7 +22,6 @@
 
 #include <stdio.h>
 #include <glib/gi18n-lib.h>
-#include <libsoup/soup.h>
 
 #include "flatpak-auth-private.h"
 #include "flatpak-error.h"
@@ -4223,7 +4222,7 @@ load_flatpakrepo_file (FlatpakTransaction *self,
   g_autoptr(GBytes) dep_data = NULL;
   g_autoptr(GKeyFile) dep_keyfile = g_key_file_new ();
   g_autoptr(GError) local_error = NULL;
-  g_autoptr(SoupSession) soup_session = NULL;
+  g_autoptr(FlatpakHttpSession) http_session = NULL;
 
   if (priv->disable_deps)
     return TRUE;
@@ -4233,8 +4232,8 @@ load_flatpakrepo_file (FlatpakTransaction *self,
       !g_str_has_prefix (dep_url, "file:"))
     return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Flatpakrepo URL %s not file, HTTP or HTTPS"), dep_url);
 
-  soup_session = flatpak_create_soup_session (PACKAGE_STRING);
-  dep_data = flatpak_load_uri (soup_session, dep_url, 0, NULL, NULL, NULL, NULL, cancellable, error);
+  http_session = flatpak_create_http_session (PACKAGE_STRING);
+  dep_data = flatpak_load_uri (http_session, dep_url, 0, NULL, NULL, NULL, NULL, cancellable, error);
   if (dep_data == NULL)
     {
       g_prefix_error (error, _("Can't load dependent file %s: "), dep_url);

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -30,6 +30,7 @@
 #include "flatpak-progress-private.h"
 #include "flatpak-transaction-private.h"
 #include "flatpak-utils-private.h"
+#include "flatpak-uri-private.h"
 #include "flatpak-variant-impl-private.h"
 
 /**
@@ -4264,7 +4265,7 @@ handle_runtime_repo_deps (FlatpakTransaction *self,
   g_autofree char *runtime_url = NULL;
   g_autofree char *new_remote = NULL;
   g_autofree char *basename = NULL;
-  g_autoptr(SoupURI) uri = NULL;
+  g_autoptr(GUri) uri = NULL;
   g_auto(GStrv) remotes = NULL;
   g_autoptr(GKeyFile) config = NULL;
   g_autoptr(GBytes) gpg_key = NULL;
@@ -4278,8 +4279,8 @@ handle_runtime_repo_deps (FlatpakTransaction *self,
 
   g_assert (dep_keyfile != NULL);
 
-  uri = soup_uri_new (dep_url);
-  basename = g_path_get_basename (soup_uri_get_path (uri));
+  uri = g_uri_parse (dep_url, FLATPAK_HTTP_URI_FLAGS | G_URI_FLAGS_PARSE_RELAXED, NULL);
+  basename = g_path_get_basename (g_uri_get_path (uri));
   /* Strip suffix */
   t = strchr (basename, '.');
   if (t != NULL)

--- a/common/flatpak-uri-private.h
+++ b/common/flatpak-uri-private.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2022 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#ifndef __FLATPAK_URI_PRIVATE_H__
+#define __FLATPAK_URI_PRIVATE_H__
+
+#include <string.h>
+
+#include "flatpak-utils-private.h"
+
+/* This file is mainly a backport of GUri for older versions of glib, and some helpers around it */
+
+/* Same as SOUP_HTTP_URI_FLAGS, means all possible flags for http uris */
+#define FLATPAK_HTTP_URI_FLAGS (G_URI_FLAGS_HAS_PASSWORD | G_URI_FLAGS_ENCODED_PATH | G_URI_FLAGS_ENCODED_QUERY | G_URI_FLAGS_ENCODED_FRAGMENT | G_URI_FLAGS_SCHEME_NORMALIZE)
+
+#if !GLIB_CHECK_VERSION (2, 66, 0)
+
+typedef enum {
+  G_URI_FLAGS_NONE            = 0,
+  G_URI_FLAGS_PARSE_RELAXED   = 1 << 0,
+  G_URI_FLAGS_HAS_PASSWORD    = 1 << 1,
+  G_URI_FLAGS_HAS_AUTH_PARAMS = 1 << 2,
+  G_URI_FLAGS_ENCODED         = 1 << 3,
+  G_URI_FLAGS_NON_DNS         = 1 << 4,
+  G_URI_FLAGS_ENCODED_QUERY   = 1 << 5,
+  G_URI_FLAGS_ENCODED_PATH    = 1 << 6,
+  G_URI_FLAGS_ENCODED_FRAGMENT = 1 << 7,
+  G_URI_FLAGS_SCHEME_NORMALIZE = 1 << 8,
+} GUriFlags;
+
+typedef enum {
+  G_URI_HIDE_NONE        = 0,
+  G_URI_HIDE_USERINFO    = 1 << 0,
+  G_URI_HIDE_PASSWORD    = 1 << 1,
+  G_URI_HIDE_AUTH_PARAMS = 1 << 2,
+  G_URI_HIDE_QUERY       = 1 << 3,
+  G_URI_HIDE_FRAGMENT    = 1 << 4,
+} GUriHideFlags;
+
+typedef struct _GUri GUri;
+
+GUri *       flatpak_g_uri_ref               (GUri           *uri);
+void         flatpak_g_uri_unref             (GUri           *uri);
+GUri *       flatpak_g_uri_parse             (const gchar    *uri_string,
+                                              GUriFlags       flags,
+                                              GError        **error);
+GUri *       flatpak_g_uri_parse_relative    (GUri           *base_uri,
+                                              const gchar    *uri_ref,
+                                              GUriFlags       flags,
+                                              GError        **error);
+char *       flatpak_g_uri_to_string_partial (GUri           *uri,
+                                              GUriHideFlags   flags);
+GUri *       flatpak_g_uri_build             (GUriFlags       flags,
+                                              const gchar    *scheme,
+                                              const gchar    *userinfo,
+                                              const gchar    *host,
+                                              gint            port,
+                                              const gchar    *path,
+                                              const gchar    *query,
+                                              const gchar    *fragment);
+const gchar *flatpak_g_uri_get_scheme        (GUri           *uri);
+const gchar *flatpak_g_uri_get_userinfo      (GUri           *uri);
+const gchar *flatpak_g_uri_get_user          (GUri           *uri);
+const gchar *flatpak_g_uri_get_password      (GUri           *uri);
+const gchar *flatpak_g_uri_get_auth_params   (GUri           *uri);
+const gchar *flatpak_g_uri_get_host          (GUri           *uri);
+gint         flatpak_g_uri_get_port          (GUri           *uri);
+const gchar *flatpak_g_uri_get_path          (GUri           *uri);
+const gchar *flatpak_g_uri_get_query         (GUri           *uri);
+const gchar *flatpak_g_uri_get_fragment      (GUri           *uri);
+GUriFlags    flatpak_g_uri_get_flags         (GUri           *uri);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUri, flatpak_g_uri_unref)
+
+#define g_uri_ref flatpak_g_uri_ref
+#define g_uri_unref flatpak_g_uri_unref
+#define g_uri_parse flatpak_g_uri_parse
+#define g_uri_parse_relative flatpak_g_uri_parse_relative
+#define g_uri_to_string_partial flatpak_g_uri_to_string_partial
+#define g_uri_build flatpak_g_uri_build
+#define g_uri_get_scheme flatpak_g_uri_get_scheme
+#define g_uri_get_userinfo flatpak_g_uri_get_userinfo
+#define g_uri_get_user flatpak_g_uri_get_user
+#define g_uri_get_password flatpak_g_uri_get_password
+#define g_uri_get_auth_params flatpak_g_uri_get_auth_params
+#define g_uri_get_host flatpak_g_uri_get_host
+#define g_uri_get_port flatpak_g_uri_get_port
+#define g_uri_get_path flatpak_g_uri_get_path
+#define g_uri_get_query flatpak_g_uri_get_query
+#define g_uri_get_fragment flatpak_g_uri_get_fragment
+#define g_uri_get_flags flatpak_g_uri_get_flags
+
+#endif
+
+
+#endif /* __FLATPAK_URI_PRIVATE_H__ */

--- a/common/flatpak-uri-private.h
+++ b/common/flatpak-uri-private.h
@@ -27,6 +27,12 @@
 
 /* This file is mainly a backport of GUri for older versions of glib, and some helpers around it */
 
+void flatpak_uri_encode_query_arg (GString *query,
+                                   const char *key,
+                                   const char *value);
+GHashTable * flatpak_parse_http_header_param_list (const char *header);
+
+
 /* Same as SOUP_HTTP_URI_FLAGS, means all possible flags for http uris */
 #define FLATPAK_HTTP_URI_FLAGS (G_URI_FLAGS_HAS_PASSWORD | G_URI_FLAGS_ENCODED_PATH | G_URI_FLAGS_ENCODED_QUERY | G_URI_FLAGS_ENCODED_FRAGMENT | G_URI_FLAGS_SCHEME_NORMALIZE)
 

--- a/common/flatpak-uri-private.h
+++ b/common/flatpak-uri-private.h
@@ -27,11 +27,12 @@
 
 /* This file is mainly a backport of GUri for older versions of glib, and some helpers around it */
 
-void flatpak_uri_encode_query_arg (GString *query,
-                                   const char *key,
-                                   const char *value);
-GHashTable * flatpak_parse_http_header_param_list (const char *header);
-
+void        flatpak_uri_encode_query_arg         (GString    *query,
+                                                  const char *key,
+                                                  const char *value);
+GHashTable *flatpak_parse_http_header_param_list (const char *header);
+GDateTime * flatpak_parse_http_time              (const char *date_string);
+char *      flatpak_format_http_date             (GDateTime  *date);
 
 /* Same as SOUP_HTTP_URI_FLAGS, means all possible flags for http uris */
 #define FLATPAK_HTTP_URI_FLAGS (G_URI_FLAGS_HAS_PASSWORD | G_URI_FLAGS_ENCODED_PATH | G_URI_FLAGS_ENCODED_QUERY | G_URI_FLAGS_ENCODED_FRAGMENT | G_URI_FLAGS_SCHEME_NORMALIZE)

--- a/common/flatpak-uri.c
+++ b/common/flatpak-uri.c
@@ -1,0 +1,1337 @@
+/*
+ * Copyright © 1995-1998 Free Software Foundation, Inc.
+ * Copyright © 2014-2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <glib/gi18n-lib.h>
+
+#include "flatpak-uri-private.h"
+
+#if !GLIB_CHECK_VERSION (2, 66, 0)
+
+struct _GUri {
+  gchar     *scheme;
+  gchar     *userinfo;
+  gchar     *host;
+  gint       port;
+  gchar     *path;
+  gchar     *query;
+  gchar     *fragment;
+
+  gchar     *user;
+  gchar     *password;
+  gchar     *auth_params;
+
+  GUriFlags  flags;
+  int ref_count;
+};
+
+GUri *
+flatpak_g_uri_ref (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+  g_atomic_int_inc (&uri->ref_count);
+  return uri;
+}
+
+void
+flatpak_g_uri_unref (GUri *uri)
+{
+  g_return_if_fail (uri != NULL);
+
+  if (g_atomic_int_dec_and_test (&uri->ref_count))
+    {
+      g_free (uri->scheme);
+      g_free (uri->userinfo);
+      g_free (uri->host);
+      g_free (uri->path);
+      g_free (uri->query);
+      g_free (uri->fragment);
+      g_free (uri->user);
+      g_free (uri->password);
+      g_free (uri->auth_params);
+      g_free (uri);
+    }
+}
+
+static gboolean
+flatpak_g_uri_char_is_unreserved (gchar ch)
+{
+  if (g_ascii_isalnum (ch))
+    return TRUE;
+  return ch == '-' || ch == '.' || ch == '_' || ch == '~';
+}
+
+#define XDIGIT(c) ((c) <= '9' ? (c) - '0' : ((c) & 0x4F) - 'A' + 10)
+#define HEXCHAR(s) ((XDIGIT (s[1]) << 4) + XDIGIT (s[2]))
+
+static gssize
+uri_decoder (gchar       **out,
+             const gchar  *illegal_chars,
+             const gchar  *start,
+             gsize         length,
+             gboolean      just_normalize,
+             gboolean      www_form,
+             GUriFlags     flags,
+             GError      **error)
+{
+  gchar c;
+  GString *decoded;
+  const gchar *invalid, *s, *end;
+  gssize len;
+
+  if (!(flags & G_URI_FLAGS_ENCODED))
+    just_normalize = FALSE;
+
+  decoded = g_string_sized_new (length + 1);
+  for (s = start, end = s + length; s < end; s++)
+    {
+      if (*s == '%')
+        {
+          if (s + 2 >= end ||
+              !g_ascii_isxdigit (s[1]) ||
+              !g_ascii_isxdigit (s[2]))
+            {
+              /* % followed by non-hex or the end of the string; this is an error */
+              if (!(flags & G_URI_FLAGS_PARSE_RELAXED))
+                {
+                  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                                       /* xgettext: no-c-format */
+                                       _("Invalid %-encoding in URI"));
+                  g_string_free (decoded, TRUE);
+                  return -1;
+                }
+
+              /* In non-strict mode, just let it through; we *don't*
+               * fix it to "%25", since that might change the way that
+               * the URI's owner would interpret it.
+               */
+              g_string_append_c (decoded, *s);
+              continue;
+            }
+
+          c = HEXCHAR (s);
+          if (illegal_chars && strchr (illegal_chars, c))
+            {
+              g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                                   _("Illegal character in URI"));
+              g_string_free (decoded, TRUE);
+              return -1;
+            }
+          if (just_normalize && !flatpak_g_uri_char_is_unreserved (c))
+            {
+              /* Leave the % sequence there but normalize it. */
+              g_string_append_c (decoded, *s);
+              g_string_append_c (decoded, g_ascii_toupper (s[1]));
+              g_string_append_c (decoded, g_ascii_toupper (s[2]));
+              s += 2;
+            }
+          else
+            {
+              g_string_append_c (decoded, c);
+              s += 2;
+            }
+        }
+      else if (www_form && *s == '+')
+        g_string_append_c (decoded, ' ');
+      /* Normalize any illegal characters. */
+      else if (just_normalize && (!g_ascii_isgraph (*s)))
+        g_string_append_printf (decoded, "%%%02X", (guchar)*s);
+      else
+        g_string_append_c (decoded, *s);
+    }
+
+  len = decoded->len;
+  g_assert (len >= 0);
+
+  if (!(flags & G_URI_FLAGS_ENCODED) &&
+      !g_utf8_validate (decoded->str, len, &invalid))
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                           _("Non-UTF-8 characters in URI"));
+      g_string_free (decoded, TRUE);
+      return -1;
+    }
+
+  if (out)
+    *out = g_string_free (decoded, FALSE);
+  else
+    g_string_free (decoded, TRUE);
+
+  return len;
+}
+
+static gboolean
+uri_decode (gchar       **out,
+            const gchar  *illegal_chars,
+            const gchar  *start,
+            gsize         length,
+            gboolean      www_form,
+            GUriFlags     flags,
+            GError      **error)
+{
+  return uri_decoder (out, illegal_chars, start, length, FALSE, www_form, flags,
+                      error) != -1;
+}
+
+static gboolean
+uri_normalize (gchar       **out,
+               const gchar  *start,
+               gsize         length,
+               GUriFlags     flags,
+               GError      **error)
+{
+  return uri_decoder (out, NULL, start, length, TRUE, FALSE, flags,
+                      error) != -1;
+}
+
+static gboolean
+parse_ip_literal (const gchar  *start,
+                  gsize         length,
+                  GUriFlags     flags,
+                  gchar       **out,
+                  GError      **error)
+{
+  gchar *pct, *zone_id = NULL;
+  gchar *addr = NULL;
+  gsize addr_length = 0;
+  gsize zone_id_length = 0;
+  gchar *decoded_zone_id = NULL;
+
+  if (start[length - 1] != ']')
+    goto bad_ipv6_literal;
+
+  /* Drop the square brackets */
+  addr = g_strndup (start + 1, length - 2);
+  addr_length = length - 2;
+
+  /* If there's an IPv6 scope ID, split out the zone. */
+  pct = strchr (addr, '%');
+  if (pct != NULL)
+    {
+      *pct = '\0';
+
+      if (addr_length - (pct - addr) >= 4 &&
+          *(pct + 1) == '2' && *(pct + 2) == '5')
+        {
+          zone_id = pct + 3;
+          zone_id_length = addr_length - (zone_id - addr);
+        }
+      else if (flags & G_URI_FLAGS_PARSE_RELAXED &&
+               addr_length - (pct - addr) >= 2)
+        {
+          zone_id = pct + 1;
+          zone_id_length = addr_length - (zone_id - addr);
+        }
+      else
+        goto bad_ipv6_literal;
+
+      g_assert (zone_id_length >= 1);
+    }
+
+  /* addr must be an IPv6 address */
+  if (!g_hostname_is_ip_address (addr) || !strchr (addr, ':'))
+    goto bad_ipv6_literal;
+
+  /* Zone ID must be valid. It can contain %-encoded characters. */
+  if (zone_id != NULL &&
+      !uri_decode (&decoded_zone_id, NULL, zone_id, zone_id_length, FALSE,
+                   flags, NULL))
+    goto bad_ipv6_literal;
+
+  /* Success */
+  if (out != NULL && decoded_zone_id != NULL)
+    *out = g_strconcat (addr, "%", decoded_zone_id, NULL);
+  else if (out != NULL)
+    *out = g_steal_pointer (&addr);
+
+  g_free (addr);
+  g_free (decoded_zone_id);
+
+  return TRUE;
+
+bad_ipv6_literal:
+  g_free (addr);
+  g_free (decoded_zone_id);
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+               _("Invalid IPv6 address ‘%.*s’ in URI"),
+               (gint)length, start);
+
+  return FALSE;
+}
+
+static gboolean
+parse_host (const gchar  *start,
+            gsize         length,
+            GUriFlags     flags,
+            gchar       **out,
+            GError      **error)
+{
+  gchar *decoded = NULL, *host;
+  gchar *addr = NULL;
+
+  if (*start == '[')
+    {
+      if (!parse_ip_literal (start, length, flags, &host, error))
+        return FALSE;
+      goto ok;
+    }
+
+  if (g_ascii_isdigit (*start))
+    {
+      addr = g_strndup (start, length);
+      if (g_hostname_is_ip_address (addr))
+        {
+          host = addr;
+          goto ok;
+        }
+      g_free (addr);
+    }
+
+  if (flags & G_URI_FLAGS_NON_DNS)
+    {
+      if (!uri_normalize (&decoded, start, length, flags,
+                          error))
+        return FALSE;
+      host = g_steal_pointer (&decoded);
+      goto ok;
+    }
+
+  flags &= ~G_URI_FLAGS_ENCODED;
+  if (!uri_decode (&decoded, NULL, start, length, FALSE, flags,
+                   error))
+    return FALSE;
+
+  /* You're not allowed to %-encode an IP address, so if it wasn't
+   * one before, it better not be one now.
+   */
+  if (g_hostname_is_ip_address (decoded))
+    {
+      g_free (decoded);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   _("Illegal encoded IP address ‘%.*s’ in URI"),
+                   (gint)length, start);
+      return FALSE;
+    }
+
+  if (g_hostname_is_non_ascii (decoded))
+    {
+      host = g_hostname_to_ascii (decoded);
+      if (host == NULL)
+        {
+          g_free (decoded);
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                       _("Illegal internationalized hostname ‘%.*s’ in URI"),
+                       (gint) length, start);
+          return FALSE;
+        }
+    }
+  else
+    {
+      host = g_steal_pointer (&decoded);
+    }
+
+ ok:
+  if (out)
+    *out = g_steal_pointer (&host);
+  g_free (host);
+  g_free (decoded);
+
+  return TRUE;
+}
+
+static gboolean
+parse_port (const gchar  *start,
+            gsize         length,
+            gint         *out,
+            GError      **error)
+{
+  gchar *end;
+  gulong parsed_port;
+
+  /* strtoul() allows leading + or -, so we have to check this first. */
+  if (!g_ascii_isdigit (*start))
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   _("Could not parse port ‘%.*s’ in URI"),
+                   (gint)length, start);
+      return FALSE;
+    }
+
+  /* We know that *(start + length) is either '\0' or a non-numeric
+   * character, so strtoul() won't scan beyond it.
+   */
+  parsed_port = strtoul (start, &end, 10);
+  if (end != start + length)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   _("Could not parse port ‘%.*s’ in URI"),
+                   (gint)length, start);
+      return FALSE;
+    }
+  else if (parsed_port > 65535)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   _("Port ‘%.*s’ in URI is out of range"),
+                   (gint)length, start);
+      return FALSE;
+    }
+
+  if (out)
+    *out = parsed_port;
+  return TRUE;
+}
+
+static gboolean
+parse_userinfo (const gchar  *start,
+                gsize         length,
+                GUriFlags     flags,
+                gchar       **user,
+                gchar       **password,
+                gchar       **auth_params,
+                GError      **error)
+{
+  const gchar *user_end = NULL, *password_end = NULL, *auth_params_end;
+
+  auth_params_end = start + length;
+  if (flags & G_URI_FLAGS_HAS_AUTH_PARAMS)
+    password_end = memchr (start, ';', auth_params_end - start);
+  if (!password_end)
+    password_end = auth_params_end;
+  if (flags & G_URI_FLAGS_HAS_PASSWORD)
+    user_end = memchr (start, ':', password_end - start);
+  if (!user_end)
+    user_end = password_end;
+
+  if (!uri_normalize (user, start, user_end - start, flags,
+                      error))
+    return FALSE;
+
+  if (*user_end == ':')
+    {
+      start = user_end + 1;
+      if (!uri_normalize (password, start, password_end - start, flags,
+                          error))
+        {
+          if (user)
+            g_clear_pointer (user, g_free);
+          return FALSE;
+        }
+    }
+  else if (password)
+    *password = NULL;
+
+  if (*password_end == ';')
+    {
+      start = password_end + 1;
+      if (!uri_normalize (auth_params, start, auth_params_end - start, flags,
+                          error))
+        {
+          if (user)
+            g_clear_pointer (user, g_free);
+          if (password)
+            g_clear_pointer (password, g_free);
+          return FALSE;
+        }
+    }
+  else if (auth_params)
+    *auth_params = NULL;
+
+  return TRUE;
+}
+
+static gchar *
+uri_cleanup (const gchar *uri_string)
+{
+  GString *copy;
+  const gchar *end;
+
+  /* Skip leading whitespace */
+  while (g_ascii_isspace (*uri_string))
+    uri_string++;
+
+  /* Ignore trailing whitespace */
+  end = uri_string + strlen (uri_string);
+  while (end > uri_string && g_ascii_isspace (*(end - 1)))
+    end--;
+
+  /* Copy the rest, encoding unencoded spaces and stripping other whitespace */
+  copy = g_string_sized_new (end - uri_string);
+  while (uri_string < end)
+    {
+      if (*uri_string == ' ')
+        g_string_append (copy, "%20");
+      else if (g_ascii_isspace (*uri_string))
+        ;
+      else
+        g_string_append_c (copy, *uri_string);
+      uri_string++;
+    }
+
+  return g_string_free (copy, FALSE);
+}
+
+static gboolean
+should_normalize_empty_path (const char *scheme)
+{
+  const char * const schemes[] = { "https", "http", "wss", "ws" };
+  gsize i;
+  for (i = 0; i < G_N_ELEMENTS (schemes); ++i)
+    {
+      if (!strcmp (schemes[i], scheme))
+        return TRUE;
+    }
+  return FALSE;
+}
+
+static int
+normalize_port (const char *scheme,
+                int         port)
+{
+  const char *default_schemes[3] = { NULL };
+  int i;
+
+  switch (port)
+    {
+    case 21:
+      default_schemes[0] = "ftp";
+      break;
+    case 80:
+      default_schemes[0] = "http";
+      default_schemes[1] = "ws";
+      break;
+    case 443:
+      default_schemes[0] = "https";
+      default_schemes[1] = "wss";
+      break;
+    default:
+      break;
+    }
+
+  for (i = 0; default_schemes[i]; ++i)
+    {
+      if (!strcmp (scheme, default_schemes[i]))
+        return -1;
+    }
+
+  return port;
+}
+
+static int
+default_scheme_port (const char *scheme)
+{
+  if (strcmp (scheme, "http") == 0 || strcmp (scheme, "ws") == 0)
+    return 80;
+
+  if (strcmp (scheme, "https") == 0 || strcmp (scheme, "wss") == 0)
+    return 443;
+
+  if (strcmp (scheme, "ftp") == 0)
+    return 21;
+
+  return -1;
+}
+
+static gboolean
+flatpak_g_uri_split_internal (const gchar  *uri_string,
+                      GUriFlags     flags,
+                      gchar       **scheme,
+                      gchar       **userinfo,
+                      gchar       **user,
+                      gchar       **password,
+                      gchar       **auth_params,
+                      gchar       **host,
+                      gint         *port,
+                      gchar       **path,
+                      gchar       **query,
+                      gchar       **fragment,
+                      GError      **error)
+{
+  const gchar *end, *colon, *at, *path_start, *semi, *question;
+  const gchar *p, *bracket, *hostend;
+  gchar *cleaned_uri_string = NULL;
+  gchar *normalized_scheme = NULL;
+
+  if (scheme)
+    *scheme = NULL;
+  if (userinfo)
+    *userinfo = NULL;
+  if (user)
+    *user = NULL;
+  if (password)
+    *password = NULL;
+  if (auth_params)
+    *auth_params = NULL;
+  if (host)
+    *host = NULL;
+  if (port)
+    *port = -1;
+  if (path)
+    *path = NULL;
+  if (query)
+    *query = NULL;
+  if (fragment)
+    *fragment = NULL;
+
+  if ((flags & G_URI_FLAGS_PARSE_RELAXED) && strpbrk (uri_string, " \t\n\r"))
+    {
+      cleaned_uri_string = uri_cleanup (uri_string);
+      uri_string = cleaned_uri_string;
+    }
+
+  /* Find scheme */
+  p = uri_string;
+  while (*p && (g_ascii_isalpha (*p) ||
+               (p > uri_string && (g_ascii_isdigit (*p) ||
+                                   *p == '.' || *p == '+' || *p == '-'))))
+    p++;
+
+  if (p > uri_string && *p == ':')
+    {
+      normalized_scheme = g_ascii_strdown (uri_string, p - uri_string);
+      if (scheme)
+        *scheme = g_steal_pointer (&normalized_scheme);
+      p++;
+    }
+  else
+    {
+      if (scheme)
+        *scheme = NULL;
+      p = uri_string;
+    }
+
+  /* Check for authority */
+  if (strncmp (p, "//", 2) == 0)
+    {
+      p += 2;
+
+      path_start = p + strcspn (p, "/?#");
+      at = memchr (p, '@', path_start - p);
+      if (at)
+        {
+          if (flags & G_URI_FLAGS_PARSE_RELAXED)
+            {
+              gchar *next_at;
+
+              /* Any "@"s in the userinfo must be %-encoded, but
+               * people get this wrong sometimes. Since "@"s in the
+               * hostname are unlikely (and also wrong anyway), assume
+               * that if there are extra "@"s, they belong in the
+               * userinfo.
+               */
+              do
+                {
+                  next_at = memchr (at + 1, '@', path_start - (at + 1));
+                  if (next_at)
+                    at = next_at;
+                }
+              while (next_at);
+            }
+
+          if (user || password || auth_params ||
+              (flags & (G_URI_FLAGS_HAS_PASSWORD|G_URI_FLAGS_HAS_AUTH_PARAMS)))
+            {
+              if (!parse_userinfo (p, at - p, flags,
+                                   user, password, auth_params,
+                                   error))
+                goto fail;
+            }
+
+          if (!uri_normalize (userinfo, p, at - p, flags,
+                              error))
+            goto fail;
+
+          p = at + 1;
+        }
+
+      if (flags & G_URI_FLAGS_PARSE_RELAXED)
+        {
+          semi = strchr (p, ';');
+          if (semi && semi < path_start)
+            {
+              /* Technically, semicolons are allowed in the "host"
+               * production, but no one ever does this, and some
+               * schemes mistakenly use semicolon as a delimiter
+               * marking the start of the path. We have to check this
+               * after checking for userinfo though, because a
+               * semicolon before the "@" must be part of the
+               * userinfo.
+               */
+              path_start = semi;
+            }
+        }
+
+      /* Find host and port. The host may be a bracket-delimited IPv6
+       * address, in which case the colon delimiting the port must come
+       * (immediately) after the close bracket.
+       */
+      if (*p == '[')
+        {
+          bracket = memchr (p, ']', path_start - p);
+          if (bracket && *(bracket + 1) == ':')
+            colon = bracket + 1;
+          else
+            colon = NULL;
+        }
+      else
+        colon = memchr (p, ':', path_start - p);
+
+      hostend = colon ? colon : path_start;
+      if (!parse_host (p, hostend - p, flags, host, error))
+        goto fail;
+
+      if (colon && colon != path_start - 1)
+        {
+          p = colon + 1;
+          if (!parse_port (p, path_start - p, port, error))
+            goto fail;
+        }
+
+      p = path_start;
+    }
+
+  /* Find fragment. */
+  end = p + strcspn (p, "#");
+  if (*end == '#')
+    {
+      if (!uri_normalize (fragment, end + 1, strlen (end + 1),
+                          flags | (flags & G_URI_FLAGS_ENCODED_FRAGMENT ? G_URI_FLAGS_ENCODED : 0),
+                          error))
+        goto fail;
+    }
+
+  /* Find query */
+  question = memchr (p, '?', end - p);
+  if (question)
+    {
+      if (!uri_normalize (query, question + 1, end - (question + 1),
+                          flags | (flags & G_URI_FLAGS_ENCODED_QUERY ? G_URI_FLAGS_ENCODED : 0),
+                          error))
+        goto fail;
+      end = question;
+    }
+
+  if (!uri_normalize (path, p, end - p,
+                      flags | (flags & G_URI_FLAGS_ENCODED_PATH ? G_URI_FLAGS_ENCODED : 0),
+                      error))
+    goto fail;
+
+  /* Scheme-based normalization */
+  if (flags & G_URI_FLAGS_SCHEME_NORMALIZE && ((scheme && *scheme) || normalized_scheme))
+    {
+      const char *scheme_str = scheme && *scheme ? *scheme : normalized_scheme;
+
+      if (should_normalize_empty_path (scheme_str) && path && !**path)
+        {
+          g_free (*path);
+          *path = g_strdup ("/");
+        }
+
+      if (port && *port == -1)
+        *port = default_scheme_port (scheme_str);
+    }
+
+  g_free (normalized_scheme);
+  g_free (cleaned_uri_string);
+  return TRUE;
+
+ fail:
+  if (scheme)
+    g_clear_pointer (scheme, g_free);
+  if (userinfo)
+    g_clear_pointer (userinfo, g_free);
+  if (host)
+    g_clear_pointer (host, g_free);
+  if (port)
+    *port = -1;
+  if (path)
+    g_clear_pointer (path, g_free);
+  if (query)
+    g_clear_pointer (query, g_free);
+  if (fragment)
+    g_clear_pointer (fragment, g_free);
+
+  g_free (normalized_scheme);
+  g_free (cleaned_uri_string);
+  return FALSE;
+}
+
+
+/* Implements the "Remove Dot Segments" algorithm from section 5.2.4 of
+ * RFC 3986.
+ *
+ * See https://tools.ietf.org/html/rfc3986#section-5.2.4
+ */
+static void
+remove_dot_segments (gchar *path)
+{
+  /* The output can be written to the same buffer that the input
+   * is read from, as the output pointer is only ever increased
+   * when the input pointer is increased as well, and the input
+   * pointer is never decreased. */
+  gchar *input = path;
+  gchar *output = path;
+
+  if (!*path)
+    return;
+
+  while (*input)
+    {
+      /*  A.  If the input buffer begins with a prefix of "../" or "./",
+       *      then remove that prefix from the input buffer; otherwise,
+       */
+      if (strncmp (input, "../", 3) == 0)
+        input += 3;
+      else if (strncmp (input, "./", 2) == 0)
+        input += 2;
+
+      /*  B.  if the input buffer begins with a prefix of "/./" or "/.",
+       *      where "." is a complete path segment, then replace that
+       *      prefix with "/" in the input buffer; otherwise,
+       */
+      else if (strncmp (input, "/./", 3) == 0)
+        input += 2;
+      else if (strcmp (input, "/.") == 0)
+        input[1] = '\0';
+
+      /*  C.  if the input buffer begins with a prefix of "/../" or "/..",
+       *      where ".." is a complete path segment, then replace that
+       *      prefix with "/" in the input buffer and remove the last
+       *      segment and its preceding "/" (if any) from the output
+       *      buffer; otherwise,
+       */
+      else if (strncmp (input, "/../", 4) == 0)
+        {
+          input += 3;
+          if (output > path)
+            {
+              do
+                {
+                  output--;
+                }
+              while (*output != '/' && output > path);
+            }
+        }
+      else if (strcmp (input, "/..") == 0)
+        {
+          input[1] = '\0';
+          if (output > path)
+            {
+              do
+                 {
+                   output--;
+                 }
+              while (*output != '/' && output > path);
+            }
+        }
+
+      /*  D.  if the input buffer consists only of "." or "..", then remove
+       *      that from the input buffer; otherwise,
+       */
+      else if (strcmp (input, "..") == 0 || strcmp (input, ".") == 0)
+        input[0] = '\0';
+
+      /*  E.  move the first path segment in the input buffer to the end of
+       *      the output buffer, including the initial "/" character (if
+       *      any) and any subsequent characters up to, but not including,
+       *      the next "/" character or the end of the input buffer.
+       */
+      else
+        {
+          *output++ = *input++;
+          while (*input && *input != '/')
+            *output++ = *input++;
+        }
+    }
+  *output = '\0';
+}
+
+GUri *
+flatpak_g_uri_parse (const gchar  *uri_string,
+             GUriFlags     flags,
+             GError      **error)
+{
+  g_return_val_if_fail (uri_string != NULL, NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
+  return flatpak_g_uri_parse_relative (NULL, uri_string, flags, error);
+}
+
+GUri *
+flatpak_g_uri_parse_relative (GUri         *base_uri,
+                      const gchar  *uri_ref,
+                      GUriFlags     flags,
+                      GError      **error)
+{
+  GUri *uri = NULL;
+
+  g_return_val_if_fail (uri_ref != NULL, NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+  g_return_val_if_fail (base_uri == NULL || base_uri->scheme != NULL, NULL);
+
+  /* Use GUri struct to construct the return value: there is no guarantee it is
+   * actually correct within the function body. */
+  uri = g_new0 (GUri, 1);
+  uri->ref_count = 1;
+  uri->flags = flags;
+
+  if (!flatpak_g_uri_split_internal (uri_ref, flags,
+                             &uri->scheme, &uri->userinfo,
+                             &uri->user, &uri->password, &uri->auth_params,
+                             &uri->host, &uri->port,
+                             &uri->path, &uri->query, &uri->fragment,
+                             error))
+    {
+      flatpak_g_uri_unref (uri);
+      return NULL;
+    }
+
+  if (!uri->scheme && !base_uri)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                           _("URI is not absolute, and no base URI was provided"));
+      flatpak_g_uri_unref (uri);
+      return NULL;
+    }
+
+  if (base_uri)
+    {
+      /* This is section 5.2.2 of RFC 3986, except that we're doing
+       * it in place in @uri rather than copying from R to T.
+       *
+       * See https://tools.ietf.org/html/rfc3986#section-5.2.2
+       */
+      if (uri->scheme)
+        remove_dot_segments (uri->path);
+      else
+        {
+          uri->scheme = g_strdup (base_uri->scheme);
+          if (uri->host)
+            remove_dot_segments (uri->path);
+          else
+            {
+              if (!*uri->path)
+                {
+                  g_free (uri->path);
+                  uri->path = g_strdup (base_uri->path);
+                  if (!uri->query)
+                    uri->query = g_strdup (base_uri->query);
+                }
+              else
+                {
+                  if (*uri->path == '/')
+                    remove_dot_segments (uri->path);
+                  else
+                    {
+                      gchar *newpath, *last;
+
+                      last = strrchr (base_uri->path, '/');
+                      if (last)
+                        {
+                          newpath = g_strdup_printf ("%.*s/%s",
+                                                     (gint)(last - base_uri->path),
+                                                     base_uri->path,
+                                                     uri->path);
+                        }
+                      else
+                        newpath = g_strdup_printf ("/%s", uri->path);
+
+                      g_free (uri->path);
+                      uri->path = g_steal_pointer (&newpath);
+
+                      remove_dot_segments (uri->path);
+                    }
+                }
+
+              uri->userinfo = g_strdup (base_uri->userinfo);
+              uri->user = g_strdup (base_uri->user);
+              uri->password = g_strdup (base_uri->password);
+              uri->auth_params = g_strdup (base_uri->auth_params);
+              uri->host = g_strdup (base_uri->host);
+              uri->port = base_uri->port;
+            }
+        }
+
+      /* Scheme normalization couldn't have been done earlier
+       * as the relative URI may not have had a scheme */
+      if (flags & G_URI_FLAGS_SCHEME_NORMALIZE)
+        {
+          if (should_normalize_empty_path (uri->scheme) && !*uri->path)
+            {
+              g_free (uri->path);
+              uri->path = g_strdup ("/");
+            }
+
+          uri->port = normalize_port (uri->scheme, uri->port);
+        }
+    }
+  else
+    {
+      remove_dot_segments (uri->path);
+    }
+
+  return g_steal_pointer (&uri);
+}
+
+/* userinfo as a whole can contain sub-delims + ":", but split-out
+ * user can't contain ":" or ";", and split-out password can't contain
+ * ";".
+ */
+#define USERINFO_ALLOWED_CHARS G_URI_RESERVED_CHARS_ALLOWED_IN_USERINFO
+#define USER_ALLOWED_CHARS "!$&'()*+,="
+#define PASSWORD_ALLOWED_CHARS "!$&'()*+,=:"
+#define AUTH_PARAMS_ALLOWED_CHARS USERINFO_ALLOWED_CHARS
+#define IP_ADDR_ALLOWED_CHARS ":"
+#define HOST_ALLOWED_CHARS G_URI_RESERVED_CHARS_SUBCOMPONENT_DELIMITERS
+#define PATH_ALLOWED_CHARS G_URI_RESERVED_CHARS_ALLOWED_IN_PATH
+#define QUERY_ALLOWED_CHARS G_URI_RESERVED_CHARS_ALLOWED_IN_PATH "?"
+#define FRAGMENT_ALLOWED_CHARS G_URI_RESERVED_CHARS_ALLOWED_IN_PATH "?"
+
+static gchar *
+flatpak_g_uri_join_internal (GUriFlags    flags,
+                     const gchar *scheme,
+                     gboolean     userinfo,
+                     const gchar *user,
+                     const gchar *password,
+                     const gchar *auth_params,
+                     const gchar *host,
+                     gint         port,
+                     const gchar *path,
+                     const gchar *query,
+                     const gchar *fragment)
+{
+  gboolean encoded = (flags & G_URI_FLAGS_ENCODED);
+  GString *str;
+  char *normalized_scheme = NULL;
+
+  /* Restrictions on path prefixes. See:
+   * https://tools.ietf.org/html/rfc3986#section-3
+   */
+  g_return_val_if_fail (path != NULL, NULL);
+  g_return_val_if_fail (host == NULL || (path[0] == '\0' || path[0] == '/'), NULL);
+  g_return_val_if_fail (host != NULL || (path[0] != '/' || path[1] != '/'), NULL);
+
+  str = g_string_new (scheme);
+  if (scheme)
+    g_string_append_c (str, ':');
+
+  if (flags & G_URI_FLAGS_SCHEME_NORMALIZE && scheme && ((host && port != -1) || path[0] == '\0'))
+    normalized_scheme = g_ascii_strdown (scheme, -1);
+
+  if (host)
+    {
+      g_string_append (str, "//");
+
+      if (user)
+        {
+          if (encoded)
+            g_string_append (str, user);
+          else
+            {
+              if (userinfo)
+                g_string_append_uri_escaped (str, user, USERINFO_ALLOWED_CHARS, TRUE);
+              else
+                /* Encode ':' and ';' regardless of whether we have a
+                 * password or auth params, since it may be parsed later
+                 * under the assumption that it does.
+                 */
+                g_string_append_uri_escaped (str, user, USER_ALLOWED_CHARS, TRUE);
+            }
+
+          if (password)
+            {
+              g_string_append_c (str, ':');
+              if (encoded)
+                g_string_append (str, password);
+              else
+                g_string_append_uri_escaped (str, password,
+                                             PASSWORD_ALLOWED_CHARS, TRUE);
+            }
+
+          if (auth_params)
+            {
+              g_string_append_c (str, ';');
+              if (encoded)
+                g_string_append (str, auth_params);
+              else
+                g_string_append_uri_escaped (str, auth_params,
+                                             AUTH_PARAMS_ALLOWED_CHARS, TRUE);
+            }
+
+          g_string_append_c (str, '@');
+        }
+
+      if (strchr (host, ':') && g_hostname_is_ip_address (host))
+        {
+          g_string_append_c (str, '[');
+          if (encoded)
+            g_string_append (str, host);
+          else
+            g_string_append_uri_escaped (str, host, IP_ADDR_ALLOWED_CHARS, TRUE);
+          g_string_append_c (str, ']');
+        }
+      else
+        {
+          if (encoded)
+            g_string_append (str, host);
+          else
+            g_string_append_uri_escaped (str, host, HOST_ALLOWED_CHARS, TRUE);
+        }
+
+      if (port != -1 && (!normalized_scheme || normalize_port (normalized_scheme, port) != -1))
+        g_string_append_printf (str, ":%d", port);
+    }
+
+  if (path[0] == '\0' && normalized_scheme && should_normalize_empty_path (normalized_scheme))
+    g_string_append (str, "/");
+  else if (encoded || flags & G_URI_FLAGS_ENCODED_PATH)
+    g_string_append (str, path);
+  else
+    g_string_append_uri_escaped (str, path, PATH_ALLOWED_CHARS, TRUE);
+
+  g_free (normalized_scheme);
+
+  if (query)
+    {
+      g_string_append_c (str, '?');
+      if (encoded || flags & G_URI_FLAGS_ENCODED_QUERY)
+        g_string_append (str, query);
+      else
+        g_string_append_uri_escaped (str, query, QUERY_ALLOWED_CHARS, TRUE);
+    }
+  if (fragment)
+    {
+      g_string_append_c (str, '#');
+      if (encoded || flags & G_URI_FLAGS_ENCODED_FRAGMENT)
+        g_string_append (str, fragment);
+      else
+        g_string_append_uri_escaped (str, fragment, FRAGMENT_ALLOWED_CHARS, TRUE);
+    }
+
+  return g_string_free (str, FALSE);
+}
+
+static gchar *
+flatpak_g_uri_join (GUriFlags    flags,
+            const gchar *scheme,
+            const gchar *userinfo,
+            const gchar *host,
+            gint         port,
+            const gchar *path,
+            const gchar *query,
+            const gchar *fragment)
+{
+  g_return_val_if_fail (port >= -1 && port <= 65535, NULL);
+  g_return_val_if_fail (path != NULL, NULL);
+
+  return flatpak_g_uri_join_internal (flags,
+                              scheme,
+                              TRUE, userinfo, NULL, NULL,
+                              host,
+                              port,
+                              path,
+                              query,
+                              fragment);
+}
+
+static gchar *
+flatpak_g_uri_join_with_user (GUriFlags    flags,
+                      const gchar *scheme,
+                      const gchar *user,
+                      const gchar *password,
+                      const gchar *auth_params,
+                      const gchar *host,
+                      gint         port,
+                      const gchar *path,
+                      const gchar *query,
+                      const gchar *fragment)
+{
+  g_return_val_if_fail (port >= -1 && port <= 65535, NULL);
+  g_return_val_if_fail (path != NULL, NULL);
+
+  return flatpak_g_uri_join_internal (flags,
+                              scheme,
+                              FALSE, user, password, auth_params,
+                              host,
+                              port,
+                              path,
+                              query,
+                              fragment);
+}
+
+GUri *
+flatpak_g_uri_build (GUriFlags    flags,
+             const gchar *scheme,
+             const gchar *userinfo,
+             const gchar *host,
+             gint         port,
+             const gchar *path,
+             const gchar *query,
+             const gchar *fragment)
+{
+  GUri *uri;
+
+  g_return_val_if_fail (scheme != NULL, NULL);
+  g_return_val_if_fail (port >= -1 && port <= 65535, NULL);
+  g_return_val_if_fail (path != NULL, NULL);
+
+  uri = g_new0 (GUri, 1);
+  uri->ref_count = 1;
+  uri->flags = flags;
+  uri->scheme = g_ascii_strdown (scheme, -1);
+  uri->userinfo = g_strdup (userinfo);
+  uri->host = g_strdup (host);
+  uri->port = port;
+  uri->path = g_strdup (path);
+  uri->query = g_strdup (query);
+  uri->fragment = g_strdup (fragment);
+
+  return g_steal_pointer (&uri);
+}
+
+gchar *
+flatpak_g_uri_to_string_partial (GUri          *uri,
+                         GUriHideFlags  flags)
+{
+  gboolean hide_user = (flags & G_URI_HIDE_USERINFO);
+  gboolean hide_password = (flags & (G_URI_HIDE_USERINFO | G_URI_HIDE_PASSWORD));
+  gboolean hide_auth_params = (flags & (G_URI_HIDE_USERINFO | G_URI_HIDE_AUTH_PARAMS));
+  gboolean hide_query = (flags & G_URI_HIDE_QUERY);
+  gboolean hide_fragment = (flags & G_URI_HIDE_FRAGMENT);
+
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  if (uri->flags & (G_URI_FLAGS_HAS_PASSWORD | G_URI_FLAGS_HAS_AUTH_PARAMS))
+    {
+      return flatpak_g_uri_join_with_user (uri->flags,
+                                   uri->scheme,
+                                   hide_user ? NULL : uri->user,
+                                   hide_password ? NULL : uri->password,
+                                   hide_auth_params ? NULL : uri->auth_params,
+                                   uri->host,
+                                   uri->port,
+                                   uri->path,
+                                   hide_query ? NULL : uri->query,
+                                   hide_fragment ? NULL : uri->fragment);
+    }
+
+  return flatpak_g_uri_join (uri->flags,
+                     uri->scheme,
+                     hide_user ? NULL : uri->userinfo,
+                     uri->host,
+                     uri->port,
+                     uri->path,
+                     hide_query ? NULL : uri->query,
+                     hide_fragment ? NULL : uri->fragment);
+}
+
+const gchar *
+flatpak_g_uri_get_scheme (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->scheme;
+}
+
+const gchar *
+flatpak_g_uri_get_userinfo (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->userinfo;
+}
+
+const gchar *
+flatpak_g_uri_get_user (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->user;
+}
+
+const gchar *
+flatpak_g_uri_get_password (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->password;
+}
+
+const gchar *
+flatpak_g_uri_get_auth_params (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->auth_params;
+}
+
+const gchar *
+flatpak_g_uri_get_host (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->host;
+}
+
+gint
+flatpak_g_uri_get_port (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, -1);
+
+  if (uri->port == -1 && uri->flags & G_URI_FLAGS_SCHEME_NORMALIZE)
+    return default_scheme_port (uri->scheme);
+
+  return uri->port;
+}
+
+const gchar *
+flatpak_g_uri_get_path (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->path;
+}
+
+const gchar *
+flatpak_g_uri_get_query (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->query;
+}
+
+const gchar *
+flatpak_g_uri_get_fragment (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  return uri->fragment;
+}
+
+GUriFlags
+flatpak_g_uri_get_flags (GUri *uri)
+{
+  g_return_val_if_fail (uri != NULL, G_URI_FLAGS_NONE);
+
+  return uri->flags;
+}
+
+#endif /* GLIB_CHECK_VERSION (2, 66, 0) */

--- a/common/flatpak-utils-http-private.h
+++ b/common/flatpak-utils-http-private.h
@@ -22,7 +22,6 @@
 #define __FLATPAK_UTILS_HTTP_H__
 
 #include <string.h>
-#include <libsoup/soup.h>
 
 typedef enum {
   FLATPAK_HTTP_ERROR_NOT_CHANGED = 0,
@@ -32,8 +31,6 @@ typedef enum {
 #define FLATPAK_HTTP_ERROR flatpak_http_error_quark ()
 
 GQuark flatpak_http_error_quark (void);
-
-SoupSession * flatpak_create_soup_session (const char *user_agent);
 
 typedef struct FlatpakHttpSession FlatpakHttpSession;
 

--- a/common/flatpak-utils-http-private.h
+++ b/common/flatpak-utils-http-private.h
@@ -22,7 +22,6 @@
 #define __FLATPAK_UTILS_HTTP_H__
 
 #include <string.h>
-
 #include <libsoup/soup.h>
 
 typedef enum {
@@ -34,8 +33,14 @@ typedef enum {
 
 GQuark flatpak_http_error_quark (void);
 
-
 SoupSession * flatpak_create_soup_session (const char *user_agent);
+
+typedef struct FlatpakHttpSession FlatpakHttpSession;
+
+FlatpakHttpSession* flatpak_create_http_session (const char *user_agent);
+void flatpak_http_session_free (FlatpakHttpSession* http_session);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FlatpakHttpSession, flatpak_http_session_free)
 
 typedef enum {
   FLATPAK_HTTP_FLAGS_NONE = 0,
@@ -46,7 +51,7 @@ typedef enum {
 typedef void (*FlatpakLoadUriProgress) (guint64  downloaded_bytes,
                                         gpointer user_data);
 
-GBytes * flatpak_load_uri (SoupSession           *soup_session,
+GBytes * flatpak_load_uri (FlatpakHttpSession    *http_session,
                            const char            *uri,
                            FlatpakHTTPFlags       flags,
                            const char            *token,
@@ -55,7 +60,7 @@ GBytes * flatpak_load_uri (SoupSession           *soup_session,
                            char                 **out_content_type,
                            GCancellable          *cancellable,
                            GError               **error);
-gboolean flatpak_download_http_uri (SoupSession           *soup_session,
+gboolean flatpak_download_http_uri (FlatpakHttpSession    *http_session,
                                     const char            *uri,
                                     FlatpakHTTPFlags       flags,
                                     GOutputStream         *out,
@@ -64,7 +69,7 @@ gboolean flatpak_download_http_uri (SoupSession           *soup_session,
                                     gpointer               user_data,
                                     GCancellable          *cancellable,
                                     GError               **error);
-gboolean flatpak_cache_http_uri (SoupSession           *soup_session,
+gboolean flatpak_cache_http_uri (FlatpakHttpSession    *http_session,
                                  const char            *uri,
                                  FlatpakHTTPFlags       flags,
                                  int                    dest_dfd,

--- a/common/flatpak-utils-http-private.h
+++ b/common/flatpak-utils-http-private.h
@@ -45,12 +45,26 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(FlatpakHttpSession, flatpak_http_session_free)
 typedef enum {
   FLATPAK_HTTP_FLAGS_NONE = 0,
   FLATPAK_HTTP_FLAGS_ACCEPT_OCI = 1 << 0,
-  FLATPAK_HTTP_FLAGS_STORE_COMPRESSED = 2 << 0,
+  FLATPAK_HTTP_FLAGS_STORE_COMPRESSED = 1 << 1,
+  FLATPAK_HTTP_FLAGS_NOCHECK_STATUS = 1 << 2,
+  FLATPAK_HTTP_FLAGS_HEAD = 1 << 3,
 } FlatpakHTTPFlags;
 
 typedef void (*FlatpakLoadUriProgress) (guint64  downloaded_bytes,
                                         gpointer user_data);
 
+GBytes * flatpak_load_uri_full (FlatpakHttpSession    *http_session,
+                                const char            *uri,
+                                FlatpakHTTPFlags       flags,
+                                const char            *auth,
+                                const char            *token,
+                                FlatpakLoadUriProgress progress,
+                                gpointer               user_data,
+                                int                   *out_status,
+                                char                 **out_content_type,
+                                char                 **out_www_authenticate,
+                                GCancellable          *cancellable,
+                                GError               **error);
 GBytes * flatpak_load_uri (FlatpakHttpSession    *http_session,
                            const char            *uri,
                            FlatpakHTTPFlags       flags,

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -18,6 +18,7 @@
  *       Alexander Larsson <alexl@redhat.com>
  */
 
+#include <gio/gio.h>
 #include "flatpak-utils-http-private.h"
 #include "flatpak-oci-registry-private.h"
 
@@ -27,6 +28,15 @@
 
 #include <sys/types.h>
 #include <sys/xattr.h>
+
+#if !defined(SOUP_AUTOCLEANUPS_H) && !defined(__SOUP_AUTOCLEANUPS_H__)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupSession, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupMessage, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupRequest, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupRequestHTTP, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupURI, soup_uri_free)
+#endif
+
 
 /* copied from libostree */
 #define DEFAULT_N_NETWORK_RETRIES 5
@@ -542,7 +552,7 @@ load_uri_callback (GObject      *source_object,
                              load_uri_read_cb, data);
 }
 
-SoupSession *
+static SoupSession *
 flatpak_create_soup_session (const char *user_agent)
 {
   SoupSession *soup_session;

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -18,16 +18,21 @@
  *       Alexander Larsson <alexl@redhat.com>
  */
 
+#include "config.h"
+
 #include <gio/gio.h>
+#include <glib-unix.h>
 #include "flatpak-utils-http-private.h"
+#include "flatpak-uri-private.h"
 #include "flatpak-oci-registry-private.h"
 
 #include <gio/gunixoutputstream.h>
-#include <libsoup/soup.h>
 #include "libglnx.h"
 
 #include <sys/types.h>
 #include <sys/xattr.h>
+
+#include <libsoup/soup.h>
 
 #if !defined(SOUP_AUTOCLEANUPS_H) && !defined(__SOUP_AUTOCLEANUPS_H__)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupSession, g_object_unref)
@@ -37,12 +42,16 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupRequestHTTP, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupURI, soup_uri_free)
 #endif
 
+#define FLATPAK_HTTP_TIMEOUT_SECS 60
 
 /* copied from libostree */
 #define DEFAULT_N_NETWORK_RETRIES 5
 
 G_DEFINE_QUARK (flatpak_http_error, flatpak_http_error)
 
+/* Information about the cache status of a file.
+   Encoded in an xattr on the cached file, or a file on the side if xattrs don't work.
+*/
 typedef struct
 {
   char  *uri;
@@ -56,25 +65,656 @@ typedef struct
   GMainContext          *context;
   gboolean               done;
   GError                *error;
-  gboolean               store_compressed;
+
+  /* Input args */
+
+  FlatpakHTTPFlags       flags;
+  const char            *auth;
+  const char            *token;
+  FlatpakLoadUriProgress progress;
+  GCancellable          *cancellable;
+  gpointer               user_data;
+  CacheHttpData         *cache_data;
+
+  /* Output from the request, set even on http server errors */
+
+  guint64               downloaded_bytes;
+  int                   status;
+  char                  *hdr_content_type;
+  char                  *hdr_www_authenticate;
+  char                  *hdr_etag;
+  char                  *hdr_last_modified;
+  char                  *hdr_cache_control;
+  char                  *hdr_expires;
+
+  /* Data destination */
 
   GOutputStream         *out; /*or */
   GString               *content; /* or */
   GLnxTmpfile           *out_tmpfile;
   int                    out_tmpfile_parent_dfd;
 
-  guint64                downloaded_bytes;
+  /* Used during operation */
+
   char                   buffer[16 * 1024];
-  FlatpakHTTPFlags       flags;
-  FlatpakLoadUriProgress progress;
-  GCancellable          *cancellable;
-  gpointer               user_data;
   guint64                last_progress_time;
-  CacheHttpData         *cache_data;
-  int                   *status_out;
-  char                 **content_type_out;
-  char                 **www_authenticate_out;
+  gboolean               store_compressed;
+
 } LoadUriData;
+
+static void
+clear_load_uri_data_headers (LoadUriData *data)
+{
+  g_clear_pointer (&data->hdr_content_type, g_free);
+  g_clear_pointer (&data->hdr_www_authenticate, g_free);
+  g_clear_pointer (&data->hdr_etag, g_free);
+  g_clear_pointer (&data->hdr_last_modified, g_free);
+  g_clear_pointer (&data->hdr_last_modified, g_free);
+  g_clear_pointer (&data->hdr_cache_control, g_free);
+  g_clear_pointer (&data->hdr_expires, g_free);
+}
+
+/* Reset between requests retries */
+static void
+reset_load_uri_data (LoadUriData *data)
+{
+  g_clear_error (&data->error);
+  data->status = 0;
+  data->downloaded_bytes = 0;
+  if (data->content)
+    g_string_set_size (data->content, 0);
+
+  clear_load_uri_data_headers (data);
+
+  if (data->out_tmpfile)
+    glnx_tmpfile_clear (data->out_tmpfile);
+
+  /* Reset the progress */
+  if (data->progress)
+    data->progress (0, data->user_data);
+}
+
+/* Free allocated data at end of full repeated download */
+static void
+clear_load_uri_data (LoadUriData *data)
+{
+  if (data->content)
+    {
+      g_string_free (data->content, TRUE);
+      data->content = NULL;
+    }
+
+  g_clear_error (&data->error);
+
+  clear_load_uri_data_headers (data);
+}
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(LoadUriData, clear_load_uri_data)
+
+static gboolean
+check_http_status (guint status_code,
+                   GError **error)
+{
+  GQuark domain;
+  int code;
+
+  if (status_code >= 200 && status_code < 300)
+    return TRUE;
+
+  switch (status_code)
+    {
+    case 304: /* Not Modified */
+      domain = FLATPAK_HTTP_ERROR;
+      code = FLATPAK_HTTP_ERROR_NOT_CHANGED;
+      break;
+
+    case 401: /* Unauthorized */
+      domain = FLATPAK_HTTP_ERROR;
+      code = FLATPAK_HTTP_ERROR_UNAUTHORIZED;
+      break;
+
+    case 403: /* Forbidden */
+    case 404: /* Not found */
+    case 410: /* Gone */
+      domain = G_IO_ERROR;
+      code = G_IO_ERROR_NOT_FOUND;
+      break;
+
+    case 408: /* Request Timeout */
+      domain = G_IO_ERROR;
+      code = G_IO_ERROR_TIMED_OUT;
+      break;
+
+    case 500: /* Internal Server Error */
+      /* The server did return something, but it was useless to us, so that’s basically equivalent to not returning */
+      domain = G_IO_ERROR;
+      code = G_IO_ERROR_HOST_UNREACHABLE;
+      break;
+
+    default:
+      domain = G_IO_ERROR;
+      code = G_IO_ERROR_FAILED;
+    }
+
+  g_set_error (error, domain, code,
+               "Server returned status %u",
+               status_code);
+  return FALSE;
+}
+
+/************************************************************************
+ *                        Soup implementation                           *
+ ***********************************************************************/
+
+static gboolean
+check_soup_transfer_error (SoupMessage *msg, GError **error)
+{
+  GQuark domain = G_IO_ERROR;
+  int code;
+
+  if (!SOUP_STATUS_IS_TRANSPORT_ERROR (msg->status_code))
+    return TRUE;
+
+  switch (msg->status_code)
+    {
+    case SOUP_STATUS_CANCELLED:
+      code = G_IO_ERROR_CANCELLED;
+      break;
+
+    case SOUP_STATUS_CANT_RESOLVE:
+    case SOUP_STATUS_CANT_CONNECT:
+      code = G_IO_ERROR_HOST_NOT_FOUND;
+      break;
+
+    case SOUP_STATUS_IO_ERROR:
+      code = G_IO_ERROR_CONNECTION_CLOSED;
+      break;
+
+    default:
+      code = G_IO_ERROR_FAILED;
+    }
+
+  g_set_error (error, domain, code,
+               "Error connecting to server: %s",
+               soup_status_get_phrase (msg->status_code));
+  return FALSE;
+}
+
+/* The soup input stream was closed */
+static void
+stream_closed (GObject *source, GAsyncResult *res, gpointer user_data)
+{
+  LoadUriData *data = user_data;
+  GInputStream *stream = G_INPUT_STREAM (source);
+  g_autoptr(GError) error = NULL;
+
+  if (!g_input_stream_close_finish (stream, res, &error))
+    g_warning ("Error closing http stream: %s", error->message);
+
+  if (data->out_tmpfile)
+    {
+      if (!g_output_stream_close (data->out, data->cancellable, &error))
+        {
+          if (data->error == NULL)
+            g_propagate_error (&data->error, g_steal_pointer (&error));
+        }
+
+      g_clear_pointer (&data->out, g_object_unref);
+    }
+
+  data->done = TRUE;
+  g_main_context_wakeup (data->context);
+}
+
+/* Got some data from the soup input stream */
+static void
+load_uri_read_cb (GObject *source, GAsyncResult *res, gpointer user_data)
+{
+  LoadUriData *data = user_data;
+  GInputStream *stream = G_INPUT_STREAM (source);
+  gssize nread;
+
+  nread = g_input_stream_read_finish (stream, res, &data->error);
+  if (nread == -1 || nread == 0)
+    {
+      if (data->progress)
+        data->progress (data->downloaded_bytes, data->user_data);
+      g_input_stream_close_async (stream,
+                                  G_PRIORITY_DEFAULT, NULL,
+                                  stream_closed, data);
+
+      return;
+    }
+
+  if (data->out != NULL)
+    {
+      gsize n_written;
+
+      if (!g_output_stream_write_all (data->out, data->buffer, nread, &n_written,
+                                      NULL, &data->error))
+        {
+          data->downloaded_bytes += n_written;
+          g_input_stream_close_async (stream,
+                                      G_PRIORITY_DEFAULT, NULL,
+                                      stream_closed, data);
+          return;
+        }
+
+      data->downloaded_bytes += n_written;
+    }
+  else
+    {
+      g_assert (data->content != NULL);
+      data->downloaded_bytes += nread;
+      g_string_append_len (data->content, data->buffer, nread);
+    }
+
+  if (g_get_monotonic_time () - data->last_progress_time > 1 * G_USEC_PER_SEC)
+    {
+      if (data->progress)
+        data->progress (data->downloaded_bytes, data->user_data);
+      data->last_progress_time = g_get_monotonic_time ();
+    }
+
+  g_input_stream_read_async (stream, data->buffer, sizeof (data->buffer),
+                             G_PRIORITY_DEFAULT, data->cancellable,
+                             load_uri_read_cb, data);
+}
+
+/* The http header part of the request is ready */
+static void
+load_uri_callback (GObject      *source_object,
+                   GAsyncResult *res,
+                   gpointer      user_data)
+{
+  SoupRequestHTTP *request = SOUP_REQUEST_HTTP (source_object);
+  g_autoptr(GInputStream) in = NULL;
+  LoadUriData *data = user_data;
+
+  in = soup_request_send_finish (SOUP_REQUEST (request), res, &data->error);
+  if (in == NULL)
+    {
+      g_main_context_wakeup (data->context);
+      return;
+    }
+
+  g_autoptr(SoupMessage) msg = soup_request_http_get_message ((SoupRequestHTTP *) request);
+
+  if (!check_soup_transfer_error (msg, &data->error))
+    {
+      g_main_context_wakeup (data->context);
+      return;
+    }
+
+  /* We correctly made a connection, although it may be a http failure like 404.
+     The status and headers are valid on return, even of a http failure though. */
+
+  data->status = msg->status_code;
+  data->hdr_content_type = g_strdup (soup_message_headers_get_content_type (msg->response_headers, NULL));
+  data->hdr_www_authenticate = g_strdup (soup_message_headers_get_one (msg->response_headers, "WWW-Authenticate"));
+  data->hdr_etag = g_strdup (soup_message_headers_get_one (msg->response_headers, "ETag"));
+  data->hdr_last_modified = g_strdup (soup_message_headers_get_one (msg->response_headers, "Last-Modified"));
+  data->hdr_cache_control = g_strdup (soup_message_headers_get_list (msg->response_headers, "Cache-Control"));
+  data->hdr_expires = g_strdup (soup_message_headers_get_list (msg->response_headers, "Expires"));
+
+  if ((data->flags & FLATPAK_HTTP_FLAGS_NOCHECK_STATUS) == 0 &&
+      !check_http_status (data->status, &data->error))
+    {
+      g_main_context_wakeup (data->context);
+      return;
+    }
+
+  /* All is good, write the body to the destination */
+
+  if (data->out_tmpfile)
+    {
+      g_autoptr(GOutputStream) out = NULL;
+
+      if (!glnx_open_tmpfile_linkable_at (data->out_tmpfile_parent_dfd, ".",
+                                          O_WRONLY, data->out_tmpfile,
+                                          &data->error))
+        {
+          g_main_context_wakeup (data->context);
+          return;
+        }
+
+      g_assert (data->out == NULL);
+
+      out = g_unix_output_stream_new (data->out_tmpfile->fd, FALSE);
+      if (data->store_compressed &&
+          g_strcmp0 (soup_message_headers_get_one (msg->response_headers, "Content-Encoding"), "gzip") != 0)
+        {
+          g_autoptr(GZlibCompressor) compressor = g_zlib_compressor_new (G_ZLIB_COMPRESSOR_FORMAT_GZIP, -1);
+          data->out = g_converter_output_stream_new (out, G_CONVERTER (compressor));
+        }
+      else
+        {
+          data->out = g_steal_pointer (&out);
+        }
+    }
+
+  g_input_stream_read_async (in, data->buffer, sizeof (data->buffer),
+                             G_PRIORITY_DEFAULT, data->cancellable,
+                             load_uri_read_cb, data);
+}
+
+static SoupSession *
+flatpak_create_soup_session (const char *user_agent)
+{
+  SoupSession *soup_session;
+  const char *http_proxy;
+
+  soup_session = soup_session_new_with_options (SOUP_SESSION_USER_AGENT, user_agent,
+                                                SOUP_SESSION_SSL_USE_SYSTEM_CA_FILE, TRUE,
+                                                SOUP_SESSION_USE_THREAD_CONTEXT, TRUE,
+                                                SOUP_SESSION_TIMEOUT, FLATPAK_HTTP_TIMEOUT_SECS,
+                                                SOUP_SESSION_IDLE_TIMEOUT, FLATPAK_HTTP_TIMEOUT_SECS,
+                                                NULL);
+  http_proxy = g_getenv ("http_proxy");
+  if (http_proxy)
+    {
+      g_autoptr(SoupURI) proxy_uri = soup_uri_new (http_proxy);
+      if (!proxy_uri)
+        g_warning ("Invalid proxy URI '%s'", http_proxy);
+      else
+        g_object_set (soup_session, SOUP_SESSION_PROXY_URI, proxy_uri, NULL);
+    }
+
+  if (g_getenv ("OSTREE_DEBUG_HTTP"))
+    soup_session_add_feature (soup_session, (SoupSessionFeature *) soup_logger_new (SOUP_LOGGER_LOG_BODY, 500));
+
+  return soup_session;
+}
+
+FlatpakHttpSession *
+flatpak_create_http_session (const char *user_agent)
+{
+  return (FlatpakHttpSession *)flatpak_create_soup_session (user_agent);
+}
+
+void
+flatpak_http_session_free (FlatpakHttpSession* http_session)
+{
+  SoupSession *soup_session = (SoupSession *)http_session;
+
+  g_object_unref (soup_session);
+}
+
+static gboolean
+flatpak_download_http_uri_once (FlatpakHttpSession    *http_session,
+                                LoadUriData           *data,
+                                const char            *uri,
+                                GError               **error)
+{
+  SoupSession *soup_session = (SoupSession *)http_session;
+  g_autoptr(SoupRequestHTTP) request = NULL;
+  SoupMessage *m;
+
+  g_debug ("Loading %s using libsoup", uri);
+
+  request = soup_session_request_http (soup_session,
+                                       (data->flags & FLATPAK_HTTP_FLAGS_HEAD) != 0 ? "HEAD" : "GET",
+                                       uri, error);
+  if (request == NULL)
+    return FALSE;
+
+  m = soup_request_http_get_message (request);
+
+  if (data->flags & FLATPAK_HTTP_FLAGS_ACCEPT_OCI)
+    soup_message_headers_replace (m->request_headers, "Accept",
+                                  FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST ", " FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2 ", " FLATPAK_OCI_MEDIA_TYPE_IMAGE_INDEX);
+
+  if (data->auth)
+    {
+      g_autofree char *basic_auth = g_strdup_printf ("Basic %s", data->auth);
+      soup_message_headers_replace (m->request_headers, "Authorization", basic_auth);
+    }
+
+  if (data->token)
+    {
+      g_autofree char *bearer_token = g_strdup_printf ("Bearer %s", data->token);
+      soup_message_headers_replace (m->request_headers, "Authorization", bearer_token);
+    }
+
+  if (data->cache_data)
+    {
+      CacheHttpData *cache_data = data->cache_data;
+
+      if (cache_data->etag && cache_data->etag[0])
+        soup_message_headers_replace (m->request_headers, "If-None-Match", cache_data->etag);
+      else if (cache_data->last_modified != 0)
+        {
+          g_autoptr(GDateTime) date = g_date_time_new_from_unix_utc (cache_data->last_modified);
+          g_autofree char *date_str = flatpak_format_http_date (date);
+          soup_message_headers_replace (m->request_headers, "If-Modified-Since", date_str);
+        }
+    }
+
+  if (data->flags & FLATPAK_HTTP_FLAGS_STORE_COMPRESSED)
+    {
+      soup_session_remove_feature_by_type (soup_session, SOUP_TYPE_CONTENT_DECODER);
+      soup_message_headers_replace (m->request_headers, "Accept-Encoding", "gzip");
+      data->store_compressed = TRUE;
+    }
+  else if (!soup_session_has_feature (soup_session, SOUP_TYPE_CONTENT_DECODER))
+    {
+      soup_session_add_feature_by_type (soup_session, SOUP_TYPE_CONTENT_DECODER);
+      data->store_compressed = FALSE;
+    }
+
+  soup_request_send_async (SOUP_REQUEST (request),
+                           data->cancellable,
+                           load_uri_callback, data);
+
+  while (data->error == NULL && !data->done)
+    g_main_context_iteration (data->context, TRUE);
+
+  if (data->error)
+    {
+      g_propagate_error (error, g_steal_pointer (&data->error));
+      return FALSE;
+    }
+
+  g_debug ("Received %" G_GUINT64_FORMAT " bytes", data->downloaded_bytes);
+
+  return TRUE;
+}
+
+
+
+/* Check whether a particular operation should be retried. This is entirely
+ * based on how it failed (if at all) last time, and whether the operation has
+ * some retries left. The retry count is set when the operation is first
+ * created, and must be decremented by the caller. (@n_retries_remaining == 0)
+ * will always return %FALSE from this function.
+ *
+ * This code is copied from libostree's _ostree_fetcher_should_retry_request()
+ */
+static gboolean
+flatpak_http_should_retry_request (const GError *error,
+                                   guint         n_retries_remaining)
+{
+  if (error == NULL || n_retries_remaining == 0)
+    return FALSE;
+
+  /* Return TRUE for transient errors. */
+  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
+      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
+      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE))
+    {
+      g_debug ("Should retry request (remaining: %u retries), due to transient error: %s",
+               n_retries_remaining, error->message);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+GBytes *
+flatpak_load_uri_full (FlatpakHttpSession    *http_session,
+                       const char            *uri,
+                       FlatpakHTTPFlags       flags,
+                       const char            *auth,
+                       const char            *token,
+                       FlatpakLoadUriProgress progress,
+                       gpointer               user_data,
+                       int                   *out_status,
+                       char                 **out_content_type,
+                       char                 **out_www_authenticate,
+                       GCancellable          *cancellable,
+                       GError               **error)
+{
+  g_auto(LoadUriData) data = { NULL };
+  g_autoptr(GError) local_error = NULL;
+  guint n_retries_remaining = DEFAULT_N_NETWORK_RETRIES;
+  g_autoptr(GMainContextPopDefault) main_context = NULL;
+  gboolean success = FALSE;
+
+  /* Ensure we handle file: uris the same independent of backend */
+  if (g_ascii_strncasecmp (uri, "file:", 5) == 0)
+    {
+      g_autoptr(GFile) file = g_file_new_for_uri (uri);
+      gchar *contents;
+      gsize len;
+
+      if (!g_file_load_contents (file, cancellable, &contents, &len, NULL, error))
+        return NULL;
+
+      return g_bytes_new_take (g_steal_pointer (&contents), len);
+    }
+
+  main_context = flatpak_main_context_new_default ();
+
+  data.context = main_context;
+  data.progress = progress;
+  data.user_data = user_data;
+  data.last_progress_time = g_get_monotonic_time ();
+  data.cancellable = cancellable;
+  data.flags = flags;
+  data.auth = auth;
+  data.token = token;
+
+  data.content = g_string_new ("");
+
+  do
+    {
+      if (n_retries_remaining < DEFAULT_N_NETWORK_RETRIES)
+        {
+          g_clear_error (&local_error);
+          reset_load_uri_data (&data);
+        }
+
+      success = flatpak_download_http_uri_once (http_session, &data, uri, &local_error);
+
+      if (success)
+        break;
+
+      g_assert (local_error != NULL);
+    }
+  while (flatpak_http_should_retry_request (local_error, n_retries_remaining--));
+
+  if (success)
+    {
+      if (out_content_type)
+        *out_content_type = g_steal_pointer (&data.hdr_content_type);
+
+      if (out_www_authenticate)
+        *out_www_authenticate = g_steal_pointer (&data.hdr_www_authenticate);
+
+      if (out_status)
+        *out_status = data.status;
+
+      return g_string_free_to_bytes (g_steal_pointer (&data.content));
+    }
+
+  g_assert (local_error != NULL);
+  g_propagate_error (error, g_steal_pointer (&local_error));
+  return NULL;
+}
+
+
+GBytes *
+flatpak_load_uri (FlatpakHttpSession    *http_session,
+                  const char            *uri,
+                  FlatpakHTTPFlags       flags,
+                  const char            *token,
+                  FlatpakLoadUriProgress progress,
+                  gpointer               user_data,
+                  char                 **out_content_type,
+                  GCancellable          *cancellable,
+                  GError               **error)
+{
+  return flatpak_load_uri_full (http_session, uri, flags, NULL, token,
+                                progress, user_data, NULL, out_content_type, NULL,
+                                cancellable, error);
+}
+
+gboolean
+flatpak_download_http_uri (FlatpakHttpSession    *http_session,
+                           const char            *uri,
+                           FlatpakHTTPFlags       flags,
+                           GOutputStream         *out,
+                           const char            *token,
+                           FlatpakLoadUriProgress progress,
+                           gpointer               user_data,
+                           GCancellable          *cancellable,
+                           GError               **error)
+{
+  g_auto(LoadUriData) data = { NULL };
+  g_autoptr(GError) local_error = NULL;
+  guint n_retries_remaining = DEFAULT_N_NETWORK_RETRIES;
+  g_autoptr(GMainContextPopDefault) main_context = NULL;
+  gboolean success = FALSE;
+
+  main_context = flatpak_main_context_new_default ();
+
+  data.context = main_context;
+  data.progress = progress;
+  data.user_data = user_data;
+  data.last_progress_time = g_get_monotonic_time ();
+  data.cancellable = cancellable;
+  data.flags = flags;
+  data.token = token;
+
+  data.out = out;
+
+  do
+    {
+      if (n_retries_remaining < DEFAULT_N_NETWORK_RETRIES)
+        {
+          g_clear_error (&local_error);
+          reset_load_uri_data (&data);
+        }
+
+      success =  flatpak_download_http_uri_once (http_session, &data, uri, &local_error);
+
+      if (success)
+        break;
+
+      g_assert (local_error != NULL);
+
+      /* If the output stream has already been written to we can't retry.
+       * TODO: use a range request to resume the download */
+      if (data.downloaded_bytes > 0)
+        break;
+    }
+  while (flatpak_http_should_retry_request (local_error, n_retries_remaining--));
+
+  if (success)
+    return TRUE;
+
+  g_assert (local_error != NULL);
+  g_propagate_error (error, g_steal_pointer (&local_error));
+  return FALSE;
+}
+
+/************************************************************************
+ *                        Cached http support                           *
+ ***********************************************************************/
 
 #define CACHE_HTTP_XATTR "user.flatpak.http"
 #define CACHE_HTTP_SUFFIX ".flatpak.http"
@@ -190,94 +830,6 @@ load_cache_http_data (int           dfd,
   return g_steal_pointer (&data);
 }
 
-static void
-set_cache_http_data_from_headers (CacheHttpData *data,
-                                  SoupMessage   *msg)
-{
-  const char *etag = soup_message_headers_get_one (msg->response_headers, "ETag");
-  const char *last_modified = soup_message_headers_get_one (msg->response_headers, "Last-Modified");
-  const char *cache_control = soup_message_headers_get_list (msg->response_headers, "Cache-Control");
-  const char *expires = soup_message_headers_get_list (msg->response_headers, "Expires");
-  gboolean expires_computed = FALSE;
-
-  /* The original HTTP 1/1 specification only required sending the ETag header in a 304
-   * response, and implied that a cache might need to save the old Cache-Control
-   * values. The updated RFC 7232 from 2014 requires sending Cache-Control, ETags, and
-   * Expire if they would have been sent in the original 200 response, and recommends
-   * sending Last-Modified for requests without an etag. Since sending these headers was
-   * apparently normal previously, for simplicity we assume the RFC 7232 behavior and start
-   * from scratch for a 304 response.
-   */
-  clear_cache_http_data (data, FALSE);
-
-  if (etag && *etag)
-    {
-      data->etag = g_strdup (etag);
-    }
-  else if (last_modified && *last_modified)
-    {
-      SoupDate *date = soup_date_new_from_string (last_modified);
-      if (date)
-        {
-          data->last_modified = soup_date_to_time_t (date);
-          soup_date_free (date);
-        }
-    }
-
-  if (cache_control && *cache_control)
-    {
-      g_autoptr(GHashTable) params = soup_header_parse_param_list (cache_control);
-      GHashTableIter iter;
-      gpointer key, value;
-
-      g_hash_table_iter_init (&iter, params);
-      while (g_hash_table_iter_next (&iter, &key, &value))
-        {
-          if (g_strcmp0 (key, "max-age") == 0)
-            {
-              char *end;
-
-              char *max_age = value;
-              int max_age_sec = g_ascii_strtoll (max_age,  &end, 10);
-              if (*max_age != '\0' && *end == '\0')
-                {
-                  GTimeVal now;
-                  g_get_current_time (&now);
-                  data->expires = now.tv_sec + max_age_sec;
-                  expires_computed = TRUE;
-                }
-            }
-          else if (g_strcmp0 (key, "no-cache") == 0)
-            {
-              data->expires = 0;
-              expires_computed = TRUE;
-            }
-        }
-    }
-
-  if (!expires_computed && expires && *expires)
-    {
-      SoupDate *date = soup_date_new_from_string (expires);
-      if (date)
-        {
-          data->expires = soup_date_to_time_t (date);
-          soup_date_free (date);
-          expires_computed = TRUE;
-        }
-    }
-
-  if (!expires_computed)
-    {
-      /* If nothing implies an expires time, use 30 minutes. Browsers use
-       * 0.1 * (Date - Last-Modified), but it's clearly appropriate here, and
-       * better if server's send a value.
-       */
-      GTimeVal now;
-      g_get_current_time (&now);
-      data->expires = now.tv_sec + 1800;
-    }
-}
-
 static gboolean
 save_cache_http_data_xattr (int      fd,
                             GBytes  *bytes,
@@ -343,563 +895,6 @@ save_cache_http_data_to_file (int           dfd,
   return TRUE;
 }
 
-static void
-stream_closed (GObject *source, GAsyncResult *res, gpointer user_data)
-{
-  LoadUriData *data = user_data;
-  GInputStream *stream = G_INPUT_STREAM (source);
-  g_autoptr(GError) error = NULL;
-
-  if (!g_input_stream_close_finish (stream, res, &error))
-    g_warning ("Error closing http stream: %s", error->message);
-
-  if (data->out_tmpfile)
-    {
-      if (!g_output_stream_close (data->out, data->cancellable, &error))
-        {
-          if (data->error == NULL)
-            g_propagate_error (&data->error, g_steal_pointer (&error));
-        }
-
-      g_clear_pointer (&data->out, g_object_unref);
-    }
-
-  data->done = TRUE;
-  g_main_context_wakeup (data->context);
-}
-
-static void
-load_uri_read_cb (GObject *source, GAsyncResult *res, gpointer user_data)
-{
-  LoadUriData *data = user_data;
-  GInputStream *stream = G_INPUT_STREAM (source);
-  gssize nread;
-
-  nread = g_input_stream_read_finish (stream, res, &data->error);
-  if (nread == -1 || nread == 0)
-    {
-      if (data->progress)
-        data->progress (data->downloaded_bytes, data->user_data);
-      g_input_stream_close_async (stream,
-                                  G_PRIORITY_DEFAULT, NULL,
-                                  stream_closed, data);
-
-      return;
-    }
-
-  if (data->out != NULL)
-    {
-      gsize n_written;
-
-      if (!g_output_stream_write_all (data->out, data->buffer, nread, &n_written,
-                                      NULL, &data->error))
-        {
-          data->downloaded_bytes += n_written;
-          g_input_stream_close_async (stream,
-                                      G_PRIORITY_DEFAULT, NULL,
-                                      stream_closed, data);
-          return;
-        }
-
-      data->downloaded_bytes += n_written;
-    }
-  else
-    {
-      data->downloaded_bytes += nread;
-      g_string_append_len (data->content, data->buffer, nread);
-    }
-
-  if (g_get_monotonic_time () - data->last_progress_time > 1 * G_USEC_PER_SEC)
-    {
-      if (data->progress)
-        data->progress (data->downloaded_bytes, data->user_data);
-      data->last_progress_time = g_get_monotonic_time ();
-    }
-
-  g_input_stream_read_async (stream, data->buffer, sizeof (data->buffer),
-                             G_PRIORITY_DEFAULT, data->cancellable,
-                             load_uri_read_cb, data);
-}
-
-static void
-load_uri_callback (GObject      *source_object,
-                   GAsyncResult *res,
-                   gpointer      user_data)
-{
-  SoupRequestHTTP *request = SOUP_REQUEST_HTTP (source_object);
-  g_autoptr(GInputStream) in = NULL;
-  LoadUriData *data = user_data;
-
-  in = soup_request_send_finish (SOUP_REQUEST (request), res, &data->error);
-  if (in == NULL)
-    {
-      /* data->error has been set */
-      g_main_context_wakeup (data->context);
-      return;
-    }
-
-  g_autoptr(SoupMessage) msg = soup_request_http_get_message ((SoupRequestHTTP *) request);
-  if (!SOUP_STATUS_IS_SUCCESSFUL (msg->status_code))
-    {
-      int code;
-      GQuark domain = G_IO_ERROR;
-      gboolean http_error = TRUE;
-
-      switch (msg->status_code)
-        {
-        case 304:
-          if (data->cache_data)
-            set_cache_http_data_from_headers (data->cache_data, msg);
-
-          domain = FLATPAK_HTTP_ERROR;
-          code = FLATPAK_HTTP_ERROR_NOT_CHANGED;
-          break;
-
-        case 401:
-          domain = FLATPAK_HTTP_ERROR;
-          code = FLATPAK_HTTP_ERROR_UNAUTHORIZED;
-          break;
-
-        case 403:
-        case 404:
-        case 410:
-          code = G_IO_ERROR_NOT_FOUND;
-          break;
-
-        case 408:
-          code = G_IO_ERROR_TIMED_OUT;
-          break;
-
-        case SOUP_STATUS_CANCELLED:
-          http_error = FALSE;
-          code = G_IO_ERROR_CANCELLED;
-          break;
-
-        case SOUP_STATUS_CANT_RESOLVE:
-        case SOUP_STATUS_CANT_CONNECT:
-          http_error = FALSE;
-          code = G_IO_ERROR_HOST_NOT_FOUND;
-          break;
-
-        case SOUP_STATUS_INTERNAL_SERVER_ERROR:
-          /* The server did return something, but it was useless to us, so that’s basically equivalent to not returning */
-          http_error = FALSE;
-          code = G_IO_ERROR_HOST_UNREACHABLE;
-          break;
-
-        case SOUP_STATUS_IO_ERROR:
-          http_error = FALSE;
-          code = G_IO_ERROR_CONNECTION_CLOSED;
-          break;
-
-        default:
-          http_error = FALSE;
-          code = G_IO_ERROR_FAILED;
-        }
-
-      if (!http_error || (data->flags & FLATPAK_HTTP_FLAGS_NOCHECK_STATUS) == 0)
-        {
-          data->error = g_error_new (domain, code,
-                                     "Server returned status %u: %s",
-                                     msg->status_code,
-                                     soup_status_get_phrase (msg->status_code));
-          g_main_context_wakeup (data->context);
-          return;
-        }
-    }
-
-  if (data->cache_data)
-    set_cache_http_data_from_headers (data->cache_data, msg);
-
-  if (data->content_type_out)
-    *data->content_type_out = g_strdup (soup_message_headers_get_content_type (msg->response_headers, NULL));
-
-  if (data->www_authenticate_out)
-    *data->www_authenticate_out = g_strdup (soup_message_headers_get_one (msg->response_headers, "WWW-Authenticate"));
-
-  if (data->status_out)
-    *data->status_out = msg->status_code;
-
-  if (data->out_tmpfile)
-    {
-      g_autoptr(GOutputStream) out = NULL;
-
-      if (!glnx_open_tmpfile_linkable_at (data->out_tmpfile_parent_dfd, ".",
-                                          O_WRONLY, data->out_tmpfile,
-                                          &data->error))
-        {
-          g_main_context_wakeup (data->context);
-          return;
-        }
-
-      g_assert (data->out == NULL);
-
-      out = g_unix_output_stream_new (data->out_tmpfile->fd, FALSE);
-      if (data->store_compressed &&
-          g_strcmp0 (soup_message_headers_get_one (msg->response_headers, "Content-Encoding"), "gzip") != 0)
-        {
-          g_autoptr(GZlibCompressor) compressor = g_zlib_compressor_new (G_ZLIB_COMPRESSOR_FORMAT_GZIP, -1);
-          data->out = g_converter_output_stream_new (out, G_CONVERTER (compressor));
-        }
-      else
-        {
-          data->out = g_steal_pointer (&out);
-        }
-    }
-
-  g_input_stream_read_async (in, data->buffer, sizeof (data->buffer),
-                             G_PRIORITY_DEFAULT, data->cancellable,
-                             load_uri_read_cb, data);
-}
-
-static SoupSession *
-flatpak_create_soup_session (const char *user_agent)
-{
-  SoupSession *soup_session;
-  const char *http_proxy;
-
-  soup_session = soup_session_new_with_options (SOUP_SESSION_USER_AGENT, user_agent,
-                                                SOUP_SESSION_SSL_USE_SYSTEM_CA_FILE, TRUE,
-                                                SOUP_SESSION_USE_THREAD_CONTEXT, TRUE,
-                                                SOUP_SESSION_TIMEOUT, 60,
-                                                SOUP_SESSION_IDLE_TIMEOUT, 60,
-                                                NULL);
-  http_proxy = g_getenv ("http_proxy");
-  if (http_proxy)
-    {
-      g_autoptr(SoupURI) proxy_uri = soup_uri_new (http_proxy);
-      if (!proxy_uri)
-        g_warning ("Invalid proxy URI '%s'", http_proxy);
-      else
-        g_object_set (soup_session, SOUP_SESSION_PROXY_URI, proxy_uri, NULL);
-    }
-
-  if (g_getenv ("OSTREE_DEBUG_HTTP"))
-    soup_session_add_feature (soup_session, (SoupSessionFeature *) soup_logger_new (SOUP_LOGGER_LOG_BODY, 500));
-
-  return soup_session;
-}
-
-FlatpakHttpSession *
-flatpak_create_http_session (const char *user_agent)
-{
-  return (FlatpakHttpSession *)flatpak_create_soup_session (user_agent);
-}
-
-void
-flatpak_http_session_free (FlatpakHttpSession* http_session)
-{
-  SoupSession *soup_session = (SoupSession *)http_session;
-
-  g_object_unref (soup_session);
-}
-
-/* Check whether a particular operation should be retried. This is entirely
- * based on how it failed (if at all) last time, and whether the operation has
- * some retries left. The retry count is set when the operation is first
- * created, and must be decremented by the caller. (@n_retries_remaining == 0)
- * will always return %FALSE from this function.
- *
- * This code is copied from libostree's _ostree_fetcher_should_retry_request()
- */
-static gboolean
-flatpak_http_should_retry_request (const GError *error,
-                                   guint         n_retries_remaining)
-{
-  if (error == NULL || n_retries_remaining == 0)
-    return FALSE;
-
-  /* Return TRUE for transient errors. */
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
-      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
-      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE))
-    {
-      g_debug ("Should retry request (remaining: %u retries), due to transient error: %s",
-               n_retries_remaining, error->message);
-      return TRUE;
-    }
-
-  return FALSE;
-}
-
-static GBytes *
-flatpak_load_http_uri_once (FlatpakHttpSession    *http_session,
-                            const char            *uri,
-                            FlatpakHTTPFlags       flags,
-                            const char            *auth,
-                            const char            *token,
-                            FlatpakLoadUriProgress progress,
-                            gpointer               user_data,
-                            int                   *out_status,
-                            char                 **out_content_type,
-                            char                 **out_www_authenticate,
-                            GCancellable          *cancellable,
-                            GError               **error)
-{
-  SoupSession *soup_session = (SoupSession *)http_session;
-  GBytes *bytes = NULL;
-  g_autoptr(GMainContext) context = NULL;
-  g_autoptr(SoupRequestHTTP) request = NULL;
-  g_autoptr(GString) content = g_string_new ("");
-  LoadUriData data = { NULL };
-  SoupMessage *m;
-
-  g_debug ("Loading %s using libsoup", uri);
-
-  context = g_main_context_ref_thread_default ();
-
-  data.context = context;
-  data.content = content;
-  data.progress = progress;
-  data.cancellable = cancellable;
-  data.user_data = user_data;
-  data.flags = flags;
-  data.last_progress_time = g_get_monotonic_time ();
-  data.www_authenticate_out = out_www_authenticate;
-  data.content_type_out = out_content_type;
-  data.status_out = out_status;
-
-  request = soup_session_request_http (soup_session, (data.flags & FLATPAK_HTTP_FLAGS_HEAD) != 0 ? "HEAD" : "GET",
-                                       uri, error);
-  if (request == NULL)
-    return NULL;
-
-  m = soup_request_http_get_message (request);
-
-  if (flags & FLATPAK_HTTP_FLAGS_ACCEPT_OCI)
-    soup_message_headers_replace (m->request_headers, "Accept",
-                                  FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST ", " FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2 ", " FLATPAK_OCI_MEDIA_TYPE_IMAGE_INDEX);
-
-  if (auth)
-    {
-      g_autofree char *basic_auth = g_strdup_printf ("Basic %s", auth);
-      soup_message_headers_replace (m->request_headers, "Authorization", basic_auth);
-    }
-
-  if (token)
-    {
-      g_autofree char *bearer_token = g_strdup_printf ("Bearer %s", token);
-      soup_message_headers_replace (m->request_headers, "Authorization", bearer_token);
-    }
-
-  soup_request_send_async (SOUP_REQUEST (request),
-                           cancellable,
-                           load_uri_callback, &data);
-
-  while (data.error == NULL && !data.done)
-    g_main_context_iteration (data.context, TRUE);
-
-  if (data.error)
-    {
-      g_propagate_error (error, data.error);
-      return NULL;
-    }
-
-  bytes = g_string_free_to_bytes (g_steal_pointer (&content));
-  g_debug ("Received %" G_GUINT64_FORMAT " bytes", data.downloaded_bytes);
-
-  return bytes;
-}
-
-GBytes *
-flatpak_load_uri_full (FlatpakHttpSession    *http_session,
-                       const char            *uri,
-                       FlatpakHTTPFlags       flags,
-                       const char            *auth,
-                       const char            *token,
-                       FlatpakLoadUriProgress progress,
-                       gpointer               user_data,
-                       int                   *out_status,
-                       char                 **out_content_type,
-                       char                 **out_www_authenticate,
-                       GCancellable          *cancellable,
-                       GError               **error)
-{
-  g_autoptr(GError) local_error = NULL;
-  guint n_retries_remaining = DEFAULT_N_NETWORK_RETRIES;
-  g_autoptr(GMainContextPopDefault) main_context = NULL;
-
-  main_context = flatpak_main_context_new_default ();
-
-  /* Ensure we handle file: uris always */
-  if (g_ascii_strncasecmp (uri, "file:", 5) == 0)
-    {
-      g_autoptr(GFile) file = g_file_new_for_uri (uri);
-      gchar *contents;
-      gsize len;
-
-      if (!g_file_load_contents (file, cancellable, &contents, &len, NULL, error))
-        return NULL;
-
-      return g_bytes_new_take (g_steal_pointer (&contents), len);
-    }
-
-  do
-    {
-      g_autoptr(GBytes) bytes = NULL;
-
-      if (n_retries_remaining < DEFAULT_N_NETWORK_RETRIES)
-        {
-          g_clear_error (&local_error);
-
-          if (progress)
-            progress (0, user_data); /* Reset the progress */
-        }
-
-      bytes = flatpak_load_http_uri_once (http_session, uri, flags, auth, token,
-                                          progress, user_data,
-                                          out_status, out_content_type, out_www_authenticate,
-                                          cancellable, &local_error);
-
-      if (local_error == NULL)
-        return g_steal_pointer (&bytes);
-    }
-  while (flatpak_http_should_retry_request (local_error, n_retries_remaining--));
-
-  g_assert (local_error != NULL);
-  g_propagate_error (error, g_steal_pointer (&local_error));
-  return NULL;
-}
-
-GBytes *
-flatpak_load_uri (FlatpakHttpSession    *http_session,
-                  const char            *uri,
-                  FlatpakHTTPFlags       flags,
-                  const char            *token,
-                  FlatpakLoadUriProgress progress,
-                  gpointer               user_data,
-                  char                 **out_content_type,
-                  GCancellable          *cancellable,
-                  GError               **error)
-{
-  return flatpak_load_uri_full (http_session, uri, flags, NULL, token,
-                                progress, user_data, NULL, out_content_type, NULL,
-                                cancellable, error);
-}
-
-
-static gboolean
-flatpak_download_http_uri_once (FlatpakHttpSession    *http_session,
-                                const char            *uri,
-                                FlatpakHTTPFlags       flags,
-                                GOutputStream         *out,
-                                const char            *token,
-                                FlatpakLoadUriProgress progress,
-                                gpointer               user_data,
-                                guint64               *out_bytes_written,
-                                GCancellable          *cancellable,
-                                GError               **error)
-{
-  SoupSession *soup_session = (SoupSession *)http_session;
-  g_autoptr(SoupRequestHTTP) request = NULL;
-  g_autoptr(GMainContext) context = NULL;
-  LoadUriData data = { NULL };
-  SoupMessage *m;
-
-  g_debug ("Loading %s using libsoup", uri);
-
-  context = g_main_context_ref_thread_default ();
-
-  data.context = context;
-  data.out = out;
-  data.progress = progress;
-  data.cancellable = cancellable;
-  data.user_data = user_data;
-  data.last_progress_time = g_get_monotonic_time ();
-  data.flags = flags;
-
-  request = soup_session_request_http (soup_session, "GET",
-                                       uri, error);
-  if (request == NULL)
-    return FALSE;
-
-  m = soup_request_http_get_message (request);
-  if (flags & FLATPAK_HTTP_FLAGS_ACCEPT_OCI)
-    soup_message_headers_replace (m->request_headers, "Accept",
-                                  FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST ", " FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2);
-
-  if (token)
-    {
-      g_autofree char *bearer_token = g_strdup_printf ("Bearer %s", token);
-      soup_message_headers_replace (m->request_headers, "Authorization", bearer_token);
-    }
-
-  soup_request_send_async (SOUP_REQUEST (request),
-                           cancellable,
-                           load_uri_callback, &data);
-
-  while (data.error == NULL && !data.done)
-    g_main_context_iteration (data.context, TRUE);
-
-  if (out_bytes_written)
-    *out_bytes_written = data.downloaded_bytes;
-
-  if (data.error)
-    {
-      g_propagate_error (error, data.error);
-      return FALSE;
-    }
-
-  g_debug ("Received %" G_GUINT64_FORMAT " bytes", data.downloaded_bytes);
-
-  return TRUE;
-}
-
-gboolean
-flatpak_download_http_uri (FlatpakHttpSession    *http_session,
-                           const char            *uri,
-                           FlatpakHTTPFlags       flags,
-                           GOutputStream         *out,
-                           const char            *token,
-                           FlatpakLoadUriProgress progress,
-                           gpointer               user_data,
-                           GCancellable          *cancellable,
-                           GError               **error)
-{
-  g_autoptr(GError) local_error = NULL;
-  guint n_retries_remaining = DEFAULT_N_NETWORK_RETRIES;
-  g_autoptr(GMainContextPopDefault) main_context = NULL;
-
-  main_context = flatpak_main_context_new_default ();
-
-  do
-    {
-      guint64 bytes_written = 0;
-
-      if (n_retries_remaining < DEFAULT_N_NETWORK_RETRIES)
-        {
-          g_clear_error (&local_error);
-
-          if (progress)
-            progress (0, user_data); /* Reset the progress */
-        }
-
-      if (flatpak_download_http_uri_once (http_session, uri, flags,
-                                          out, token,
-                                          progress, user_data,
-                                          &bytes_written,
-                                          cancellable, &local_error))
-        {
-          g_assert (local_error == NULL);
-          return TRUE;
-        }
-
-      /* If the output stream has already been written to we can't retry.
-       * TODO: use a range request to resume the download */
-      if (bytes_written > 0)
-        break;
-    }
-  while (flatpak_http_should_retry_request (local_error, n_retries_remaining--));
-
-  g_assert (local_error != NULL);
-  g_propagate_error (error, g_steal_pointer (&local_error));
-  return FALSE;
-}
-
 static gboolean
 sync_and_rename_tmpfile (GLnxTmpfile *tmpfile,
                          const char  *dest_name,
@@ -932,35 +927,119 @@ sync_and_rename_tmpfile (GLnxTmpfile *tmpfile,
   return TRUE;
 }
 
-static gboolean
-flatpak_cache_http_uri_once (FlatpakHttpSession    *http_session,
-                             const char            *uri,
-                             FlatpakHTTPFlags       flags,
-                             int                    dest_dfd,
-                             const char            *dest_subpath,
-                             FlatpakLoadUriProgress progress,
-                             gpointer               user_data,
-                             GCancellable          *cancellable,
-                             GError               **error)
+static void
+set_cache_http_data_from_headers (CacheHttpData *cache_data,
+                                  LoadUriData *data)
 {
-  SoupSession *soup_session = (SoupSession *)http_session;
-  g_autoptr(SoupRequestHTTP) request = NULL;
-  g_autoptr(GMainContext) context = NULL;
+  const char *etag = data->hdr_etag;
+  const char *last_modified = data->hdr_last_modified;
+  const char *cache_control = data->hdr_cache_control;
+  const char *expires = data->hdr_expires;
+  gboolean expires_computed = FALSE;
+
+  /* The original HTTP 1/1 specification only required sending the ETag header in a 304
+   * response, and implied that a cache might need to save the old Cache-Control
+   * values. The updated RFC 7232 from 2014 requires sending Cache-Control, ETags, and
+   * Expire if they would have been sent in the original 200 response, and recommends
+   * sending Last-Modified for requests without an etag. Since sending these headers was
+   * apparently normal previously, for simplicity we assume the RFC 7232 behavior and start
+   * from scratch for a 304 response.
+   */
+  clear_cache_http_data (cache_data, FALSE);
+
+  if (etag && *etag)
+    {
+      cache_data->etag = g_strdup (etag);
+    }
+  else if (last_modified && *last_modified)
+    {
+      g_autoptr(GDateTime) date = flatpak_parse_http_time (last_modified);
+      if (date)
+        cache_data->last_modified = g_date_time_to_unix (date);
+    }
+
+  if (cache_control && *cache_control)
+    {
+      g_autoptr(GHashTable) params = flatpak_parse_http_header_param_list (cache_control);
+      GHashTableIter iter;
+      gpointer key, value;
+
+      g_hash_table_iter_init (&iter, params);
+      while (g_hash_table_iter_next (&iter, &key, &value))
+        {
+          if (g_strcmp0 (key, "max-age") == 0)
+            {
+              char *end;
+
+              char *max_age = value;
+              int max_age_sec = g_ascii_strtoll (max_age,  &end, 10);
+              if (*max_age != '\0' && *end == '\0')
+                {
+                  GTimeVal now;
+                  g_get_current_time (&now);
+                  cache_data->expires = now.tv_sec + max_age_sec;
+                  expires_computed = TRUE;
+                }
+            }
+          else if (g_strcmp0 (key, "no-cache") == 0)
+            {
+              cache_data->expires = 0;
+              expires_computed = TRUE;
+            }
+        }
+    }
+
+  if (!expires_computed && expires && *expires)
+    {
+      g_autoptr(GDateTime) date = flatpak_parse_http_time (expires);
+      if (date)
+        {
+          cache_data->expires = g_date_time_to_unix (date);
+          expires_computed = TRUE;
+        }
+    }
+
+  if (!expires_computed)
+    {
+      /* If nothing implies an expires time, use 30 minutes. Browsers use
+       * 0.1 * (Date - Last-Modified), but it's clearly appropriate here, and
+       * better if server's send a value.
+       */
+      GTimeVal now;
+      g_get_current_time (&now);
+      cache_data->expires = now.tv_sec + 1800;
+    }
+}
+
+gboolean
+flatpak_cache_http_uri (FlatpakHttpSession    *http_session,
+                        const char            *uri,
+                        FlatpakHTTPFlags       flags,
+                        int                    dest_dfd,
+                        const char            *dest_subpath,
+                        FlatpakLoadUriProgress progress,
+                        gpointer               user_data,
+                        GCancellable          *cancellable,
+                        GError               **error)
+{
+  g_auto(LoadUriData) data = { NULL };
+  g_autoptr(GError) local_error = NULL;
+  guint n_retries_remaining = DEFAULT_N_NETWORK_RETRIES;
   g_autoptr(CacheHttpData) cache_data = NULL;
+  g_autoptr(GMainContextPopDefault) main_context = NULL;
   g_autofree char *parent_path = g_path_get_dirname (dest_subpath);
   g_autofree char *name = g_path_get_basename (dest_subpath);
-  glnx_autofd int dfd = -1;
-  gboolean no_xattr = FALSE;
-  LoadUriData data = { NULL };
   g_auto(GLnxTmpfile) out_tmpfile = { 0 };
   g_auto(GLnxTmpfile) cache_tmpfile = { 0 };
   g_autoptr(GBytes) cache_bytes = NULL;
-  SoupMessage *m;
+  gboolean no_xattr = FALSE;
+  glnx_autofd int cache_dfd = -1;
+  gboolean success;
 
-  if (!glnx_opendirat (dest_dfd, parent_path, TRUE, &dfd, error))
+  if (!glnx_opendirat (dest_dfd, parent_path, TRUE, &cache_dfd, error))
     return FALSE;
 
-  cache_data = load_cache_http_data (dfd, name, &no_xattr,
+  cache_data = load_cache_http_data (cache_dfd, name, &no_xattr,
                                      cancellable, error);
   if (!cache_data)
     return FALSE;
@@ -975,10 +1054,9 @@ flatpak_cache_http_uri_once (FlatpakHttpSession    *http_session,
       g_get_current_time (&now);
       if (cache_data->expires > now.tv_sec)
         {
-          if (error)
-            *error = g_error_new (FLATPAK_HTTP_ERROR,
-                                  FLATPAK_HTTP_ERROR_NOT_CHANGED,
-                                  "Reusing cached value");
+          g_set_error (error, FLATPAK_HTTP_ERROR,
+                       FLATPAK_HTTP_ERROR_NOT_CHANGED,
+                       "Reusing cached value");
           return FALSE;
         }
     }
@@ -986,84 +1064,66 @@ flatpak_cache_http_uri_once (FlatpakHttpSession    *http_session,
   if (cache_data->uri == NULL)
     cache_data->uri = g_strdup (uri);
 
-  /* Must revalidate */
+  /* Missing from cache, or expired so must revalidate via etag/last-modified headers */
 
-  g_debug ("Loading %s using libsoup", uri);
+  main_context = flatpak_main_context_new_default ();
 
-  context = g_main_context_ref_thread_default ();
-
-  data.context = context;
-  data.cache_data = cache_data;
-  data.out_tmpfile = &out_tmpfile;
-  data.out_tmpfile_parent_dfd = dfd;
+  data.context = main_context;
   data.progress = progress;
-  data.cancellable = cancellable;
   data.user_data = user_data;
-  data.flags = flags;
   data.last_progress_time = g_get_monotonic_time ();
+  data.cancellable = cancellable;
+  data.flags = flags;
 
-  request = soup_session_request_http (soup_session, "GET",
-                                       uri, error);
-  if (request == NULL)
-    return FALSE;
+  data.cache_data = cache_data;
 
-  m = soup_request_http_get_message (request);
+  data.out_tmpfile = &out_tmpfile;
+  data.out_tmpfile_parent_dfd = cache_dfd;
 
-  if (cache_data->etag && cache_data->etag[0])
-    soup_message_headers_replace (m->request_headers, "If-None-Match", cache_data->etag);
-  else if (cache_data->last_modified != 0)
+  do
     {
-      SoupDate *date = soup_date_new_from_time_t (cache_data->last_modified);
-      g_autofree char *date_str = soup_date_to_string (date, SOUP_DATE_HTTP);
-      soup_message_headers_replace (m->request_headers, "If-Modified-Since", date_str);
-      soup_date_free (date);
+      if (n_retries_remaining < DEFAULT_N_NETWORK_RETRIES)
+        {
+          g_clear_error (&local_error);
+          reset_load_uri_data (&data);
+        }
+
+      success = flatpak_download_http_uri_once (http_session, &data, uri, &local_error);
+
+      if (success)
+        break;
+
+      g_assert (local_error != NULL);
+    }
+  while (flatpak_http_should_retry_request (local_error, n_retries_remaining--));
+
+  /* Update the cache data on success or cache-valid */
+  if (success || g_error_matches (local_error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_NOT_CHANGED))
+    {
+      set_cache_http_data_from_headers (cache_data, &data);
+      cache_bytes = serialize_cache_http_data (cache_data);
     }
 
-  if (flags & FLATPAK_HTTP_FLAGS_ACCEPT_OCI)
-    soup_message_headers_replace (m->request_headers, "Accept",
-                                  FLATPAK_OCI_MEDIA_TYPE_IMAGE_MANIFEST ", " FLATPAK_DOCKER_MEDIA_TYPE_IMAGE_MANIFEST2);
-
-  if (flags & FLATPAK_HTTP_FLAGS_STORE_COMPRESSED)
+  if (local_error)
     {
-      soup_session_remove_feature_by_type (soup_session, SOUP_TYPE_CONTENT_DECODER);
-      soup_message_headers_replace (m->request_headers, "Accept-Encoding",
-                                    "gzip");
-      data.store_compressed = TRUE;
-    }
-  else if (!soup_session_has_feature (soup_session, SOUP_TYPE_CONTENT_DECODER))
-    soup_session_add_feature_by_type (soup_session, SOUP_TYPE_CONTENT_DECODER);
-
-  soup_request_send_async (SOUP_REQUEST (request),
-                           cancellable,
-                           load_uri_callback, &data);
-
-  while (data.error == NULL && !data.done)
-    g_main_context_iteration (data.context, TRUE);
-
-  if (data.error)
-    {
-      if (data.error->domain == FLATPAK_HTTP_ERROR &&
-          data.error->code == FLATPAK_HTTP_ERROR_NOT_CHANGED)
+      if (cache_bytes)
         {
           GError *tmp_error = NULL;
 
-          cache_bytes = serialize_cache_http_data (cache_data);
-
-          if (!save_cache_http_data_to_file (dfd, name, cache_bytes, no_xattr,
+          if (!save_cache_http_data_to_file (cache_dfd, name, cache_bytes, no_xattr,
                                              cancellable, &tmp_error))
             {
-              g_clear_error (&data.error);
+              g_clear_error (&local_error);
               g_propagate_error (error, tmp_error);
 
               return FALSE;
             }
         }
 
-      g_propagate_error (error, data.error);
+      g_propagate_error (error, g_steal_pointer (&local_error));
       return FALSE;
     }
 
-  cache_bytes = serialize_cache_http_data (cache_data);
   if (!no_xattr)
     {
       if (!save_cache_http_data_xattr (out_tmpfile.fd, cache_bytes, error))
@@ -1078,7 +1138,7 @@ flatpak_cache_http_uri_once (FlatpakHttpSession    *http_session,
 
   if (no_xattr)
     {
-      if (!glnx_open_tmpfile_linkable_at (dfd, ".", O_WRONLY, &cache_tmpfile, error))
+      if (!glnx_open_tmpfile_linkable_at (cache_dfd, ".", O_WRONLY, &cache_tmpfile, error))
         return FALSE;
 
       if (!save_cache_http_data_fallback (cache_tmpfile.fd, cache_bytes, error))
@@ -1096,50 +1156,5 @@ flatpak_cache_http_uri_once (FlatpakHttpSession    *http_session,
         return FALSE;
     }
 
-  g_debug ("Received %" G_GUINT64_FORMAT " bytes", data.downloaded_bytes);
-
   return TRUE;
-}
-
-gboolean
-flatpak_cache_http_uri (FlatpakHttpSession    *http_session,
-                        const char            *uri,
-                        FlatpakHTTPFlags       flags,
-                        int                    dest_dfd,
-                        const char            *dest_subpath,
-                        FlatpakLoadUriProgress progress,
-                        gpointer               user_data,
-                        GCancellable          *cancellable,
-                        GError               **error)
-{
-  g_autoptr(GError) local_error = NULL;
-  guint n_retries_remaining = DEFAULT_N_NETWORK_RETRIES;
-  g_autoptr(GMainContextPopDefault) main_context = NULL;
-
-  main_context = flatpak_main_context_new_default ();
-
-  do
-    {
-      if (n_retries_remaining < DEFAULT_N_NETWORK_RETRIES)
-        {
-          g_clear_error (&local_error);
-
-          if (progress)
-            progress (0, user_data); /* Reset the progress */
-        }
-
-      if (flatpak_cache_http_uri_once (http_session, uri, flags,
-                                       dest_dfd, dest_subpath,
-                                       progress, user_data,
-                                       cancellable, &local_error))
-        {
-          g_assert (local_error == NULL);
-          return TRUE;
-        }
-    }
-  while (flatpak_http_should_retry_request (local_error, n_retries_remaining--));
-
-  g_assert (local_error != NULL);
-  g_propagate_error (error, g_steal_pointer (&local_error));
-  return FALSE;
 }

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -738,14 +738,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakRepoTransaction, flatpak_repo_transaction_
 
 #define AUTOLOCK(name) G_GNUC_UNUSED __attribute__((cleanup (flatpak_auto_unlock_helper))) GMutex * G_PASTE (auto_unlock, __LINE__) = flatpak_auto_lock_helper (&G_LOCK_NAME (name))
 
-#if !defined(SOUP_AUTOCLEANUPS_H) && !defined(__SOUP_AUTOCLEANUPS_H__)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupSession, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupMessage, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupRequest, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupRequestHTTP, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (SoupURI, soup_uri_free)
-#endif
-
 #if !JSON_CHECK_VERSION (1, 1, 2)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonArray, json_array_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (JsonBuilder, g_object_unref)

--- a/configure.ac
+++ b/configure.ac
@@ -222,7 +222,6 @@ POLKIT_GOBJECT_REQUIRED=0.98
 
 PKG_CHECK_MODULES(ARCHIVE, [libarchive >= 2.8.0])
 PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0])
-PKG_CHECK_MODULES(SOUP, [libsoup-2.4])
 PKG_CHECK_MODULES(XML, [libxml-2.0 >= 2.4])
 PKG_CHECK_MODULES(ZSTD, [libzstd >= 0.8.1], [have_zstd=yes], [have_zstd=no])
 if test $have_zstd = yes; then
@@ -258,6 +257,23 @@ save_LIBS=$LIBS
 LIBS=$ARCHIVE_LIBS
 AC_CHECK_FUNCS(archive_read_support_filter_all)
 LIBS=$save_LIBS
+
+CURL_DEPENDENCY=7.29.0
+AC_ARG_WITH(curl,
+	    AS_HELP_STRING([--with-curl], [Use libcurl @<:@default=yes@:>@]),
+	    [], [with_curl=yes])
+AS_IF([test x$with_curl != xno ], [
+    PKG_CHECK_MODULES(CURL, libcurl >= $CURL_DEPENDENCY)
+    with_curl=yes
+    http_backend=curl
+    AC_DEFINE([HAVE_CURL], 1, [Define if we have libcurl.pc])
+], [
+   PKG_CHECK_MODULES(SOUP, [libsoup-2.4])
+    AC_DEFINE([HAVE_SOUP], 1, [Define if we have libsoup-2.4.pc])
+    http_backend=soup
+])
+AM_CONDITIONAL(USE_CURL, test x$with_curl != xno)
+AM_CONDITIONAL(USE_SOUP, test x$with_curl == xno)
 
 LIBGPGME_DEPENDENCY="1.1.8"
 PKG_CHECK_MODULES(DEP_GPGME, gpgme-pthread >= $LIBGPGME_DEPENDENCY, have_gpgme=yes, [
@@ -612,4 +628,5 @@ echo "          Use libsystemd:         $have_libsystemd"
 echo "          Use libmalcontent:      $have_libmalcontent"
 echo "          Use libzstd:            $have_zstd"
 echo "          Use auto sideloading:   $enable_auto_sideloading"
+echo "          HTTP backend:           $http_backend"
 echo ""

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -33,7 +33,7 @@ FlatpakAuthenticator *authenticator;
 static GMainLoop *main_loop = NULL;
 static guint name_owner_id = 0;
 static gboolean no_idle_exit = FALSE;
-static SoupSession *http_session = NULL;
+static FlatpakHttpSession *http_session = NULL;
 
 #define IDLE_TIMEOUT_SECS 10 * 60
 
@@ -769,7 +769,7 @@ main (int    argc,
 
   g_debug ("Started flatpak-authenticator");
 
-  http_session = flatpak_create_soup_session (PACKAGE_STRING);
+  http_session = flatpak_create_http_session (PACKAGE_STRING);
 
   session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
   if (session_bus == NULL)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -63,7 +63,6 @@ testcommon_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(BASE_CFLAGS) \
 	$(OSTREE_CFLAGS) \
-	$(SOUP_CFLAGS) \
 	$(JSON_CFLAGS) \
 	$(APPSTREAM_CFLAGS) \
 	-DFLATPAK_COMPILATION \
@@ -75,7 +74,6 @@ testcommon_LDADD = \
 	$(AM_LDADD) \
 	$(BASE_LIBS) \
 	$(OSTREE_LIBS) \
-	$(SOUP_LIBS) \
 	$(JSON_LIBS) \
 	$(APPSTREAM_LIBS) \
 	libflatpak-app.la \
@@ -115,10 +113,10 @@ tests_hold_lock_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
 tests_hold_lock_LDADD = $(AM_LDADD) $(BASE_LIBS) libglnx.la
 tests_hold_lock_SOURCES = tests/hold-lock.c
 
-tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(SOUP_CFLAGS) $(JSON_CFLAGS) \
+tests_httpcache_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(OSTREE_CFLAGS) $(JSON_CFLAGS) \
 	-DFLATPAK_COMPILATION \
 	-DLOCALEDIR=\"$(localedir)\"
-tests_httpcache_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(SOUP_LIBS) $(JSON_LIBS) \
+tests_httpcache_LDADD = $(AM_LDADD) $(BASE_LIBS) $(OSTREE_LIBS) $(JSON_LIBS) \
 	libflatpak-common.la libflatpak-common-base.la libglnx.la
 
 tests_mock_flatpak_CFLAGS = $(testcommon_CFLAGS)

--- a/tests/httpcache.c
+++ b/tests/httpcache.c
@@ -3,7 +3,7 @@
 int
 main (int argc, char *argv[])
 {
-  g_autoptr(SoupSession) session = flatpak_create_soup_session (PACKAGE_STRING);
+  g_autoptr(FlatpakHttpSession) session = flatpak_create_http_session (PACKAGE_STRING);
   GError *error = NULL;
   const char *url, *dest;
   int flags = 0;

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -86,6 +86,7 @@ elif test -n "${FLATPAK_TESTS_VALGRIND_LEAKS:-}"; then
 else
     CMD_PREFIX=""
 fi
+unset OSTREE_DEBUG_HTTP
 
 export MALLOC_CHECK_=3
 export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))

--- a/tests/test-http-utils.sh
+++ b/tests/test-http-utils.sh
@@ -52,11 +52,11 @@ assert_cached() {
 }
 
 assert_304() {
-    assert_result "Server returned status 304:" $@
+    assert_result "Server returned status 304" $@
 }
 
 assert_ok() {
-    assert_result "Server returned status 200:" $@
+    assert_result "Server returned status 200" $@
 }
 
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -192,7 +192,7 @@ port=$(cat httpd-port)
 if ${FLATPAK} ${U} install -y http://127.0.0.1:${port}/nonexistent.flatpakref &> install-error-log; then
     assert_not_reached "Should not be able to install a nonexistent flatpakref"
 fi
-assert_file_has_content install-error-log "Server returned status 404: Not Found"
+assert_file_has_content install-error-log "Server returned status 404"
 
 ok "install fails gracefully for 404 URLs"
 


### PR DESCRIPTION
As discussed in https://github.com/flatpak/flatpak/pull/4582 we might want to support libcurl in addition to soup2, and maybe also soup3. This is some preparatory work for this that centralizes all the current code using soup into a single file where it can easily be made switchable.