### PR TITLE
flatpak-dir: Clean up old leaked deploy dirs at start of deploy

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4554,6 +4554,7 @@ remove_old_appstream_tmpdirs (GFile *dir)
       tmp = g_file_get_child (dir, dent->d_name);
 
       /* We ignore errors here, no need to worry anyone */
+      g_debug ("Deleting stale appstream deploy tmpdir %s", flatpak_file_get_path_cached (tmp));
       (void)flatpak_rm_rf (tmp, NULL, NULL);
     }
 }


### PR DESCRIPTION
Following on from commit 85a83a06f95, add some code to clean up old
leaked deploy tmpdirs when we next try to deploy the same app
(successfully or not).

This should free up disk space leaked by failed deploys pre-85a83a06f95.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>