### PR TITLE
libcurl fixes

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -388,8 +388,10 @@ flatpak_create_http_session (const char *user_agent)
    * libcurl 7.43.0.
    */
 #if CURL_AT_LEAST_VERSION(7, 51, 0)
-  rc = curl_easy_setopt (curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
-  g_assert_cmpint (rc, ==, CURLM_OK);
+  if ((curl_version_info (CURLVERSION_NOW))->features & CURL_VERSION_HTTP2) {
+    rc = curl_easy_setopt (curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+    g_assert_cmpint (rc, ==, CURLM_OK);
+  }
 #endif
   /* https://github.com/curl/curl/blob/curl-7_53_0/docs/examples/http2-download.c */
 #if (CURLPIPE_MULTIPLEX > 0)


### PR DESCRIPTION
~~The CURLOPT_PROTOCOLS option has been deprecated for CURLOPT_PROTOCOLS_STR in 7.85.0 and using CURLOPT_PROTOCOLS returns an error code.~~ Nvm, I mistook the line numbers, using the deprecated option works fine as of now.

A check has also been added to ensure that curl actually supports HTTP2 before trying to use it

Also all the error code checking seems to use CURLM_OK instead of CURLE_OK. Is this intentional? Doesn't matter though since both are defined to 0

The same fixes are required in ostree https://github.com/ostreedev/ostree/blob/main/src/libostree/ostree-fetcher-curl.c#L875-L887