### PR TITLE
app: Add -u alias for --user

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -176,7 +176,7 @@ static GOptionEntry empty_entries[] = {
 };
 
 GOptionEntry user_entries[] = {
-  { "user", 0, 0, G_OPTION_ARG_NONE, &opt_user, N_("Work on the user installation"), NULL },
+  { "user", 'u', 0, G_OPTION_ARG_NONE, &opt_user, N_("Work on the user installation"), NULL },
   { "system", 0, 0, G_OPTION_ARG_NONE, &opt_system, N_("Work on the system-wide installation (default)"), NULL },
   { "installation", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_installations, N_("Work on a non-default system-wide installation"), N_("NAME") },
   { NULL }

--- a/doc/flatpak-config.xml
+++ b/doc/flatpak-config.xml
@@ -135,6 +135,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-create-usb.xml
+++ b/doc/flatpak-create-usb.xml
@@ -110,6 +110,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-history.xml
+++ b/doc/flatpak-history.xml
@@ -70,6 +70,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-info.xml
+++ b/doc/flatpak-info.xml
@@ -73,6 +73,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -148,6 +148,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-list.xml
+++ b/doc/flatpak-list.xml
@@ -74,6 +74,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-make-current.xml
+++ b/doc/flatpak-make-current.xml
@@ -72,6 +72,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-mask.xml
+++ b/doc/flatpak-mask.xml
@@ -84,6 +84,7 @@ org.some.App/arm
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -78,6 +78,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-pin.xml
+++ b/doc/flatpak-pin.xml
@@ -89,6 +89,7 @@ org.some.Runtime/arm
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-add.xml
+++ b/doc/flatpak-remote-add.xml
@@ -81,6 +81,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-delete.xml
+++ b/doc/flatpak-remote-delete.xml
@@ -68,6 +68,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-info.xml
+++ b/doc/flatpak-remote-info.xml
@@ -75,6 +75,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-ls.xml
+++ b/doc/flatpak-remote-ls.xml
@@ -74,6 +74,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remote-modify.xml
+++ b/doc/flatpak-remote-modify.xml
@@ -68,6 +68,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-remotes.xml
+++ b/doc/flatpak-remotes.xml
@@ -65,6 +65,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-repair.xml
+++ b/doc/flatpak-repair.xml
@@ -84,6 +84,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -162,6 +162,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-search.xml
+++ b/doc/flatpak-search.xml
@@ -53,6 +53,7 @@
 
         <variablelist>
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-uninstall.xml
+++ b/doc/flatpak-uninstall.xml
@@ -106,6 +106,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-update.xml
+++ b/doc/flatpak-update.xml
@@ -111,6 +111,7 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-u</option></term>
                 <term><option>--user</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
Save folks a few keystrokes. There is a command which already has a '-u'
option, document-export, but it doesn't support --user so there should
be no conflict. However '-s' is used by the info command among others,
so we can't use that for --system.