### PR TITLE
[flatpak-1.12.x] flatpak-dir: Clean up temp deploy dir on failure of flatpak_dir_deploy()

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8277,6 +8277,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autofree char *ref_id = NULL;
   g_autoptr(GFile) root = NULL;
   g_autoptr(GFile) deploy_base = NULL;
+  glnx_autofd int deploy_base_dfd = -1;
   g_autoptr(GFile) checkoutdir = NULL;
   g_autoptr(GFile) bindir = NULL;
   g_autofree char *checkoutdirpath = NULL;
@@ -8293,8 +8294,6 @@ flatpak_dir_deploy (FlatpakDir          *self,
   OstreeRepoCheckoutAtOptions options = { 0, };
   const char *checksum;
   glnx_autofd int checkoutdir_dfd = -1;
-  g_autoptr(GFile) tmp_dir_template = NULL;
-  g_autofree char *tmp_dir_path = NULL;
   const char *xa_ref = NULL;
   g_autofree char *checkout_basename = NULL;
   gboolean created_extra_data = FALSE;
@@ -8304,6 +8303,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
   g_autofree char *metadata_contents = NULL;
   gsize metadata_size = 0;
   const char *flatpak;
+  g_auto(GLnxTmpDir) tmp_dir_handle = { 0, };
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -8317,6 +8317,9 @@ flatpak_dir_deploy (FlatpakDir          *self,
     return FALSE;
 
   deploy_base = flatpak_dir_get_deploy_dir (self, ref);
+
+  if (!glnx_opendirat (AT_FDCWD, flatpak_file_get_path_cached (deploy_base), TRUE, &deploy_base_dfd, error))
+    return FALSE;
 
   if (checksum_or_latest == NULL)
     {
@@ -8352,17 +8355,15 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                _("%s commit %s already installed"), flatpak_decomposed_get_ref (ref), checksum);
 
   g_autofree char *template = g_strdup_printf (".%s-XXXXXX", checkout_basename);
-  tmp_dir_template = g_file_get_child (deploy_base, template);
-  tmp_dir_path = g_file_get_path (tmp_dir_template);
 
-  if (g_mkdtemp_full (tmp_dir_path, 0755) == NULL)
+  if (!glnx_mkdtempat (deploy_base_dfd, template, 0755, &tmp_dir_handle, NULL))
     {
       g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            _("Can't create deploy directory"));
       return FALSE;
     }
 
-  checkoutdir = g_file_new_for_path (tmp_dir_path);
+  checkoutdir = g_file_get_child (deploy_base, tmp_dir_handle.path);
 
   if (!ostree_repo_read_commit (self->repo, checksum, &root, NULL, cancellable, error))
     {
@@ -8660,6 +8661,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
   if (!g_file_move (checkoutdir, real_checkoutdir, G_FILE_COPY_NO_FALLBACK_FOR_MOVE,
                     cancellable, NULL, NULL, error))
     return FALSE;
+
+  glnx_tmpdir_unset (&tmp_dir_handle);
 
   if (!flatpak_dir_set_active (self, ref, checkout_basename, cancellable, error))
     return FALSE;


### PR DESCRIPTION
This already happens for installs due to the cleanup path in `flatpak_dir_deploy_install()`, but it doesn’t happen for other calls to `flatpak_dir_deploy()`. Notably, during updates of already installed apps.

Specifically, this means that if an app update is cancelled due to being blocked by a parental controls policy, the temp deploy dir for that app (such as
`~/.local/share/flatpak/app/com.corp.App/x86_64/stable/.somehex-XXXXXX`) will be leaked. It will never be automatically cleaned up, as it’s not in `/var/tmp` either.

Fix that by using `glnx_mkdtempat()` to create a scoped temporary directory.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
(cherry picked from commit ce1829a703f2bc2e7868fd314ddefb63fbf7dce1)

---

Trivial backport of #5146 to `flatpak-1.12.x`. Tested, and it fixes the bug.