### PR TITLE
flatpak.pc: Add httpbackend variable for curl/libsoup detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,7 @@ AS_IF([test x$with_curl != xno ], [
 ])
 AM_CONDITIONAL(USE_CURL, test x$with_curl != xno)
 AM_CONDITIONAL(USE_SOUP, test x$with_curl == xno)
+AC_SUBST(http_backend)
 
 LIBGPGME_DEPENDENCY="1.1.8"
 PKG_CHECK_MODULES(DEP_GPGME, gpgme-pthread >= $LIBGPGME_DEPENDENCY, have_gpgme=yes, [

--- a/flatpak.pc.in
+++ b/flatpak.pc.in
@@ -7,6 +7,9 @@ datadir=@datadir@
 
 interfaces_dir=${datadir}/dbus-1/interfaces/
 
+# This will either be 'soup' for libsoup-2.x or 'curl' for libcurl.
+httpbackend=@http_backend@
+
 Name: flatpak
 Description: Application sandboxing framework
 Version: @VERSION@


### PR DESCRIPTION
Some projects such as GNOME-Software need this information to know
if its safe to build against (libsoup2 vs libsoup3 conflicts).

Closes #5053 