### PR TITLE
Use g_info() for --verbose messages

### DIFF
--- a/app/flatpak-builtins-build-commit-from.c
+++ b/app/flatpak-builtins-build-commit-from.c
@@ -719,7 +719,7 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
           {
             g_autoptr(GError) local_error = NULL;
             if (!rewrite_delta (src_repo, resolved_ref, dst_repo, commit_checksum, dst_commitv, from[j], &local_error))
-              g_debug ("Failed to copy delta: %s", local_error->message);
+              g_info ("Failed to copy delta: %s", local_error->message);
           }
       }
     }
@@ -738,7 +738,7 @@ flatpak_builtin_build_commit_from (int argc, char **argv, GCancellable *cancella
       if (opt_no_summary_index)
         flags |= FLATPAK_REPO_UPDATE_FLAG_DISABLE_INDEX;
 
-      g_debug ("Updating summary");
+      g_info ("Updating summary");
       if (!flatpak_repo_update (dst_repo, flags,
                                 (const char **) opt_gpg_key_ids,
                                 opt_gpg_homedir,

--- a/app/flatpak-builtins-build-export.c
+++ b/app/flatpak-builtins-build-export.c
@@ -208,7 +208,7 @@ commit_filter (OstreeRepo *repo,
   if (matches_patterns (commit_data->exclude, path) &&
       !matches_patterns (commit_data->include, path))
     {
-      g_debug ("Excluding %s", path);
+      g_info ("Excluding %s", path);
       return OSTREE_REPO_COMMIT_FILTER_SKIP;
     }
 
@@ -395,13 +395,13 @@ validate_icon_file (GFile *file, GError **error)
                      G_SPAWN_STDOUT_TO_DEV_NULL,
                      NULL, NULL, NULL, &err, &status, error))
     {
-      g_debug ("Icon validation: %s", (*error)->message);
+      g_info ("Icon validation: %s", (*error)->message);
       return FALSE;
     }
 
   if (!g_spawn_check_exit_status (status, NULL))
     {
-      g_debug ("Icon validation: %s", err);
+      g_info ("Icon validation: %s", err);
       return flatpak_fail (error, "%s is not a valid icon: %s", name, err);
     }
 
@@ -1151,7 +1151,7 @@ flatpak_builtin_build_export (int argc, char **argv, GCancellable *cancellable, 
       if (opt_no_summary_index)
         flags |= FLATPAK_REPO_UPDATE_FLAG_DISABLE_INDEX;
 
-      g_debug ("Updating summary");
+      g_info ("Updating summary");
       if (!flatpak_repo_update (repo, flags,
                                 (const char **) opt_gpg_key_ids,
                                 opt_gpg_homedir,

--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -175,7 +175,7 @@ export_dir (int           source_parent_fd,
       else
         {
           source_printable = g_build_filename (source_relpath, dent->d_name, NULL);
-          g_debug ("Not exporting non-regular file %s", source_printable);
+          g_info ("Not exporting non-regular file %s", source_printable);
         }
     }
 
@@ -265,7 +265,7 @@ collect_exports (GFile          *base,
 
       if (g_file_query_exists (src, cancellable))
         {
-          g_debug ("Exporting from %s", path);
+          g_info ("Exporting from %s", path);
           g_autoptr(GFile) dest = NULL;
           g_autoptr(GFile) dest_parent = NULL;
 
@@ -275,10 +275,10 @@ collect_exports (GFile          *base,
             dest = g_file_resolve_relative_path (export, path);
 
           dest_parent = g_file_get_parent (dest);
-          g_debug ("Ensuring export/%s parent exists", path);
+          g_info ("Ensuring export/%s parent exists", path);
           if (!flatpak_mkdir_p (dest_parent, cancellable, error))
             return FALSE;
-          g_debug ("Copying from files/%s", path);
+          g_info ("Copying from files/%s", path);
           if (!copy_exports (src,
                              dest,
                              path,
@@ -401,14 +401,14 @@ update_metadata (GFile *base, FlatpakContext *arg_context, gboolean is_runtime, 
     {
       if (g_key_file_has_key (keyfile, group, FLATPAK_METADATA_KEY_COMMAND, NULL))
         {
-          g_debug ("Command key is present");
+          g_info ("Command key is present");
 
           if (opt_command)
             g_key_file_set_string (keyfile, group, FLATPAK_METADATA_KEY_COMMAND, opt_command);
         }
       else if (opt_command)
         {
-          g_debug ("Using explicitly provided command %s", opt_command);
+          g_info ("Using explicitly provided command %s", opt_command);
 
           g_key_file_set_string (keyfile, group, FLATPAK_METADATA_KEY_COMMAND, opt_command);
         }
@@ -419,7 +419,7 @@ update_metadata (GFile *base, FlatpakContext *arg_context, gboolean is_runtime, 
           g_autoptr(GFileEnumerator) bin_enum = NULL;
           g_autoptr(GFileInfo) child_info = NULL;
 
-          g_debug ("Looking for executables");
+          g_info ("Looking for executables");
 
           bin_dir = g_file_resolve_relative_path (base, "files/bin");
           if (g_file_query_exists (bin_dir, cancellable))
@@ -687,12 +687,12 @@ flatpak_builtin_build_finish (int argc, char **argv, GCancellable *cancellable, 
 
   if (!is_runtime)
     {
-      g_debug ("Collecting exports");
+      g_info ("Collecting exports");
       if (!collect_exports (base, id, arg_context, cancellable, error))
         return FALSE;
     }
 
-  g_debug ("Updating metadata");
+  g_info ("Updating metadata");
   if (!update_metadata (base, arg_context, is_runtime, cancellable, error))
     return FALSE;
 

--- a/app/flatpak-builtins-build-import-bundle.c
+++ b/app/flatpak-builtins-build-import-bundle.c
@@ -248,7 +248,7 @@ flatpak_builtin_build_import (int argc, char **argv, GCancellable *cancellable, 
       if (opt_no_summary_index)
         flags |= FLATPAK_REPO_UPDATE_FLAG_DISABLE_INDEX;
 
-      g_debug ("Updating summary");
+      g_info ("Updating summary");
       if (!flatpak_repo_update (repo, flags,
                                 (const char **) opt_gpg_key_ids,
                                 opt_gpg_homedir,

--- a/app/flatpak-builtins-build-update-repo.c
+++ b/app/flatpak-builtins-build-update-repo.c
@@ -400,7 +400,7 @@ generate_all_deltas (OstreeRepo   *repo,
 
       if (ignore_ref)
         {
-          g_debug ("Ignoring deltas for ref %s", ref);
+          g_info ("Ignoring deltas for ref %s", ref);
           continue;
         }
 

--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -111,7 +111,7 @@ add_related (GHashTable        *all_refs,
   g_autofree char *branch = NULL;
   GList *extensions, *l;
 
-  g_debug ("Finding related refs for ‘%s’", flatpak_decomposed_get_ref (ref));
+  g_info ("Finding related refs for ‘%s’", flatpak_decomposed_get_ref (ref));
 
   arch = flatpak_decomposed_dup_arch (ref);
   branch = flatpak_decomposed_dup_branch (ref);
@@ -228,7 +228,7 @@ add_runtime (GHashTable        *all_refs,
   CommitAndSubpaths *c_s;
   g_autoptr(GVariant) extra_data_sources = NULL;
 
-  g_debug ("Finding the runtime for ‘%s’", flatpak_decomposed_get_ref (ref));
+  g_info ("Finding the runtime for ‘%s’", flatpak_decomposed_get_ref (ref));
 
   deploy_data = flatpak_dir_get_deploy_data (dir, ref, FLATPAK_DEPLOY_VERSION_ANY, cancellable, error);
   if (deploy_data == NULL)
@@ -316,7 +316,7 @@ ostree_create_usb (GOptionContext *context,
    * more performant than bare-user */
   OstreeRepoMode mode = OSTREE_REPO_MODE_ARCHIVE;
 
-  g_debug ("%s: Creating repository in mode %u", G_STRFUNC, mode);
+  g_info ("%s: Creating repository in mode %u", G_STRFUNC, mode);
   g_autoptr(OstreeRepo) dest_repo = ostree_repo_create_at (mount_root_dfd, dest_repo_path,
                                                            mode, NULL, cancellable, error);
 
@@ -785,7 +785,7 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
             else
               {
                 /* Appstream2 is only for efficiency, so just print a debug message */
-                g_debug (_("Couldn't find appstream2 data for remote ‘%s’ arch ‘%s’: %s\n"),
+                g_info (_("Couldn't find appstream2 data for remote ‘%s’ arch ‘%s’: %s\n"),
                          remote_name, current_arch, appstream2_error->message);
               }
           }
@@ -814,7 +814,7 @@ flatpak_builtin_create_usb (int argc, char **argv, GCancellable *cancellable, GE
 
       g_string_append_printf (all_refs_str, "(%s, %s) ", collection_ref->collection_id, collection_ref->ref_name);
     }
-    g_debug ("Copying the following refs: %s", all_refs_str->str);
+    g_info ("Copying the following refs: %s", all_refs_str->str);
 
     if (!ostree_create_usb (context, src_repo, mount_root_path, mount_root_stbuf,
                             mount_root_dfd, all_refs, cancellable, error))

--- a/app/flatpak-builtins-kill.c
+++ b/app/flatpak-builtins-kill.c
@@ -62,7 +62,7 @@ kill_instance (const char *id,
         }
     }
 
-  g_debug ("Killed %d instances", killed);
+  g_info ("Killed %d instances", killed);
 
   if (killed == 0)
     return flatpak_fail (error, _("%s is not running"), id);

--- a/app/flatpak-builtins-ps.c
+++ b/app/flatpak-builtins-ps.c
@@ -108,7 +108,7 @@ get_compositor_apps (void)
   if (ret)
     g_variant_get (ret, "(@a{sv})", &list);
   else
-    g_debug ("Failed to get information about running apps from background portal backends");
+    g_info ("Failed to get information about running apps from background portal backends");
 
   return list;
 }

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -285,8 +285,8 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
           if (bundle == NULL || as_bundle_get_id (bundle) == NULL ||
               (decomposed = flatpak_decomposed_new_from_ref (as_bundle_get_id (bundle), NULL)) == NULL)
             {
-              g_debug ("Ignoring app %s from remote %s as it lacks a flatpak bundle",
-                       as_component_get_id (app), remote_name);
+              g_info ("Ignoring app %s from remote %s as it lacks a flatpak bundle",
+                      as_component_get_id (app), remote_name);
               continue;
             }
 

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -180,8 +180,8 @@ confirm_runtime_removal (gboolean           yes_opt,
                                                                &udir->extension_app_map,
                                                                ref, NULL, &local_error);
       if (apps == NULL)
-        g_debug ("Unable to list apps using extension %s: %s\n",
-                 flatpak_decomposed_get_ref (ref), local_error->message);
+        g_info ("Unable to list apps using extension %s: %s\n",
+                flatpak_decomposed_get_ref (ref), local_error->message);
     }
   else
     {
@@ -189,8 +189,8 @@ confirm_runtime_removal (gboolean           yes_opt,
                                                      &udir->runtime_app_map,
                                                      ref, NULL, &local_error);
       if (apps == NULL)
-        g_debug ("Unable to list apps using runtime %s: %s\n",
-                 flatpak_decomposed_get_ref (ref), local_error->message);
+        g_info ("Unable to list apps using runtime %s: %s\n",
+                flatpak_decomposed_get_ref (ref), local_error->message);
     }
 
   if (apps == NULL || apps->len == 0)

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -677,11 +677,11 @@ update_appstream (GPtrArray    *dirs,
               ts_file_age = get_appstream_timestamp (dir, remotes[i], arch);
               if (ts_file_age < ttl)
                 {
-                  g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, remotes[i], arch, ts_file_age, ttl);
+                  g_info ("%s:%s appstream age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, remotes[i], arch, ts_file_age, ttl);
                   continue;
                 }
               else
-                g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, remotes[i], arch, ts_file_age, ttl);
+                g_info ("%s:%s appstream age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, remotes[i], arch, ts_file_age, ttl);
 
               if (flatpak_dir_get_remote_disabled (dir, remotes[i]) ||
                   flatpak_dir_get_remote_noenumerate (dir, remotes[i]))
@@ -690,7 +690,7 @@ update_appstream (GPtrArray    *dirs,
               if (flatpak_dir_is_user (dir))
                 {
                   if (quiet)
-                    g_debug (_("Updating appstream data for user remote %s"), remotes[i]);
+                    g_info (_("Updating appstream data for user remote %s"), remotes[i]);
                   else
                     {
                       g_print (_("Updating appstream data for user remote %s"), remotes[i]);
@@ -700,7 +700,7 @@ update_appstream (GPtrArray    *dirs,
               else
                 {
                   if (quiet)
-                    g_debug (_("Updating appstream data for remote %s"), remotes[i]);
+                    g_info (_("Updating appstream data for remote %s"), remotes[i]);
                   else
                     {
                       g_print (_("Updating appstream data for remote %s"), remotes[i]);
@@ -711,7 +711,7 @@ update_appstream (GPtrArray    *dirs,
                                                  NULL, cancellable, &local_error))
                 {
                   if (quiet)
-                    g_debug ("%s: %s", _("Error updating"), local_error->message);
+                    g_info ("%s: %s", _("Error updating"), local_error->message);
                   else
                     g_printerr ("%s: %s\n", _("Error updating"), local_error->message);
                 }
@@ -735,11 +735,11 @@ update_appstream (GPtrArray    *dirs,
               ts_file_age = get_appstream_timestamp (dir, remote, arch);
               if (ts_file_age < ttl)
                 {
-                  g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, remote, arch, ts_file_age, ttl);
+                  g_info ("%s:%s appstream age %" G_GUINT64_FORMAT " is less than ttl %" G_GUINT64_FORMAT, remote, arch, ts_file_age, ttl);
                   continue;
                 }
               else
-                g_debug ("%s:%s appstream age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, remote, arch, ts_file_age, ttl);
+                g_info ("%s:%s appstream age %" G_GUINT64_FORMAT " is greater than ttl %" G_GUINT64_FORMAT, remote, arch, ts_file_age, ttl);
 
               if (!flatpak_dir_update_appstream (dir, remote, arch, &changed,
                                                  NULL, cancellable, error))

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -841,8 +841,8 @@ find_reverse_dep_apps (FlatpakTransaction *transaction,
                                                                ref, NULL, &local_error);
       if (apps == NULL)
         {
-          g_debug ("Unable to list apps using extension %s: %s\n",
-                   flatpak_decomposed_get_ref (ref), local_error->message);
+          g_info ("Unable to list apps using extension %s: %s\n",
+                  flatpak_decomposed_get_ref (ref), local_error->message);
           return NULL;
         }
     }
@@ -853,8 +853,8 @@ find_reverse_dep_apps (FlatpakTransaction *transaction,
                                                      NULL, &local_error);
       if (apps == NULL)
         {
-          g_debug ("Unable to find apps using runtime %s: %s\n",
-                   flatpak_decomposed_get_ref (ref), local_error->message);
+          g_info ("Unable to find apps using runtime %s: %s\n",
+                  flatpak_decomposed_get_ref (ref), local_error->message);
           return NULL;
         }
     }
@@ -975,7 +975,7 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
     }
   else
     {
-      g_debug ("%s is end-of-life, using action from parent ref", name);
+      g_info ("%s is end-of-life, using action from parent ref", name);
     }
 
   /* Cache for later comparison and reuse */

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -611,7 +611,7 @@ install_polkit_agent (void)
 
   if (bus == NULL)
     {
-      g_debug ("Unable to connect to system bus: %s", local_error->message);
+      g_info ("Unable to connect to system bus: %s", local_error->message);
       return NULL;
     }
 
@@ -619,7 +619,7 @@ install_polkit_agent (void)
   listener = flatpak_polkit_agent_text_listener_new (NULL, &local_error);
   if (listener == NULL)
     {
-      g_debug ("Failed to create polkit agent listener: %s", local_error->message);
+      g_info ("Failed to create polkit agent listener: %s", local_error->message);
     }
   else
     {
@@ -643,7 +643,7 @@ install_polkit_agent (void)
                                                            &local_error);
       if (agent == NULL)
         {
-          g_debug ("Failed to register polkit agent listener: %s", local_error->message);
+          g_info ("Failed to register polkit agent listener: %s", local_error->message);
         }
       g_object_unref (listener);
     }

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -358,9 +358,9 @@ flatpak_option_context_parse (GOptionContext     *context,
   else
     {
       if (opt_verbose > 0)
-        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, message_handler, NULL);
       if (opt_verbose > 1)
-        g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
 
       if (opt_ostree_verbose)
         g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -372,7 +372,7 @@ flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
 
   fd = glnx_steal_fd (&args_tmpf.fd);
 
-  flatpak_debug2 ("bwrap --args %d = ...", fd);
+  g_debug ("bwrap --args %d = ...", fd);
 
   for (i = start; i < end; i++)
     {
@@ -380,11 +380,11 @@ flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
         {
           g_autofree char *quoted = g_shell_quote (bwrap->argv->pdata[i]);
 
-          flatpak_debug2 ("    %s", quoted);
+          g_debug ("    %s", quoted);
         }
       else
         {
-          flatpak_debug2 ("    %s", (const char *) bwrap->argv->pdata[i]);
+          g_debug ("    %s", (const char *) bwrap->argv->pdata[i]);
         }
     }
 

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1613,7 +1613,7 @@ flatpak_context_load_metadata (FlatpakContext *context,
 
           share = flatpak_context_share_from_string (parse_negated (shares[i], &remove), NULL);
           if (share == 0)
-            g_debug ("Unknown share type %s", shares[i]);
+            g_info ("Unknown share type %s", shares[i]);
           else
             {
               if (remove)
@@ -1635,7 +1635,7 @@ flatpak_context_load_metadata (FlatpakContext *context,
         {
           FlatpakContextSockets socket = flatpak_context_socket_from_string (parse_negated (sockets[i], &remove), NULL);
           if (socket == 0)
-            g_debug ("Unknown socket type %s", sockets[i]);
+            g_info ("Unknown socket type %s", sockets[i]);
           else
             {
               if (remove)
@@ -1658,7 +1658,7 @@ flatpak_context_load_metadata (FlatpakContext *context,
         {
           FlatpakContextDevices device = flatpak_context_device_from_string (parse_negated (devices[i], &remove), NULL);
           if (device == 0)
-            g_debug ("Unknown device type %s", devices[i]);
+            g_info ("Unknown device type %s", devices[i]);
           else
             {
               if (remove)
@@ -1681,7 +1681,7 @@ flatpak_context_load_metadata (FlatpakContext *context,
         {
           FlatpakContextFeatures feature = flatpak_context_feature_from_string (parse_negated (features[i], &remove), NULL);
           if (feature == 0)
-            g_debug ("Unknown feature type %s", features[i]);
+            g_info ("Unknown feature type %s", features[i]);
           else
             {
               if (remove)
@@ -1707,7 +1707,7 @@ flatpak_context_load_metadata (FlatpakContext *context,
 
           if (!flatpak_context_parse_filesystem (fs, remove,
                                                  &filesystem, &mode, NULL))
-            g_debug ("Unknown filesystem type %s", filesystems[i]);
+            g_info ("Unknown filesystem type %s", filesystems[i]);
           else
             {
               g_assert (mode == FLATPAK_FILESYSTEM_MODE_NONE || !remove);
@@ -2463,7 +2463,7 @@ flatpak_context_export (FlatpakContext *context,
       DIR *dir;
       struct dirent *dirent;
 
-      g_debug ("Allowing host-fs access");
+      g_info ("Allowing host-fs access");
       home_access = TRUE;
 
       /* Bind mount most dirs in / into the new root */
@@ -2500,7 +2500,7 @@ flatpak_context_export (FlatpakContext *context,
   home_mode = GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "home"));
   if (home_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     {
-      g_debug ("Allowing homedir access");
+      g_info ("Allowing homedir access");
       home_access = TRUE;
 
       flatpak_exports_add_path_expose (exports, MAX (home_mode, fs_mode), g_get_home_dir ());
@@ -2535,7 +2535,7 @@ flatpak_context_export (FlatpakContext *context,
               /* xdg-user-dirs sets disabled dirs to $HOME, and its in general not a good
                  idea to set full access to $HOME other than explicitly, so we ignore
                  these */
-              g_debug ("Xdg dir %s is $HOME (i.e. disabled), ignoring", filesystem);
+              g_info ("Xdg dir %s is $HOME (i.e. disabled), ignoring", filesystem);
               continue;
             }
 
@@ -2544,7 +2544,7 @@ flatpak_context_export (FlatpakContext *context,
           if (mode == FLATPAK_FILESYSTEM_MODE_CREATE && do_create)
             {
               if (g_mkdir_with_parents (subpath, 0755) != 0)
-                g_debug ("Unable to create directory %s", subpath);
+                g_info ("Unable to create directory %s", subpath);
             }
 
           if (g_file_test (subpath, G_FILE_TEST_EXISTS))
@@ -2565,7 +2565,7 @@ flatpak_context_export (FlatpakContext *context,
           if (mode == FLATPAK_FILESYSTEM_MODE_CREATE && do_create)
             {
               if (g_mkdir_with_parents (path, 0755) != 0)
-                g_debug ("Unable to create directory %s", path);
+                g_info ("Unable to create directory %s", path);
             }
 
           if (g_file_test (path, G_FILE_TEST_EXISTS))
@@ -2576,7 +2576,7 @@ flatpak_context_export (FlatpakContext *context,
           if (mode == FLATPAK_FILESYSTEM_MODE_CREATE && do_create)
             {
               if (g_mkdir_with_parents (filesystem, 0755) != 0)
-                g_debug ("Unable to create directory %s", filesystem);
+                g_info ("Unable to create directory %s", filesystem);
             }
 
           if (g_file_test (filesystem, G_FILE_TEST_EXISTS))
@@ -2707,7 +2707,7 @@ flatpak_context_append_bwrap_filesystem (FlatpakContext  *context,
           g_autofree char *dest = g_build_filename (g_get_home_dir (), persist, NULL);
 
           if (g_mkdir_with_parents (src, 0755) != 0)
-            g_debug ("Unable to create directory %s", src);
+            g_info ("Unable to create directory %s", src);
 
           flatpak_bwrap_add_bind_arg (bwrap, "--bind", src, dest);
         }

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -431,14 +431,14 @@ flatpak_remote_state_add_sideload_repo (FlatpakRemoteState *self,
           /* We expect to hit this code path when the repo is providing things
            * from other remotes
            */
-          g_debug ("Sideload repo at path %s not valid for remote %s: %s",
-                   flatpak_file_get_path_cached (dir), self->remote_name, local_error->message);
+          g_info ("Sideload repo at path %s not valid for remote %s: %s",
+                  flatpak_file_get_path_cached (dir), self->remote_name, local_error->message);
           flatpak_sideload_state_free (ss);
         }
       else
         {
           g_ptr_array_add (self->sideload_repos, ss);
-          g_debug ("Using sideloaded repo %s for remote %s", flatpak_file_get_path_cached (dir), self->remote_name);
+          g_info ("Using sideloaded repo %s for remote %s", flatpak_file_get_path_cached (dir), self->remote_name);
         }
     }
 }
@@ -809,7 +809,7 @@ flatpak_remote_state_match_subrefs (FlatpakRemoteState *self,
 
   if (self->summary == NULL && self->index == NULL)
     {
-      g_debug ("flatpak_remote_state_match_subrefs with no summary");
+      g_info ("flatpak_remote_state_match_subrefs with no summary");
       return g_ptr_array_new_with_free_func ((GDestroyNotify)flatpak_decomposed_unref);
     }
 
@@ -1644,7 +1644,7 @@ append_locations_from_config_file (GPtrArray    *locations,
 
   if (!g_key_file_load_from_file (keyfile, file_path, G_KEY_FILE_NONE, &my_error))
     {
-      g_debug ("Could not get list of system installations from '%s': %s", file_path, my_error->message);
+      g_info ("Could not get list of system installations from '%s': %s", file_path, my_error->message);
       g_propagate_error (error, g_steal_pointer (&my_error));
       goto out;
     }
@@ -1690,7 +1690,7 @@ append_locations_from_config_file (GPtrArray    *locations,
       path = g_key_file_get_string (keyfile, groups[i], "Path", &my_error);
       if (path == NULL)
         {
-          g_debug ("While reading '%s': Unable to get path for installation '%s': %s", file_path, id, my_error->message);
+          g_info ("While reading '%s': Unable to get path for installation '%s': %s", file_path, id, my_error->message);
           g_propagate_error (error, g_steal_pointer (&my_error));
           goto out;
         }
@@ -1758,7 +1758,7 @@ system_locations_from_configuration (GCancellable *cancellable,
 
   if (!g_file_test (config_dir, G_FILE_TEST_IS_DIR))
     {
-      g_debug ("No installations directory in %s. Skipping", config_dir);
+      g_info ("No installations directory in %s. Skipping", config_dir);
       goto out;
     }
 
@@ -1769,8 +1769,8 @@ system_locations_from_configuration (GCancellable *cancellable,
                                         cancellable, &my_error);
   if (my_error != NULL)
     {
-      g_debug ("Unexpected error retrieving extra installations in %s: %s",
-               config_dir, my_error->message);
+      g_info ("Unexpected error retrieving extra installations in %s: %s",
+              config_dir, my_error->message);
       g_propagate_error (error, g_steal_pointer (&my_error));
       goto out;
     }
@@ -1785,8 +1785,8 @@ system_locations_from_configuration (GCancellable *cancellable,
       if (!g_file_enumerator_iterate (dir_enum, &file_info, &path,
                                       cancellable, &my_error))
         {
-          g_debug ("Unexpected error reading file in %s: %s",
-                   config_dir, my_error->message);
+          g_info ("Unexpected error reading file in %s: %s",
+                  config_dir, my_error->message);
           g_propagate_error (error, g_steal_pointer (&my_error));
           goto out;
         }
@@ -2173,7 +2173,7 @@ flatpak_dir_system_helper_call (FlatpakDir         *self,
       return NULL;
     }
 
-  g_debug ("Calling system helper: %s", method_name);
+  g_info ("Calling system helper: %s", method_name);
   res = g_dbus_connection_call_with_unix_fd_list_sync (self->system_helper_bus,
                                                        FLATPAK_SYSTEM_HELPER_BUS_NAME,
                                                        FLATPAK_SYSTEM_HELPER_PATH,
@@ -2478,7 +2478,7 @@ flatpak_dir_system_helper_call_cancel_pull (FlatpakDir    *self,
   if (flatpak_dir_get_no_interaction (self))
     arg_flags |= FLATPAK_HELPER_CANCEL_PULL_FLAGS_NO_INTERACTION;
 
-  g_debug ("Calling system helper: CancelPull");
+  g_info ("Calling system helper: CancelPull");
 
   g_autoptr(GVariant) ret =
     flatpak_dir_system_helper_call (self, "CancelPull",
@@ -2508,7 +2508,7 @@ flatpak_dir_system_helper_call_get_revokefs_fd (FlatpakDir   *self,
   if (flatpak_dir_get_no_interaction (self))
     arg_flags |= FLATPAK_HELPER_GET_REVOKEFS_FD_FLAGS_NO_INTERACTION;
 
-  g_debug ("Calling system helper: GetRevokefsFd");
+  g_info ("Calling system helper: GetRevokefsFd");
 
   g_autoptr(GVariant) ret =
     flatpak_dir_system_helper_call (self, "GetRevokefsFd",
@@ -3786,7 +3786,7 @@ flatpak_dir_migrate_config (FlatpakDir   *self,
           if (config == NULL)
             config = ostree_repo_copy_config (flatpak_dir_get_repo (self));
 
-          g_debug ("Migrating remote '%s' to gpg-verify-summary", remote);
+          g_info ("Migrating remote '%s' to gpg-verify-summary", remote);
           g_key_file_set_boolean (config, group, "gpg-verify-summary", TRUE);
         }
     }
@@ -3802,7 +3802,7 @@ flatpak_dir_migrate_config (FlatpakDir   *self,
                                                            FLATPAK_HELPER_ENSURE_REPO_FLAGS_NONE,
                                                            installation ? installation : "",
                                                            NULL, &local_error))
-            g_debug ("Failed to migrate system config: %s", local_error->message);
+            g_info ("Failed to migrate system config: %s", local_error->message);
         }
       else
         {
@@ -3912,8 +3912,8 @@ _flatpak_dir_find_new_flatpakrepos (FlatpakDir *self, OstreeRepo *repo)
       if (!g_file_enumerator_iterate (dir_enum, &file_info, &path,
                                       NULL, &my_error))
         {
-          g_debug ("Unexpected error reading file in %s: %s",
-                   config_dir, my_error->message);
+          g_info ("Unexpected error reading file in %s: %s",
+                  config_dir, my_error->message);
           break;
         }
 
@@ -4001,7 +4001,7 @@ apply_new_flatpakrepo (const char *remote_name,
                                           NULL, &imported, NULL, error))
         return FALSE;
 
-      g_debug ("Imported %u GPG key%s to remote \"%s\"", imported, (imported == 1) ? "" : "s", remote_name);
+      g_info ("Imported %u GPG key%s to remote \"%s\"", imported, (imported == 1) ? "" : "s", remote_name);
     }
 
   return TRUE;
@@ -4554,7 +4554,7 @@ remove_old_appstream_tmpdirs (GFile *dir)
       tmp = g_file_get_child (dir, dent->d_name);
 
       /* We ignore errors here, no need to worry anyone */
-      g_debug ("Deleting stale appstream deploy tmpdir %s", flatpak_file_get_path_cached (tmp));
+      g_info ("Deleting stale appstream deploy tmpdir %s", flatpak_file_get_path_cached (tmp));
       (void)flatpak_rm_rf (tmp, NULL, NULL);
     }
 }
@@ -4614,7 +4614,7 @@ remove_old_deploy_tmpdirs (GFile *dir)
       tmp = g_file_get_child (dir, dent->d_name);
 
       /* We ignore errors here, no need to worry anyone */
-      g_debug ("Deleting stale deploy tmpdir %s", flatpak_file_get_path_cached (tmp));
+      g_info ("Deleting stale deploy tmpdir %s", flatpak_file_get_path_cached (tmp));
       (void)flatpak_rm_rf (tmp, NULL, NULL);
     }
 }
@@ -5463,7 +5463,7 @@ repo_pull (OstreeRepo                           *self,
 
       sideload_url = g_file_get_uri (sideload_repo);
 
-      g_debug ("Sideloading %s from %s in pull", ref_to_fetch, sideload_url);
+      g_info ("Sideloading %s from %s in pull", ref_to_fetch, sideload_url);
 
       g_assert (state->collection_id != NULL);
 
@@ -5734,7 +5734,7 @@ flatpak_dir_pull_extra_data (FlatpakDir          *self,
       extra_local_file = flatpak_build_file (base_dir, "extra-data", extra_data_sha256, extra_data_name, NULL);
       if (g_file_query_exists (extra_local_file, cancellable))
         {
-          g_debug ("Loading extra-data from local file %s", flatpak_file_get_path_cached (extra_local_file));
+          g_info ("Loading extra-data from local file %s", flatpak_file_get_path_cached (extra_local_file));
           gsize extra_local_size;
           g_autofree char *extra_local_contents = NULL;
           g_autoptr(GError) my_error = NULL;
@@ -5885,7 +5885,7 @@ flatpak_dir_mirror_oci (FlatpakDir          *self,
 
   flatpak_progress_start_oci_pull (progress);
 
-  g_debug ("Mirroring OCI image %s", oci_digest);
+  g_info ("Mirroring OCI image %s", oci_digest);
 
   res = flatpak_mirror_image_from_oci (dst_registry, registry, oci_repository, oci_digest, state->remote_name, ref, delta_url, self->repo, oci_pull_progress_cb,
                                        progress, cancellable, error);
@@ -5966,7 +5966,7 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
 
   flatpak_progress_start_oci_pull (progress);
 
-  g_debug ("Pulling OCI image %s", oci_digest);
+  g_info ("Pulling OCI image %s", oci_digest);
 
   checksum = flatpak_pull_from_oci (repo, registry, oci_repository, oci_digest, delta_url, FLATPAK_OCI_MANIFEST (versioned), image_config,
                                     state->remote_name, ref, flatpak_flags, oci_pull_progress_cb, progress, cancellable, error);
@@ -5974,7 +5974,7 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
   if (checksum == NULL)
     return FALSE;
 
-  g_debug ("Imported OCI image as checksum %s", checksum);
+  g_info ("Imported OCI image as checksum %s", checksum);
 
   if (repo == self->repo)
     name = flatpak_dir_get_name (self);
@@ -6054,11 +6054,11 @@ flatpak_dir_pull (FlatpakDir                           *self,
       return FALSE;
     }
 
-  g_debug ("%s: Using commit %s for pull of ref %s from remote %s%s%s",
-           G_STRFUNC, rev, ref, state->remote_name,
-           sideload_repo ? "sideloaded from " : "",
-           sideload_repo ? flatpak_file_get_path_cached (sideload_repo) : ""
-           );
+  g_info ("%s: Using commit %s for pull of ref %s from remote %s%s%s",
+          G_STRFUNC, rev, ref, state->remote_name,
+          sideload_repo ? "sideloaded from " : "",
+          sideload_repo ? flatpak_file_get_path_cached (sideload_repo) : ""
+          );
 
   if (repo == NULL)
     repo = self->repo;
@@ -7082,7 +7082,7 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
   if (triggerspath == NULL)
     triggerspath = FLATPAK_TRIGGERDIR;
 
-  g_debug ("running triggers from %s", triggerspath);
+  g_info ("running triggers from %s", triggerspath);
 
   triggersdir = g_file_new_for_path (triggerspath);
 
@@ -7112,7 +7112,7 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
           g_autoptr(FlatpakBwrap) bwrap = NULL;
           g_autofree char *commandline = NULL;
 
-          g_debug ("running trigger %s", name);
+          g_info ("running trigger %s", name);
 
           bwrap = flatpak_bwrap_new (NULL);
 
@@ -7135,7 +7135,7 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
           flatpak_bwrap_finish (bwrap);
 
           commandline = flatpak_quote_argv ((const char **) bwrap->argv->pdata, -1);
-          g_debug ("Running '%s'", commandline);
+          g_info ("Running '%s'", commandline);
 
           /* We use LEAVE_DESCRIPTORS_OPEN to work around dead-lock, see flatpak_close_fds_workaround */
           if (!g_spawn_sync ("/",
@@ -8092,7 +8092,7 @@ extract_extra_data (FlatpakDir   *self,
   if (n_extra_data_sources == 0)
     return TRUE;
 
-  g_debug ("extracting extra data to %s", flatpak_file_get_path_cached (extradir));
+  g_info ("extracting extra data to %s", flatpak_file_get_path_cached (extradir));
 
   if (!ostree_repo_read_commit_detached_metadata (self->repo, checksum, &detached_metadata,
                                                   cancellable, error))
@@ -8348,7 +8348,7 @@ apply_extra_data (FlatpakDir   *self,
 
   flatpak_bwrap_finish (bwrap);
 
-  g_debug ("Running /app/bin/apply_extra ");
+  g_info ("Running /app/bin/apply_extra ");
 
   /* We run the sandbox without caps, but it can still create files owned by itself with
    * arbitrary permissions, including setuid myself. This is extra risky in the case where
@@ -8436,7 +8436,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
    * system-helper, self->source_pid is non-zero. */
   if (self->source_pid == 0 && getuid () == 0)
     {
-      g_debug ("Skipping parental controls check for %s due to running as root", ref);
+      g_info ("Skipping parental controls check for %s due to running as root", ref);
       return TRUE;
     }
 
@@ -8446,7 +8446,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   if (!g_str_has_prefix (ref, "app/"))
     return TRUE;
 
-  g_debug ("Getting parental controls details for %s from %s",
+  g_info ("Getting parental controls details for %s from %s",
            ref, flatpak_deploy_data_get_origin (deploy_data));
 
   if (on_session != NULL)
@@ -8454,8 +8454,8 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
       /* FIXME: Instead of skipping the parental controls check in the test
        * environment, make a mock service for it.
        * https://github.com/flatpak/flatpak/issues/2993 */
-      g_debug ("Skipping parental controls check for %s since the "
-               "system bus is unavailable in the test environment", ref);
+      g_info ("Skipping parental controls check for %s since the "
+              "system bus is unavailable in the test environment", ref);
       return TRUE;
     }
 
@@ -8489,15 +8489,15 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
                                            cancellable, &local_error);
   if (g_error_matches (local_error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_DISABLED))
     {
-      g_debug ("Skipping parental controls check for %s since parental "
-               "controls are disabled globally", ref);
+      g_info ("Skipping parental controls check for %s since parental "
+              "controls are disabled globally", ref);
       return TRUE;
     }
   else if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
            g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER))
     {
-      g_debug ("Skipping parental controls check for %s since a required "
-               "service was not found", ref);
+      g_info ("Skipping parental controls check for %s since a required "
+              "service was not found", ref);
       return TRUE;
     }
   else if (local_error != NULL)
@@ -8518,7 +8518,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
 
   if (repo_installation_allowed && app_is_appropriate)
     {
-      g_debug ("Parental controls policy satisfied for %s", ref);
+      g_info ("Parental controls policy satisfied for %s", ref);
       return TRUE;
     }
 
@@ -8549,7 +8549,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
                                _("Installing %s is not allowed by the policy set by your administrator"),
                                ref);
 
-  g_debug ("Parental controls policy overridden by polkit for %s", ref);
+  g_info ("Parental controls policy overridden by polkit for %s", ref);
 #endif  /* USE_SYSTEM_HELPER */
 #endif  /* HAVE_LIBMALCONTENT */
 
@@ -8639,7 +8639,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
 
   if (checksum_or_latest == NULL)
     {
-      g_debug ("No checksum specified, getting tip of %s from origin %s", flatpak_decomposed_get_ref (ref), origin);
+      g_info ("No checksum specified, getting tip of %s from origin %s", flatpak_decomposed_get_ref (ref), origin);
 
       resolved_ref = flatpak_dir_read_latest (self, origin, flatpak_decomposed_get_ref (ref), NULL, cancellable, error);
       if (resolved_ref == NULL)
@@ -8649,12 +8649,12 @@ flatpak_dir_deploy (FlatpakDir          *self,
         }
 
       checksum = resolved_ref;
-      g_debug ("tip resolved to: %s", checksum);
+      g_info ("tip resolved to: %s", checksum);
     }
   else
     {
       checksum = checksum_or_latest;
-      g_debug ("Looking for checksum %s in local repo", checksum);
+      g_info ("Looking for checksum %s in local repo", checksum);
       if (!ostree_repo_read_commit (self->repo, checksum, NULL, NULL, cancellable, NULL))
         return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("%s is not available"), flatpak_decomposed_get_ref (ref));
     }
@@ -8739,7 +8739,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
 
           if (!g_file_query_exists (child, cancellable))
             {
-              g_debug ("subpath %s not in tree", subpaths[i]);
+              g_info ("subpath %s not in tree", subpaths[i]);
               continue;
             }
 
@@ -9065,7 +9065,7 @@ flatpak_dir_deploy_install (FlatpakDir        *self,
           if (strcmp (old_origin, origin) != 0)
             remove_ref_from_remote = g_strdup (old_origin);
 
-          g_debug ("Removing old deployment for reinstall");
+          g_info ("Removing old deployment for reinstall");
           if (!flatpak_dir_undeploy (self, ref, old_active,
                                      TRUE, FALSE,
                                      cancellable, error))
@@ -9264,7 +9264,7 @@ rewrite_one_dynamic_launcher (const char *portal_desktop_dir,
     }
   if (!g_key_file_has_key (old_key_file, G_KEY_FILE_DESKTOP_GROUP, "X-Flatpak", NULL))
     {
-      g_debug ("Ignoring non-Flatpak dynamic launcher: %s", desktop_path);
+      g_info ("Ignoring non-Flatpak dynamic launcher: %s", desktop_path);
       return;
     }
 
@@ -9301,7 +9301,7 @@ rewrite_one_dynamic_launcher (const char *portal_desktop_dir,
   if (!g_file_delete (link_file, NULL, &local_error) &&
       !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
     {
-      g_debug ("Unable to delete desktop file link %s: %s", desktop_name, local_error->message);
+      g_info ("Unable to delete desktop file link %s: %s", desktop_name, local_error->message);
       g_clear_error (&local_error);
     }
 
@@ -9649,7 +9649,7 @@ flatpak_dir_setup_revokefs_fuse_mount (FlatpakDir    *self,
                                                        &local_error))
     {
       if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED))
-        g_debug ("revokefs-fuse not supported on your installation: %s", local_error->message);
+        g_info ("revokefs-fuse not supported on your installation: %s", local_error->message);
       else
         g_warning ("Failed to get revokefs-fuse socket from system-helper: %s", local_error->message);
 
@@ -10774,7 +10774,7 @@ flatpak_dir_uninstall (FlatpakDir                 *self,
 
   old_active = g_strdup (flatpak_deploy_data_get_commit (deploy_data));
 
-  g_debug ("dropping active ref");
+  g_info ("dropping active ref");
   if (!flatpak_dir_set_active (self, ref, NULL, cancellable, error))
     return FALSE;
 
@@ -10784,7 +10784,7 @@ flatpak_dir_uninstall (FlatpakDir                 *self,
       if (current_ref != NULL &&
           flatpak_decomposed_equal (ref, current_ref))
         {
-          g_debug ("dropping current ref");
+          g_info ("dropping current ref");
           if (!flatpak_dir_drop_current_ref (self, name, cancellable, error))
             return FALSE;
         }
@@ -11201,7 +11201,7 @@ flatpak_dir_undeploy_all (FlatpakDir        *self,
 
   for (i = 0; deployed[i] != NULL; i++)
     {
-      g_debug ("undeploying %s", deployed[i]);
+      g_info ("undeploying %s", deployed[i]);
       if (!flatpak_dir_undeploy (self, ref, deployed[i], FALSE, force_remove, cancellable, error))
         return FALSE;
     }
@@ -11210,12 +11210,12 @@ flatpak_dir_undeploy_all (FlatpakDir        *self,
   was_deployed = g_file_query_exists (deploy_base, cancellable);
   if (was_deployed)
     {
-      g_debug ("removing deploy base");
+      g_info ("removing deploy base");
       if (!flatpak_rm_rf (deploy_base, cancellable, error))
         return FALSE;
     }
 
-  g_debug ("cleaning up empty directories");
+  g_info ("cleaning up empty directories");
   arch_dir = g_file_get_parent (deploy_base);
   if (g_file_query_exists (arch_dir, cancellable) &&
       !g_file_delete (arch_dir, cancellable, &temp_error))
@@ -11385,7 +11385,7 @@ flatpak_dir_prune (FlatpakDir   *self,
          the shared lock operation is released and we will do a prune then */
       if (g_error_matches (lock_error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
         {
-          g_debug ("Skipping prune due to in progress operation");
+          g_info ("Skipping prune due to in progress operation");
           return TRUE;
         }
 
@@ -11393,7 +11393,7 @@ flatpak_dir_prune (FlatpakDir   *self,
       return FALSE;
     }
 
-  g_debug ("Pruning repo");
+  g_info ("Pruning repo");
   if (!ostree_repo_prune (self->repo,
                           OSTREE_REPO_PRUNE_FLAGS_REFS_ONLY,
                           0,
@@ -11404,7 +11404,7 @@ flatpak_dir_prune (FlatpakDir   *self,
     goto out;
 
   formatted_freed_size = g_format_size_full (pruned_object_size_total, 0);
-  g_debug ("Pruned %d/%d objects, size %s", objects_total, objects_pruned, formatted_freed_size);
+  g_info ("Pruned %d/%d objects, size %s", objects_total, objects_pruned, formatted_freed_size);
 
   ret = TRUE;
 
@@ -11444,7 +11444,7 @@ flatpak_dir_update_summary (FlatpakDir   *self,
       g_autoptr(GError) local_error = NULL;
       g_autoptr(GFile) summary_file = NULL;
 
-      g_debug ("Deleting summary");
+      g_info ("Deleting summary");
 
       summary_file = g_file_get_child (ostree_repo_get_path (self->repo), "summary");
 
@@ -11460,7 +11460,7 @@ flatpak_dir_update_summary (FlatpakDir   *self,
     {
       g_auto(GLnxLockFile) lock = { 0, };
 
-      g_debug ("Updating summary");
+      g_info ("Updating summary");
 
       /* Keep a shared repo lock to avoid prunes removing objects we're relying on
        * while generating the summary. */
@@ -11762,7 +11762,7 @@ flatpak_dir_lookup_cached_summary (FlatpakDir *self,
       if ((now - summary->time) / G_USEC_PER_SEC < SUMMARY_CACHE_TIMEOUT_SEC &&
           strcmp (url, summary->url) == 0)
         {
-          /* g_debug ("Using cached summary for remote %s", name); */
+          /* g_info ("Using cached summary for remote %s", name); */
           *bytes_out = g_bytes_ref (summary->bytes);
           if (bytes_sig_out)
             {
@@ -12036,7 +12036,7 @@ flatpak_dir_remote_clear_cached_summary (FlatpakDir   *self,
                                          GCancellable *cancellable,
                                          GError      **error)
 {
-  g_debug ("Clearing cached summaries for remote %s", remote);
+  g_info ("Clearing cached summaries for remote %s", remote);
   if (!_flatpak_dir_remote_clear_cached_summary (self, remote, NULL, cancellable, error))
     return FALSE;
   if (!_flatpak_dir_remote_clear_cached_summary (self, remote, ".sig", cancellable, error))
@@ -12144,7 +12144,7 @@ flatpak_dir_remote_load_cached_summary (FlatpakDir   *self,
               !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
             {
               g_autofree char *path = g_file_get_path (main_cache_file);
-              g_debug ("Unable to delete file %s: %s", path, local_error->message);
+              g_info ("Unable to delete file %s: %s", path, local_error->message);
               g_clear_error (&local_error);
             }
 
@@ -12154,7 +12154,7 @@ flatpak_dir_remote_load_cached_summary (FlatpakDir   *self,
                   !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
                 {
                   g_autofree char *path = g_file_get_path (sig_cache_file);
-                  g_debug ("Unable to delete file %s: %s", path, local_error->message);
+                  g_info ("Unable to delete file %s: %s", path, local_error->message);
                   g_clear_error (&local_error);
                 }
             }
@@ -12219,11 +12219,11 @@ flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
           if (!flatpak_dir_remote_load_cached_summary (self, name_or_uri, NULL, NULL, ".sig",
                                                        &summary, &summary_sig, cancellable, error))
             return FALSE;
-          g_debug ("Loaded summary from cache for remote ‘%s’", name_or_uri);
+          g_info ("Loaded summary from cache for remote ‘%s’", name_or_uri);
         }
       else
         {
-          g_debug ("Fetching summary file for remote ‘%s’", name_or_uri);
+          g_info ("Fetching summary file for remote ‘%s’", name_or_uri);
           if (!ostree_repo_remote_fetch_summary (self->repo, name_or_uri,
                                                  &summary, &summary_sig,
                                                  cancellable,
@@ -12383,7 +12383,7 @@ flatpak_dir_remote_fetch_summary_index (FlatpakDir   *self,
           g_propagate_error (error, g_steal_pointer (&cache_error));
           return FALSE;
         }
-      g_debug ("Loaded summary index from cache for remote ‘%s’", name_or_uri);
+      g_info ("Loaded summary index from cache for remote ‘%s’", name_or_uri);
 
       index = g_steal_pointer (&cached_index);
       if (gpg_verify_summary)
@@ -12395,7 +12395,7 @@ flatpak_dir_remote_fetch_summary_index (FlatpakDir   *self,
       g_autoptr(GBytes) dl_index = NULL;
       gboolean used_download = FALSE;
 
-      g_debug ("Fetching summary index file for remote ‘%s’", name_or_uri);
+      g_info ("Fetching summary index file for remote ‘%s’", name_or_uri);
 
       dl_index = flatpak_load_uri (self->http_session, index_url, 0, NULL,
                                    NULL, NULL, NULL,
@@ -12566,13 +12566,13 @@ flatpak_dir_remote_fetch_indexed_summary (FlatpakDir   *self,
           g_autofree char *delta_filename = g_strconcat (old_checksum, "-", checksum, ".delta", NULL);
           g_autofree char *delta_url = g_build_filename (url, "summaries", delta_filename, NULL);
 
-          g_debug ("Fetching indexed summary delta %s for remote ‘%s’", delta_filename, name_or_uri);
+          g_info ("Fetching indexed summary delta %s for remote ‘%s’", delta_filename, name_or_uri);
 
           g_autoptr(GBytes) delta = flatpak_load_uri (self->http_session, delta_url, 0, NULL,
                                                       NULL, NULL, NULL,
                                                       cancellable, &delta_error);
           if (delta == NULL)
-            g_debug ("Failed to load delta, falling back: %s", delta_error->message);
+            g_info ("Failed to load delta, falling back: %s", delta_error->message);
           else
             {
               g_autoptr(GBytes) applied = flatpak_summary_apply_diff (old_summary, delta, &delta_error);
@@ -12593,7 +12593,7 @@ flatpak_dir_remote_fetch_indexed_summary (FlatpakDir   *self,
       if (summary == NULL)
         {
           g_autofree char *filename = g_strconcat (checksum, ".gz", NULL);
-          g_debug ("Fetching indexed summary file %s for remote ‘%s’", filename, name_or_uri);
+          g_info ("Fetching indexed summary file %s for remote ‘%s’", filename, name_or_uri);
           g_autofree char *subsummary_url = g_build_filename (url, "summaries", filename, NULL);
           summary_z = flatpak_load_uri (self->http_session, subsummary_url, 0, NULL,
                                         NULL, NULL, NULL,
@@ -12625,7 +12625,7 @@ flatpak_dir_remote_fetch_indexed_summary (FlatpakDir   *self,
         }
     }
   else
-    g_debug ("Loaded indexed summary file %s from cache for remote ‘%s’", checksum, name_or_uri);
+    g_info ("Loaded indexed summary file %s from cache for remote ‘%s’", checksum, name_or_uri);
 
   /* Cache in memory */
   if (!is_local && !only_cached)
@@ -12761,7 +12761,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
               got_summary = TRUE;
               if (optional && !g_cancellable_is_cancelled (cancellable))
                 {
-                  g_debug ("Failed to download optional summary index: %s", local_error->message);
+                  g_info ("Failed to download optional summary index: %s", local_error->message);
                   state->summary_fetch_error = g_steal_pointer (&local_error);
                 }
               else
@@ -12787,7 +12787,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
         {
           if (optional && !g_cancellable_is_cancelled (cancellable))
             {
-              g_debug ("Failed to download optional summary: %s", local_error->message);
+              g_info ("Failed to download optional summary: %s", local_error->message);
               state->summary_fetch_error = g_steal_pointer (&local_error);
             }
           else
@@ -12852,7 +12852,7 @@ _flatpak_dir_get_remote_state (FlatpakDir   *self,
           var_subsummary_peek_checksum (subsummary, &checksum_bytes_len);
           if (G_UNLIKELY (checksum_bytes_len != OSTREE_SHA256_DIGEST_LEN))
             {
-              g_debug ("Invalid checksum for digested summary, not using cache");
+              g_info ("Invalid checksum for digested summary, not using cache");
               continue;
             }
 
@@ -14944,8 +14944,8 @@ flatpak_dir_modify_remote (FlatpakDir   *self,
         return FALSE;
 
       /* XXX If we ever add internationalization, use ngettext() here. */
-      g_debug ("Imported %u GPG key%s to remote \"%s\"",
-               imported, (imported == 1) ? "" : "s", remote_name);
+      g_info ("Imported %u GPG key%s to remote \"%s\"",
+              imported, (imported == 1) ? "" : "s", remote_name);
     }
 
   filter_path = g_key_file_get_value (new_config, group, "xa.filter", NULL);
@@ -14966,11 +14966,11 @@ flatpak_dir_modify_remote (FlatpakDir   *self,
 
           if (!g_file_replace_contents (filter_copy, backup_data_copy, strlen (backup_data_copy),
                                         NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, cancellable, &local_error))
-            g_debug ("Failed to save backup copy of filter file %s: %s\n", filter_path, local_error->message);
+            g_info ("Failed to save backup copy of filter file %s: %s\n", filter_path, local_error->message);
         }
       else
         {
-          g_debug ("Failed to read filter %s file while making a backup copy: %s\n", filter_path, local_error->message);
+          g_info ("Failed to read filter %s file while making a backup copy: %s\n", filter_path, local_error->message);
         }
     }
 
@@ -15293,14 +15293,14 @@ flatpak_dir_update_remote_configuration (FlatpakDir   *self,
 
       if (!gpg_verify_summary || !gpg_verify)
         {
-          g_debug ("Ignoring automatic updates for system-helper remotes without gpg signatures");
+          g_info ("Ignoring automatic updates for system-helper remotes without gpg signatures");
           return TRUE;
         }
 
       if ((state->summary != NULL && state->summary_sig_bytes == NULL) ||
           (state->index != NULL && state->index_sig_bytes == NULL))
         {
-          g_debug ("Can't update remote configuration as user, no GPG signature");
+          g_info ("Can't update remote configuration as user, no GPG signature");
           return TRUE;
         }
 
@@ -15437,9 +15437,9 @@ add_related (FlatpakDir        *self,
     flatpak_find_unmaintained_extension_dir_if_exists (id, arch, branch, NULL);
   if (unmaintained_path != NULL && deploy_data == NULL)
     {
-      g_debug ("Skipping related extension ‘%s’ because it is already "
-               "installed as an unmaintained extension in ‘%s’.",
-               id, flatpak_file_get_path_cached (unmaintained_path));
+      g_info ("Skipping related extension ‘%s’ because it is already "
+              "installed as an unmaintained extension in ‘%s’.",
+              id, flatpak_file_get_path_cached (unmaintained_path));
       download = FALSE;
     }
 
@@ -15752,7 +15752,7 @@ flatpak_dir_find_remote_related (FlatpakDir         *self,
       metadata_file = g_file_get_child (deploy_dir, "metadata");
       if (!g_file_load_contents (metadata_file, cancellable, &metadata, NULL, NULL, NULL))
         {
-          g_debug ("No metadata in local deploy");
+          g_info ("No metadata in local deploy");
           /* No metadata => no related, but no error */
         }
     }
@@ -16044,7 +16044,7 @@ flatpak_dir_find_local_related (FlatpakDir        *self,
           metadata = g_file_get_child (deploy_dir, "metadata");
           if (!g_file_load_contents (metadata, cancellable, &metadata_contents, NULL, NULL, NULL))
             {
-              g_debug ("No metadata in local deploy");
+              g_info ("No metadata in local deploy");
               /* No metadata => no related, but no error */
             }
         }
@@ -16058,7 +16058,7 @@ flatpak_dir_find_local_related (FlatpakDir        *self,
           g_autoptr(GVariant) commit_metadata = g_variant_get_child_value (commit_data, 0);
           g_variant_lookup (commit_metadata, "xa.metadata", "s", &metadata_contents);
           if (metadata_contents == NULL)
-            g_debug ("No xa.metadata in local commit %s ref %s", checksum, flatpak_decomposed_get_ref (ref));
+            g_info ("No xa.metadata in local commit %s ref %s", checksum, flatpak_decomposed_get_ref (ref));
         }
     }
 
@@ -16084,7 +16084,7 @@ flatpak_dir_get_remote_auto_install_authenticator_ref (FlatpakDir         *self,
       g_autoptr(GError) local_error = NULL;
       ref = flatpak_decomposed_new_from_parts (FLATPAK_KINDS_APP, authenticator_name, flatpak_get_arch (), "autoinstall", &local_error);
       if (ref == NULL)
-        g_debug ("Invalid authenticator ref: %s\n", local_error->message);
+        g_info ("Invalid authenticator ref: %s\n", local_error->message);
     }
 
   return g_steal_pointer (&ref);
@@ -16508,8 +16508,8 @@ flatpak_dir_delete_mirror_refs (FlatpakDir    *self,
     {
       if (g_strv_contains ((const char * const *)ignore_collections->pdata, c_r->collection_id))
         {
-          g_debug ("Ignoring collection-ref (%s, %s) since its remote is disabled or it matches the repo collection ID",
-                   c_r->collection_id, c_r->ref_name);
+          g_info ("Ignoring collection-ref (%s, %s) since its remote is disabled or it matches the repo collection ID",
+                  c_r->collection_id, c_r->ref_name);
           continue;
         }
 

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -881,13 +881,13 @@ _exports_path_expose (FlatpakExports *exports,
 
   if (level > 40) /* 40 is the current kernel ELOOP check */
     {
-      g_debug ("Expose too deep, bail");
+      g_info ("Expose too deep, bail");
       return FALSE;
     }
 
   if (!g_path_is_absolute (path))
     {
-      g_debug ("Not exposing relative path %s", path);
+      g_info ("Not exposing relative path %s", path);
       return FALSE;
     }
 
@@ -896,14 +896,14 @@ _exports_path_expose (FlatpakExports *exports,
 
   if (o_path_fd == -1)
     {
-      g_debug ("Unable to open path %s to %s: %s",
-               path, export_mode_to_verb (mode), g_strerror (errno));
+      g_info ("Unable to open path %s to %s: %s",
+              path, export_mode_to_verb (mode), g_strerror (errno));
       return FALSE;
     }
 
   if (fstat (o_path_fd, &st) != 0)
     {
-      g_debug ("Unable to get file type of %s: %s", path, g_strerror (errno));
+      g_info ("Unable to get file type of %s: %s", path, g_strerror (errno));
       return FALSE;
     }
 
@@ -913,15 +913,15 @@ _exports_path_expose (FlatpakExports *exports,
         S_ISLNK (st.st_mode) ||
         S_ISSOCK (st.st_mode)))
     {
-      g_debug ("%s has unsupported file type 0o%o", path, st.st_mode & S_IFMT);
+      g_info ("%s has unsupported file type 0o%o", path, st.st_mode & S_IFMT);
       return FALSE;
     }
 
   /* O_PATH + fstatfs is the magic that we need to statfs without automounting the target */
   if (fstatfs (o_path_fd, &stfs) != 0)
     {
-      g_debug ("Unable to get filesystem information for %s: %s",
-               path, g_strerror (errno));
+      g_info ("Unable to get filesystem information for %s: %s",
+              path, g_strerror (errno));
       return FALSE;
     }
 
@@ -931,7 +931,7 @@ _exports_path_expose (FlatpakExports *exports,
     {
       if (!check_if_autofs_works (exports, path))
         {
-          g_debug ("ignoring blocking autofs path %s", path);
+          g_info ("ignoring blocking autofs path %s", path);
           return FALSE;
         }
     }
@@ -946,7 +946,7 @@ _exports_path_expose (FlatpakExports *exports,
          create the parents for them anyway */
       if (flatpak_has_path_prefix (path, dont_export_in[i]))
         {
-          g_debug ("skipping export for path %s in unsupported prefix", path);
+          g_info ("skipping export for path %s in unsupported prefix", path);
           return FALSE;
         }
     }
@@ -956,7 +956,7 @@ _exports_path_expose (FlatpakExports *exports,
       /* Same as /usr, but for the directories that get merged into /usr */
       if (flatpak_has_path_prefix (path, flatpak_abs_usrmerged_dirs[i]))
         {
-          g_debug ("skipping export for path %s in a /usr-merged directory", path);
+          g_info ("skipping export for path %s in a /usr-merged directory", path);
           return FALSE;
         }
     }

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -428,7 +428,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
 
   g_qsort_with_data (keys, n_keys, sizeof (char *), (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
 
-  flatpak_debug2 ("Converting FlatpakExports to bwrap arguments...");
+  g_debug ("Converting FlatpakExports to bwrap arguments...");
 
   for (l = eps; l != NULL; l = l->next)
     {
@@ -439,12 +439,12 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
 
       if (ep->mode == FAKE_MODE_SYMLINK)
         {
-          flatpak_debug2 ("\"%s\" is meant to be a symlink", path);
+          g_debug ("\"%s\" is meant to be a symlink", path);
 
           if (path_parent_is_mapped (keys, n_keys, exports->hash, path))
             {
-              flatpak_debug2 ("Not creating \"%s\" as symlink because its parent is "
-                              "already mapped", path);
+              g_debug ("Not creating \"%s\" as symlink because its parent is "
+                       "already mapped", path);
             }
           else
             {
@@ -456,19 +456,19 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
                   g_autofree char *parent = g_path_get_dirname (path);
                   g_autofree char *relative = make_relative (parent, resolved);
 
-                  flatpak_debug2 ("Resolved \"%s\" to \"%s\" in host", path, resolved);
-                  flatpak_debug2 ("Creating \"%s\" -> \"%s\" in sandbox", path, relative);
+                  g_debug ("Resolved \"%s\" to \"%s\" in host", path, resolved);
+                  g_debug ("Creating \"%s\" -> \"%s\" in sandbox", path, relative);
                   flatpak_bwrap_add_args (bwrap, "--symlink", relative, path,  NULL);
                 }
               else
                 {
-                  flatpak_debug2 ("Unable to resolve \"%s\" in host, skipping", path);
+                  g_debug ("Unable to resolve \"%s\" in host, skipping", path);
                 }
             }
         }
       else if (ep->mode == FAKE_MODE_TMPFS)
         {
-          flatpak_debug2 ("\"%s\" is meant to be a tmpfs or empty directory", path);
+          g_debug ("\"%s\" is meant to be a tmpfs or empty directory", path);
 
           /* Mount a tmpfs to hide the subdirectory, but only if there
              is a pre-existing dir we can mount the path on. */
@@ -477,38 +477,38 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
               if (!path_parent_is_mapped (keys, n_keys, exports->hash, path))
                 /* If the parent is not mapped, it will be a tmpfs, no need to mount another one */
                 {
-                  flatpak_debug2 ("Parent of \"%s\" is not mapped, creating empty directory", path);
+                  g_debug ("Parent of \"%s\" is not mapped, creating empty directory", path);
                   flatpak_bwrap_add_args (bwrap, "--dir", path, NULL);
                 }
               else
                 {
-                  flatpak_debug2 ("Parent of \"%s\" is mapped, creating tmpfs to shadow it", path);
+                  g_debug ("Parent of \"%s\" is mapped, creating tmpfs to shadow it", path);
                   flatpak_bwrap_add_args (bwrap, "--tmpfs", path, NULL);
                 }
             }
           else
             {
-              flatpak_debug2 ("Not a directory, skipping: \"%s\"", path);
+              g_debug ("Not a directory, skipping: \"%s\"", path);
             }
         }
       else if (ep->mode == FAKE_MODE_DIR)
         {
-          flatpak_debug2 ("\"%s\" is meant to be a directory", path);
+          g_debug ("\"%s\" is meant to be a directory", path);
 
           if (path_is_dir (exports, path))
             {
-              flatpak_debug2 ("Ensuring \"%s\" is created as a directory", path);
+              g_debug ("Ensuring \"%s\" is created as a directory", path);
               flatpak_bwrap_add_args (bwrap, "--dir", path, NULL);
             }
           else
             {
-              flatpak_debug2 ("Not a directory, skipping: \"%s\"", path);
+              g_debug ("Not a directory, skipping: \"%s\"", path);
             }
         }
       else
         {
-          flatpak_debug2 ("\"%s\" is meant to be shared (ro or rw) with the container",
-                          path);
+          g_debug ("\"%s\" is meant to be shared (ro or rw) with the container",
+                   path);
           flatpak_bwrap_add_args (bwrap,
                                   (ep->mode == FLATPAK_FILESYSTEM_MODE_READ_ONLY) ? "--ro-bind" : "--bind",
                                   path, path, NULL);
@@ -755,24 +755,24 @@ do_export_path (FlatpakExports *exports,
     {
       if (old_ep->mode < mode)
         {
-          flatpak_debug2 ("Increasing export mode from \"%s\" to \"%s\": %s",
-                          export_mode_to_verb (old_ep->mode),
-                          export_mode_to_verb (mode),
-                          path);
+          g_debug ("Increasing export mode from \"%s\" to \"%s\": %s",
+                   export_mode_to_verb (old_ep->mode),
+                   export_mode_to_verb (mode),
+                   path);
           ep->mode = mode;
         }
       else
         {
-          flatpak_debug2 ("Not changing export mode from \"%s\" to \"%s\": %s",
-                          export_mode_to_verb (old_ep->mode),
-                          export_mode_to_verb (mode),
-                          path);
+          g_debug ("Not changing export mode from \"%s\" to \"%s\": %s",
+                   export_mode_to_verb (old_ep->mode),
+                   export_mode_to_verb (mode),
+                   path);
           ep->mode = old_ep->mode;
         }
     }
   else
     {
-      flatpak_debug2 ("Will %s: %s", export_mode_to_verb (mode), path);
+      g_debug ("Will %s: %s", export_mode_to_verb (mode), path);
       ep->mode = mode;
     }
 
@@ -877,7 +877,7 @@ _exports_path_expose (FlatpakExports *exports,
 
   g_return_val_if_fail (is_export_mode (mode), FALSE);
 
-  flatpak_debug2 ("Trying to %s: %s", export_mode_to_verb (mode), path);
+  g_debug ("Trying to %s: %s", export_mode_to_verb (mode), path);
 
   if (level > 40) /* 40 is the current kernel ELOOP check */
     {
@@ -972,11 +972,11 @@ _exports_path_expose (FlatpakExports *exports,
 
       if (!path_is_symlink (exports, path))
         {
-          flatpak_debug2 ("%s is not a symlink", path);
+          g_debug ("%s is not a symlink", path);
         }
       else if (never_export_as_symlink (path))
         {
-          flatpak_debug2 ("%s is a symlink, but we avoid exporting it as such", path);
+          g_debug ("%s is a symlink, but we avoid exporting it as such", path);
         }
       else
         {
@@ -986,14 +986,14 @@ _exports_path_expose (FlatpakExports *exports,
 
           if (resolved)
             {
-              flatpak_debug2 ("%s is a symlink, resolved to %s", path, resolved);
+              g_debug ("%s is a symlink, resolved to %s", path, resolved);
 
               if (slash)
                 new_target = g_build_filename (resolved, slash + 1, NULL);
               else
                 new_target = g_strdup (resolved);
 
-              flatpak_debug2 ("Trying to export the target instead: %s", new_target);
+              g_debug ("Trying to export the target instead: %s", new_target);
 
               if (_exports_path_expose (exports, mode, new_target, level + 1))
                 {
@@ -1001,14 +1001,14 @@ _exports_path_expose (FlatpakExports *exports,
                   return TRUE;
                 }
 
-              flatpak_debug2 ("Could not export target %s, so ignoring %s",
-                              new_target, path);
+              g_debug ("Could not export target %s, so ignoring %s",
+                       new_target, path);
               return FALSE;
             }
           else
             {
-              flatpak_debug2 ("%s is a symlink but we were unable to resolve it: %s",
-                              path, error->message);
+              g_debug ("%s is a symlink but we were unable to resolve it: %s",
+                       path, error->message);
               return FALSE;
             }
         }

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -320,11 +320,11 @@ flatpak_installation_new_system_with_id (const char   *id,
                                                    &local_error);
   if (installation == NULL)
     {
-      g_debug ("Error creating Flatpak installation: %s", local_error->message);
+      g_info ("Error creating Flatpak installation: %s", local_error->message);
       g_propagate_error (error, g_steal_pointer (&local_error));
     }
 
-  g_debug ("Found Flatpak installation for '%s'", id);
+  g_info ("Found Flatpak installation for '%s'", id);
   return g_steal_pointer (&installation);
 }
 
@@ -1013,7 +1013,7 @@ transaction_ready (FlatpakTransaction  *transaction,
       if (type == FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
         {
           const char *ref = flatpak_transaction_operation_get_ref (op);
-          g_debug ("Update transaction wants to uninstall %s", ref);
+          g_info ("Update transaction wants to uninstall %s", ref);
           continue;
         }
 
@@ -1105,7 +1105,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
 
       if (g_error_matches (local_error, FLATPAK_ERROR, FLATPAK_ERROR_REMOTE_NOT_FOUND))
         {
-          g_debug ("%s: Unable to update %s: %s", G_STRFUNC, ref, local_error->message);
+          g_info ("%s: Unable to update %s: %s", G_STRFUNC, ref, local_error->message);
           g_clear_error (&local_error);
         }
       else
@@ -1159,7 +1159,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
           if (!g_hash_table_contains (installed_refs_for_update_set, op_ref))
             {
               g_hash_table_add (installed_refs_for_update_set, (char *)op_ref);
-              g_debug ("%s: Installed ref %s needs update", G_STRFUNC, op_ref);
+              g_info ("%s: Installed ref %s needs update", G_STRFUNC, op_ref);
               g_ptr_array_add (installed_refs_for_update,
                                g_object_ref (installed_ref));
             }
@@ -1177,7 +1177,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
                   if (installed_ref != NULL)
                     {
                       g_hash_table_add (installed_refs_for_update_set, (char *)related_op_ref);
-                      g_debug ("%s: Installed ref %s needs update", G_STRFUNC, related_op_ref);
+                      g_info ("%s: Installed ref %s needs update", G_STRFUNC, related_op_ref);
                       g_ptr_array_add (installed_refs_for_update,
                                        g_object_ref (installed_ref));
                     }
@@ -1200,7 +1200,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
           if (!g_hash_table_contains (installed_refs_for_update_set, rebased_ref))
             {
               g_hash_table_add (installed_refs_for_update_set, (char *)rebased_ref);
-              g_debug ("%s: Installed ref %s needs update", G_STRFUNC, rebased_ref);
+              g_info ("%s: Installed ref %s needs update", G_STRFUNC, rebased_ref);
               g_ptr_array_add (installed_refs_for_update,
                                g_object_ref (installed_ref));
             }

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -1107,7 +1107,7 @@ flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances)
               g_info ("Cleaning up unused container id %s", dent->d_name);
 
               if (!flatpak_instance_gc_per_app_dirs (dent->d_name, &local_error))
-                flatpak_debug2 ("Not cleaning up per-app dir: %s", local_error->message);
+                g_debug ("Not cleaning up per-app dir: %s", local_error->message);
 
               glnx_shutil_rm_rf_at (iter.fd, dent->d_name, NULL, NULL);
               continue;

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -322,7 +322,7 @@ get_instance_info (const char *dir)
   key_file = g_key_file_new ();
   if (!g_key_file_load_from_file (key_file, file, G_KEY_FILE_NONE, &error))
     {
-      g_debug ("Failed to load instance info file '%s': %s", file, error->message);
+      g_info ("Failed to load instance info file '%s': %s", file, error->message);
       return NULL;
     }
 
@@ -344,21 +344,21 @@ get_child_pid (const char *dir)
 
   if (!g_file_get_contents (file, &contents, &length, &error))
     {
-      g_debug ("Failed to load bwrapinfo.json file '%s': %s", file, error->message);
+      g_info ("Failed to load bwrapinfo.json file '%s': %s", file, error->message);
       return 0;
     }
 
   parser = json_parser_new ();
   if (!json_parser_load_from_data (parser, contents, length, &error))
     {
-      g_debug ("Failed to parse bwrapinfo.json file '%s': %s", file, error->message);
+      g_info ("Failed to parse bwrapinfo.json file '%s': %s", file, error->message);
       return 0;
     }
 
   node = json_parser_get_root (parser);
   if (!node)
     {
-      g_debug ("Failed to parse bwrapinfo.json file '%s': %s", file, "empty");
+      g_info ("Failed to parse bwrapinfo.json file '%s': %s", file, "empty");
       return 0;
     }
 
@@ -378,7 +378,7 @@ get_pid (const char *dir)
 
   if (!g_file_get_contents (file, &contents, NULL, &error))
     {
-      g_debug ("Failed to load pid file '%s': %s", file, error->message);
+      g_info ("Failed to load pid file '%s': %s", file, error->message);
       return 0;
     }
 
@@ -767,7 +767,7 @@ flatpak_instance_allocate_id (char **host_dir_out,
           if (lock_fd != -1 && fcntl (lock_fd, F_SETLK, &l) == 0)
             {
               *lock_fd_out = glnx_steal_fd (&lock_fd);
-              g_debug ("Allocated instance id %s", instance_id);
+              g_info ("Allocated instance id %s", instance_id);
               *host_dir_out = g_steal_pointer (&instance_dir);
               return g_steal_pointer (&instance_id);
             }
@@ -990,7 +990,7 @@ flatpak_instance_gc_per_app_dirs (const char *instance_id,
   if (statbuf.st_mtime + 3 >= time (NULL))
     return glnx_throw (error, "lock file too recent, avoiding race condition");
 
-  g_debug ("Cleaning up per-app-ID state for %s", app_id);
+  g_info ("Cleaning up per-app-ID state for %s", app_id);
 
   /* /dev/shm is offloaded onto the host's /dev/shm to get consistent
    * free space behaviour and make sure it's actually in RAM. It could
@@ -1018,13 +1018,13 @@ flatpak_instance_gc_per_app_dirs (const char *instance_id,
           g_assert (g_str_has_prefix (path, "/dev/shm/"));
 
           if (unlinkat (per_app_dir_fd, "dev-shm", 0) != 0)
-            g_debug ("Unable to clean up %s/%s: %s",
-                     per_app_dir, "dev-shm", g_strerror (errno));
+            g_info ("Unable to clean up %s/%s: %s",
+                    per_app_dir, "dev-shm", g_strerror (errno));
 
           if (!glnx_shutil_rm_rf_at (AT_FDCWD, path, NULL, &local_error))
             {
-              g_debug ("Unable to clean up %s: %s",
-                       path, local_error->message);
+              g_info ("Unable to clean up %s: %s",
+                      path, local_error->message);
               g_clear_error (&local_error);
             }
         }
@@ -1035,9 +1035,9 @@ flatpak_instance_gc_per_app_dirs (const char *instance_id,
         }
       else
         {
-          g_debug ("%s/%s no longer points to the expected directory and "
-                   "was removed: %s",
-                   per_app_dir, "dev-shm", local_error->message);
+          g_info ("%s/%s no longer points to the expected directory and "
+                  "was removed: %s",
+                  per_app_dir, "dev-shm", local_error->message);
           g_clear_error (&local_error);
         }
     }
@@ -1049,8 +1049,8 @@ flatpak_instance_gc_per_app_dirs (const char *instance_id,
    * and not a symlink. If it's a symlink, we'll just unlink it. */
   if (!glnx_shutil_rm_rf_at (per_app_dir_fd, "tmp", NULL, &local_error))
     {
-      g_debug ("Unable to clean up %s/tmp: %s", per_app_dir,
-               local_error->message);
+      g_info ("Unable to clean up %s/tmp: %s", per_app_dir,
+              local_error->message);
       g_clear_error (&local_error);
     }
 
@@ -1104,7 +1104,7 @@ flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances)
               g_autoptr(GError) local_error = NULL;
 
               /* The instance is not used, remove it */
-              g_debug ("Cleaning up unused container id %s", dent->d_name);
+              g_info ("Cleaning up unused container id %s", dent->d_name);
 
               if (!flatpak_instance_gc_per_app_dirs (dent->d_name, &local_error))
                 flatpak_debug2 ("Not cleaning up per-app dir: %s", local_error->message);

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -1072,7 +1072,7 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
         }
 
       if (error_detail == NULL)
-        g_debug ("Unhandled error body format: %s", body_data);
+        g_info ("Unhandled error body format: %s", body_data);
 
       if (http_status == 401 /* UNAUTHORIZED */)
         {
@@ -2985,7 +2985,7 @@ flatpak_oci_index_make_summary (GFile        *index,
 
       if (!g_str_has_prefix (image->digest, "sha256:"))
         {
-          g_debug ("Ignoring digest type %s", image->digest);
+          g_info ("Ignoring digest type %s", image->digest);
           continue;
         }
 

--- a/common/flatpak-parental-controls.c
+++ b/common/flatpak-parental-controls.c
@@ -129,10 +129,10 @@ flatpak_oars_check_rating (GHashTable   *content_rating,
           (rating_value != MCT_APP_FILTER_OARS_VALUE_UNKNOWN &&
            filter_value == MCT_APP_FILTER_OARS_VALUE_UNKNOWN))
         {
-          g_debug ("%s: Comparing rating ‘%s’: app has ‘%s’ but policy has ‘%s’ unknown: OARS check failed",
-                   G_STRFUNC, oars_sections[i],
-                   app_filter_oars_value_to_string (rating_value),
-                   app_filter_oars_value_to_string (filter_value));
+          g_info ("%s: Comparing rating ‘%s’: app has ‘%s’ but policy has ‘%s’ unknown: OARS check failed",
+                  G_STRFUNC, oars_sections[i],
+                  app_filter_oars_value_to_string (rating_value),
+                  app_filter_oars_value_to_string (filter_value));
           return FALSE;
         }
     }

--- a/common/flatpak-progress.c
+++ b/common/flatpak-progress.c
@@ -314,7 +314,7 @@ out:
   if (new_progress > 100)
     {
       if (!self->reported_overflow)
-        g_debug ("Unexpectedly got > 100%% progress, limiting");
+        g_info ("Unexpectedly got > 100%% progress, limiting");
       self->reported_overflow = TRUE;
       new_progress = 100;
     }

--- a/common/flatpak-prune.c
+++ b/common/flatpak-prune.c
@@ -767,14 +767,14 @@ flatpak_repo_prune (OstreeRepo    *repo,
       return FALSE;
 
     timer = g_timer_new ();
-    g_debug ("Finding reachable objects, unlocked (depth=%d)", depth);
+    g_info ("Finding reachable objects, unlocked (depth=%d)", depth);
     g_timer_start (timer);
 
     if (!traverse_reachable_refs_unlocked (repo, depth, reachable, cancellable, error))
       return FALSE;
 
     g_timer_stop (timer);
-    g_debug ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
+    g_info ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
   }
 
   {
@@ -785,7 +785,7 @@ flatpak_repo_prune (OstreeRepo    *repo,
       return FALSE;
 
     timer = g_timer_new ();
-    g_debug ("Finding reachable objects, locked (depth=%d)", depth);
+    g_info ("Finding reachable objects, locked (depth=%d)", depth);
     g_timer_start (timer);
 
     if (!traverse_reachable_refs_unlocked (repo, depth, reachable, cancellable, error))
@@ -796,29 +796,29 @@ flatpak_repo_prune (OstreeRepo    *repo,
     data.dont_prune = dry_run;
 
     g_timer_stop (timer);
-    g_debug ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
+    g_info ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
 
-    g_debug ("Pruning unreachable objects");
+    g_info ("Pruning unreachable objects");
     g_timer_start (timer);
 
     if (!prune_unreachable_loose_objects (repo, &data, cancellable, error))
       return FALSE;
 
     g_timer_stop (timer);
-    g_debug ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
+    g_info ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
   }
 
   /* Prune static deltas outside lock to avoid conflict with its exclusive lock */
   if (!dry_run)
     {
-      g_debug ("Pruning static deltas");
+      g_info ("Pruning static deltas");
       g_timer_start (timer);
 
       if (!ostree_repo_prune_static_deltas (repo, NULL, cancellable, error))
         return FALSE;
 
       g_timer_stop (timer);
-      g_debug ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
+      g_info ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
     }
 
   *out_objects_total = data.n_reachable + data.n_unreachable;

--- a/common/flatpak-prune.c
+++ b/common/flatpak-prune.c
@@ -517,7 +517,7 @@ traverse_reachable_refs_unlocked (OstreeRepo                  *repo,
       if (object_name_bag_contains (reachable, &commit_name))
         continue;
 
-      flatpak_debug2 ("Finding objects to keep for commit %s", checksum);
+      g_debug ("Finding objects to keep for commit %s", checksum);
 
       if (!load_extra_commitmeta (repo, checksum, &extra_commitmeta, cancellable, error))
         return FALSE;
@@ -608,8 +608,8 @@ prune_loose_object (OtPruneData          *data,
 {
   guint64 storage_size = 0;
 
-  flatpak_debug2 ("Pruning unneeded object %s.%s", checksum,
-                  ostree_object_type_to_string (objtype));
+  g_debug ("Pruning unneeded object %s.%s", checksum,
+           ostree_object_type_to_string (objtype));
 
   if (!ostree_repo_query_object_storage_size (data->repo, objtype, checksum,
                                               &storage_size, cancellable, error))

--- a/common/flatpak-remote-ref.c
+++ b/common/flatpak-remote-ref.c
@@ -341,7 +341,7 @@ flatpak_remote_ref_new (FlatpakDecomposed   *decomposed,
                                        &download_size, &installed_size, &metadata,
                                        NULL))
     {
-      g_debug ("Can't find metadata for ref %s", flatpak_decomposed_get_ref (decomposed));
+      g_info ("Can't find metadata for ref %s", flatpak_decomposed_get_ref (decomposed));
     }
 
   if (metadata)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -313,7 +313,7 @@ flatpak_run_add_x11_args (FlatpakBwrap         *bwrap,
       return;
     }
 
-  g_debug ("Allowing x11 access");
+  g_info ("Allowing x11 access");
 
   display = g_getenv ("DISPLAY");
 
@@ -520,7 +520,7 @@ flatpak_run_get_cups_server_name_config (const char *path)
   input_stream = g_file_read (file, NULL, &my_error);
   if (my_error)
     {
-      g_debug ("CUPS configuration file '%s': %s", path, my_error->message);
+      g_info ("CUPS configuration file '%s': %s", path, my_error->message);
       return NULL;
     }
 
@@ -592,7 +592,7 @@ flatpak_run_add_cups_args (FlatpakBwrap *bwrap)
 
   if (!g_file_test (cups_server_name, G_FILE_TEST_EXISTS))
     {
-      g_debug ("Could not find CUPS server");
+      g_info ("Could not find CUPS server");
       return;
     }
 
@@ -617,7 +617,7 @@ flatpak_run_add_gpg_agent_args (FlatpakBwrap *bwrap)
 
   if (gpgconf_error)
     {
-      g_debug ("GPG-Agent directories: %s", gpgconf_error->message);
+      g_info ("GPG-Agent directories: %s", gpgconf_error->message);
       return;
     }
 
@@ -630,7 +630,7 @@ flatpak_run_add_gpg_agent_args (FlatpakBwrap *bwrap)
 
   if (!agent_socket || gpgconf_error)
     {
-      g_debug ("GPG-Agent directories: %s", gpgconf_error->message);
+      g_info ("GPG-Agent directories: %s", gpgconf_error->message);
       return;
     }
 
@@ -654,7 +654,7 @@ flatpak_run_get_pulseaudio_server_user_config (const char *path)
   input_stream = g_file_read (file, NULL, &my_error);
   if (my_error)
     {
-      g_debug ("Pulseaudio user configuration file '%s': %s", path, my_error->message);
+      g_info ("Pulseaudio user configuration file '%s': %s", path, my_error->message);
       return NULL;
     }
 
@@ -693,7 +693,7 @@ flatpak_run_get_pulseaudio_server_user_config (const char *path)
               if (strcmp ("default-server", tokens[0]) == 0)
                 {
                   g_strstrip (tokens[1]);
-                  g_debug ("Found pulseaudio socket from configuration file '%s': %s", path, tokens[1]);
+                  g_info ("Found pulseaudio socket from configuration file '%s': %s", path, tokens[1]);
                   return g_strdup (tokens[1]);
                 }
             }
@@ -920,7 +920,7 @@ flatpak_run_add_pulseaudio_args (FlatpakBwrap         *bwrap,
           g_warning ("PulseAudio access will require --share=network permission.");
         }
 
-      g_debug ("Using remote PulseAudio server \"%s\"", pulseaudio_server);
+      g_info ("Using remote PulseAudio server \"%s\"", pulseaudio_server);
       flatpak_bwrap_set_env (bwrap, "PULSE_SERVER", pulseaudio_server, TRUE);
     }
   else if (pulseaudio_socket && g_file_test (pulseaudio_socket, G_FILE_TEST_EXISTS))
@@ -944,7 +944,7 @@ flatpak_run_add_pulseaudio_args (FlatpakBwrap         *bwrap,
       flatpak_bwrap_add_runtime_dir_member (bwrap, "pulse");
     }
   else
-    g_debug ("Could not find pulseaudio socket");
+    g_info ("Could not find pulseaudio socket");
 
   /* Also allow ALSA access. This was added in 1.8, and is not ideally named. However,
    * since the practical permission of ALSA and PulseAudio are essentially the same, and
@@ -1030,7 +1030,7 @@ flatpak_run_add_system_dbus_args (FlatpakBwrap   *app_bwrap,
 
   unrestricted = (context->sockets & FLATPAK_CONTEXT_SOCKET_SYSTEM_BUS) != 0;
   if (unrestricted)
-    g_debug ("Allowing system-dbus access");
+    g_info ("Allowing system-dbus access");
 
   no_proxy = (flags & FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY) != 0;
 
@@ -1111,7 +1111,7 @@ flatpak_run_add_session_dbus_args (FlatpakBwrap   *app_bwrap,
     }
 
   if (unrestricted)
-    g_debug ("Allowing session-dbus access");
+    g_info ("Allowing session-dbus access");
 
   no_proxy = (flags & FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY) != 0;
 
@@ -1364,7 +1364,7 @@ start_dbus_proxy (FlatpakBwrap *app_bwrap,
   flatpak_bwrap_finish (proxy_bwrap);
 
   commandline = flatpak_quote_argv ((const char **) proxy_bwrap->argv->pdata, -1);
-  g_debug ("Running '%s'", commandline);
+  g_info ("Running '%s'", commandline);
 
   /* We use LEAVE_DESCRIPTORS_OPEN to work around dead-lock, see flatpak_close_fds_workaround */
   if (!g_spawn_async (NULL,
@@ -1597,13 +1597,13 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
 
   if ((context->shares & FLATPAK_CONTEXT_SHARED_IPC) == 0)
     {
-      g_debug ("Disallowing ipc access");
+      g_info ("Disallowing ipc access");
       flatpak_bwrap_add_args (bwrap, "--unshare-ipc", NULL);
     }
 
   if ((context->shares & FLATPAK_CONTEXT_SHARED_NETWORK) == 0)
     {
-      g_debug ("Disallowing network access");
+      g_info ("Disallowing network access");
       flatpak_bwrap_add_args (bwrap, "--unshare-net", NULL);
     }
 
@@ -1700,7 +1700,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
                               NULL);
       if (context->devices & FLATPAK_CONTEXT_DEVICE_DRI)
         {
-          g_debug ("Allowing dri access");
+          g_info ("Allowing dri access");
           int i;
           char *dri_devices[] = {
             "/dev/dri",
@@ -1735,7 +1735,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
 
       if (context->devices & FLATPAK_CONTEXT_DEVICE_KVM)
         {
-          g_debug ("Allowing kvm access");
+          g_info ("Allowing kvm access");
           if (g_file_test ("/dev/kvm", G_FILE_TEST_EXISTS))
             flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/kvm", "/dev/kvm", NULL);
         }
@@ -1745,7 +1745,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
           /* This is a symlink to /run/shm on debian, so bind to real target */
           g_autofree char *real_dev_shm = realpath ("/dev/shm", NULL);
 
-          g_debug ("Allowing /dev/shm access (as %s)", real_dev_shm);
+          g_info ("Allowing /dev/shm access (as %s)", real_dev_shm);
           if (real_dev_shm != NULL)
               flatpak_bwrap_add_args (bwrap, "--bind", real_dev_shm, "/dev/shm", NULL);
         }
@@ -1804,7 +1804,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
 
   if (context->sockets & FLATPAK_CONTEXT_SOCKET_WAYLAND)
     {
-      g_debug ("Allowing wayland access");
+      g_info ("Allowing wayland access");
       has_wayland = flatpak_run_add_wayland_args (bwrap);
     }
 
@@ -1822,7 +1822,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
 
   if (context->sockets & FLATPAK_CONTEXT_SOCKET_PULSEAUDIO)
     {
-      g_debug ("Allowing pulseaudio access");
+      g_info ("Allowing pulseaudio access");
       flatpak_run_add_pulseaudio_args (bwrap, context->shares);
     }
 
@@ -1851,7 +1851,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
     {
       /* We still run along even if we don't get a cgroup, as nothing
          really depends on it. Its just nice to have */
-      g_debug ("Failed to run in transient scope: %s", my_error->message);
+      g_info ("Failed to run in transient scope: %s", my_error->message);
       g_clear_error (&my_error);
     }
 
@@ -2514,17 +2514,17 @@ get_dconf_data (const char  *app_id,
 
   if (migrate_path)
     {
-      g_debug ("Add values in dir '%s', prefix is '%s'", migrate_path, prefix);
+      g_info ("Add values in dir '%s', prefix is '%s'", migrate_path, prefix);
       if (flatpak_dconf_path_is_similar (migrate_path, prefix))
         add_dconf_dir_to_keyfile (values_data, client, migrate_path, DCONF_READ_USER_VALUE);
       else
         g_warning ("Ignoring D-Conf migrate-path setting %s", migrate_path);
     }
 
-  g_debug ("Add defaults in dir %s", prefix);
+  g_info ("Add defaults in dir %s", prefix);
   add_dconf_dir_to_keyfile (defaults_data, client, prefix, DCONF_READ_DEFAULT_VALUE);
 
-  g_debug ("Add locks in dir %s", prefix);
+  g_info ("Add locks in dir %s", prefix);
   add_dconf_locks_to_list (locks_data, client, prefix);
 
   /* We allow extra paths for defaults and locks, but not for user values */
@@ -2535,15 +2535,15 @@ get_dconf_data (const char  *app_id,
         {
           if (dconf_is_dir (paths[i], NULL))
             {
-              g_debug ("Add defaults in dir %s", paths[i]);
+              g_info ("Add defaults in dir %s", paths[i]);
               add_dconf_dir_to_keyfile (defaults_data, client, paths[i], DCONF_READ_DEFAULT_VALUE);
 
-              g_debug ("Add locks in dir %s", paths[i]);
+              g_info ("Add locks in dir %s", paths[i]);
               add_dconf_locks_to_list (locks_data, client, paths[i]);
             }
           else if (dconf_is_key (paths[i], NULL))
             {
-              g_debug ("Add individual key %s", paths[i]);
+              g_info ("Add individual key %s", paths[i]);
               add_dconf_key_to_keyfile (defaults_data, client, paths[i], DCONF_READ_DEFAULT_VALUE);
               add_dconf_key_to_keyfile (values_data, client, paths[i], DCONF_READ_USER_VALUE);
             }
@@ -2627,7 +2627,7 @@ flatpak_run_add_dconf_args (FlatpakBwrap *bwrap,
                                    "config/glib-2.0/settings/keyfile",
                                    NULL);
 
-      g_debug ("writing D-Conf values to %s", filename);
+      g_info ("writing D-Conf values to %s", filename);
 
       if (values_size != 0 && !g_file_test (filename, G_FILE_TEST_EXISTS))
         {
@@ -3058,7 +3058,7 @@ add_document_portal_args (FlatpakBwrap *bwrap,
           if (g_dbus_message_to_gerror (reply, &local_error))
             {
               if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))
-                g_debug ("Document portal not available, not mounting /run/flatpak/doc");
+                g_info ("Document portal not available, not mounting /run/flatpak/doc");
               else
                 g_message ("Can't get document portal: %s", local_error->message);
             }
@@ -3471,8 +3471,8 @@ flatpak_run_setup_usr_links (FlatpakBwrap *bwrap,
         }
       else
         {
-          g_debug ("%s does not exist",
-                   flatpak_file_get_path_cached (runtime_subdir));
+          g_info ("%s does not exist",
+                  flatpak_file_get_path_cached (runtime_subdir));
         }
     }
 }
@@ -3644,7 +3644,7 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
   if ((flags & FLATPAK_RUN_FLAG_SET_PERSONALITY) &&
       flatpak_is_linux32_arch (arch))
     {
-      g_debug ("Setting personality linux32");
+      g_info ("Setting personality linux32");
       pers = PER_LINUX32;
     }
 
@@ -3798,7 +3798,7 @@ add_rest_args (FlatpakBwrap   *bwrap,
               g_assert (doc_path != NULL);
             }
 
-          g_debug ("Forwarding file '%s' as '%s' to %s", args[i], doc_path, app_id);
+          g_info ("Forwarding file '%s' as '%s' to %s", args[i], doc_path, app_id);
           flatpak_bwrap_add_arg (bwrap, doc_path);
         }
       else
@@ -3894,7 +3894,7 @@ regenerate_ld_cache (GPtrArray    *base_argv_array,
   if (ld_so_fd >= 0)
     return glnx_steal_fd (&ld_so_fd);
 
-  g_debug ("Regenerating ld.so.cache %s", flatpak_file_get_path_cached (ld_so_cache));
+  g_info ("Regenerating ld.so.cache %s", flatpak_file_get_path_cached (ld_so_cache));
 
   if (!flatpak_mkdir_p (ld_so_dir, cancellable, error))
     return FALSE;
@@ -3942,7 +3942,7 @@ regenerate_ld_cache (GPtrArray    *base_argv_array,
   flatpak_bwrap_finish (bwrap);
 
   commandline = flatpak_quote_argv ((const char **) bwrap->argv->pdata, -1);
-  g_debug ("Running: '%s'", commandline);
+  g_info ("Running: '%s'", commandline);
 
   combined_fd_array = g_array_new (FALSE, TRUE, sizeof (int));
   g_array_append_vals (combined_fd_array, base_fd_array->data, base_fd_array->len);
@@ -4025,15 +4025,15 @@ check_parental_controls (FlatpakDecomposed *app_ref,
                                            cancellable, &local_error);
   if (g_error_matches (local_error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_DISABLED))
     {
-      g_debug ("Skipping parental controls check for %s since parental "
-               "controls are disabled globally", flatpak_decomposed_get_ref (app_ref));
+      g_info ("Skipping parental controls check for %s since parental "
+              "controls are disabled globally", flatpak_decomposed_get_ref (app_ref));
       return TRUE;
     }
   else if (g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
            g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER))
     {
-      g_debug ("Skipping parental controls check for %s since a required "
-               "service was not found", flatpak_decomposed_get_ref (app_ref));
+      g_info ("Skipping parental controls check for %s since a required "
+              "service was not found", flatpak_decomposed_get_ref (app_ref));
       return TRUE;
     }
   else if (local_error != NULL)
@@ -4719,7 +4719,7 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
   flatpak_bwrap_finish (bwrap);
 
   commandline = flatpak_quote_argv ((const char **) bwrap->argv->pdata, -1);
-  g_debug ("Running '%s'", commandline);
+  g_info ("Running '%s'", commandline);
 
   if ((flags & (FLATPAK_RUN_FLAG_BACKGROUND)) != 0 ||
       g_getenv ("FLATPAK_TEST_COVERAGE") != NULL)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -369,7 +369,7 @@ flatpak_run_add_x11_args (FlatpakBwrap         *bwrap,
         }
       else
         {
-          flatpak_debug2 ("Assuming --share=network gives access to remote X11");
+          g_debug ("Assuming --share=network gives access to remote X11");
         }
 
 #ifdef ENABLE_XAUTH
@@ -3350,8 +3350,8 @@ setup_seccomp (FlatpakBwrap   *bwrap,
        * libseccomp cannot map the syscall number to a name and back to a
        * number for the non-native architecture. */
       if (r == -EFAULT)
-        flatpak_debug2 ("Unable to block syscall %d: syscall not known to libseccomp?",
-                        scall);
+        g_debug ("Unable to block syscall %d: syscall not known to libseccomp?",
+                 scall);
       else if (r < 0)
         return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Failed to block syscall %d: %s"), scall, flatpak_seccomp_strerror (r));
     }
@@ -3367,8 +3367,8 @@ setup_seccomp (FlatpakBwrap   *bwrap,
 
       /* See above for the meaning of EFAULT. */
       if (r == -EFAULT)
-        flatpak_debug2 ("Unable to block syscall %d: syscall not known to libseccomp?",
-                        scall);
+        g_debug ("Unable to block syscall %d: syscall not known to libseccomp?",
+                 scall);
       else if (r < 0)
         return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Failed to block syscall %d: %s"), scall, flatpak_seccomp_strerror (r));
     }
@@ -3389,8 +3389,8 @@ setup_seccomp (FlatpakBwrap   *bwrap,
 
           /* See above for the meaning of EFAULT. */
           if (r == -EFAULT)
-            flatpak_debug2 ("Unable to block syscall %d: syscall not known to libseccomp?",
-                            scall);
+            g_debug ("Unable to block syscall %d: syscall not known to libseccomp?",
+                     scall);
           else if (r < 0)
             return flatpak_fail_error (error, FLATPAK_ERROR_SETUP_FAILED, _("Failed to block syscall %d: %s"), scall, flatpak_seccomp_strerror (r));
         }

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2121,11 +2121,11 @@ flatpak_transaction_add_op (FlatpakTransaction             *self,
   g_autofree char *subpaths_str = NULL;
 
   subpaths_str = subpaths_to_string (subpaths);
-  g_debug ("Transaction: %s %s:%s%s%s%s",
-           kind_to_str (kind), remote, flatpak_decomposed_get_ref (ref),
-           commit != NULL ? "@" : "",
-           commit != NULL ? commit : "",
-           subpaths_str);
+  g_info ("Transaction: %s %s:%s%s%s%s",
+          kind_to_str (kind), remote, flatpak_decomposed_get_ref (ref),
+          commit != NULL ? "@" : "",
+          commit != NULL ? commit : "",
+          subpaths_str);
 
   op = flatpak_transaction_get_last_op_for_ref (self, ref);
   /* If previous_ids is given, then this is a rebase operation. */
@@ -2192,7 +2192,7 @@ op_get_related (FlatpakTransaction           *self,
 
   if (op->resolved_metakey == NULL)
     {
-      g_debug ("no resolved metadata for related to %s", flatpak_decomposed_get_ref (op->ref));
+      g_info ("no resolved metadata for related to %s", flatpak_decomposed_get_ref (op->ref));
       return TRUE;
     }
 
@@ -2345,7 +2345,7 @@ search_for_dependency (FlatpakTransaction  *self,
       state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_INSTALL, remote, arch, &local_error);
       if (state == NULL)
         {
-          g_debug ("Can't get state for remote %s, ignoring: %s", remote, local_error->message);
+          g_info ("Can't get state for remote %s, ignoring: %s", remote, local_error->message);
           continue;
         }
 
@@ -2468,7 +2468,7 @@ op_get_runtime_ref (FlatpakTransactionOperation *op)
 
   decomposed = flatpak_decomposed_new_from_pref (FLATPAK_KINDS_RUNTIME, runtime_pref, NULL);
   if (decomposed == NULL)
-    g_debug ("Invalid runtime ref %s in metadata", runtime_pref);
+    g_info ("Invalid runtime ref %s in metadata", runtime_pref);
 
   return decomposed;
 }
@@ -2488,7 +2488,7 @@ op_get_sdk_ref (FlatpakTransactionOperation *op)
 
   decomposed = flatpak_decomposed_new_from_pref (FLATPAK_KINDS_RUNTIME, sdk_pref, NULL);
   if (decomposed == NULL)
-    g_debug ("Invalid runtime ref %s in metadata", sdk_pref);
+    g_info ("Invalid runtime ref %s in metadata", sdk_pref);
 
   return decomposed;
 }
@@ -2505,8 +2505,8 @@ add_new_dep_op (FlatpakTransaction           *self,
 
   if (!ref_is_installed (self, dep_ref))
     {
-      g_debug ("Installing dependency %s of %s", flatpak_decomposed_get_pref (dep_ref),
-               flatpak_decomposed_get_pref (op->ref));
+      g_info ("Installing dependency %s of %s", flatpak_decomposed_get_pref (dep_ref),
+              flatpak_decomposed_get_pref (op->ref));
       dep_remote = find_runtime_remote (self, op->ref, op->remote, dep_ref, op->kind, NULL, error);
       if (dep_remote == NULL)
         return FALSE;
@@ -2521,8 +2521,8 @@ add_new_dep_op (FlatpakTransaction           *self,
       /* Update if in same dir */
       if (dir_ref_is_installed (priv->dir, dep_ref, &dep_remote, NULL))
         {
-          g_debug ("Updating dependency %s of %s", flatpak_decomposed_get_pref (dep_ref),
-                   flatpak_decomposed_get_pref (op->ref));
+          g_info ("Updating dependency %s of %s", flatpak_decomposed_get_pref (dep_ref),
+                  flatpak_decomposed_get_pref (op->ref));
           *dep_op = flatpak_transaction_add_op (self, dep_remote, dep_ref, NULL, NULL, NULL, NULL,
                                                 FLATPAK_TRANSACTION_OPERATION_UPDATE, FALSE, error);
           if (*dep_op == NULL)
@@ -2668,7 +2668,7 @@ flatpak_transaction_add_ref (FlatpakTransaction             *self,
 
       if (flatpak_dir_get_remote_disabled (priv->dir, origin))
         {
-          g_debug (_("Remote %s disabled, ignoring %s update"), origin, pref);
+          g_info (_("Remote %s disabled, ignoring %s update"), origin, pref);
           return TRUE;
         }
       remote = origin;
@@ -3006,13 +3006,13 @@ flatpak_transaction_update_metadata (FlatpakTransaction *self,
       g_autoptr(GError) my_error = NULL;
       g_autoptr(FlatpakRemoteState) state = flatpak_transaction_ensure_remote_state (self, FLATPAK_TRANSACTION_OPERATION_UPDATE, remote, NULL, NULL);
 
-      g_debug ("Looking for remote metadata updates for %s", remote);
+      g_info ("Looking for remote metadata updates for %s", remote);
       if (!flatpak_dir_update_remote_configuration (priv->dir, remote, state, &updated, cancellable, &my_error))
-        g_debug (_("Error updating remote metadata for '%s': %s"), remote, my_error->message);
+        g_info (_("Error updating remote metadata for '%s': %s"), remote, my_error->message);
 
       if (updated)
         {
-          g_debug ("Got updated metadata for %s", remote);
+          g_info ("Got updated metadata for %s", remote);
           some_updated = TRUE;
         }
     }
@@ -3070,13 +3070,13 @@ flatpak_transaction_add_auto_install (FlatpakTransaction *self,
               if (state != NULL &&
                   flatpak_remote_state_lookup_ref (state, flatpak_decomposed_get_ref (auto_install_ref), NULL, NULL, NULL, NULL, NULL))
                 {
-                  g_debug ("Auto adding install of %s from remote %s", flatpak_decomposed_get_ref (auto_install_ref), remote);
+                  g_info ("Auto adding install of %s from remote %s", flatpak_decomposed_get_ref (auto_install_ref), remote);
 
                   if (!flatpak_transaction_add_ref (self, remote, auto_install_ref, NULL, NULL, NULL,
                                                     FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE,
                                                     NULL, NULL, FALSE,
                                                     &local_error))
-                    g_debug ("Failed to add auto-install ref %s: %s", flatpak_decomposed_get_ref (auto_install_ref),
+                    g_info ("Failed to add auto-install ref %s: %s", flatpak_decomposed_get_ref (auto_install_ref),
                              local_error->message);
                 }
             }
@@ -3144,7 +3144,7 @@ load_deployed_metadata (FlatpakTransaction *self, FlatpakDecomposed *ref, char *
 
   if (!g_file_load_contents (metadata_file, NULL, &metadata_contents, &metadata_contents_length, NULL, NULL))
     {
-      g_debug ("No metadata in local deploy of %s", flatpak_decomposed_get_ref (ref));
+      g_info ("No metadata in local deploy of %s", flatpak_decomposed_get_ref (ref));
       return NULL;
     }
 
@@ -3176,7 +3176,7 @@ mark_op_resolved (FlatpakTransactionOperation *op,
                   GBytes                      *old_metadata,
                   GError                     **error)
 {
-  g_debug ("marking op %s:%s resolved to %s", kind_to_str (op->kind), flatpak_decomposed_get_ref (op->ref), commit ? commit : "-");
+  g_info ("marking op %s:%s resolved to %s", kind_to_str (op->kind), flatpak_decomposed_get_ref (op->ref), commit ? commit : "-");
 
   g_assert (op != NULL);
 
@@ -3478,7 +3478,7 @@ resolve_ops (FlatpakTransaction *self,
                   if (latest_sideload_path != NULL && local_commit_data && latest_timestamp != 0 &&
                       ostree_commit_get_timestamp (local_commit_data) > latest_timestamp)
                     {
-                      g_debug ("Installed commit %s newer than sideloaded %s, ignoring", local_checksum, latest_checksum);
+                      g_info ("Installed commit %s newer than sideloaded %s, ignoring", local_checksum, latest_checksum);
                       checksum = g_steal_pointer (&local_checksum);
                     }
                   else
@@ -3536,7 +3536,7 @@ resolve_ops (FlatpakTransaction *self,
                   if (g_error_matches (local_error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_UNAUTHORIZED) && !op->requested_token)
                     {
 
-                      g_debug ("Unauthorized access during resolve by commit of %s, retrying with token", flatpak_decomposed_get_ref (op->ref));
+                      g_info ("Unauthorized access during resolve by commit of %s, retrying with token", flatpak_decomposed_get_ref (op->ref));
                       priv->needs_resolve = TRUE;
                       priv->needs_tokens = TRUE;
 
@@ -3622,7 +3622,7 @@ request_tokens_webflow (FlatpakAuthenticatorRequest *object,
   g_assert (priv->active_request_id == 0);
   priv->active_request_id = ++priv->next_request_id;
 
-  g_debug ("Webflow start %s", arg_uri);
+  g_info ("Webflow start %s", arg_uri);
   g_signal_emit (transaction, signals[WEBFLOW_START], 0, data->remote, arg_uri, options, priv->active_request_id, &retval);
   if (!retval)
     {
@@ -3632,7 +3632,7 @@ request_tokens_webflow (FlatpakAuthenticatorRequest *object,
 
       /* We didn't handle the uri, cancel the auth op. */
       if (!flatpak_authenticator_request_call_close_sync (data->request, NULL, &local_error))
-        g_debug ("Failed to close auth request: %s", local_error->message);
+        g_info ("Failed to close auth request: %s", local_error->message);
     }
 }
 
@@ -3652,7 +3652,7 @@ request_tokens_webflow_done (FlatpakAuthenticatorRequest *object,
   id = priv->active_request_id;
   priv->active_request_id = 0;
 
-  g_debug ("Webflow done");
+  g_info ("Webflow done");
   g_signal_emit (transaction, signals[WEBFLOW_DONE], 0, options, id);
 }
 
@@ -3672,7 +3672,7 @@ request_tokens_basic_auth (FlatpakAuthenticatorRequest *object,
   g_assert (priv->active_request_id == 0);
   priv->active_request_id = ++priv->next_request_id;
 
-  g_debug ("BasicAuth start %s", arg_realm);
+  g_info ("BasicAuth start %s", arg_realm);
   g_signal_emit (transaction, signals[BASIC_AUTH_START], 0, data->remote, arg_realm, options, priv->active_request_id, &retval);
   if (!retval)
     {
@@ -3682,7 +3682,7 @@ request_tokens_basic_auth (FlatpakAuthenticatorRequest *object,
 
       /* We didn't handle the request, cancel the auth op. */
       if (!flatpak_authenticator_request_call_close_sync (data->request, NULL, &local_error))
-        g_debug ("Failed to close auth request: %s", local_error->message);
+        g_info ("Failed to close auth request: %s", local_error->message);
     }
 
 }
@@ -3719,7 +3719,7 @@ flatpak_transaction_abort_webflow (FlatpakTransaction *self,
       if (!data->done)
         {
           if (!flatpak_authenticator_request_call_close_sync (data->request, NULL, &local_error))
-            g_debug ("Failed to close auth request: %s", local_error->message);
+            g_info ("Failed to close auth request: %s", local_error->message);
         }
     }
 }
@@ -3763,7 +3763,7 @@ flatpak_transaction_complete_basic_auth (FlatpakTransaction *self,
       if (user == NULL)
         {
           if (!flatpak_authenticator_request_call_close_sync (data->request, NULL, &local_error))
-            g_debug ("Failed to abort basic auth request: %s", local_error->message);
+            g_info ("Failed to abort basic auth request: %s", local_error->message);
         }
       else
         {
@@ -3771,7 +3771,7 @@ flatpak_transaction_complete_basic_auth (FlatpakTransaction *self,
                                                                          user, password,
                                                                          options,
                                                                          NULL, &local_error))
-            g_debug ("Failed to reply to basic auth request: %s", local_error->message);
+            g_info ("Failed to reply to basic auth request: %s", local_error->message);
         }
     }
 }
@@ -3858,7 +3858,7 @@ request_tokens_for_remote (FlatpakTransaction *self,
         g_string_append (refs_as_str, ", ");
     }
 
-  g_debug ("Requesting tokens for remote %s: %s", remote, refs_as_str->str);
+  g_info ("Requesting tokens for remote %s: %s", remote, refs_as_str->str);
   refs = g_variant_ref_sink (g_variant_builder_end (&refs_builder));
 
   extra_builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
@@ -3904,7 +3904,7 @@ request_tokens_for_remote (FlatpakTransaction *self,
 
   {
     g_autofree char *results_str = results != NULL ? g_variant_print (results, FALSE) : g_strdup ("NULL");
-    g_debug ("Response from request_tokens: %d - %s\n", data.response, results_str);
+    g_info ("Response from request_tokens: %d - %s\n", data.response, results_str);
   }
 
   if (data.response == FLATPAK_AUTH_RESPONSE_CANCELLED)
@@ -4755,7 +4755,7 @@ _run_op_kind (FlatpakTransaction           *self,
             }
         }
       else
-        g_debug ("%s need no update", flatpak_decomposed_get_ref (op->ref));
+        g_info ("%s need no update", flatpak_decomposed_get_ref (op->ref));
     }
   else if (op->kind == FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE)
     {

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -459,7 +459,7 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *session,
   long response;
   CURL *curl = session->curl;
 
-  g_debug ("Loading %s using curl", uri);
+  g_info ("Loading %s using curl", uri);
 
   curl_easy_setopt (curl, CURLOPT_URL, uri);
   curl_easy_setopt (curl, CURLOPT_WRITEDATA, (void *)data);
@@ -548,7 +548,7 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *session,
       !check_http_status (data->status, error))
     return FALSE;
 
-  g_debug ("Received %" G_GUINT64_FORMAT " bytes", data->downloaded_bytes);
+  g_info ("Received %" G_GUINT64_FORMAT " bytes", data->downloaded_bytes);
 
   /* This is not really needed, but the auto-pointer confuses some compilers in the CI */
   g_clear_pointer (&curl_lock, g_mutex_locker_free);
@@ -808,7 +808,7 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *http_session,
   g_autoptr(SoupRequestHTTP) request = NULL;
   SoupMessage *m;
 
-  g_debug ("Loading %s using libsoup", uri);
+  g_info ("Loading %s using libsoup", uri);
 
   request = soup_session_request_http (soup_session,
                                        (data->flags & FLATPAK_HTTP_FLAGS_HEAD) != 0 ? "HEAD" : "GET",
@@ -873,7 +873,7 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *http_session,
       return FALSE;
     }
 
-  g_debug ("Received %" G_GUINT64_FORMAT " bytes", data->downloaded_bytes);
+  g_info ("Received %" G_GUINT64_FORMAT " bytes", data->downloaded_bytes);
 
   return TRUE;
 }
@@ -904,8 +904,8 @@ flatpak_http_should_retry_request (const GError *error,
       g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
       g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE))
     {
-      g_debug ("Should retry request (remaining: %u retries), due to transient error: %s",
-               n_retries_remaining, error->message);
+      g_info ("Should retry request (remaining: %u retries), due to transient error: %s",
+              n_retries_remaining, error->message);
       return TRUE;
     }
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -102,8 +102,6 @@ gboolean flatpak_fail_error (GError     **error,
                              const char  *fmt,
                              ...) G_GNUC_PRINTF (3, 4);
 
-#define flatpak_debug2(...) g_log (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __VA_ARGS__)
-
 gint flatpak_strcmp0_ptr (gconstpointer a,
                           gconstpointer b);
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -102,8 +102,7 @@ gboolean flatpak_fail_error (GError     **error,
                              const char  *fmt,
                              ...) G_GNUC_PRINTF (3, 4);
 
-void flatpak_debug2 (const char *format,
-                     ...) G_GNUC_PRINTF (1, 2);
+#define flatpak_debug2(...) g_log (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __VA_ARGS__)
 
 gint flatpak_strcmp0_ptr (gconstpointer a,
                           gconstpointer b);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -120,18 +120,6 @@ flatpak_fail_error (GError **error, FlatpakError code, const char *fmt, ...)
   return FALSE;
 }
 
-void
-flatpak_debug2 (const char *format, ...)
-{
-  va_list var_args;
-
-  va_start (var_args, format);
-  g_logv (G_LOG_DOMAIN "2",
-          G_LOG_LEVEL_DEBUG,
-          format, var_args);
-  va_end (var_args);
-}
-
 gboolean
 flatpak_write_update_checksum (GOutputStream *out,
                                gconstpointer  data,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -628,7 +628,7 @@ load_kernel_module_list (void)
   
   if (!g_file_get_contents ("/proc/modules", &modules_data, NULL, &error))
     {
-      g_debug ("Failed to read /proc/modules: %s", error->message);
+      g_info ("Failed to read /proc/modules: %s", error->message);
       return modules;
     }
 
@@ -3199,7 +3199,7 @@ flatpak_repo_save_digested_summary (OstreeRepo   *repo,
   if (fstatat (repo_dfd, path, &stbuf, 0) == 0 &&
       stbuf.st_size != 0)
     {
-      g_debug ("Reusing digested summary at %s for %s", path, name);
+      g_info ("Reusing digested summary at %s for %s", path, name);
       return g_steal_pointer (&digest);
     }
 
@@ -3215,7 +3215,7 @@ flatpak_repo_save_digested_summary (OstreeRepo   *repo,
                                       cancellable, error))
     return NULL;
 
-  g_debug ("Wrote digested summary at %s for %s", path, name);
+  g_info ("Wrote digested summary at %s for %s", path, name);
   return g_steal_pointer (&digest);
 }
 
@@ -3244,7 +3244,7 @@ flatpak_repo_save_digested_summary_delta (OstreeRepo   *repo,
   if (fstatat (repo_dfd, path, &stbuf, 0) == 0 &&
       stbuf.st_size == g_bytes_get_size (delta))
     {
-      g_debug ("Reusing digested summary-diff for %s", filename);
+      g_info ("Reusing digested summary-diff for %s", filename);
       return TRUE;
     }
 
@@ -3255,7 +3255,7 @@ flatpak_repo_save_digested_summary_delta (OstreeRepo   *repo,
                                       cancellable, error))
     return FALSE;
 
-  g_debug ("Wrote digested summary delta at %s", path);
+  g_info ("Wrote digested summary delta at %s", path);
   return TRUE;
 }
 
@@ -3318,7 +3318,7 @@ populate_commit_data_cache (OstreeRepo *repo,
   if (cache_version < FLATPAK_XA_CACHE_VERSION)
     {
       /* Need to re-index to get all data */
-      g_debug ("Old summary cache version %d, not using cache", cache_version);
+      g_info ("Old summary cache version %d, not using cache", cache_version);
       return NULL;
     }
 
@@ -3340,7 +3340,7 @@ populate_commit_data_cache (OstreeRepo *repo,
       checksum_bytes = var_subsummary_peek_checksum (subsummary, &checksum_bytes_len);
       if (G_UNLIKELY (checksum_bytes_len != OSTREE_SHA256_DIGEST_LEN))
         {
-          g_debug ("Invalid checksum for digested summary, not using cache");
+          g_info ("Invalid checksum for digested summary, not using cache");
           return NULL;
         }
       digest = ostree_checksum_from_bytes (checksum_bytes);
@@ -3354,7 +3354,7 @@ populate_commit_data_cache (OstreeRepo *repo,
       summary_v = flatpak_repo_load_digested_summary (repo, digest, NULL);
       if (summary_v == NULL)
         {
-          g_debug ("Failed to load digested summary %s, not using cache", digest);
+          g_info ("Failed to load digested summary %s, not using cache", digest);
           return NULL;
         }
 
@@ -3386,7 +3386,7 @@ populate_commit_data_cache (OstreeRepo *repo,
           if (!var_metadata_lookup (commit_metadata, "xa.data", NULL, &xa_data_v) ||
               !var_variant_is_type (xa_data_v, G_VARIANT_TYPE ("(tts)")))
             {
-              g_debug ("Missing xa.data for ref %s, not using cache", ref);
+              g_info ("Missing xa.data for ref %s, not using cache", ref);
               return NULL;
             }
 
@@ -4291,7 +4291,7 @@ add_summary_metadata (OstreeRepo   *repo,
     g_variant_builder_add (metadata_builder, "{sv}", "xa.deploy-collection-id",
                            g_variant_new_string (collection_id));
   else if (deploy_collection_id)
-    g_debug ("Ignoring deploy-collection-id=true because no collection ID is set.");
+    g_info ("Ignoring deploy-collection-id=true because no collection ID is set.");
 
   if (authenticator_name)
     g_variant_builder_add (metadata_builder, "{sv}", "xa.authenticator-name",
@@ -4753,7 +4753,7 @@ flatpak_repo_gc_digested_summaries (OstreeRepo *repo,
               /* Keep all the referenced summaries */
               if (g_hash_table_contains (digested_summary_cache, sha256))
                 {
-                  g_debug ("Keeping referenced summary %s", dent->d_name);
+                  g_info ("Keeping referenced summary %s", dent->d_name);
                   continue;
                 }
               /* Remove rest */
@@ -4769,7 +4769,7 @@ flatpak_repo_gc_digested_summaries (OstreeRepo *repo,
                   /* Only keep deltas going to a generated summary */
                   if (g_hash_table_contains (digested_summaries, to_sha256))
                     {
-                      g_debug ("Keeping delta to generated summary %s", dent->d_name);
+                      g_info ("Keeping delta to generated summary %s", dent->d_name);
                       continue;
                     }
                   /* Remove rest */
@@ -4793,7 +4793,7 @@ flatpak_repo_gc_digested_summaries (OstreeRepo *repo,
 
       if (remove)
         {
-          g_debug ("Removing old digested summary file %s", dent->d_name);
+          g_info ("Removing old digested summary file %s", dent->d_name);
           if (unlinkat (iter.fd, dent->d_name, 0) != 0)
             {
               glnx_set_error_from_errno (error);
@@ -4801,7 +4801,7 @@ flatpak_repo_gc_digested_summaries (OstreeRepo *repo,
             }
         }
       else
-        g_debug ("Keeping unexpected summary file %s", dent->d_name);
+        g_info ("Keeping unexpected summary file %s", dent->d_name);
     }
 
   return TRUE;
@@ -5316,7 +5316,7 @@ copy_icon (const char        *id,
 
   if (!ostree_repo_file_ensure_resolved (OSTREE_REPO_FILE(icon_file), NULL))
     {
-      g_debug ("No icon at size %s for %s", size, id);
+      g_info ("No icon at size %s for %s", size, id);
       return TRUE;
     }
 
@@ -5614,9 +5614,9 @@ _flatpak_repo_generate_appstream (OstreeRepo   *repo,
   const char *collection_id;
 
   if (subset != NULL && *subset != 0)
-    g_debug ("Generating appstream for %s, subset %s", arch, subset);
+    g_info ("Generating appstream for %s, subset %s", arch, subset);
   else
-    g_debug ("Generating appstream for %s", arch);
+    g_info ("Generating appstream for %s", arch);
 
   collection_id = ostree_repo_get_collection_id (repo);
 
@@ -5676,7 +5676,7 @@ _flatpak_repo_generate_appstream (OstreeRepo   *repo,
       if (var_metadata_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE, NULL, NULL) ||
           var_metadata_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, NULL, NULL))
         {
-          g_debug (_("%s is end-of-life, ignoring for appstream"), flatpak_decomposed_get_ref (ref));
+          g_info (_("%s is end-of-life, ignoring for appstream"), flatpak_decomposed_get_ref (ref));
           continue;
         }
 
@@ -5768,7 +5768,7 @@ _flatpak_repo_generate_appstream (OstreeRepo   *repo,
           if (g_file_equal (root, parent_root))
             {
               skip_commit = TRUE;
-              g_debug ("Not updating %s, no change", branch);
+              g_info ("Not updating %s, no change", branch);
             }
         }
 
@@ -5819,7 +5819,7 @@ _flatpak_repo_generate_appstream (OstreeRepo   *repo,
                 }
             }
 
-          g_debug ("Creating appstream branch %s", branch);
+          g_info ("Creating appstream branch %s", branch);
           if (collection_id != NULL)
             {
               const OstreeCollectionRef collection_ref = { (char *) collection_id, branch };
@@ -6993,7 +6993,7 @@ flatpak_mirror_image_from_oci (FlatpakOciRegistry    *dst_registry,
 
       if (delta_layer)
         {
-          g_debug ("Using OCI delta %s for layer %s", delta_layer->digest, layer->digest);
+          g_info ("Using OCI delta %s for layer %s", delta_layer->digest, layer->digest);
           g_autofree char *delta_digest = NULL;
           glnx_autofd int delta_fd = flatpak_oci_registry_download_blob (registry, oci_repository, FALSE,
                                                                          delta_layer->digest, (const char **)delta_layer->urls,
@@ -7182,7 +7182,7 @@ flatpak_pull_from_oci (OstreeRepo            *repo,
 
       if (delta_layer)
         {
-          g_debug ("Using OCI delta %s for layer %s", delta_layer->digest, layer->digest);
+          g_info ("Using OCI delta %s for layer %s", delta_layer->digest, layer->digest);
           expected_digest = image_config->rootfs.diff_ids[i]; /* The delta recreates the uncompressed tar so use that digest */
         }
       else
@@ -8244,7 +8244,7 @@ flatpak_log_dir_access (FlatpakDir *dir)
       if (dir_path != NULL)
         dir_path_str = g_file_get_path (dir_path);
       dir_name = flatpak_dir_get_name (dir);
-      g_debug ("Opening %s flatpak installation at path %s", dir_name, dir_path_str);
+      g_info ("Opening %s flatpak installation at path %s", dir_name, dir_path_str);
     }
 }
 

--- a/icon-validator/validate-icon.c
+++ b/icon-validator/validate-icon.c
@@ -233,7 +233,7 @@ rerun_in_sandbox (const char *arg_width,
 
   {
     g_autofree char *cmdline = g_strjoinv (" ", (char **) args->pdata);
-    g_debug ("Icon validation: Spawning %s", cmdline);
+    g_info ("Icon validation: Spawning %s", cmdline);
   }
 
   execvpe (flatpak_get_bwrap (), (char **) args->pdata, NULL);

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -765,7 +765,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, message_handler, NULL);
 
   g_info ("Started flatpak-authenticator");
 

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -40,7 +40,7 @@ static FlatpakHttpSession *http_session = NULL;
 static void
 skeleton_died_cb (gpointer data)
 {
-  g_debug ("skeleton finalized, exiting");
+  g_info ("skeleton finalized, exiting");
   g_main_loop_quit (main_loop);
 }
 
@@ -49,7 +49,7 @@ unref_skeleton_in_timeout_cb (gpointer user_data)
 {
   static gboolean unreffed = FALSE;
 
-  g_debug ("unreffing authenticator main ref");
+  g_info ("unreffing authenticator main ref");
   if (!unreffed)
     {
       g_object_unref (authenticator);
@@ -79,7 +79,7 @@ idle_timeout_cb (gpointer user_data)
 {
   if (name_owner_id)
     {
-      g_debug ("Idle - unowning name");
+      g_info ("Idle - unowning name");
       unref_skeleton_in_timeout ();
     }
   return G_SOURCE_REMOVE;
@@ -130,7 +130,7 @@ handle_request_ref_tokens_close (FlatpakAuthenticatorRequest *object,
 {
   BasicAuthData *auth = user_data;
 
-  g_debug ("handlling Request.Close");
+  g_info ("handlling Request.Close");
 
   flatpak_authenticator_request_complete_close (object, invocation);
 
@@ -181,7 +181,7 @@ peer_died (const char *name)
         {
           for (GList *l = active; l != NULL; l = l->next)
             {
-              g_debug ("Cancelling auth operation for dying peer %s", name);
+              g_info ("Cancelling auth operation for dying peer %s", name);
               cancel_basic_auth (l->data);
             }
           g_list_free (active);
@@ -202,7 +202,7 @@ handle_request_ref_tokens_basic_auth_reply (FlatpakAuthenticatorRequest *object,
 {
   BasicAuthData *auth = user_data;
 
-  g_debug ("handlling Request.BasicAuthReply %s %s", arg_user, arg_password);
+  g_info ("handlling Request.BasicAuthReply %s %s", arg_user, arg_password);
 
   flatpak_authenticator_request_complete_basic_auth_reply (object, invocation);
 
@@ -465,7 +465,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
   GVariantBuilder results;
   g_autofree char *sender = g_strdup (g_dbus_method_invocation_get_sender (invocation));
 
-  g_debug ("handling Authenticator.RequestRefTokens");
+  g_info ("handling Authenticator.RequestRefTokens");
 
   g_variant_lookup (arg_authenticator_options, "auth", "&s", &auth);
   have_auth = auth != NULL;
@@ -509,7 +509,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
   /* Look up credentials in config files */
   if (!have_auth)
     {
-      g_debug ("Looking for %s in auth info", oci_registry_uri);
+      g_info ("Looking for %s in auth info", oci_registry_uri);
       auth = lookup_auth_from_config (oci_registry_uri);
       have_auth = auth != NULL;
     }
@@ -520,7 +520,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
     {
       g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
 
-      g_debug ("Trying anonymous authentication");
+      g_info ("Trying anonymous authentication");
 
       first_token = get_token_for_ref (registry, ref_data, NULL, &anon_error);
       if (first_token != NULL)
@@ -529,7 +529,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
         {
           if (g_error_matches (anon_error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_AUTHORIZED))
             {
-              g_debug ("Anonymous authentication failed: %s", anon_error->message);
+              g_info ("Anonymous authentication failed: %s", anon_error->message);
 
               /* Continue trying with authentication below */
             }
@@ -551,7 +551,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
     {
       g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
 
-      g_debug ("Trying user/password based authentication");
+      g_info ("Trying user/password based authentication");
 
       while (auth == NULL)
         {
@@ -576,7 +576,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
                 return error_request (request, sender, error);
               else
                 {
-                  g_debug ("Auth failed getting token: %s", error->message);
+                  g_info ("Auth failed getting token: %s", error->message);
                   /* Keep error for reporting below, or clear on next iteration start */
                 }
             }
@@ -612,7 +612,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
   g_variant_builder_init (&results, G_VARIANT_TYPE ("a{sv}"));
   g_variant_builder_add (&results, "{sv}", "tokens", g_variant_builder_end (&tokens));
 
-  g_debug ("emitting OK response");
+  g_info ("emitting OK response");
   flatpak_authenticator_request_emit_response (request,
                                                FLATPAK_AUTH_RESPONSE_OK,
                                                g_variant_builder_end (&results));
@@ -639,7 +639,7 @@ on_bus_acquired (GDBusConnection *connection,
 {
   GError *error = NULL;
 
-  g_debug ("Bus acquired, creating skeleton");
+  g_info ("Bus acquired, creating skeleton");
 
   g_dbus_connection_set_exit_on_close (connection, FALSE);
 
@@ -673,7 +673,7 @@ on_name_acquired (GDBusConnection *connection,
                   const gchar     *name,
                   gpointer         user_data)
 {
-  g_debug ("Name acquired");
+  g_info ("Name acquired");
 }
 
 static void
@@ -681,7 +681,7 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
-  g_debug ("Name lost");
+  g_info ("Name lost");
 }
 
 
@@ -767,7 +767,7 @@ main (int    argc,
   if (opt_verbose)
     g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
-  g_debug ("Started flatpak-authenticator");
+  g_info ("Started flatpak-authenticator");
 
   http_session = flatpak_create_http_session (PACKAGE_STRING);
 

--- a/portal/flatpak-portal-app-info.c
+++ b/portal/flatpak-portal-app-info.c
@@ -86,7 +86,7 @@ parse_app_id_from_fileinfo (int pid)
       /* Not able to open the root dir shouldn't happen. Probably the app died and
        * we're failing due to /proc/$pid not existing. In that case fail instead
          of treating this as privileged. */
-      g_debug ("Unable to open %s", root_path);
+      g_info ("Unable to open %s", root_path);
       return NULL;
     }
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -133,7 +133,7 @@ static gboolean           handle_update            (PortalFlatpakUpdateMonitor *
 static void
 skeleton_died_cb (gpointer data)
 {
-  g_debug ("skeleton finalized, exiting");
+  g_info ("skeleton finalized, exiting");
   g_main_loop_quit (main_loop);
 }
 
@@ -142,7 +142,7 @@ unref_skeleton_in_timeout_cb (gpointer user_data)
 {
   static gboolean unreffed = FALSE;
 
-  g_debug ("unreffing portal main ref");
+  g_info ("unreffing portal main ref");
   if (!unreffed)
     {
       g_object_unref (portal);
@@ -176,7 +176,7 @@ idle_timeout_cb (gpointer user_data)
       g_hash_table_size (client_pid_data_hash) == 0 &&
       !has_update_monitors ())
     {
-      g_debug ("Idle - unowning name");
+      g_info ("Idle - unowning name");
       unref_skeleton_in_timeout ();
     }
 
@@ -225,7 +225,7 @@ child_watch_died (GPid     pid,
   PidData *pid_data = user_data;
   g_autoptr(GVariant) signal_variant = NULL;
 
-  g_debug ("Client Pid %d died", pid_data->pid);
+  g_info ("Client Pid %d died", pid_data->pid);
 
   signal_variant = g_variant_ref_sink (g_variant_new ("(uu)", pid, status));
   g_dbus_connection_emit_signal (session_bus,
@@ -386,7 +386,7 @@ check_child_pid_status (void *user_data)
       else
         timeout = timeouts[MIN (data->attempt, G_N_ELEMENTS (timeouts) - 1)];
 
-      g_debug ("Failed to read child PID, trying again in %d ms", timeout);
+      g_info ("Failed to read child PID, trying again in %d ms", timeout);
 
       /* The timer source only needs to be re-added if the timeout has changed,
           which won't happen while staying on the 100 or 1000ms timeouts.
@@ -417,7 +417,7 @@ check_child_pid_status (void *user_data)
         g_warning ("Failed to find relative PID for %d: %s", child_pid, error->message);
     }
 
-  g_debug ("Emitting SpawnStarted(%u, %d)", pid, relative_child_pid);
+  g_info ("Emitting SpawnStarted(%u, %d)", pid, relative_child_pid);
 
   signal_variant = g_variant_ref_sink (g_variant_new ("(uu)", pid, relative_child_pid));
   g_dbus_connection_emit_signal (session_bus,
@@ -541,8 +541,8 @@ child_setup_func (gpointer user_data)
           if (fd_map[i].from == data->tty)
             {
               if (ioctl (fd_map[i].final, TIOCSCTTY, 0) == -1)
-                g_debug ("ioctl(%d, TIOCSCTTY, 0) failed: %s",
-                         fd_map[i].final, strerror (errno));
+                g_info ("ioctl(%d, TIOCSCTTY, 0) failed: %s",
+                        fd_map[i].final, strerror (errno));
               break;
             }
         }
@@ -811,13 +811,13 @@ handle_spawn (PortalFlatpak         *object,
                                   FLATPAK_METADATA_KEY_NAME, NULL);
   g_assert (app_id != NULL);
 
-  g_debug ("spawn() called from app: '%s'", app_id);
+  g_info ("spawn() called from app: '%s'", app_id);
 
   if (*app_id == 0 && g_getenv ("FLATPAK_PORTAL_MOCK_FLATPAK") != NULL)
     {
       /* Pretend we had been called from an app for test purposes */
       testing = TRUE;
-      g_debug ("In unit tests, behaving as though app ID was com.example.App");
+      g_info ("In unit tests, behaving as though app ID was com.example.App");
       g_clear_pointer (&app_id, g_free);
       app_id = g_strdup ("com.example.App");
     }
@@ -922,7 +922,7 @@ handle_spawn (PortalFlatpak         *object,
     {
       const char *expose = sandbox_expose[i];
 
-      g_debug ("exposing %s", expose);
+      g_info ("exposing %s", expose);
       if (!is_valid_expose (expose, &error))
         {
           g_dbus_method_invocation_return_gerror (invocation, error);
@@ -933,7 +933,7 @@ handle_spawn (PortalFlatpak         *object,
   for (i = 0; sandbox_expose_ro != NULL && sandbox_expose_ro[i] != NULL; i++)
     {
       const char *expose = sandbox_expose_ro[i];
-      g_debug ("exposing %s", expose);
+      g_info ("exposing %s", expose);
       if (!is_valid_expose (expose, &error))
         {
           g_dbus_method_invocation_return_gerror (invocation, error);
@@ -941,7 +941,7 @@ handle_spawn (PortalFlatpak         *object,
         }
     }
 
-  g_debug ("Running spawn command %s", arg_argv[0]);
+  g_info ("Running spawn command %s", arg_argv[0]);
 
   n_fds = 0;
   if (fds != NULL)
@@ -1257,7 +1257,7 @@ handle_spawn (PortalFlatpak         *object,
   for (i = 0; sandbox_expose_ro != NULL && sandbox_expose_ro[i] != NULL; i++)
     {
       const char *expose = sandbox_expose_ro[i];
-      g_debug ("exposing %s", expose);
+      g_info ("exposing %s", expose);
     }
 
   if (sandbox_expose_fd != NULL)
@@ -1281,8 +1281,8 @@ handle_spawn (PortalFlatpak         *object,
                 }
               else
                 {
-                  g_debug ("unable to get path for sandbox-exposed fd %d, ignoring: %s",
-                           handle_fd, error->message);
+                  g_info ("unable to get path for sandbox-exposed fd %d, ignoring: %s",
+                          handle_fd, error->message);
                   g_clear_error (&error);
                 }
             }
@@ -1318,8 +1318,8 @@ handle_spawn (PortalFlatpak         *object,
                 }
               else
                 {
-                  g_debug ("unable to get path for sandbox-exposed fd %d, ignoring: %s",
-                           handle_fd, error->message);
+                  g_info ("unable to get path for sandbox-exposed fd %d, ignoring: %s",
+                          handle_fd, error->message);
                   g_clear_error (&error);
                 }
             }
@@ -1369,7 +1369,7 @@ handle_spawn (PortalFlatpak         *object,
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      g_debug ("Using %s as /app instead of app", path);
+      g_info ("Using %s as /app instead of app", path);
       g_ptr_array_add (flatpak_argv, g_strdup_printf ("--app-path=%s", path));
     }
   else if (empty_app)
@@ -1402,7 +1402,7 @@ handle_spawn (PortalFlatpak         *object,
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      g_debug ("Using %s as /usr instead of runtime", path);
+      g_info ("Using %s as /usr instead of runtime", path);
       g_ptr_array_add (flatpak_argv, g_strdup_printf ("--usr-path=%s", path));
     }
 
@@ -1439,7 +1439,7 @@ handle_spawn (PortalFlatpak         *object,
           g_string_append (cmd, flatpak_argv->pdata[i]);
         }
 
-      g_debug ("Starting: %s\n", cmd->str);
+      g_info ("Starting: %s\n", cmd->str);
     }
 
   /* We make a second pass over the fds to find if any "to" fd index
@@ -1510,7 +1510,7 @@ handle_spawn (PortalFlatpak         *object,
                                                   pid_data,
                                                   NULL);
 
-  g_debug ("Client Pid is %d", pid_data->pid);
+  g_info ("Client Pid is %d", pid_data->pid);
 
   g_hash_table_replace (client_pid_data_hash, GUINT_TO_POINTER (pid_data->pid),
                         pid_data);
@@ -1528,7 +1528,7 @@ handle_spawn_signal (PortalFlatpak         *object,
 {
   PidData *pid_data = NULL;
 
-  g_debug ("spawn_signal(%d %d)", arg_pid, arg_signal);
+  g_info ("spawn_signal(%d %d)", arg_pid, arg_signal);
 
   pid_data = g_hash_table_lookup (client_pid_data_hash, GUINT_TO_POINTER (arg_pid));
   if (pid_data == NULL ||
@@ -1540,7 +1540,7 @@ handle_spawn_signal (PortalFlatpak         *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_debug ("Sending signal %d to client pid %d", arg_signal, arg_pid);
+  g_info ("Sending signal %d to client pid %d", arg_signal, arg_pid);
 
   if (arg_to_process_group)
     killpg (pid_data->pid, arg_signal);
@@ -1739,7 +1739,7 @@ create_update_monitor (GDBusMethodInvocation *invocation,
   g_object_set_data_full (G_OBJECT (monitor), "update-monitor-data", m, update_monitor_data_free);
   g_object_set_data_full (G_OBJECT (monitor), "required-sender", g_strdup (m->sender), g_free);
 
-  g_debug ("created UpdateMonitor for %s/%s at %s", m->name, m->branch, obj_path);
+  g_info ("created UpdateMonitor for %s/%s at %s", m->name, m->branch, obj_path);
 
   return monitor;
 }
@@ -1846,12 +1846,12 @@ check_for_updates (PortalFlatpakUpdateMonitor *monitor)
 
   installation_path = update_monitor_get_installation_path (monitor);
 
-  g_debug ("Checking for updates for %s/%s/%s in %s", m->name, m->arch, m->branch, flatpak_file_get_path_cached (installation_path));
+  g_info ("Checking for updates for %s/%s/%s in %s", m->name, m->arch, m->branch, flatpak_file_get_path_cached (installation_path));
 
   installation = lookup_installation_for_path (installation_path, &error);
   if (installation == NULL)
     {
-      g_debug ("Unable to find installation for path %s: %s", flatpak_file_get_path_cached (installation_path), error->message);
+      g_info ("Unable to find installation for path %s: %s", flatpak_file_get_path_cached (installation_path), error->message);
       return;
     }
 
@@ -1861,7 +1861,7 @@ check_for_updates (PortalFlatpakUpdateMonitor *monitor)
                                                           m->cancellable, &error);
   if (installed_ref == NULL)
     {
-      g_debug ("getting installed ref failed: %s", error->message);
+      g_info ("getting installed ref failed: %s", error->message);
       return; /* Never report updates for uninstalled refs */
     }
 
@@ -1886,7 +1886,7 @@ check_for_updates (PortalFlatpakUpdateMonitor *monitor)
       /* Probably some network issue.
        * Fall back to the local_commit to at least be able to pick up already installed updates.
        */
-      g_debug ("getting remote ref failed: %s", error->message);
+      g_info ("getting remote ref failed: %s", error->message);
       g_clear_error (&error);
       remote_commit = local_commit;
     }
@@ -1898,7 +1898,7 @@ check_for_updates (PortalFlatpakUpdateMonitor *monitor)
           /* This can happen if we're offline and there is an update from an usb drive.
            * Not much we can do in terms of reporting it, but at least handle the case
            */
-          g_debug ("Unknown remote commit, setting to local_commit");
+          g_info ("Unknown remote commit, setting to local_commit");
           remote_commit = local_commit;
         }
     }
@@ -1915,7 +1915,7 @@ check_for_updates (PortalFlatpakUpdateMonitor *monitor)
       g_free (m->reported_remote_commit);
       m->reported_remote_commit = g_strdup (remote_commit);
 
-      g_debug ("Found update for %s/%s/%s, local: %s, remote: %s", m->name, m->arch, m->branch, local_commit, remote_commit);
+      g_info ("Found update for %s/%s/%s, local: %s, remote: %s", m->name, m->arch, m->branch, local_commit, remote_commit);
       g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
       g_variant_builder_add (&builder, "{sv}", "running-commit", g_variant_new_string (m->commit));
       g_variant_builder_add (&builder, "{sv}", "local-commit", g_variant_new_string (local_commit));
@@ -2005,12 +2005,12 @@ check_all_for_updates_cb (void *data)
   if (!opt_poll_when_metered &&
       g_network_monitor_get_network_metered (network_monitor))
     {
-      g_debug ("Skipping update check on metered network");
+      g_info ("Skipping update check on metered network");
 
       return G_SOURCE_CONTINUE;
     }
 
-  g_debug ("Checking all update monitors");
+  g_info ("Checking all update monitors");
 
   G_LOCK (update_monitors);
   update_monitors_timeout = 0;
@@ -2041,7 +2041,7 @@ handle_create_update_monitor (PortalFlatpak *object,
     token = g_strdup_printf ("%d", g_random_int_range (0, 1000));
 
   sender = g_dbus_method_invocation_get_sender (invocation);
-  g_debug ("handle CreateUpdateMonitor from %s", sender);
+  g_info ("handle CreateUpdateMonitor from %s", sender);
 
   sender_escaped = g_strdup (sender + 1);
   for (i = 0; sender_escaped[i]; i++)
@@ -2089,7 +2089,7 @@ handle_close (PortalFlatpakUpdateMonitor *monitor,
 {
   update_monitor_close (monitor);
 
-  g_debug ("handle UpdateMonitor.Close");
+  g_info ("handle UpdateMonitor.Close");
 
   portal_flatpak_update_monitor_complete_close (monitor, invocation);
 
@@ -2116,7 +2116,7 @@ close_update_monitors_in_thread_func (GTask *task,
       PortalFlatpakUpdateMonitor *monitor = l->data;
       UpdateMonitorData *m = update_monitor_get_data (monitor);
 
-      g_debug ("closing monitor %s", m->obj_path);
+      g_info ("closing monitor %s", m->obj_path);
       update_monitor_close (monitor);
     }
 }
@@ -2131,7 +2131,7 @@ close_update_monitors_for_sender (const char *sender)
       g_autoptr(GTask) task = g_task_new (NULL, NULL, NULL, NULL);
       g_task_set_task_data (task, list, deep_free_object_list);
 
-      g_debug ("%s dropped off the bus, closing monitors", sender);
+      g_info ("%s dropped off the bus, closing monitors", sender);
       g_task_run_in_thread (task, close_update_monitors_in_thread_func);
     }
 }
@@ -2146,7 +2146,7 @@ get_update_permission (const char *app_id)
 
   if (permission_store == NULL)
     {
-      g_debug ("No portals installed, assume no permissions");
+      g_info ("No portals installed, assume no permissions");
       return NO;
     }
 
@@ -2159,7 +2159,7 @@ get_update_permission (const char *app_id)
                                                    &error))
     {
       g_dbus_error_strip_remote_error (error);
-      g_debug ("No updates permissions found: %s", error->message);
+      g_info ("No updates permissions found: %s", error->message);
       g_clear_error (&error);
     }
 
@@ -2178,7 +2178,7 @@ get_update_permission (const char *app_id)
         }
     }
 
-  g_debug ("Updates permissions for %s: %d", app_id, ret);
+  g_info ("Updates permissions for %s: %d", app_id, ret);
 
   return ret;
 }
@@ -2330,7 +2330,7 @@ emit_progress (PortalFlatpakUpdateMonitor *monitor,
   GVariantBuilder builder;
   g_autoptr(GError) error = NULL;
 
-  g_debug ("%d/%d ops, progress %d, status: %d", op, n_ops, progress, status);
+  g_info ("%d/%d ops, progress %d, status: %d", op, n_ops, progress, status);
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
   if (n_ops > 0)
@@ -2696,7 +2696,7 @@ handle_update_responses (PortalFlatpakUpdateMonitor *monitor,
       v = read_variant (in, m->cancellable, error);
       if (v == NULL)
         {
-          g_debug ("Reading message from child update process failed %s", (*error)->message);
+          g_info ("Reading message from child update process failed %s", (*error)->message);
           return FALSE;
         }
 
@@ -2778,7 +2778,7 @@ handle_update (PortalFlatpakUpdateMonitor *monitor,
   g_autoptr(GTask) task = NULL;
   gboolean already_installing = FALSE;
 
-  g_debug ("handle UpdateMonitor.Update");
+  g_info ("handle UpdateMonitor.Update");
 
   g_mutex_lock (&m->lock);
   if (m->installing)
@@ -2842,7 +2842,7 @@ name_owner_changed (GDBusConnection *connection,
       for (l = list; l; l = l->next)
         {
           pid_data = l->data;
-          g_debug ("%s dropped off the bus, killing %d", pid_data->client, pid_data->pid);
+          g_info ("%s dropped off the bus, killing %d", pid_data->client, pid_data->pid);
           killpg (pid_data->pid, SIGINT);
         }
 
@@ -2876,7 +2876,7 @@ on_bus_acquired (GDBusConnection *connection,
 {
   GError *error = NULL;
 
-  g_debug ("Bus acquired, creating skeleton");
+  g_info ("Bus acquired, creating skeleton");
 
   g_dbus_connection_set_exit_on_close (connection, FALSE);
 
@@ -2929,7 +2929,7 @@ on_name_acquired (GDBusConnection *connection,
                   const gchar     *name,
                   gpointer         user_data)
 {
-  g_debug ("Name acquired");
+  g_info ("Name acquired");
 }
 
 static void
@@ -2937,7 +2937,7 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
-  g_debug ("Name lost");
+  g_info ("Name lost");
   unref_skeleton_in_timeout ();
 }
 
@@ -2952,7 +2952,7 @@ binary_file_changed_cb (GFileMonitor     *file_monitor,
 
   if (!got_it)
     {
-      g_debug ("binary file changed");
+      g_info ("binary file changed");
       unref_skeleton_in_timeout ();
     }
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -3037,7 +3037,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, message_handler, NULL);
 
   client_pid_data_hash = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) pid_data_free);
 

--- a/portal/portal-impl.c
+++ b/portal/portal-impl.c
@@ -50,7 +50,7 @@ register_portal (const char *path, gboolean opt_verbose, GError **error)
   g_autoptr(PortalImplementation) impl = g_new0 (PortalImplementation, 1);
   int i;
 
-  g_debug ("loading %s", path);
+  g_info ("loading %s", path);
 
   if (!g_key_file_load_from_file (keyfile, path, G_KEY_FILE_NONE, error))
     return FALSE;
@@ -92,9 +92,9 @@ register_portal (const char *path, gboolean opt_verbose, GError **error)
   if (opt_verbose)
     {
       g_autofree char *uses = g_strjoinv (", ", impl->use_in);
-      g_debug ("portal implementation for %s", uses);
+      g_info ("portal implementation for %s", uses);
       for (i = 0; impl->interfaces[i]; i++)
-        g_debug ("portal implementation supports %s", impl->interfaces[i]);
+        g_info ("portal implementation supports %s", impl->interfaces[i]);
     }
 
   implementations = g_list_prepend (implementations, impl);
@@ -125,7 +125,7 @@ load_installed_portals (gboolean opt_verbose)
   if (portal_dir == NULL)
     portal_dir = DATADIR "/xdg-desktop-portal/portals";
 
-  g_debug ("load portals from %s", portal_dir);
+  g_info ("load portals from %s", portal_dir);
 
   dir = g_file_new_for_path (portal_dir);
   enumerator = g_file_enumerate_children (dir, "*", G_FILE_QUERY_INFO_NONE, NULL, NULL);
@@ -199,7 +199,7 @@ find_portal_implementation (const char *interface)
 
           if (g_strv_case_contains ((const char **)impl->use_in, desktops[i]))
             {
-              g_debug ("Using %s for %s in %s", impl->source, interface, desktops[i]);
+              g_info ("Using %s for %s in %s", impl->source, interface, desktops[i]);
               return impl;
             }
         }
@@ -213,7 +213,7 @@ find_portal_implementation (const char *interface)
       if (!g_strv_contains ((const char **)impl->interfaces, interface))
         continue;
 
-      g_debug ("Falling back to %s for %s", impl->source, interface);
+      g_info ("Falling back to %s for %s", impl->source, interface);
       return impl;
     }
 

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -826,7 +826,7 @@ main (int    argc,
     }
 
   if (verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, message_handler, NULL);
 
   client_pid_data_hash = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) pid_data_free);
 

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -101,7 +101,7 @@ child_watch_died (GPid     pid,
   PidData *pid_data = user_data;
   g_autoptr(GVariant) signal_variant = NULL;
 
-  g_debug ("Client Pid %d died", pid_data->pid);
+  g_info ("Client Pid %d died", pid_data->pid);
 
   signal_variant = g_variant_ref_sink (g_variant_new ("(uu)", pid, status));
   g_dbus_connection_emit_signal (session_bus,
@@ -188,8 +188,8 @@ child_setup_func (gpointer user_data)
           if (fd_map[i].from == data->tty)
             {
               if (ioctl (fd_map[i].final, TIOCSCTTY, 0) == -1)
-                g_debug ("ioctl(%d, TIOCSCTTY, 0) failed: %s",
-                         fd_map[i].final, strerror (errno));
+                g_info ("ioctl(%d, TIOCSCTTY, 0) failed: %s",
+                        fd_map[i].final, strerror (errno));
               break;
             }
         }
@@ -239,7 +239,7 @@ handle_host_command (FlatpakDevelopment    *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_debug ("Running host command %s", arg_argv[0]);
+  g_info ("Running host command %s", arg_argv[0]);
 
   n_fds = 0;
   fds = NULL;
@@ -354,7 +354,7 @@ handle_host_command (FlatpakDevelopment    *object,
                                                   pid_data,
                                                   NULL);
 
-  g_debug ("Client Pid is %d", pid_data->pid);
+  g_info ("Client Pid is %d", pid_data->pid);
 
   g_hash_table_replace (client_pid_data_hash, GUINT_TO_POINTER (pid_data->pid),
                         pid_data);
@@ -384,7 +384,7 @@ handle_host_command_signal (FlatpakDevelopment    *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  g_debug ("Sending signal %d to client pid %d", arg_signal, arg_pid);
+  g_info ("Sending signal %d to client pid %d", arg_signal, arg_pid);
 
   if (to_process_group)
     killpg (pid_data->pid, arg_signal);
@@ -566,8 +566,8 @@ update_real_monitor (MonitorData *data)
 
   if (real == NULL)
     {
-      g_debug ("unable to get real path to monitor host file %s: %s", data->source,
-               g_strerror (errno));
+      g_info ("unable to get real path to monitor host file %s: %s", data->source,
+              g_strerror (errno));
       return;
     }
 
@@ -606,7 +606,7 @@ update_real_monitor (MonitorData *data)
   data->monitor_real = g_file_monitor_file (r, G_FILE_MONITOR_NONE, NULL, &err);
   if (!data->monitor_real)
     {
-      g_debug ("failed to monitor host file %s (real path of %s): %s",
+      g_info ("failed to monitor host file %s (real path of %s): %s",
                real, data->source, err->message);
       return;
     }
@@ -665,7 +665,7 @@ setup_file_monitor (const char *source)
     }
   else
     {
-      g_debug ("failed to monitor host file %s: %s", source, err->message);
+      g_info ("failed to monitor host file %s: %s", source, err->message);
     }
 
   file_monitor_do (data);
@@ -709,7 +709,7 @@ start_p11_kit_server (const char *flatpak_dir)
     NULL
   };
 
-  g_debug ("starting p11-kit server");
+  g_info ("starting p11-kit server");
 
   if (!g_spawn_sync (NULL,
                      p11_argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_STDERR_TO_DEV_NULL,
@@ -750,11 +750,11 @@ start_p11_kit_server (const char *flatpak_dir)
 
   if (p11_kit_server_pid != 0)
     {
-      g_debug ("Using p11-kit socket path %s, pid %d", socket_path, p11_kit_server_pid);
+      g_info ("Using p11-kit socket path %s, pid %d", socket_path, p11_kit_server_pid);
       p11_kit_server_socket_path = g_steal_pointer (&socket_path);
     }
   else
-    g_debug ("Not using p11-kit due to older version");
+    g_info ("Not using p11-kit due to older version");
 }
 
 int
@@ -847,7 +847,7 @@ main (int    argc,
   if (g_find_program_in_path ("p11-kit"))
     start_p11_kit_server (flatpak_dir);
   else
-    g_debug ("p11-kit not found");
+    g_info ("p11-kit not found");
 
   monitor_dir = g_build_filename (flatpak_dir, "monitor", NULL);
   if (g_mkdir_with_parents (monitor_dir, 0755) != 0)

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -152,7 +152,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (OngoingPull, ongoing_pull_free);
 static void
 skeleton_died_cb (gpointer data)
 {
-  g_debug ("skeleton finalized, exiting");
+  g_info ("skeleton finalized, exiting");
   g_main_loop_quit (main_loop);
 }
 
@@ -161,7 +161,7 @@ unref_skeleton_in_timeout_cb (gpointer user_data)
 {
   static gboolean unreffed = FALSE;
 
-  g_debug ("unreffing helper main ref");
+  g_info ("unreffing helper main ref");
   if (!unreffed)
     {
       g_object_unref (helper);
@@ -197,7 +197,7 @@ idle_timeout_cb (gpointer user_data)
 
   if (name_owner_id)
     {
-      g_debug ("Idle - unowning name");
+      g_info ("Idle - unowning name");
       unref_skeleton_in_timeout ();
     }
   return G_SOURCE_REMOVE;
@@ -405,7 +405,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   g_autofree gchar *src_dir = NULL;
   g_autoptr(FlatpakDecomposed) ref = NULL;
 
-  g_debug ("Deploy %s %u %s %s %s", arg_repo_path, arg_flags, arg_ref, arg_origin, arg_installation);
+  g_info ("Deploy %s %u %s %s %s", arg_repo_path, arg_flags, arg_ref, arg_origin, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -726,7 +726,7 @@ handle_cancel_pull (FlatpakSystemHelper   *object,
   g_autoptr(GError) error = NULL;
   uid_t uid;
 
-  g_debug ("CancelPull %s %u %s", arg_installation, arg_flags, arg_src_dir);
+  g_info ("CancelPull %s %u %s", arg_installation, arg_flags, arg_src_dir);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CANCEL_PULL_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -784,7 +784,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
   g_autofree char *subset = NULL;
   gboolean is_oci;
 
-  g_debug ("DeployAppstream %s %u %s %s %s", arg_repo_path, arg_flags, arg_origin, arg_arch, arg_installation);
+  g_info ("DeployAppstream %s %u %s %s %s", arg_repo_path, arg_flags, arg_origin, arg_arch, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_DEPLOY_APPSTREAM_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -952,7 +952,7 @@ handle_uninstall (FlatpakSystemHelper   *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(FlatpakDecomposed) ref = NULL;
 
-  g_debug ("Uninstall %u %s %s", arg_flags, arg_ref, arg_installation);
+  g_info ("Uninstall %u %s %s", arg_flags, arg_ref, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UNINSTALL_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1005,7 +1005,7 @@ handle_install_bundle (FlatpakSystemHelper   *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(FlatpakDecomposed) ref = NULL;
 
-  g_debug ("InstallBundle %s %u %s %s", arg_bundle_path, arg_flags, arg_remote, arg_installation);
+  g_info ("InstallBundle %s %u %s %s", arg_bundle_path, arg_flags, arg_remote, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_INSTALL_BUNDLE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1056,7 +1056,7 @@ handle_configure_remote (FlatpakSystemHelper   *object,
   g_autoptr(GBytes) gpg_data = NULL;
   gboolean force_remove;
 
-  g_debug ("ConfigureRemote %u %s %s", arg_flags, arg_remote, arg_installation);
+  g_info ("ConfigureRemote %u %s %s", arg_flags, arg_remote, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CONFIGURE_REMOTE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1131,7 +1131,7 @@ handle_configure (FlatpakSystemHelper   *object,
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
 
-  g_debug ("Configure %u %s=%s %s", arg_flags, arg_key, arg_value, arg_installation);
+  g_info ("Configure %u %s=%s %s", arg_flags, arg_key, arg_value, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_CONFIGURE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1197,7 +1197,7 @@ handle_update_remote (FlatpakSystemHelper   *object,
   g_autoptr(FlatpakRemoteState) state = NULL;
   gboolean summary_is_index = (arg_flags & FLATPAK_HELPER_UPDATE_REMOTE_FLAGS_SUMMARY_IS_INDEX) != 0;
 
-  g_debug ("UpdateRemote %u %s %s %s %s", arg_flags, arg_remote, arg_installation, arg_summary_path, arg_summary_sig_path);
+  g_info ("UpdateRemote %u %s %s %s %s", arg_flags, arg_remote, arg_installation, arg_summary_path, arg_summary_sig_path);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UPDATE_REMOTE_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1276,7 +1276,7 @@ handle_remove_local_ref (FlatpakSystemHelper   *object,
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
 
-  g_debug ("RemoveLocalRef %u %s %s %s", arg_flags, arg_remote, arg_ref, arg_installation);
+  g_info ("RemoveLocalRef %u %s %s %s", arg_flags, arg_remote, arg_ref, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_REMOVE_LOCAL_REF_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1325,7 +1325,7 @@ handle_prune_local_repo (FlatpakSystemHelper   *object,
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
 
-  g_debug ("PruneLocalRepo %u %s", arg_flags, arg_installation);
+  g_info ("PruneLocalRepo %u %s", arg_flags, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_PRUNE_LOCAL_REPO_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1369,7 +1369,7 @@ handle_ensure_repo (FlatpakSystemHelper   *object,
   g_autoptr(GError) error = NULL;
   g_autoptr(GError) local_error = NULL;
 
-  g_debug ("EnsureRepo %u %s", arg_flags, arg_installation);
+  g_info ("EnsureRepo %u %s", arg_flags, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_ENSURE_REPO_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1408,7 +1408,7 @@ handle_run_triggers (FlatpakSystemHelper   *object,
   g_autoptr(FlatpakDir) system = NULL;
   g_autoptr(GError) error = NULL;
 
-  g_debug ("RunTriggers %u %s", arg_flags, arg_installation);
+  g_info ("RunTriggers %u %s", arg_flags, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_RUN_TRIGGERS_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1618,7 +1618,7 @@ reuse_cache_dir_if_available (const gchar    *repo_tmp,
   const gchar *name;
   gboolean res = FALSE;
 
-  g_debug ("Checking for any temporary cache directory available to reuse");
+  g_info ("Checking for any temporary cache directory available to reuse");
 
   repo_tmpfile = g_file_new_for_path (repo_tmp);
   enumerator = g_file_enumerate_children (repo_tmpfile,
@@ -1693,7 +1693,7 @@ handle_get_revokefs_fd (FlatpakSystemHelper   *object,
   uid_t uid;
   int fd_index = -1;
 
-  g_debug ("GetRevokefsFd %u %s", arg_flags, arg_installation);
+  g_info ("GetRevokefsFd %u %s", arg_flags, arg_installation);
 
   if (disable_revokefs)
     {
@@ -1736,7 +1736,7 @@ handle_get_revokefs_fd (FlatpakSystemHelper   *object,
   repo_tmp = g_build_filename (flatpak_dir, "repo", "tmp", NULL);
 
    if (reuse_cache_dir_if_available (repo_tmp, &src_dir, &passwd))
-     g_debug ("Cache dir %s can be reused", src_dir);
+     g_info ("Cache dir %s can be reused", src_dir);
   else
     {
       /* Create a new cache dir and add it to cache_dirs_in_use. Do all this under
@@ -1796,7 +1796,7 @@ handle_update_summary (FlatpakSystemHelper   *object,
   g_autoptr(GError) error = NULL;
   gboolean delete_summary;
 
-  g_debug ("UpdateSummary %u %s", arg_flags, arg_installation);
+  g_info ("UpdateSummary %u %s", arg_flags, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_UPDATE_SUMMARY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -1842,7 +1842,7 @@ handle_generate_oci_summary (FlatpakSystemHelper   *object,
   gboolean only_cached;
   gboolean is_oci;
 
-  g_debug ("GenerateOciSummary %u %s %s", arg_flags, arg_origin, arg_installation);
+  g_info ("GenerateOciSummary %u %s %s", arg_flags, arg_origin, arg_installation);
 
   system = dir_get_system (arg_installation, get_sender_pid (invocation), (arg_flags & FLATPAK_HELPER_GENERATE_OCI_SUMMARY_FLAGS_NO_INTERACTION) != 0, &error);
   if (system == NULL)
@@ -2204,7 +2204,7 @@ on_bus_acquired (GDBusConnection *connection,
 {
   GError *error = NULL;
 
-  g_debug ("Bus acquired, creating skeleton");
+  g_info ("Bus acquired, creating skeleton");
 
   g_dbus_connection_set_exit_on_close (connection, FALSE);
 
@@ -2252,7 +2252,7 @@ on_name_acquired (GDBusConnection *connection,
                   const gchar     *name,
                   gpointer         user_data)
 {
-  g_debug ("Name acquired");
+  g_info ("Name acquired");
 }
 
 static void
@@ -2260,7 +2260,7 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
-  g_debug ("Name lost");
+  g_info ("Name lost");
   unref_skeleton_in_timeout ();
 }
 
@@ -2275,7 +2275,7 @@ binary_file_changed_cb (GFileMonitor     *file_monitor,
 
   if (!got_it)
     {
-      g_debug ("binary file changed");
+      g_info ("binary file changed");
       unref_skeleton_in_timeout ();
     }
 

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -2373,9 +2373,9 @@ main (int    argc,
   flatpak_disable_fancy_output ();
 
   if (opt_verbose > 0)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, message_handler, NULL);
   if (opt_verbose > 1)
-    g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
 
   if (opt_ostree_verbose)
     g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);

--- a/tests/mock-flatpak.c
+++ b/tests/mock-flatpak.c
@@ -32,7 +32,7 @@ main (int argc,
 {
   int i;
 
-  g_debug ("This is a mock implementation of `flatpak run` for the portal");
+  g_info ("This is a mock implementation of `flatpak run` for the portal");
 
   for (i = 0; i < argc; i++)
     g_print ("argv[%d] = %s\n", i, argv[i]);

--- a/tests/test-authenticator.c
+++ b/tests/test-authenticator.c
@@ -112,7 +112,7 @@ finish_request_ref_tokens (TokenRequestData *data)
   g_variant_builder_init (&results, G_VARIANT_TYPE ("a{sv}"));
   g_variant_builder_add (&results, "{sv}", "tokens", g_variant_builder_end (&tokens));
 
-  g_debug ("emitting response");
+  g_info ("emitting response");
   flatpak_authenticator_request_emit_response (data->request,
                                                FLATPAK_AUTH_RESPONSE_OK,
                                                g_variant_builder_end (&results));
@@ -130,9 +130,9 @@ http_incoming (GSocketService    *service,
   g_assert_true (data->request != NULL);
 
   /* For the test, just assume any connection is a valid use of the web flow */
-  g_debug ("handling incoming http request");
+  g_info ("handling incoming http request");
 
-  g_debug ("emitting webflow done");
+  g_info ("emitting webflow done");
   flatpak_authenticator_request_emit_webflow_done (data->request, options);
 
   finish_request_ref_tokens (data);
@@ -149,7 +149,7 @@ handle_request_close (FlatpakAuthenticatorRequest *object,
 {
   TokenRequestData *data = user_data;
 
-  g_debug ("handle_request_close");
+  g_info ("handle_request_close");
 
   flatpak_authenticator_request_complete_close (object, invocation);
 
@@ -157,7 +157,7 @@ handle_request_close (FlatpakAuthenticatorRequest *object,
     {
       GVariantBuilder results;
 
-      g_debug ("Webflow was cancelled by client");
+      g_info ("Webflow was cancelled by client");
 
       g_variant_builder_init (&results, G_VARIANT_TYPE ("a{sv}"));
       flatpak_authenticator_request_emit_response (data->request,
@@ -166,7 +166,7 @@ handle_request_close (FlatpakAuthenticatorRequest *object,
     }
   else
     {
-      g_debug ("Ignored webflow cancel by client");
+      g_info ("Ignored webflow cancel by client");
       finish_request_ref_tokens (data); /* Silently succeed anyway */
     }
 
@@ -196,7 +196,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *authenticator,
   gsize n_refs, i;
   g_autofree char *options_s = NULL;
 
-  g_debug ("handling RequestRefTokens");
+  g_info ("handling RequestRefTokens");
 
   options_s = g_variant_print (arg_options, FALSE);
   write_request (g_strdup_printf ("remote: %s\n"
@@ -260,7 +260,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *authenticator,
     {
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0));
       uri = g_strdup_printf ("http://localhost:%d", (int)port);
-      g_debug ("Requesting webflow %s", uri);
+      g_info ("Requesting webflow %s", uri);
       flatpak_authenticator_request_emit_webflow (request, uri, options);
     }
   else
@@ -279,7 +279,7 @@ on_bus_acquired (GDBusConnection *connection,
 {
   GError *error = NULL;
 
-  g_debug ("Bus acquired, creating skeleton");
+  g_info ("Bus acquired, creating skeleton");
 
   g_dbus_connection_set_exit_on_close (connection, FALSE);
 
@@ -303,7 +303,7 @@ on_name_acquired (GDBusConnection *connection,
                   const gchar     *name,
                   gpointer         user_data)
 {
-  g_debug ("Name acquired");
+  g_info ("Name acquired");
 }
 
 static void
@@ -311,7 +311,7 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
-  g_debug ("Name lost");
+  g_info ("Name lost");
 }
 
 
@@ -374,7 +374,7 @@ main (int    argc,
   if (opt_verbose)
     g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
-  g_debug ("Started test-authenticator");
+  g_info ("Started test-authenticator");
 
   session_bus = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
   if (session_bus == NULL)

--- a/tests/test-authenticator.c
+++ b/tests/test-authenticator.c
@@ -372,7 +372,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, message_handler, NULL);
 
   g_info ("Started test-authenticator");
 

--- a/tests/test-portal-impl.c
+++ b/tests/test-portal-impl.c
@@ -100,7 +100,7 @@ on_bus_acquired (GDBusConnection *connection,
   GError *error = NULL;
   guint registration_id;
 
-  g_debug ("Bus acquired, creating skeleton");
+  g_info ("Bus acquired, creating skeleton");
   registration_id = g_dbus_connection_register_object (connection,
                                                        "/org/freedesktop/portal/desktop",
                                                        (GDBusInterfaceInfo *) &access_interface_info,
@@ -114,7 +114,7 @@ on_name_acquired (GDBusConnection *connection,
                   const gchar     *name,
                   gpointer         user_data)
 {
-  g_debug ("Name acquired");
+  g_info ("Name acquired");
 }
 
 static void
@@ -122,7 +122,7 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
-  g_debug ("Name lost");
+  g_info ("Name lost");
 }
 
 int

--- a/tests/test-portal.c
+++ b/tests/test-portal.c
@@ -226,7 +226,7 @@ count_successful_exit_cb (PortalFlatpak *proxy,
 {
   gsize *times_exited_p = user_data;
 
-  g_debug ("Process %u exited with wait status %u", pid, wait_status);
+  g_info ("Process %u exited with wait status %u", pid, wait_status);
   g_assert_true (WIFEXITED (wait_status));
   g_assert_cmpuint (WEXITSTATUS (wait_status), ==, 0);
   (*times_exited_p) += 1;

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -2382,7 +2382,7 @@ make_bundle (void)
   argv[2] = arg2;
   argv[4] = file;
 
-  g_debug ("Making dir %s", path);
+  g_info ("Making dir %s", path);
   g_mkdir_with_parents (path, S_IRWXU | S_IRWXG | S_IRWXO);
 
   run_test_subprocess (argv, RUN_TEST_SUBPROCESS_DEFAULT);


### PR DESCRIPTION
Implements #5001.

---

* common: Use g_info() for messages that will be shown by flatpak -v
    
    This brings us one step closer to being able to stop using the flatpak2
    log domain for messages that are exclusive to `flatpak -v -v`.

* app: Use g_info() for messages that will be shown by flatpak -v
    
    This brings us one step closer to being able to stop using the flatpak2
    log domain for messages that are exclusive to `flatpak -v -v`.

* daemons, etc.: Use g_info() for messages that are enabled by -v

* common: Make flatpak_debug2() use the same domain as g_debug()
    
    Now that we are logging `flatpak -v` messages with log level INFO,
    and printing INFO messages in the same way as DEBUG, we can reserve
    log level DEBUG for `flatpak -v -v` messages. This means we no longer
    need a weird secondary debug domain.
    
    There is a very small behaviour change here: G_MESSAGES_DEBUG=flatpak
    is now similar to `flatpak -v -v` (previously `flatpak -v`), and
    G_MESSAGES_DEBUG=flatpak2 no longer has any effect. This seems more in
    line with what would be expected from a GLib-based application.
    
    In flatpak(1) and the system helper, this does not change behaviour
    other than that: the same messages are logged by `-v` and by `-v -v`
    as before.
    
    In daemons that do not implement `-v -v` (the OCI authenticator, portal
    and session helper), it continues to be necessary to use
    G_MESSAGES_DEBUG to see flatpak_debug2() messages.

* common: Replace all flatpak_debug2() with g_debug()
    
    They are now equivalent.
    
    Resolves: https://github.com/flatpak/flatpak/issues/5001