### PR TITLE
Refactoring to prepare for #5084

### DIFF
--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -129,6 +129,7 @@ gboolean flatpak_extension_matches_reason (const char *extension_id,
                                            gboolean    default_value);
 
 const char * flatpak_get_bwrap (void);
+gboolean flatpak_bwrap_is_unprivileged (void);
 
 char **flatpak_strv_sort_by_length (const char * const *strv);
 char **flatpak_strv_merge (char   **strv1,

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -740,6 +740,19 @@ flatpak_get_bwrap (void)
 }
 
 gboolean
+flatpak_bwrap_is_unprivileged (void)
+{
+  const char *path = g_find_program_in_path (flatpak_get_bwrap ());
+  struct stat st;
+
+  /* Various features are supported only if bwrap exists and is not setuid */
+  return
+    path != NULL &&
+    stat (path, &st) == 0 &&
+    (st.st_mode & S_ISUID) == 0;
+}
+
+gboolean
 flatpak_get_allowed_exports (const char     *source_path,
                              const char     *app_id,
                              FlatpakContext *context,

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -2856,19 +2856,6 @@ name_owner_changed (GDBusConnection *connection,
 #define DBUS_INTERFACE_DBUS DBUS_NAME_DBUS
 #define DBUS_PATH_DBUS "/org/freedesktop/DBus"
 
-static gboolean
-supports_expose_pids (void)
-{
-  const char *path = g_find_program_in_path (flatpak_get_bwrap ());
-  struct stat st;
-
-  /* This is supported only if bwrap exists and is not setuid */
-  return
-    path != NULL &&
-    stat (path, &st) == 0 &&
-    (st.st_mode & S_ISUID) == 0;
-}
-
 static void
 on_bus_acquired (GDBusConnection *connection,
                  const gchar     *name,
@@ -3070,7 +3057,7 @@ main (int    argc,
 
   flatpak_connection_track_name_owners (session_bus);
 
-  if (supports_expose_pids ())
+  if (flatpak_bwrap_is_unprivileged ())
     supports |= FLATPAK_SPAWN_SUPPORT_FLAGS_EXPOSE_PIDS;
 
   flags = G_BUS_NAME_OWNER_FLAGS_ALLOW_REPLACEMENT;


### PR DESCRIPTION
* portal: Factor out flatpak_bwrap_is_unprivileged()
    
    We can use this for other features that rely on having a non-setuid
    version of bubblewrap.

* dir: Use consistent FlatpakRunFlags everywhere
    
    In principle either of these functions might read any of the flags.

---

Prerequisite for the version of #5084 I'm now proposing.