### PR TITLE
Allow sub-sandboxes to own MPRIS names

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2358,7 +2358,10 @@ flatpak_context_add_bus_filters (FlatpakContext *context,
           flatpak_bwrap_add_arg_printf (bwrap, "--own=org.mpris.MediaPlayer2.%s.*", app_id);
         }
       else
-        flatpak_bwrap_add_arg_printf (bwrap, "--own=%s.Sandboxed.*", app_id);
+        {
+          flatpak_bwrap_add_arg_printf (bwrap, "--own=%s.Sandboxed.*", app_id);
+          flatpak_bwrap_add_arg_printf (bwrap, "--own=org.mpris.MediaPlayer2.%s.Sandboxed.*", app_id);
+        }
     }
 
   if (session_bus)

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -562,9 +562,9 @@ key=v1;v2;
                 <listitem><para>
                   Allow filtered access to the session dbus connection. This is the default, except when run with --sandbox.
                   </para><para>
-                  Isandbox mode, even if you allow access to the session bus the sandbox cannot talk to or own
+                  In sandbox mode, even if you allow access to the session bus the sandbox cannot talk to or own
                   the application ids (org.the.App.*) on the bus (unless explicitly added), only names in the
-                  .Sandbox subset (org.the.App.Sandbox.*).
+                  .Sandboxed subset (org.the.App.Sandboxed.* and org.mpris.MediaPlayer2.org.the.App.Sandboxed.*).
                 </para></listitem>
             </varlistentry>
 


### PR DESCRIPTION
We already allow normal apps to own MPRIS names but subsandboxes could not.

This allows them with the same dbus restrictions that they must be prefixed by `$app_id.Sandboxed.`.

This will be used by WebKitGTK.