### PR TITLE
main: Treat g_info() as equivalent to g_debug()

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -358,12 +358,12 @@ flatpak_option_context_parse (GOptionContext     *context,
   else
     {
       if (opt_verbose > 0)
-        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
       if (opt_verbose > 1)
-        g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+        g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
       if (opt_ostree_verbose)
-        g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+        g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
       if (opt_verbose > 0 || opt_ostree_verbose)
         flatpak_disable_fancy_output ();

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -692,7 +692,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -765,7 +765,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   g_debug ("Started flatpak-authenticator");
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -2967,7 +2967,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -3037,7 +3037,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   client_pid_data_hash = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) pid_data_free);
 

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -680,7 +680,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -826,7 +826,7 @@ main (int    argc,
     }
 
   if (verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   client_pid_data_hash = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) pid_data_free);
 

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -2289,7 +2289,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("FH: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -2373,12 +2373,12 @@ main (int    argc,
   flatpak_disable_fancy_output ();
 
   if (opt_verbose > 0)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
   if (opt_verbose > 1)
-    g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   if (opt_ostree_verbose)
-    g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   if (!on_session_bus)
     {

--- a/tests/test-authenticator.c
+++ b/tests/test-authenticator.c
@@ -322,7 +322,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -372,7 +372,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   g_debug ("Started test-authenticator");
 


### PR DESCRIPTION
* main: Treat g_info() as equivalent to g_debug()
    
    This makes us consistent with the default behaviour of GLib, and
    its behaviour with G_MESSAGES_DEBUG=all. g_debug() and g_info() are
    the two lowest priority levels, and GLib normally silences them by
    default.
    
    At the moment, Flatpak uses G_LOG_LEVEL_DEBUG in the flatpak2 domain
    as its lowest-priority log level (only shown with flatpak -v -v), and
    G_LOG_LEVEL_DEBUG in the flatpak domain as its second-lowest
    (shown with flatpak -v or higher). I want to move towards using
    G_LOG_LEVEL_INFO for flatpak -v messages, and G_LOG_LEVEL_DEBUG for
    flapak -v -v, so that we don't need a second log domain: this is a
    policy I've used successfully in Flatpak-derived Steam Runtime code.
    
    This change does not fully implement that policy, but gives us a
    migration path towards it, by allowing us to start using g_info() for
    flatpak -v messages.
    
    Helps: https://github.com/flatpak/flatpak/issues/5001

* daemons: Treat g_info() as equivalent to g_debug()
    
    Same as the previous commit, but for anything that runs in the
    background.

---

I want this as a starting point for #5001, but I've written this first so that I can already use `G_LOG_LEVEL_INFO` in #5213.

To test, apply this:

```diff
diff --git a/app/flatpak-builtins-ps.c b/app/flatpak-builtins-ps.c
index dd6d4686..4015f565 100644
--- a/app/flatpak-builtins-ps.c
+++ b/app/flatpak-builtins-ps.c
@@ -253,6 +253,10 @@ flatpak_builtin_ps (int           argc,
       return FALSE;
     }
 
+  g_info ("info");
+  g_debug ("debug");
+  flatpak_debug2 ("debug2");
+
   columns = handle_column_args (all_columns, FALSE, opt_cols, error);
   if (columns == NULL)
     return FALSE;
```

and run `flatpak ps`, `flatpak ps -v`, `flatpak ps -v -v`. The expected result is that `debug2` only appears with `-v -v`, `info` appears with at least `-v`, and the status of `debug` is going to change during #5001 but at the moment it appears with at least `-v`.