### PR TITLE
uri: Don't rely on g_time_zone_new_offset()

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,12 +41,12 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
+        sudo apt-get install -y libglib2.0-dev attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse3-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev bubblewrap xdg-dbus-proxy \
-        python3-pip meson ninja-build libyaml-dev libstemmer-dev gperf itstool
+        python3-pip meson ninja-build libyaml-dev libstemmer-dev gperf itstool libmalcontent-0-dev
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
@@ -99,6 +99,7 @@ jobs:
   # * Soup instead of curl
   # * Use built in bubblewrap instead of external
   # * Use built in xdg-dbus-proxy instead of external
+  # * Disable malcontent build-dependency
   check-alt2:
     name: Build with gcc and test (older)
     runs-on: ubuntu-18.04
@@ -106,10 +107,9 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo add-apt-repository ppa:flatpak/stable
-        sudo add-apt-repository ppa:alexlarsson/glib260
         sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update
-        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
+        sudo apt-get install -y libglib2.0-dev attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
@@ -120,14 +120,6 @@ jobs:
       uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Build malcontent dependency
-      run: |
-        git clone --branch 0.4.0 --depth 1 --no-tags https://gitlab.freedesktop.org/pwithnall/malcontent.git ./malcontent
-        pushd ./malcontent
-        meson setup --prefix=/usr _build
-        ninja -C _build
-        sudo ninja -C _build install
-        popd
     - name: Create logs dir
       run: mkdir test-logs
     - name: autogen.sh
@@ -144,6 +136,15 @@ jobs:
         CFLAGS: -O2 -Wp,-D_FORTIFY_SOURCE=2
     - name: Build flatpak
       run: make -C _build -j $(getconf _NPROCESSORS_ONLN)
+    # We build with Ubuntu 18.04's GLib to prove that we can, but there's a
+    # race condition that makes it fail tests, so upgrade to a version from
+    # a PPA before running the tests: see
+    # https://github.com/flatpak/flatpak/pull/3121,
+    # https://gitlab.gnome.org/GNOME/glib/-/issues/1014
+    - name: Upgrade GLib before running tests
+      run: |
+        sudo add-apt-repository ppa:alexlarsson/glib260
+        sudo apt-get install -y libglib2.0-dev
     - name: Run tests
       run: make -C _build check -j $(getconf _NPROCESSORS_ONLN)
       env:
@@ -186,10 +187,9 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo add-apt-repository ppa:flatpak/stable
-        sudo add-apt-repository ppa:alexlarsson/glib260
         sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
         sudo apt-get update
-        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
+        sudo apt-get install -y libglib2.0-dev attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
@@ -218,7 +218,7 @@ jobs:
         sudo add-apt-repository ppa:flatpak/stable
         sudo apt-get update
         sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-focal main' # Needed for updates to work
-        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
+        sudo apt-get install -y libglib2.0-dev attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \


### PR DESCRIPTION
g_time_zone_new_offset() was new in GLib 2.58, but Ubuntu 18.04 'bionic'
only has GLib 2.56, and in theory we still claim to support versions
all the way back to GLib 2.46. If that function isn't available,
reimplement it in terms of the deprecated g_time_zone_new().

---

Yes, I've been packaging backports today. How could you tell?