### PR TITLE
selinux: Install when using meson

### DIFF
--- a/selinux/meson.build
+++ b/selinux/meson.build
@@ -11,6 +11,7 @@ custom_target(
     '@OUTPUT0@',
     '@INPUT@',
   ],
+  install : true,
   install_dir : get_option('datadir') / 'selinux' / 'packages',
 )
 

--- a/selinux/meson.build
+++ b/selinux/meson.build
@@ -17,5 +17,5 @@ custom_target(
 
 install_data(
   'flatpak.if',
-  install_dir : get_option('datadir') / 'selinux' / 'include' / 'contrib',
+  install_dir : get_option('datadir') / 'selinux' / 'devel' / 'include' / 'contrib',
 )


### PR DESCRIPTION
With custom_target, providing build_by_default is not enough to install the output, which must be explicitly requested.