### PR TITLE
CI: Disable Valgrind test for now

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -216,6 +216,7 @@ jobs:
     name: Run tests in valgrind
     needs: check # Don't run expensive test if main check fails
     runs-on: ubuntu-20.04 # Might as well test with a different one too
+    if: ${{ false }} # Currently Valgrind takes too long and always fails
     steps:
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
This test has consistently failed for months as it takes too long.

While it should be looked into its not helpful to show CI as always failing either.