### PR TITLE
profile.d: Only add new directories to XDG_DATA_DIRS in fish

### DIFF
--- a/profile/flatpak.fish
+++ b/profile/flatpak.fish
@@ -13,5 +13,9 @@ if type -q flatpak
         set installations $installations (flatpak --installations)
     end
 
-    set XDG_DATA_DIRS {$installations}/exports/share $XDG_DATA_DIRS
+    for dir in {$installations[-1..1]}/exports/share
+        if not contains $dir $XDG_DATA_DIRS
+            set -p XDG_DATA_DIRS $dir
+        end
+    end
 end


### PR DESCRIPTION
Previously in a0505f52d993837ce7ce96801f54eb37d55dadfb
the profile script was modified to preserve XDG_DATA_DIRS.
This had the side-effect of making the script not idempotent,
adding duplicate entries for every installation every time it's sourced.

On my current system  that results in this value:

    /home/mkhl/.local/share/flatpak/exports/share /var/lib/flatpak/exports/share /home/mkhl/.local/share/flatpak/exports/share /var/lib/flatpak/exports/share /usr/local/share /usr/share

which in turn has the side-effect of the GNOME search settings showing two entries
for every application installed via flatpak.

This change makes the script check that an entry is new before adding it.
It also uses `set -p` (short for `--prepend`) to add them.

N.B.
`set -p VAR val` is equivalent to `set VAR val $VAR`
`$var[-1..1]` reverses the order of elements
so after iterating the first element of `$installations`
becomes the first element of `$XDG_DATA_DIRS`