### PR TITLE
flatpak-bisect: Update default branch

### DIFF
--- a/scripts/flatpak-bisect
+++ b/scripts/flatpak-bisect
@@ -205,7 +205,7 @@ class Bisector():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('name', nargs=1, help='Application/Runtime to bisect')
-    parser.add_argument('-b', '--branch', default='master', help='The branch to bisect')
+    parser.add_argument('-b', '--branch', default='stable', help='The branch to bisect')
     parser.add_argument('-r', '--runtime',  action="store_true", help='Bisecting a runtime not an app')
 
     subparsers = parser.add_subparsers(dest='subparser_name')


### PR DESCRIPTION
I think 'master' is outdated. And it is very confusing to new users if you don't know you just need to set `-b stable`.

Got this "quark" error:

```
$ flatpak-bisect com.github.jeromerobert.pdfarranger start
flatpak-error-quark: Ref app/com.github.jeromerobert.pdfarranger/x86_64/master not installed (1)

Make sure com.github.jeromerobert.pdfarranger is installed as a user (flatpak install --user) and specify `--runtime` if it is a runtime.
```