### PR TITLE
Export Manpages

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -237,6 +237,7 @@ collect_exports (GFile          *base,
     "share/gnome-shell/search-providers", /* Search providers */
     "share/appdata",                      /* Copy appdata/metainfo files (legacy path) */
     "share/metainfo",                     /* Copy appdata/metainfo files */
+    "share/man/man1",                     /* Manpages */
     NULL,
   };
 

--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -237,7 +237,7 @@ collect_exports (GFile          *base,
     "share/gnome-shell/search-providers", /* Search providers */
     "share/appdata",                      /* Copy appdata/metainfo files (legacy path) */
     "share/metainfo",                     /* Copy appdata/metainfo files */
-    "share/man/man1",                     /* Manpages */
+    "share/man",                          /* Manpages */
     NULL,
   };
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -800,6 +800,10 @@ flatpak_get_allowed_exports (const char     *source_path,
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
     }
+  else if (strcmp (source_path, "share/man/man1") == 0)
+    {
+      g_ptr_array_add (allowed_extensions, g_strdup (".1.gz"));
+    }
   else
     return FALSE;
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -800,9 +800,9 @@ flatpak_get_allowed_exports (const char     *source_path,
     {
       g_ptr_array_add (allowed_extensions, g_strdup (".xml"));
     }
-  else if (strcmp (source_path, "share/man/man1") == 0)
+  else if (strcmp (source_path, "share/man") == 0)
     {
-      g_ptr_array_add (allowed_extensions, g_strdup (".1.gz"));
+      g_ptr_array_add (allowed_extensions, g_strdup (".gz"));
     }
   else
     return FALSE;


### PR DESCRIPTION
Using Manpages are quite common in Linux. Apps which have more complex command line options are can use Manpages to describe them better. There also some cli programs distributed as Flatpak e.g. org.flatpak.Builder which contains the Builder version used on Flathub. They also would profit from this chance.