### PR TITLE
Avoid exporting reserved directories more thoroughly / improve error reporting

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2458,6 +2458,27 @@ const char *dont_mount_in_root[] = {
 };
 
 static void
+log_cannot_export_error (FlatpakFilesystemMode  mode,
+                         const char            *path,
+                         const GError          *error)
+{
+  switch (mode)
+    {
+      case FLATPAK_FILESYSTEM_MODE_NONE:
+        g_debug ("Not replacing \"%s\" with tmpfs: %s",
+                 path, error->message);
+        break;
+
+      case FLATPAK_FILESYSTEM_MODE_CREATE:
+      case FLATPAK_FILESYSTEM_MODE_READ_ONLY:
+      case FLATPAK_FILESYSTEM_MODE_READ_WRITE:
+        g_debug ("Not sharing \"%s\" with sandbox: %s",
+                 path, error->message);
+        break;
+    }
+}
+
+static void
 flatpak_context_export (FlatpakContext *context,
                         FlatpakExports *exports,
                         GFile          *app_id_dir,
@@ -2471,6 +2492,7 @@ flatpak_context_export (FlatpakContext *context,
   FlatpakFilesystemMode fs_mode, os_mode, etc_mode, home_mode;
   GHashTableIter iter;
   gpointer key, value;
+  g_autoptr(GError) local_error = NULL;
 
   if (xdg_dirs_conf_out != NULL)
     xdg_dirs_conf = g_string_new ("");
@@ -2496,11 +2518,21 @@ flatpak_context_export (FlatpakContext *context,
                 continue;
 
               path = g_build_filename ("/", dirent->d_name, NULL);
-              flatpak_exports_add_path_expose (exports, fs_mode, path);
+
+              if (!flatpak_exports_add_path_expose (exports, fs_mode, path, &local_error))
+                {
+                  log_cannot_export_error (fs_mode, path, local_error);
+                  g_clear_error (&local_error);
+                }
             }
           closedir (dir);
         }
-      flatpak_exports_add_path_expose (exports, fs_mode, "/run/media");
+
+      if (!flatpak_exports_add_path_expose (exports, fs_mode, "/run/media", &local_error))
+        {
+          log_cannot_export_error (fs_mode, "/run/media", local_error);
+          g_clear_error (&local_error);
+        }
     }
 
   os_mode = MAX (GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "host-os")),
@@ -2521,7 +2553,12 @@ flatpak_context_export (FlatpakContext *context,
       g_info ("Allowing homedir access");
       home_access = TRUE;
 
-      flatpak_exports_add_path_expose (exports, MAX (home_mode, fs_mode), g_get_home_dir ());
+      if (!flatpak_exports_add_path_expose (exports, MAX (home_mode, fs_mode), g_get_home_dir (), &local_error))
+        {
+          log_cannot_export_error (MAX (home_mode, fs_mode), g_get_home_dir (),
+                                   local_error);
+          g_clear_error (&local_error);
+        }
     }
 
   g_hash_table_iter_init (&iter, context->filesystems);
@@ -2571,7 +2608,11 @@ flatpak_context_export (FlatpakContext *context,
                 g_string_append_printf (xdg_dirs_conf, "%s=\"%s\"\n",
                                         config_key, path);
 
-              flatpak_exports_add_path_expose_or_hide (exports, mode, subpath);
+              if (!flatpak_exports_add_path_expose_or_hide (exports, mode, subpath, &local_error))
+                {
+                  log_cannot_export_error (mode, subpath, local_error);
+                  g_clear_error (&local_error);
+                }
             }
         }
       else if (g_str_has_prefix (filesystem, "~/"))
@@ -2586,8 +2627,11 @@ flatpak_context_export (FlatpakContext *context,
                 g_info ("Unable to create directory %s", path);
             }
 
-          if (g_file_test (path, G_FILE_TEST_EXISTS))
-            flatpak_exports_add_path_expose_or_hide (exports, mode, path);
+          if (!flatpak_exports_add_path_expose_or_hide (exports, mode, path, &local_error))
+            {
+              log_cannot_export_error (mode, path, local_error);
+              g_clear_error (&local_error);
+            }
         }
       else if (g_str_has_prefix (filesystem, "/"))
         {
@@ -2597,8 +2641,11 @@ flatpak_context_export (FlatpakContext *context,
                 g_info ("Unable to create directory %s", filesystem);
             }
 
-          if (g_file_test (filesystem, G_FILE_TEST_EXISTS))
-            flatpak_exports_add_path_expose_or_hide (exports, mode, filesystem);
+          if (!flatpak_exports_add_path_expose_or_hide (exports, mode, filesystem, &local_error))
+            {
+              log_cannot_export_error (mode, filesystem, local_error);
+              g_clear_error (&local_error);
+            }
         }
       else
         {
@@ -2611,18 +2658,42 @@ flatpak_context_export (FlatpakContext *context,
       g_autoptr(GFile) apps_dir = g_file_get_parent (app_id_dir);
       int i;
       /* Hide the .var/app dir by default (unless explicitly made visible) */
-      flatpak_exports_add_path_tmpfs (exports, flatpak_file_get_path_cached (apps_dir));
+      if (!flatpak_exports_add_path_tmpfs (exports,
+                                           flatpak_file_get_path_cached (apps_dir),
+                                           &local_error))
+        {
+          log_cannot_export_error (FLATPAK_FILESYSTEM_MODE_NONE,
+                                   flatpak_file_get_path_cached (apps_dir),
+                                   local_error);
+          g_clear_error (&local_error);
+        }
+
       /* But let the app write to the per-app dir in it */
-      flatpak_exports_add_path_expose (exports, FLATPAK_FILESYSTEM_MODE_READ_WRITE,
-                                       flatpak_file_get_path_cached (app_id_dir));
+      if (!flatpak_exports_add_path_expose (exports, FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                            flatpak_file_get_path_cached (app_id_dir),
+                                            &local_error))
+        {
+          log_cannot_export_error (FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                   flatpak_file_get_path_cached (apps_dir),
+                                   local_error);
+          g_clear_error (&local_error);
+        }
 
       if (extra_app_id_dirs != NULL)
         {
           for (i = 0; i < extra_app_id_dirs->len; i++)
             {
               GFile *extra_app_id_dir = g_ptr_array_index (extra_app_id_dirs, i);
-              flatpak_exports_add_path_expose (exports, FLATPAK_FILESYSTEM_MODE_READ_WRITE,
-                                               flatpak_file_get_path_cached (extra_app_id_dir));
+              if (!flatpak_exports_add_path_expose (exports,
+                                                    FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                                    flatpak_file_get_path_cached (extra_app_id_dir),
+                                                    &local_error))
+                {
+                  log_cannot_export_error (FLATPAK_FILESYSTEM_MODE_READ_WRITE,
+                                           flatpak_file_get_path_cached (extra_app_id_dir),
+                                           local_error);
+                  g_clear_error (&local_error);
+                }
             }
         }
     }
@@ -2686,13 +2757,27 @@ flatpak_context_get_exports_full (FlatpakContext *context,
   if (include_default_dirs)
     {
       g_autoptr(GFile) user_flatpak_dir = NULL;
+      g_autoptr(GError) local_error = NULL;
 
       /* Hide the flatpak dir by default (unless explicitly made visible) */
       user_flatpak_dir = flatpak_get_user_base_dir_location ();
-      flatpak_exports_add_path_tmpfs (exports, flatpak_file_get_path_cached (user_flatpak_dir));
+      if (!flatpak_exports_add_path_tmpfs (exports,
+                                           flatpak_file_get_path_cached (user_flatpak_dir),
+                                           &local_error))
+        {
+          log_cannot_export_error (FLATPAK_FILESYSTEM_MODE_NONE,
+                                   flatpak_file_get_path_cached (user_flatpak_dir),
+                                   local_error);
+          g_clear_error (&local_error);
+        }
 
       /* Ensure we always have a homedir */
-      flatpak_exports_add_path_dir (exports, g_get_home_dir ());
+      if (!flatpak_exports_add_path_dir (exports, g_get_home_dir (), &local_error))
+        {
+          g_debug ("Unable to provide a temporary home directory in the sandbox: %s",
+                   local_error->message);
+          g_clear_error (&local_error);
+        }
     }
 
   return g_steal_pointer (&exports);

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2580,8 +2580,12 @@ flatpak_context_export (FlatpakContext *context,
 
       if (!flatpak_exports_add_path_expose (exports, MAX (home_mode, fs_mode), g_get_home_dir (), &local_error))
         {
-          log_cannot_export_error (MAX (home_mode, fs_mode), g_get_home_dir (),
-                                   local_error);
+          /* Even if the error is one that we would normally silence, like
+           * the path not existing, it seems reasonable to make more of a fuss
+           * about the home directory not existing or otherwise being unusable,
+           * so this is intentionally not using cannot_export() */
+          g_warning (_("Not allowing home directory access: %s"),
+                     local_error->message);
           g_clear_error (&local_error);
         }
     }
@@ -2799,8 +2803,8 @@ flatpak_context_get_exports_full (FlatpakContext *context,
       /* Ensure we always have a homedir */
       if (!flatpak_exports_add_path_dir (exports, g_get_home_dir (), &local_error))
         {
-          g_debug ("Unable to provide a temporary home directory in the sandbox: %s",
-                   local_error->message);
+          g_warning (_("Unable to provide a temporary home directory in the sandbox: %s"),
+                     local_error->message);
           g_clear_error (&local_error);
         }
     }

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2435,8 +2435,26 @@ flatpak_context_make_sandboxed (FlatpakContext *context)
 }
 
 const char *dont_mount_in_root[] = {
-  ".", "..", "lib", "lib32", "lib64", "bin", "sbin", "usr", "boot", "efi",
-  "root", "tmp", "etc", "app", "run", "proc", "sys", "dev", "var", NULL
+  ".",
+  "..",
+  "app",
+  "bin",
+  "boot",
+  "dev",
+  "efi",
+  "etc",
+  "lib",
+  "lib32",
+  "lib64",
+  "proc",
+  "root",
+  "run",
+  "sbin",
+  "sys",
+  "tmp",
+  "usr",
+  "var",
+  NULL
 };
 
 static void

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -43,16 +43,20 @@ void flatpak_exports_add_host_etc_expose (FlatpakExports       *exports,
                                           FlatpakFilesystemMode mode);
 void flatpak_exports_add_host_os_expose (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode);
-void flatpak_exports_add_path_expose (FlatpakExports       *exports,
-                                      FlatpakFilesystemMode mode,
-                                      const char           *path);
-void flatpak_exports_add_path_tmpfs (FlatpakExports *exports,
-                                     const char     *path);
-void flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
-                                              FlatpakFilesystemMode mode,
-                                              const char           *path);
-void flatpak_exports_add_path_dir (FlatpakExports *exports,
-                                   const char     *path);
+gboolean flatpak_exports_add_path_expose (FlatpakExports         *exports,
+                                          FlatpakFilesystemMode   mode,
+                                          const char             *path,
+                                          GError                **error);
+gboolean flatpak_exports_add_path_tmpfs (FlatpakExports  *exports,
+                                         const char      *path,
+                                         GError         **error);
+gboolean flatpak_exports_add_path_expose_or_hide (FlatpakExports         *exports,
+                                                  FlatpakFilesystemMode   mode,
+                                                  const char             *path,
+                                                  GError                **error);
+gboolean flatpak_exports_add_path_dir (FlatpakExports  *exports,
+                                       const char      *path,
+                                       GError         **error);
 
 gboolean flatpak_exports_path_is_visible (FlatpakExports *exports,
                                           const char     *path);

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -52,6 +52,7 @@
    flatpak_abs_usrmerged_dirs get the same treatment without having to be listed
    here. */
 const char *dont_export_in[] = {
+  "/.flatpak-info",
   "/app",
   "/dev",
   "/etc",

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -52,7 +52,12 @@
    flatpak_abs_usrmerged_dirs get the same treatment without having to be listed
    here. */
 const char *dont_export_in[] = {
-  "/usr", "/etc", "/app", "/dev", "/proc", NULL
+  "/app",
+  "/dev",
+  "/etc",
+  "/proc",
+  "/usr",
+  NULL
 };
 
 static char *

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -1050,55 +1050,46 @@ _exports_path_expose (FlatpakExports *exports,
   return TRUE;
 }
 
-void
-flatpak_exports_add_path_expose (FlatpakExports       *exports,
-                                 FlatpakFilesystemMode mode,
-                                 const char           *path)
+gboolean
+flatpak_exports_add_path_expose (FlatpakExports         *exports,
+                                 FlatpakFilesystemMode   mode,
+                                 const char             *path,
+                                 GError                **error)
 {
-  g_autoptr(GError) local_error = NULL;
-
-  g_return_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE);
-  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
-
-  if (!_exports_path_expose (exports, mode, path, 0, &local_error))
-    g_debug ("Unable to %s: \"%s\": %s",
-             export_mode_to_verb (mode), path, local_error->message);
+  g_return_val_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE, FALSE);
+  g_return_val_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST, FALSE);
+  return _exports_path_expose (exports, mode, path, 0, error);
 }
 
-void
-flatpak_exports_add_path_tmpfs (FlatpakExports *exports,
-                                const char     *path)
+gboolean
+flatpak_exports_add_path_tmpfs (FlatpakExports  *exports,
+                                const char      *path,
+                                GError         **error)
 {
-  g_autoptr(GError) local_error = NULL;
-
-  if (!_exports_path_expose (exports, FAKE_MODE_TMPFS, path, 0, &local_error))
-    g_debug ("Unable to %s: \"%s\": %s",
-             export_mode_to_verb (FAKE_MODE_TMPFS), path, local_error->message);
+  return _exports_path_expose (exports, FAKE_MODE_TMPFS, path, 0, error);
 }
 
-void
-flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
-                                         FlatpakFilesystemMode mode,
-                                         const char           *path)
+gboolean
+flatpak_exports_add_path_expose_or_hide (FlatpakExports        *exports,
+                                         FlatpakFilesystemMode  mode,
+                                         const char            *path,
+                                         GError               **error)
 {
-  g_return_if_fail (mode >= FLATPAK_FILESYSTEM_MODE_NONE);
-  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
+  g_return_val_if_fail (mode >= FLATPAK_FILESYSTEM_MODE_NONE, FALSE);
+  g_return_val_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST, FALSE);
 
   if (mode == FLATPAK_FILESYSTEM_MODE_NONE)
-    flatpak_exports_add_path_tmpfs (exports, path);
+    return flatpak_exports_add_path_tmpfs (exports, path, error);
   else
-    flatpak_exports_add_path_expose (exports, mode, path);
+    return flatpak_exports_add_path_expose (exports, mode, path, error);
 }
 
-void
-flatpak_exports_add_path_dir (FlatpakExports *exports,
-                              const char     *path)
+gboolean
+flatpak_exports_add_path_dir (FlatpakExports  *exports,
+                              const char      *path,
+                              GError         **error)
 {
-  g_autoptr(GError) local_error = NULL;
-
-  if (!_exports_path_expose (exports, FAKE_MODE_DIR, path, 0, &local_error))
-    g_debug ("Unable to %s: \"%s\": %s",
-             export_mode_to_verb (FAKE_MODE_DIR), path, local_error->message);
+  return _exports_path_expose (exports, FAKE_MODE_DIR, path, 0, error);
 }
 
 void

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -972,6 +972,19 @@ _exports_path_expose (FlatpakExports *exports,
                        dont_export_in[i]);
           return FALSE;
         }
+
+      /* Also don't expose directories that are a parent of a directory
+       * that is "owned" by the sandboxing framework. For example, because
+       * Flatpak controls /run/host and /run/flatpak, we cannot allow
+       * --filesystem=/run, which would prevent us from creating the
+       * contents of /run/host and /run/flatpak. */
+      if (flatpak_has_path_prefix (dont_export_in[i], path))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_MOUNTABLE_FILE,
+                       _("Path \"%s\" is reserved by Flatpak"),
+                       dont_export_in[i]);
+          return FALSE;
+        }
     }
 
   for (i = 0; flatpak_abs_usrmerged_dirs[i] != NULL; i++)

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -869,12 +869,18 @@ check_if_autofs_works (FlatpakExports *exports,
   return TRUE;
 }
 
-/* We use level to avoid infinite recursion */
+/* We use level to avoid infinite recursion.
+ *
+ * Note that some of the errors produced by this function are "real errors"
+ * and should show up as a user-visible warning, but others are relatively
+ * uninteresting, and in general none are actually fatal: we prefer to
+ * continue with fewer paths exposed rather than failing to run. */
 static gboolean
 _exports_path_expose (FlatpakExports *exports,
                       int             mode,
                       const char     *path,
-                      int             level)
+                      int             level,
+                      GError        **error)
 {
   g_autofree char *canonical = NULL;
   struct stat st;
@@ -889,13 +895,15 @@ _exports_path_expose (FlatpakExports *exports,
 
   if (level > 40) /* 40 is the current kernel ELOOP check */
     {
-      g_info ("Expose too deep, bail");
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_TOO_MANY_LINKS,
+                   "%s", g_strerror (ELOOP));
       return FALSE;
     }
 
   if (!g_path_is_absolute (path))
     {
-      g_info ("Not exposing relative path %s", path);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_FILENAME,
+                   _("An absolute path is required"));
       return FALSE;
     }
 
@@ -904,34 +912,38 @@ _exports_path_expose (FlatpakExports *exports,
 
   if (o_path_fd == -1)
     {
-      g_info ("Unable to open path %s to %s: %s",
-              path, export_mode_to_verb (mode), g_strerror (errno));
+      int saved_errno = errno;
+
+      /* Intentionally using G_IO_ERROR_NOT_FOUND even if errno is
+       * something different, so callers can suppress the warning in this
+       * relatively likely and uninteresting case: we don't particularly
+       * care whether this is happening as a result of ENOENT or EACCES
+       * or any other reason. */
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   _("Unable to open path \"%s\": %s"),
+                   path, g_strerror (saved_errno));
       return FALSE;
     }
 
   if (fstat (o_path_fd, &st) != 0)
-    {
-      g_info ("Unable to get file type of %s: %s", path, g_strerror (errno));
-      return FALSE;
-    }
+    return glnx_throw (error,
+                       _("Unable to get file type of \"%s\": %s"),
+                       path, g_strerror (errno));
 
   /* Don't expose weird things */
   if (!(S_ISDIR (st.st_mode) ||
         S_ISREG (st.st_mode) ||
         S_ISLNK (st.st_mode) ||
         S_ISSOCK (st.st_mode)))
-    {
-      g_info ("%s has unsupported file type 0o%o", path, st.st_mode & S_IFMT);
-      return FALSE;
-    }
+    return glnx_throw (error,
+                       _("File \"%s\" has unsupported type 0o%o"),
+                       path, st.st_mode & S_IFMT);
 
   /* O_PATH + fstatfs is the magic that we need to statfs without automounting the target */
   if (fstatfs (o_path_fd, &stfs) != 0)
-    {
-      g_info ("Unable to get filesystem information for %s: %s",
-              path, g_strerror (errno));
-      return FALSE;
-    }
+    return glnx_throw (error,
+                       _("Unable to get filesystem information for \"%s\": %s"),
+                       path, g_strerror (errno));
 
   if (stfs.f_type == AUTOFS_SUPER_MAGIC ||
       (G_UNLIKELY (exports->test_flags & FLATPAK_EXPORTS_TEST_FLAGS_AUTOFS) &&
@@ -939,7 +951,8 @@ _exports_path_expose (FlatpakExports *exports,
     {
       if (!check_if_autofs_works (exports, path))
         {
-          g_info ("ignoring blocking autofs path %s", path);
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK,
+                       _("Ignoring blocking autofs path \"%s\""), path);
           return FALSE;
         }
     }
@@ -954,17 +967,22 @@ _exports_path_expose (FlatpakExports *exports,
          create the parents for them anyway */
       if (flatpak_has_path_prefix (path, dont_export_in[i]))
         {
-          g_info ("skipping export for path %s in unsupported prefix", path);
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_MOUNTABLE_FILE,
+                       _("Path \"%s\" is reserved by Flatpak"),
+                       dont_export_in[i]);
           return FALSE;
         }
     }
 
   for (i = 0; flatpak_abs_usrmerged_dirs[i] != NULL; i++)
     {
-      /* Same as /usr, but for the directories that get merged into /usr */
+      /* Same as /usr, but for the directories that get merged into /usr.
+       * Keep the translatable string here the same as the one above */
       if (flatpak_has_path_prefix (path, flatpak_abs_usrmerged_dirs[i]))
         {
-          g_info ("skipping export for path %s in a /usr-merged directory", path);
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_MOUNTABLE_FILE,
+                       _("Path \"%s\" is reserved by Flatpak"),
+                       flatpak_abs_usrmerged_dirs[i]);
           return FALSE;
         }
     }
@@ -988,8 +1006,8 @@ _exports_path_expose (FlatpakExports *exports,
         }
       else
         {
-          g_autoptr(GError) error = NULL;
-          g_autofree char *resolved = flatpak_exports_resolve_link_in_host (exports, path, &error);
+          g_autoptr(GError) local_error = NULL;
+          g_autofree char *resolved = flatpak_exports_resolve_link_in_host (exports, path, &local_error);
           g_autofree char *new_target = NULL;
 
           if (resolved)
@@ -1003,7 +1021,7 @@ _exports_path_expose (FlatpakExports *exports,
 
               g_debug ("Trying to export the target instead: %s", new_target);
 
-              if (_exports_path_expose (exports, mode, new_target, level + 1))
+              if (_exports_path_expose (exports, mode, new_target, level + 1, &local_error))
                 {
                   do_export_path (exports, path, FAKE_MODE_SYMLINK);
                   return TRUE;
@@ -1011,12 +1029,14 @@ _exports_path_expose (FlatpakExports *exports,
 
               g_debug ("Could not export target %s, so ignoring %s",
                        new_target, path);
+              g_propagate_error (error, g_steal_pointer (&local_error));
               return FALSE;
             }
           else
             {
-              g_debug ("%s is a symlink but we were unable to resolve it: %s",
-                       path, error->message);
+              g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                           _("Unable to resolve symbolic link \"%s\": %s"),
+                           path, local_error->message);
               return FALSE;
             }
         }
@@ -1035,16 +1055,25 @@ flatpak_exports_add_path_expose (FlatpakExports       *exports,
                                  FlatpakFilesystemMode mode,
                                  const char           *path)
 {
+  g_autoptr(GError) local_error = NULL;
+
   g_return_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE);
   g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
-  _exports_path_expose (exports, mode, path, 0);
+
+  if (!_exports_path_expose (exports, mode, path, 0, &local_error))
+    g_debug ("Unable to %s: \"%s\": %s",
+             export_mode_to_verb (mode), path, local_error->message);
 }
 
 void
 flatpak_exports_add_path_tmpfs (FlatpakExports *exports,
                                 const char     *path)
 {
-  _exports_path_expose (exports, FAKE_MODE_TMPFS, path, 0);
+  g_autoptr(GError) local_error = NULL;
+
+  if (!_exports_path_expose (exports, FAKE_MODE_TMPFS, path, 0, &local_error))
+    g_debug ("Unable to %s: \"%s\": %s",
+             export_mode_to_verb (FAKE_MODE_TMPFS), path, local_error->message);
 }
 
 void
@@ -1065,7 +1094,11 @@ void
 flatpak_exports_add_path_dir (FlatpakExports *exports,
                               const char     *path)
 {
-  _exports_path_expose (exports, FAKE_MODE_DIR, path, 0);
+  g_autoptr(GError) local_error = NULL;
+
+  if (!_exports_path_expose (exports, FAKE_MODE_DIR, path, 0, &local_error))
+    g_debug ("Unable to %s: \"%s\": %s",
+             export_mode_to_verb (FAKE_MODE_DIR), path, local_error->message);
 }
 
 void

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -56,6 +56,8 @@ const char *dont_export_in[] = {
   "/dev",
   "/etc",
   "/proc",
+  "/run/flatpak",
+  "/run/host",
   "/usr",
   NULL
 };

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1266,6 +1266,8 @@ static const struct
 }
 reserved_filesystems[] =
 {
+  { "/", "/.flatpak-info" },
+  { "/.flatpak-info", "/.flatpak-info" },
   { "/app", "/app" },
   { "/app/foo", "/app" },
   { "/bin", "/bin" },
@@ -1280,6 +1282,9 @@ reserved_filesystems[] =
   { "/proc", "/proc" },
   { "/proc/1", "/proc" },
   { "/proc/sys/net", "/proc" },
+  { "/run", "/run/flatpak" },
+  { "/run/flatpak/foo/bar", "/run/flatpak" },
+  { "/run/host/foo", "/run/host" },
   { "/sbin", "/sbin" },
   { "/sbin/ldconfig", "/sbin" },
   { "/usr", "/usr" },

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1360,6 +1360,7 @@ test_exports_unusual (void)
     { "home", FAKE_SYMLINK, "var/home" },
     { "lib", FAKE_SYMLINK, "usr/lib" },
     { "recursion", FAKE_SYMLINK, "recursion" },
+    { "symlink-to-root", FAKE_SYMLINK, "." },
     { "tmp", FAKE_SYMLINK, "TMP" },
     { "usr/bin", FAKE_DIR },
     { "usr/lib", FAKE_DIR },
@@ -1414,6 +1415,14 @@ test_exports_unusual (void)
                                         "/recursion", &error);
   g_assert_error (error, G_IO_ERROR, G_IO_ERROR_TOO_MANY_LINKS);
   g_test_message ("attempting to export /recursion: %s", error->message);
+  g_assert_false (ok);
+  g_clear_error (&error);
+
+  ok = flatpak_exports_add_path_expose (exports,
+                                        FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                        "/symlink-to-root", &error);
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_MOUNTABLE_FILE);
+  g_test_message ("attempting to export /symlink-to-root: %s", error->message);
   g_assert_false (ok);
   g_clear_error (&error);
 


### PR DESCRIPTION
If we try to share certain reserved directories with the sandbox, that can break our ability to set up sandbox-specific things: the app in `/app`, the runtime in `/usr` and `/etc`, OS stuff in `/dev` and `/proc`, and Flatpak-specific information in `/.flatpak-info`, `/run/flatpak` and `/run/host`.

Previously, we would silently prevent descendants of most of these paths from being shared (#5035). We still prevent that, but now there is a warning so that users will be less mystified.

We did not previously prevent descendants of `/.flatpak-info`, `/run/flatpak` and `/run/host` from being shared, but now those three have joined the list.

We also did not previously prevent *ancestors* of the reserved paths from being shared, which in practice manifested in two ways: a symlink like `/the-root -> /` or `/the-root -> .` would prevent apps from being run successfully with `--filesystem=host` or `--filesystem=/the-root` (#1357), and `--filesystem=/run` would also fail. Now, both are prevented, with a warning in all cases except `--filesystem=host`:

```
F: Not sharing "/run" with sandbox: Path "/run/flatpak" is reserved by Flatpak
F: Not sharing "/the-root" with sandbox: Path "/.flatpak-info" is reserved by Flatpak
```

For `--filesystem=host` it seemed better for unsuitable top-level objects to be rejected silently (other than debug messages), so that there isn't a lot of noise for directories like `/bin`, `/lib`, `/libx32` or merged-/usr compat symlinks like `/bin -> usr/bin`, `/lib -> usr/lib`, `/libx32 -> usr/libx32`.

---

* exports, context: List unexported paths one per line in sorted order
    
    This will reduce conflicts when new entries are added.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Never try to export paths below /run/flatpak or /run/host
    
    These directories are reserved for Flatpak's own use.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Never try to export /.flatpak-info
    
    Just for completeness, in practice the host system will not have this.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Make _exports_path_expose produce a GError on failure
    
    This is a step towards allowing its direct and indirect callers to decide
    how serious the failure is, and debug or warn accordingly.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Move error handling up into caller
    
    This lets flatpak_context_export() or other callers decide how they want
    to handle failure to export each path. For now, the callers in
    FlatpakExports are still using g_debug() unconditionally, but we can now
    have somewhat better test coverage.
    
    Helps: https://github.com/flatpak/flatpak/issues/1357
    Helps: https://github.com/flatpak/flatpak/issues/5035
    Helps: https://github.com/flatpak/flatpak/issues/5205
    Helps: https://github.com/flatpak/flatpak/issues/5207

* context: Show a warning when --filesystem exists but can't be shared
    
    If the user gives us a override or command-line argument that we cannot
    obey, like --filesystem=/usr/share/whatever or
    --filesystem=/run/flatpak/whatever, then it's confusing that we silently
    ignore it. We should give them an opportunity to see that their override
    was ineffective.
    
    However, there are a few situations where we still want to keep quiet.
    If there is a --filesystem argument for something that simply doesn't
    exist, we don't diagnose the failure to share it: that avoids creating
    unnecessary noise for apps that opportunistically share locations that
    might or might not exist, like the way the Steam app on Flathub asks
    for access to $XDG_RUNTIME_DIR/app/com.discordapp.Discord.
    
    Similarly, if we have been asked for --filesystem=host, the root
    directory is very likely to contain symlinks into a reserved path, like
    /lib -> usr/lib. We don't need a user-visible warning for that.
    
    We actually use the equivalent of g_message() rather than g_warning(),
    to avoid this being fatal during unit testing (in particular when we
    do a `flatpak info` on an app that has never been run, which will
    be unable to share its `.var/app` subdirectory). `app/flatpak-main.c`
    currently displays them as equivalent to each other anyway.

* context: Show a warning if we cannot provide any $HOME
    
    If $HOME is below a reserved path (for example `/usr/home/thompson`
    for Unix traditionalists) or otherwise cannot be shared, or is a
    symbolic link to somewhere that cannot be shared, then we will end
    up running the app with $HOME not existing. This is unexpected, so
    we should make more noise about it.
    
    There are two situations here, both of which get a warning: if we have
    --filesystem=home or --filesystem=host then we are trying to share the
    real $HOME with the application, and if we do not, then we are trying
    to create a directory at the location of the real $HOME and replicate
    the chain of symlinks (if any) leading from $HOME to that location.
    
    Unlike the previous commit, this is not expected to happen during unit
    testing, so we do not use a g_warning() for this.
    
    Diagnoses: https://github.com/flatpak/flatpak/issues/5035

* exports: Don't export parent or ancestor of reserved directories
    
    Previously, --filesystem=/run would prevent apps from starting by
    breaking our ability to set up /run/flatpak and /run/host. Now it is
    ignored, with a diagnostic message, resolving #5205 and #5207.
    
    Similarly, --filesystem=/symlink-to-root (or --filesystem=host) would
    have prevented apps from starting if a symlink like
    `/symlink-to-root -> /` or `/symlink-to-root -> .` exists, and refusing
    to export the target of that symlink avoids that failure mode,
    resolving #1357.
    
    Resolves: https://github.com/flatpak/flatpak/issues/1357
    Resolves: https://github.com/flatpak/flatpak/issues/5205
    Resolves: https://github.com/flatpak/flatpak/issues/5207

* exports: Assert that recently-excluded paths are excluded
    
    Reproduces: https://github.com/flatpak/flatpak/issues/5205
    Reproduces: https://github.com/flatpak/flatpak/issues/5207

* exports: Test that a symlink to the root directory is rejected
    
    Reproduces: https://github.com/flatpak/flatpak/issues/1357