### PR TITLE
uri: Don't do scheme-based normalization with GLib 2.66.x

### DIFF
--- a/common/flatpak-uri-private.h
+++ b/common/flatpak-uri-private.h
@@ -35,7 +35,12 @@ GDateTime * flatpak_parse_http_time              (const char *date_string);
 char *      flatpak_format_http_date             (GDateTime  *date);
 
 /* Same as SOUP_HTTP_URI_FLAGS, means all possible flags for http uris */
+#if GLIB_CHECK_VERSION (2, 68, 0) || !GLIB_CHECK_VERSION (2, 66, 0)
 #define FLATPAK_HTTP_URI_FLAGS (G_URI_FLAGS_HAS_PASSWORD | G_URI_FLAGS_ENCODED_PATH | G_URI_FLAGS_ENCODED_QUERY | G_URI_FLAGS_ENCODED_FRAGMENT | G_URI_FLAGS_SCHEME_NORMALIZE)
+#else
+/* GLib 2.66 didn't support scheme-based normalization */
+#define FLATPAK_HTTP_URI_FLAGS (G_URI_FLAGS_HAS_PASSWORD | G_URI_FLAGS_ENCODED_PATH | G_URI_FLAGS_ENCODED_QUERY | G_URI_FLAGS_ENCODED_FRAGMENT)
+#endif
 
 #if !GLIB_CHECK_VERSION (2, 66, 0)
 


### PR DESCRIPTION
GLib 2.66.x is present in Debian 11, and didn't support scheme-based
normalization. This has two effects:

1. URIs containing an explicit port, like https://example.com:443/,
   don't get normalized to https://example.com/
2. URIs with an empty path, like https://example.com, don't get
   normalized to https://example.com/

Neither of these normalizations seems particularly critical for Flatpak.

Resolves: https://github.com/flatpak/flatpak/issues/5062