### PR TITLE
automake: Consistently include $(AM_CFLAGS) in target-specific CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,6 +90,7 @@ INTERNAL_GPGME_LIBS = $(DEP_GPGME_LIBS) $(GPGME_PTHREAD_LIBS)
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES += libglnx.la
 libglnx_srcpath := $(srcdir)/subprojects/libglnx
+# This intentionally does not include AM_CFLAGS, libglnx always uses those
 libglnx_cflags := \
 	$(BASE_CFLAGS) \
 	"-I$(libglnx_srcpath)" \

--- a/icon-validator/Makefile.am.inc
+++ b/icon-validator/Makefile.am.inc
@@ -6,4 +6,4 @@ libexec_PROGRAMS += \
 
 flatpak_validate_icon_SOURCES = icon-validator/validate-icon.c
 flatpak_validate_icon_LDADD = $(GDK_PIXBUF_LIBS)
-flatpak_validate_icon_CFLAGS = $(GDK_PIXBUF_CFLAGS) -DLIBEXECDIR=\"$(libexecdir)\"
+flatpak_validate_icon_CFLAGS = $(AM_CFLAGS) $(GDK_PIXBUF_CFLAGS) -DLIBEXECDIR=\"$(libexecdir)\"

--- a/revokefs/Makefile.am.inc
+++ b/revokefs/Makefile.am.inc
@@ -26,9 +26,9 @@ noinst_PROGRAMS += revokefs-demo
 
 revokefs_fuse_SOURCES = revokefs/main.c revokefs/writer.c revokefs/writer.h
 
-revokefs_fuse_CFLAGS = $(BASE_CFLAGS) -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 $(FUSE_CFLAGS)
+revokefs_fuse_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 $(FUSE_CFLAGS)
 revokefs_fuse_LDADD = libglnx.la $(BASE_LIBS) $(FUSE_LIBS)
 
 revokefs_demo_SOURCES = revokefs/demo.c
-revokefs_demo_CFLAGS = $(BASE_CFLAGS)
+revokefs_demo_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
 revokefs_demo_LDADD = $(BASE_LIBS)

--- a/revokefs/Makefile.am.inc
+++ b/revokefs/Makefile.am.inc
@@ -26,7 +26,7 @@ noinst_PROGRAMS += revokefs-demo
 
 revokefs_fuse_SOURCES = revokefs/main.c revokefs/writer.c revokefs/writer.h
 
-revokefs_fuse_CFLAGS = $(BASE_CFLAGS) -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 $(FUSE_CFLAGS) -I$(srcdir)/libglnx
+revokefs_fuse_CFLAGS = $(BASE_CFLAGS) -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 $(FUSE_CFLAGS)
 revokefs_fuse_LDADD = libglnx.la $(BASE_LIBS) $(FUSE_LIBS)
 
 revokefs_demo_SOURCES = revokefs/demo.c


### PR DESCRIPTION
* revokefs: Remove incorrect libglnx include directory
    
    revokefs already gets the correct include directory from the AM_CPPFLAGS.
    This would also break the build with -Werror=missing-include-dirs.

* automake: Consistently include $(AM_CFLAGS) in target-specific CFLAGS
    
    When built for i386 with Autotools, this would have detected the format
    string issue fixed in #5148.