### PR TITLE
app: Fix inefficiency in pin and mask commands

### DIFF
--- a/app/flatpak-builtins-mask.c
+++ b/app/flatpak-builtins-mask.c
@@ -49,7 +49,6 @@ flatpak_builtin_mask (int argc, char **argv, GCancellable *cancellable, GError *
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GPtrArray) dirs = NULL;
   FlatpakDir *dir;
-  g_autoptr(GPtrArray) patterns = NULL;
   int i;
 
   context = g_option_context_new (_("[PATTERN…] - disable updates and automatic installation matching patterns"));
@@ -62,10 +61,12 @@ flatpak_builtin_mask (int argc, char **argv, GCancellable *cancellable, GError *
 
   dir = g_ptr_array_index (dirs, 0);
 
-  patterns = flatpak_dir_get_config_patterns (dir, "masked");
-
   if (argc == 1)
     {
+      g_autoptr(GPtrArray) patterns = NULL;
+
+      patterns = flatpak_dir_get_config_patterns (dir, "masked");
+
       if (patterns->len == 0)
         {
           if (flatpak_fancy_output ())

--- a/app/flatpak-builtins-pin.c
+++ b/app/flatpak-builtins-pin.c
@@ -51,7 +51,6 @@ flatpak_builtin_pin (int argc, char **argv, GCancellable *cancellable, GError **
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GPtrArray) dirs = NULL;
   FlatpakDir *dir;
-  g_autoptr(GPtrArray) patterns = NULL;
   int i;
 
   context = g_option_context_new (_("[PATTERN…] - disable automatic removal of runtimes matching patterns"));
@@ -64,10 +63,12 @@ flatpak_builtin_pin (int argc, char **argv, GCancellable *cancellable, GError **
 
   dir = g_ptr_array_index (dirs, 0);
 
-  patterns = flatpak_dir_get_config_patterns (dir, "pinned");
-
   if (argc == 1)
     {
+      g_autoptr(GPtrArray) patterns = NULL;
+
+      patterns = flatpak_dir_get_config_patterns (dir, "pinned");
+
       if (patterns->len == 0)
         {
           if (flatpak_fancy_output ())

--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -265,7 +265,7 @@ flatpak_complete_partial_ref (FlatpakCompletion *completion,
           if (last_dot == NULL)
             continue; /* Shouldn't really happen */
 
-          /* Only complete to subrefs is fully matching real part.
+          /* Only complete to subrefs if fully matching real part.
            * For example, only match org.foo.Bar.Sources for
            * "org.foo.Bar", "org.foo.Bar." or "org.foo.Bar.S", but
            * not for "org.foo" or other shorter prefixes.

--- a/common/flatpak-ref-utils.c
+++ b/common/flatpak-ref-utils.c
@@ -94,8 +94,6 @@ find_last_char (const char *str, gsize len, int c)
  * 2) DBus names require only two elements
  *
  * Returns: %TRUE if valid, %FALSE otherwise.
- *
- * Since: 2.26
  */
 gboolean
 flatpak_is_valid_name (const char *string,
@@ -362,8 +360,6 @@ is_valid_branch_character (gint c)
  * Branch names must contain at least one character.
  *
  * Returns: %TRUE if valid, %FALSE otherwise.
- *
- * Since: 2.26
  */
 gboolean
 flatpak_is_valid_branch (const char *string,


### PR DESCRIPTION
There's no point reading data from disk on a code path that doesn't do
anything with it.