### PR TITLE
build-export: Fully ignore stdout content of icon validation

### DIFF
--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -391,7 +391,9 @@ validate_icon_file (GFile *file, GError **error)
 
   g_ptr_array_add (args, NULL);
 
-  if (!g_spawn_sync (NULL, (char **) args->pdata, NULL, 0, NULL, NULL, NULL, &err, &status, error))
+  if (!g_spawn_sync (NULL, (char **) args->pdata, NULL,
+                     G_SPAWN_STDOUT_TO_DEV_NULL,
+                     NULL, NULL, NULL, &err, &status, error))
     {
       g_debug ("Icon validation: %s", (*error)->message);
       return FALSE;


### PR DESCRIPTION
The docs for g_spawn_sync() say:
"Note that you must set the G_SPAWN_STDOUT_TO_DEV_NULL and
G_SPAWN_STDERR_TO_DEV_NULL flags when passing NULL for standard_output
and standard_error."

So add in the stdout flag when calling flatpak-validate-icon in the
build-export command. Without this, there's output in the test logs
from when they're building the test app, due to
https://github.com/flatpak/flatpak/pull/4803