### PR TITLE
Add /efi in the hidding list when (fs=host)

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2435,8 +2435,8 @@ flatpak_context_make_sandboxed (FlatpakContext *context)
 }
 
 const char *dont_mount_in_root[] = {
-  ".", "..", "lib", "lib32", "lib64", "bin", "sbin", "usr", "boot", "root",
-  "tmp", "etc", "app", "run", "proc", "sys", "dev", "var", NULL
+  ".", "..", "lib", "lib32", "lib64", "bin", "sbin", "usr", "boot", "efi",
+  "root", "tmp", "etc", "app", "run", "proc", "sys", "dev", "var", NULL
 };
 
 static void


### PR DESCRIPTION
When filesystem=host access is provided, some root folders are hidden, including /boot.

The bootloader specification now recommends mounting the system EFI filesystem in /efi (currently visible) instead of /boot/efi (currently hidden). This hides /efi for the same  reasons /boot is already hidden.