### PR TITLE
Revert "CI: Temporarily build without libsystemd"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-        libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libxml2-utils libgpgme11-dev gobject-introspection \
+        libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev bubblewrap xdg-dbus-proxy \
         python3-pip meson ninja-build libyaml-dev libstemmer-dev gperf itstool
         # One of the tests wants this
@@ -69,7 +69,7 @@ jobs:
       run: |
         mkdir _build
         pushd _build
-        ../configure  --enable-internal-checks --enable-asan --disable-introspection --with-curl --with-system-bubblewrap --with-system-dbus-proxy --with-systemd=no
+        ../configure  --enable-internal-checks --enable-asan --disable-introspection --with-curl --with-system-bubblewrap --with-system-dbus-proxy
         popd
       env:
         CFLAGS: -O2 -Wp,-D_FORTIFY_SOURCE=2


### PR DESCRIPTION
This reverts commit ea879dc38c40770ad9324c50582a1f0de5478b45.

Folks say the issue is fixed on launchpad:
https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1979579