### PR TITLE
run: Preserve X11 display number instead of redirecting it to :99

### DIFF
--- a/app/flatpak-builtins-enter.c
+++ b/app/flatpak-builtins-enter.c
@@ -248,7 +248,6 @@ flatpak_builtin_enter (int           argc,
   for (e = environment; e < environment + environment_len; e = e + strlen (e) + 1)
     {
       if (*e != 0 &&
-          !g_str_has_prefix (e, "DISPLAY=") &&
           !g_str_has_prefix (e, "PULSE_SERVER=") &&
           !g_str_has_prefix (e, "PULSE_CLIENTCONFIG=") &&
           !g_str_has_prefix (e, "XDG_RUNTIME_DIR=") &&
@@ -263,9 +262,6 @@ flatpak_builtin_enter (int           argc,
 
   xdg_runtime_dir = g_strdup_printf ("/run/user/%d", uid);
   g_ptr_array_add (envp_array, g_strdup_printf ("XDG_RUNTIME_DIR=%s", xdg_runtime_dir));
-
-  if (g_file_test ("/tmp/.X11-unix/X99", G_FILE_TEST_EXISTS))
-    g_ptr_array_add (envp_array, g_strdup ("DISPLAY=:99.0"));
 
   pulse_path = g_strdup_printf ("/run/user/%d/pulse/native", uid);
   if (g_file_test (pulse_path, G_FILE_TEST_EXISTS))


### PR DESCRIPTION
* run: Preserve X11 display number instead of redirecting it to :99
    
    Suppose the user's "real" X11 display on the host is Xorg or Xwayland
    listening on :42, but they also have an Xvfb server listening on :99.
    
    If we change the X11 display number to the arbitrary value :99, and
    the Flatpak sandbox shares its network namespace with the host, then
    clients inside the Flatpak sandbox will prefer to connect to the
    abstract socket @/tmp/.X11-unix/X99 (which is Xvfb), rather than the
    filesystem-backed socket /tmp/.X11-unix/X99 in the sandbox (which is
    really /tmp/.X11-unix/X42 on the host, i.e. Xorg or Xwayland).
    
    If they're relying on Xauthority (MIT-MAGIC-COOKIE-1) for access
    control (as many display managers do), then this will fail, because
    we gave the sandboxed app access to the cookies for Xorg/Xwayland
    (rewriting their display number from 42 to 99 as we did so), but
    Xvfb does not accept those cookies.
    
    If we're relying on `xhost +"si:localuser:$(id -nu)"` for access control
    (as gdm does), then the Flatpak app will successfully (!) connect to
    whatever is on :99, for example Xvfb or Xephyr, which is rarely what
    anyone wants either.
    
    Resolves: https://github.com/flatpak/flatpak/issues/3357

* enter: Don't overwrite the DISPLAY
    
    Now that we're using the same display number in the sandbox as on the
    host, we can forget about overwriting it with :99.