### PR TITLE
flatpak-run: unset GIO_EXTRA_MODULES

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1911,6 +1911,7 @@ static const ExportData default_exports[] = {
   {"GST_INSTALL_PLUGINS_HELPER", NULL},
   {"KRB5CCNAME", NULL},
   {"XKB_CONFIG_ROOT", NULL},
+  {"GIO_EXTRA_MODULES", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -102,6 +102,7 @@
             <member>XCURSOR_PATH</member>
             <member>KRB5CCNAME</member>
             <member>XKB_CONFIG_ROOT</member>
+            <member>GIO_EXTRA_MODULES</member>
         </simplelist>
         <para>
             Also several environment variables with the prefix "GST_" that are used by gstreamer


### PR DESCRIPTION
This variable contains paths to load GIO modules from. For the most part, they refer to paths outside of the sandbox or if they happen to be in the sandbox, would contain modules that are incompatible with the sandbox runtime (ie. different libc).

While I've not found programs that would crash outright, it may cause unexpected behaviors (eg. Apostrophe not being able to render math in preview panel).

This variable is set by NixOS for its dependency boxing.