### PR TITLE
Increase verbosity of extension missing error messages

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -115,7 +115,7 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_arch, const ch
 
                   subpaths = flatpak_deploy_data_get_subpaths (deploy_data);
                   if (subpaths[0] != NULL)
-                    return flatpak_fail (error, _("Requested extension %s is only partially installed"), ext->installed_id);
+                    return flatpak_fail (error, _("Requested extension %s/%s/%s is only partially installed"), ext->installed_id, default_arch, default_branch);
                 }
 
               if (top_dir)
@@ -144,7 +144,7 @@ ensure_extensions (FlatpakDeploy *src_deploy, const char *default_arch, const ch
       if (!found)
         {
           g_list_free_full (extensions, (GDestroyNotify) flatpak_extension_free);
-          return flatpak_fail (error, _("Requested extension %s not installed"), requested_extension_name);
+          return flatpak_fail (error, _("Requested extension %s/%s/%s not installed"), requested_extension_name, default_arch, default_branch);
         }
     }
 


### PR DESCRIPTION
Adds arch and branch to the error message to help with locating the required
extension arch and branch.

Right now the message doesn't point to the exact version required. This can get confusing when a different version of the extension that does not fit to the current arch or branch is already installed.