### PR TITLE
build: Require appstream 0.15.3

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1130,12 +1130,7 @@ flatpak_dir_load_appstream_store (FlatpakDir   *self,
 
   appstream_file = g_file_new_for_path (appstream_path);
   as_metadata_set_format_style (mdata, AS_FORMAT_STYLE_COLLECTION);
-#ifdef HAVE_APPSTREAM_0_14_0
   success = as_metadata_parse_file (mdata, appstream_file, AS_FORMAT_KIND_XML, &local_error);
-#else
-  as_metadata_parse_file (mdata, appstream_file, AS_FORMAT_KIND_XML, &local_error);
-  success = (local_error == NULL);
-#endif
 
   /* We want to ignore ENOENT error as it is harmless and valid */
   if (local_error != NULL &&

--- a/configure.ac
+++ b/configure.ac
@@ -347,10 +347,7 @@ PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
 
 PKG_CHECK_MODULES(JSON, [json-glib-1.0])
 
-PKG_CHECK_MODULES(APPSTREAM, [appstream >= 0.12.0])
-PKG_CHECK_MODULES(APPSTREAM_0_14_0, appstream >= 0.14.0,
-                  [AC_DEFINE([HAVE_APPSTREAM_0_14_0], [1], [Define if appstream >= 0.14.0 is available])],
-                  [true])
+PKG_CHECK_MODULES(APPSTREAM, [appstream >= 0.15.3])
 
 PKG_CHECK_MODULES(GDK_PIXBUF, [gdk-pixbuf-2.0])
 


### PR DESCRIPTION
... to have the fix for:
https://github.com/ximion/appstream/issues/384

Otherwise, the 'flatpak search' output gets littered with CRITICALs,
which also breaks the test suite.

However, appstream releases newer than 0.12.5 are impossibly difficult
to build on RHEL 8 [1].  This can make it difficult to put a future
Flatpak 1.14.x into RHEL 8, if necessary.

[1] https://github.com/flatpak/flatpak/pull/4426