### PR TITLE
Bump glib requirement to 2.46 (from 2.44)

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -471,11 +471,7 @@ load_uri_callback (GObject      *source_object,
           break;
 
         case SOUP_STATUS_IO_ERROR:
-#if !GLIB_CHECK_VERSION(2, 44, 0)
-          code = G_IO_ERROR_BROKEN_PIPE;
-#else
           code = G_IO_ERROR_CONNECTION_CLOSED;
-#endif
           break;
 
         default:
@@ -576,11 +572,7 @@ flatpak_http_should_retry_request (const GError *error,
       g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
       g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
       g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT) ||
-#if !GLIB_CHECK_VERSION(2, 44, 0)
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE) ||
-#else
       g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
-#endif
       g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
       g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE))
     {

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_INIT([Flatpak],
         [flatpak],
         [http://flatpak.org/])
 
-GLIB_REQS=2.44
+GLIB_REQS=2.46
 SYSTEM_BWRAP_REQS=0.5.0
 SYSTEM_DBUS_PROXY_REQS=0.1.0
 OSTREE_REQS=2020.8


### PR DESCRIPTION
Since we switched to libappstream we really have an implicit dependency
on this, as there are no versions of it building with glib earlier
than 2.46.

This isn't dropping a lot of old code, but at least it is more truthful
about our actual dependencies.