### PR TITLE
enum-types: Make generated files more reproducible

### DIFF
--- a/common/flatpak-enum-types.c.template
+++ b/common/flatpak-enum-types.c.template
@@ -8,7 +8,7 @@
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
-/* enumerations from "@filename@" */
+/* enumerations from "@basename@" */
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/

--- a/common/flatpak-enum-types.h.template
+++ b/common/flatpak-enum-types.h.template
@@ -9,7 +9,7 @@ G_BEGIN_DECLS
 
 /*** BEGIN file-production ***/
 
-/* enumerations from "@filename@" */
+/* enumerations from "@basename@" */
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/


### PR DESCRIPTION
`@filename@` expands to the relative or absolute path to the source
file, which varies between build systems and build directories.
`@basename@` expands to the basename of the file, which stays constant
across more build configurations.

---

Noticed while comparing build results of Autotools and Meson builds with https://github.com/flatpak/flatpak/pull/4845.