### PR TITLE
Update libglnx to 2022-10-10

### DIFF
--- a/tests/testlib.h
+++ b/tests/testlib.h
@@ -22,11 +22,6 @@
 #include <gio/gio.h>
 #include <libglnx.h>
 
-#ifndef g_assert_no_errno
-#define g_assert_no_errno(expr) \
-  g_assert_cmpstr ((expr) >= 0 ? NULL : g_strerror (errno), ==, NULL)
-#endif
-
 char *assert_mkdtemp (char *tmpl);
 
 extern char *isolated_test_dir;


### PR DESCRIPTION
* Update libglnx to commit e701578c
    
    In particular, this version has more gtestutils backports, including a
    version of g_test_message() that preserves correct TAP syntax for
    multi-line messages.

* testlib: Remove local backport of g_assert_no_errno()
    
    libglnx now provides this.