### PR TITLE
session-helper: Run default signal handler after handle_sigterm()

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -49,8 +49,11 @@ do_atexit (void)
 static void
 handle_sigterm (int signum)
 {
+  struct sigaction action = { 0 };
   do_atexit ();
-  _exit (1);
+  action.sa_handler = SIG_DFL;
+  sigaction (signum, &action, NULL);
+  raise (signum);
 }
 
 typedef struct


### PR DESCRIPTION
Exiting the process with a custom exit status (1) after systemctl stop (SIGTERM) makes systemd treat the flatpak-session-helper service as if it had failed.