### PR TITLE
build: Don't enforce -Werror by default, apply it via CI instead

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,6 +78,7 @@ jobs:
           -Dinternal_checks=true \
           -Dsystem_bubblewrap=bwrap \
           -Dsystem_dbus_proxy=xdg-dbus-proxy \
+          --werror \
           ${NULL+}
       env:
         CFLAGS: -O2 -Wp,-D_FORTIFY_SOURCE=2
@@ -137,7 +138,7 @@ jobs:
         ../configure  --enable-internal-checks --enable-asan --disable-introspection --without-curl
         popd
       env:
-        CFLAGS: -O2 -Wp,-D_FORTIFY_SOURCE=2
+        CFLAGS: -O2 -Wp,-D_FORTIFY_SOURCE=2 -Werror
     - name: Build flatpak
       run: make -C _build -j $(getconf _NPROCESSORS_ONLN)
     # We build with Ubuntu 18.04's GLib to prove that we can, but there's a
@@ -206,7 +207,7 @@ jobs:
       run: ./autogen.sh
       env:
         CC: clang
-        CFLAGS: -Werror=unused-variable
+        CFLAGS: -Werror -Werror=unused-variable
     - name: Build flatpak
       run: make -j $(getconf _NPROCESSORS_ONLN)
     - name: Perform CodeQL Analysis
@@ -243,7 +244,7 @@ jobs:
         ../configure --enable-gtk-doc --enable-gtk-doc-html --enable-introspection
         popd
       env:
-        CFLAGS: -O2
+        CFLAGS: -Werror -O2
     - name: Build flatpak
       run: make -C _build -j $(getconf _NPROCESSORS_ONLN)
     - name: Distcheck

--- a/configure.ac
+++ b/configure.ac
@@ -64,21 +64,22 @@ dnl This list is shared with https://github.com/ostreedev/ostree
 CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
 -pipe \
 -Wall \
--Werror=shadow \
--Werror=empty-body \
--Werror=strict-prototypes \
--Werror=missing-prototypes \
--Werror=implicit-function-declaration \
-"-Werror=format=2 -Werror=format-security -Werror=format-nonliteral" \
--Werror=pointer-arith -Werror=init-self \
--Werror=missing-declarations \
--Werror=return-type \
--Werror=overflow \
--Werror=int-conversion \
--Werror=parenthesis \
--Werror=incompatible-pointer-types \
--Werror=misleading-indentation \
--Werror=missing-include-dirs \
+-Wshadow \
+-Wempty-body \
+-Wstrict-prototypes \
+-Wmissing-prototypes \
+-Wimplicit-function-declaration \
+"-Wformat=2 -Wformat-security -Wformat-nonliteral" \
+-Wpointer-arith \
+-Winit-self \
+-Wmissing-declarations \
+-Wreturn-type \
+-Woverflow \
+-Wint-conversion \
+-Wparenthesis \
+-Wincompatible-pointer-types \
+-Wmisleading-indentation \
+-Wmissing-include-dirs \
 ])
 AC_SUBST(WARN_CFLAGS)
 

--- a/meson.build
+++ b/meson.build
@@ -67,24 +67,24 @@ common_include_directories = include_directories(
 )
 
 # Keep this in sync with ostree, except remove -Wall (part of Meson
-# warning_level 2) and -Werror=declaration-after-statement
+# warning_level 2) and -Wdeclaration-after-statement
 add_project_arguments(
   cc.get_supported_arguments([
-    '-Werror=shadow',
-    '-Werror=empty-body',
-    '-Werror=strict-prototypes',
-    '-Werror=missing-prototypes',
-    '-Werror=implicit-function-declaration',
-    '-Werror=pointer-arith',
-    '-Werror=init-self',
-    '-Werror=missing-declarations',
-    '-Werror=return-type',
-    '-Werror=overflow',
-    '-Werror=int-conversion',
-    '-Werror=parenthesis',
-    '-Werror=incompatible-pointer-types',
-    '-Werror=misleading-indentation',
-    '-Werror=missing-include-dirs',
+    '-Wshadow',
+    '-Wempty-body',
+    '-Wstrict-prototypes',
+    '-Wmissing-prototypes',
+    '-Wimplicit-function-declaration',
+    '-Wpointer-arith',
+    '-Winit-self',
+    '-Wmissing-declarations',
+    '-Wreturn-type',
+    '-Woverflow',
+    '-Wint-conversion',
+    '-Wparenthesis',
+    '-Wincompatible-pointer-types',
+    '-Wmisleading-indentation',
+    '-Wmissing-include-dirs',
 
     # Meson warning_level=2 would do this, but we are not fully
     # signedness-safe yet
@@ -111,14 +111,14 @@ add_project_arguments(
 add_project_arguments('-fvisibility=hidden', language : 'c')
 
 if (
-  cc.has_argument('-Werror=format=2')
-  and cc.has_argument('-Werror=format-security')
-  and cc.has_argument('-Werror=format-nonliteral')
+  cc.has_argument('-Wformat=2')
+  and cc.has_argument('-Wformat-security')
+  and cc.has_argument('-Wformat-nonliteral')
 )
   add_project_arguments([
-    '-Werror=format=2',
-    '-Werror=format-security',
-    '-Werror=format-nonliteral',
+    '-Wformat=2',
+    '-Wformat-security',
+    '-Wformat-nonliteral',
   ], language : 'c')
 endif
 


### PR DESCRIPTION
Packagers prefer projects to compile with warnings as warnings (not errors) by default, so that upgrading to a new compiler with new false-positives, or upgrading a dependency to a version that triggers new compiler warnings, will not break their downstream build.

We still want new compiler warnings to break the build for upstream CI purposes, so enable -Werror in the Github Workflows instead.

Resolves: https://github.com/flatpak/flatpak/issues/5169