### PR TITLE
Explicitly show :rw for flatpak info

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="CMakeSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" />
+    </configurations>
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="c34a8bf0-885d-499d-bfa8-2babdd8b74ec" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/common/flatpak-context.c" beforeDir="false" afterPath="$PROJECT_DIR$/common/flatpak-context.c" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ClangdSettings">
+    <option name="formatViaClangd" value="false" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MacroExpansionManager">
+    <option name="directoryName" value="88vycyu0" />
+  </component>
+  <component name="MakefileLocalSettings">
+    <option name="projectSyncType">
+      <map>
+        <entry key="$PROJECT_DIR$" value="RE_IMPORT" />
+      </map>
+    </option>
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectApplicationVersion">
+    <option name="ide" value="CLion" />
+    <option name="majorVersion" value="2022" />
+    <option name="minorVersion" value="1.2" />
+  </component>
+  <component name="ProjectId" id="2BIqi8mRgoJdicZV2C7JFF415HO" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.cidr.known.project.marker": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "cf.first.check.clang-format": "false",
+    "cidr.known.project.marker": "true",
+    "last_opened_file_path": "/var/home/user/Projects/flatpak"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="c34a8bf0-885d-499d-bfa8-2babdd8b74ec" name="Changes" comment="" />
+      <created>1656604070741</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1656604070741</updated>
+      <workItem from="1656604072611" duration="803000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -700,6 +700,7 @@ unparse_filesystem_flags (const char           *path,
       break;
 
     case FLATPAK_FILESYSTEM_MODE_READ_WRITE:
+      g_string_append (s, ":rw");
       break;
 
     case FLATPAK_FILESYSTEM_MODE_NONE:


### PR DESCRIPTION
As discussed in #4977, `flatpak info -M` currently shows no suffix when the filesystem access is set to read-write, with this pull request `flatpak info -M` would add `:rw` to directories that have read-write access to directories.
The output would change from
```
[context]
<other permissions>
filesystems=home;
```
to 
```
[context]
<other permissions>
filesystems=home:rw;
```
other filesystem permissions like `:create` or `:ro` also still get shown.