### PR TITLE
CI: Use CodeQL Action v2, not the deprecated v1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -171,7 +171,7 @@ jobs:
     steps:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -201,7 +201,7 @@ jobs:
     - name: Build flatpak
       run: make -j $(getconf _NPROCESSORS_ONLN)
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
   valgrind:
     name: Run tests in valgrind


### PR DESCRIPTION
See:
https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/