### PR TITLE
Draft: Add a trigger file for running kbuildsycoca5 when desktop files change.

### DIFF
--- a/triggers/kbuildsycoca5.trigger
+++ b/triggers/kbuildsycoca5.trigger
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if command -v kbuildsycoca5 >/dev/null; then
+    # If either the applications or icons have changed, run it
+    if test -d "$1/exports/share/applications" || 
+        test -d "$1/exports/share/icons/hicolor" ||
+        test -d "$1/exports/share/mime/packages"; then
+        exec kbuildsycoca5 
+    fi
+fi


### PR DESCRIPTION
Tells kde/plasma to update it's database of .desktop files, icon
caches, etc.