### PR TITLE
dir: Use new AccountsService feature to get languages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,6 +88,7 @@ jobs:
       run: meson test -C _build
       env:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
+        LC_ALL: en_US.UTF-8
     - name: Collect logs on failure
       if: failure() || cancelled()
       run: mv _build/meson-logs/* test-logs/ || true
@@ -151,6 +152,7 @@ jobs:
       run: make -C _build check -j $(getconf _NPROCESSORS_ONLN)
       env:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
+        LC_ALL: en_US.UTF-8
     - name: Collect overall test logs on failure
       if: failure()
       run: mv _build/test-suite.log test-logs/ || true

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -16266,6 +16266,73 @@ get_locale_langs_from_accounts_dbus (GDBusProxy *proxy, GPtrArray *langs)
     }
 }
 
+static void
+get_locale_langs_from_accounts_dbus_for_user (GDBusProxy *proxy, GPtrArray *langs, guint uid)
+{
+  const char *accounts_bus_name = "org.freedesktop.Accounts";
+  const char *accounts_interface_name = "org.freedesktop.Accounts.User";
+  g_autofree char *object_path = NULL;
+  g_autoptr(GVariant) ret = NULL;
+
+  ret = g_dbus_proxy_call_sync (G_DBUS_PROXY (proxy),
+                                "FindUserById",
+                                g_variant_new ("(x)", uid),
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                NULL);
+  if (ret != NULL)
+    g_variant_get (ret, "(o)", &object_path);
+
+  if (object_path != NULL)
+    {
+      g_autoptr(GDBusProxy) accounts_proxy = NULL;
+      g_autoptr(GVariant) value = NULL;
+
+      accounts_proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
+                                                      G_DBUS_PROXY_FLAGS_NONE,
+                                                      NULL,
+                                                      accounts_bus_name,
+                                                      object_path,
+                                                      accounts_interface_name,
+                                                      NULL,
+                                                      NULL);
+      if (!accounts_proxy)
+        return;
+
+      value = g_dbus_proxy_get_cached_property (accounts_proxy, "Languages");
+      if (value != NULL)
+        {
+          const char **locales = g_variant_get_strv (value, NULL);
+          guint i;
+
+          for (i = 0; locales != NULL && locales[i] != NULL; i++)
+            {
+              g_autofree char *lang = NULL;
+              lang = flatpak_get_lang_from_locale (locales[i]);
+              if (lang != NULL && !flatpak_g_ptr_array_contains_string (langs, lang))
+                g_ptr_array_add (langs, g_steal_pointer (&lang));
+            }
+        }
+      else
+        {
+          value = g_dbus_proxy_get_cached_property (accounts_proxy, "Language");
+          if (value != NULL)
+            {
+              const char *locale = g_variant_get_string (value, NULL);
+              g_autofree char *lang = NULL;
+
+              if (strcmp (locale, "") != 0)
+                {
+                  lang = flatpak_get_lang_from_locale (locale);
+                  if (lang != NULL && !flatpak_g_ptr_array_contains_string (langs, lang))
+                    g_ptr_array_add (langs, g_steal_pointer (&lang));
+                }
+            }
+        }
+    }
+}
+
 static int
 cmpstringp (const void *p1, const void *p2)
 {
@@ -16330,6 +16397,26 @@ get_system_locales (FlatpakDir *self)
   return (const GPtrArray *)cached;
 }
 
+static const GPtrArray *
+get_user_locales (FlatpakDir *self)
+{
+  static GPtrArray *cached = NULL;
+
+  if (g_once_init_enter (&cached))
+    {
+      GPtrArray *langs = g_ptr_array_new_with_free_func (g_free);
+      g_autoptr(GDBusProxy) accounts_proxy = NULL;
+
+      accounts_proxy = get_accounts_dbus_proxy ();
+      get_locale_langs_from_accounts_dbus_for_user (accounts_proxy, langs, getuid ());
+      g_ptr_array_add (langs, NULL);
+
+      g_once_init_leave (&cached, langs);
+    }
+
+  return (const GPtrArray *)cached;
+}
+
 char **
 flatpak_dir_get_default_locales (FlatpakDir *self)
 {
@@ -16341,8 +16428,12 @@ flatpak_dir_get_default_locales (FlatpakDir *self)
   if (flatpak_dir_is_user (self))
     {
       g_auto(GStrv) locale_langs = flatpak_get_current_locale_langs ();
+      g_auto(GStrv) merged = NULL;
 
-      return sort_strv (flatpak_strv_merge (extra_languages, locale_langs));
+      langs = get_user_locales (self);
+      merged = flatpak_strv_merge (extra_languages, (char **) langs->pdata);
+
+      return sort_strv (flatpak_strv_merge (merged, locale_langs));
     }
 
   /* Then get the system default locales */
@@ -16370,8 +16461,12 @@ flatpak_dir_get_default_locale_languages (FlatpakDir *self)
   if (flatpak_dir_is_user (self))
     {
       g_auto(GStrv) locale_langs = flatpak_get_current_locale_langs ();
+      g_auto(GStrv) merged = NULL;
 
-      return sort_strv (flatpak_strv_merge (extra_languages, locale_langs));
+      langs = get_user_locales (self);
+      merged = flatpak_strv_merge (extra_languages, (char **) langs->pdata);
+
+      return sort_strv (flatpak_strv_merge (merged, locale_langs));
     }
 
   /* Then get the system default locales */


### PR DESCRIPTION
Use the new GetUsersLanguages() method from AccountsService to get the
list of all the locales that each user is interested in.

See https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/99

Closes: #5006