### PR TITLE
system-helper: Validate ref arg in RemoveLocalRef method

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1275,6 +1275,7 @@ handle_remove_local_ref (FlatpakSystemHelper   *object,
 {
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
+  g_autoptr(FlatpakDecomposed) ref = NULL;
 
   g_debug ("RemoveLocalRef %u %s %s %s", arg_flags, arg_remote, arg_ref, arg_installation);
 
@@ -1296,6 +1297,13 @@ handle_remove_local_ref (FlatpakSystemHelper   *object,
     {
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
                                              "Invalid remote name: %s", arg_remote);
+      return G_DBUS_METHOD_INVOCATION_HANDLED;
+    }
+
+  ref = flatpak_decomposed_new_from_ref (arg_ref, &error);
+  if (ref == NULL)
+    {
+      g_dbus_method_invocation_return_gerror (invocation, error);
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 


### PR DESCRIPTION
This patch could be important in case the ref arg was maliciously
crafted to try to convince flatpak-system-helper to delete an arbitrary
file on the filesystem. However, in practice (a) recent versions of
libostree will not accept such a ref name which has e.g. "../" in it
thanks to https://github.com/ostreedev/ostree/pull/1286, and (b) even on
ancient versions of Flatpak that use a version of libostree without the
aforementioned patch, the exploit does not appear to be successful, at
least on Debian 9.

See https://github.com/flatpak/flatpak/security/advisories/GHSA-45jq-5658-v38x