### PR TITLE
common: bind wayland socket lock into the sandbox environment

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -412,7 +412,9 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
   const char *wayland_display;
   g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
   g_autofree char *wayland_socket = NULL;
+  g_autofree char *wayland_socket_lock = NULL;
   g_autofree char *sandbox_wayland_socket = NULL;
+  g_autofree char *sandbox_wayland_socket_lock = NULL;
   gboolean res = FALSE;
   struct stat statbuf;
 
@@ -434,12 +436,19 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap)
 
   sandbox_wayland_socket = g_strdup_printf ("/run/flatpak/%s", wayland_display);
 
+  wayland_socket_lock = g_strdup_printf ("%s.lock", wayland_socket);
+  sandbox_wayland_socket_lock = g_strdup_printf ("%s.lock", sandbox_wayland_socket);
+
   if (stat (wayland_socket, &statbuf) == 0 &&
       (statbuf.st_mode & S_IFMT) == S_IFSOCK)
     {
       res = TRUE;
       flatpak_bwrap_add_args (bwrap,
                               "--ro-bind", wayland_socket, sandbox_wayland_socket,
+                              NULL);
+      flatpak_bwrap_add_args (bwrap,
+                              "--ro-bind", wayland_socket_lock,
+                              sandbox_wayland_socket_lock,
                               NULL);
       flatpak_bwrap_add_runtime_dir_member (bwrap, wayland_display);
     }


### PR DESCRIPTION
This PR attempts to fix flatpak/flatpak#5167 by simply binding the lock file (e.g. `wayland-0.lock`) that is associated with the bound Wayland socket file. 