### PR TITLE
Clear more temporary file paths from env

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1880,7 +1880,11 @@ static const ExportData default_exports[] = {
   {"XDG_CONFIG_DIRS", "/app/etc/xdg:/etc/xdg"},
   {"XDG_DATA_DIRS", "/app/share:/usr/share"},
   {"SHELL", "/bin/sh"},
-  {"TMPDIR", NULL}, /* Unset TMPDIR as it may not exist in the sandbox */
+  /* Unset temporary file paths as they may not exist in the sandbox */
+  {"TEMP", NULL},
+  {"TEMPDIR", NULL},
+  {"TMP", NULL},
+  {"TMPDIR", NULL},
   /* We always use /run/user/UID, even if the user's XDG_RUNTIME_DIR
    * outside the sandbox is somewhere else. Don't allow a different
    * setting from outside the sandbox to overwrite this. */


### PR DESCRIPTION
This supplements clearing TMPDIR env variable which is only one among variables used for storing temporary files. Any of those leaking from host may confuse flatpak apps which try to save temporary files under non-existing directory in sandbox.

See https://github.com/flathub/com.logseq.Logseq/issues/29 for real world example.