### PR TITLE
revokefs: Use correct format string for a ssize_t

### DIFF
--- a/revokefs/writer.c
+++ b/revokefs/writer.c
@@ -886,7 +886,7 @@ do_writer (int basefd_arg,
 
       if (response_data_size < 0 || response_data_size > MAX_DATA_SIZE)
         {
-          g_printerr ("Invalid response size %ld", response_data_size);
+          g_printerr ("Invalid response size %zd", response_data_size);
           exit (1);
         }
 


### PR DESCRIPTION
This fixes the build on ILP32 architectures such as i386 with the Meson
build system. The Autotools build system accidentally didn't build
revokefs with -Werror=format, because it sets the target-specific CFLAGS
for revokefs but does not include the $(AM_CFLAGS) in them.

Fixes: aeecbb7d "revokefs: Split out the writing part from the fuse implementation"