### PR TITLE
profile.d: Do not destroy XDG_DATA_DIRS in fish

### DIFF
--- a/profile/flatpak.fish
+++ b/profile/flatpak.fish
@@ -1,7 +1,7 @@
 if type -q flatpak
     # Set XDG_DATA_DIRS to include Flatpak installations
 
-    set -x --path XDG_DATA_DIRS
+    set -x --path XDG_DATA_DIRS $XDG_DATA_DIRS
 
     set -q XDG_DATA_DIRS[1]; or set XDG_DATA_DIRS /usr/local/share /usr/share
     set -q XDG_DATA_HOME; or set -l XDG_DATA_HOME $HOME/.local/share


### PR DESCRIPTION
The profile script previously nuked `XDG_DATA_DIRS` and then “helpfully” re-populated it with FHS paths. This was especially bad for systems like NixOS, which do not have `/usr` and rely on `XDG_DATA_DIRS` heavily.

Quoting from https://fishshell.com/docs/current/cmds/set.html

> If a variable is set to zero elements, it will become a list with zero elements.

And indeed, that is what the `set -x --path XDG_DATA_DIRS` command does. We need to list the value explicitly, if we want to preserve it while setting variable options.
