### PR TITLE
CI: Run the valgrind checks in parallel

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -240,7 +240,7 @@ jobs:
     - name: Distcheck
       run: make -C _build distcheck
     - name: Run tests under valgrind
-      run: make -C _build check
+      run: make -C _build check -j $(getconf _NPROCESSORS_ONLN)
       env:
         FLATPAK_TESTS_VALGRIND: true
     - name: Collect overall test logs on failure


### PR DESCRIPTION
The valgrind tests keep timing out, but if we run the tests in parallel the
may succeed more often.