### PR TITLE
flatpak-run: unset XKB_CONFIG_ROOT

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1910,6 +1910,7 @@ static const ExportData default_exports[] = {
   {"GST_PTP_HELPER_1_0", NULL},
   {"GST_INSTALL_PLUGINS_HELPER", NULL},
   {"KRB5CCNAME", NULL},
+  {"XKB_CONFIG_ROOT", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -101,6 +101,7 @@
             <member>PERL5LIB</member>
             <member>XCURSOR_PATH</member>
             <member>KRB5CCNAME</member>
+            <member>XKB_CONFIG_ROOT</member>
         </simplelist>
         <para>
             Also several environment variables with the prefix "GST_" that are used by gstreamer


### PR DESCRIPTION
This variable is typically used to configure the use of a custom
set of XKB definitions. In those cases, it's mostly meant for the
X11 server or Wayland compositor. NixOS is known to employ this
variable for their custom XKB layout implementation.

When the path it points to is unreachable (due to the sandbox),
most GTK+/Qt applications will crash on Wayland.

Unsetting this does not seem to negatively impact the use of custom
XKB layouts with Flatpak applications.
