### PR TITLE
flatpak-dir: Avoid false "changed" notitications for empty installations

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4065,6 +4065,9 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
   if (self->repo != NULL)
     return TRUE;
 
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
   /* Don't trigger polkit prompts if we are just doing this opportunistically */
   if (allow_empty)
     ensure_flags |= FLATPAK_HELPER_ENSURE_REPO_FLAGS_NO_INTERACTION;
@@ -4090,6 +4093,9 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
         }
     }
 
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
   repodir = g_file_get_child (self->basedir, "repo");
 
   repo = ostree_repo_new (repodir);
@@ -4099,6 +4105,9 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
       /* We always use bare-user-only these days, except old installations
          that still user bare-user */
       OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER_ONLY;
+
+      if (g_cancellable_set_error_if_cancelled (cancellable, error))
+        return FALSE;
 
       if (flatpak_dir_use_system_helper (self, NULL))
         {
@@ -4172,6 +4181,9 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
         return FALSE;
     }
 
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
   /* Earlier flatpak used to reset min-free-space-percent to 0 every time, but now we
    * favor min-free-space-size instead of it (See below).
    */
@@ -4223,6 +4235,9 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
             return FALSE;
         }
     }
+
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
 
   flatpakrepos = _flatpak_dir_find_new_flatpakrepos (self, repo);
   if (flatpakrepos)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4110,6 +4110,8 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
         }
       else
         {
+          g_autoptr(GFile) changed_file = NULL;
+
           if (!ostree_repo_create (repo, mode, cancellable, &my_error))
             {
               const char *repo_path = flatpak_file_get_path_cached (repodir);
@@ -4133,8 +4135,11 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
               return FALSE;
             }
 
+          changed_file = flatpak_dir_get_changed_path (self);
+
           /* Create .changed file early to avoid polling non-existing file in monitor */
-          if (!flatpak_dir_mark_changed (self, &my_error))
+          if (!g_file_test (g_file_peek_path (changed_file), G_FILE_TEST_IS_REGULAR) &&
+              !flatpak_dir_mark_changed (self, &my_error))
             {
               g_warning ("Error marking directory as changed: %s", my_error->message);
               g_clear_error (&my_error);


### PR DESCRIPTION
This is related to downstream bug:
https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1989

The gnome-software could pass an already cancelled GCancellable into the libflatpak functions, which can end at `_flatpak_dir_ensure_repo`, which unconditionally calls `flatpak_dir_mark_changed()` to create the `.changed` file, even when it exists, because the earlier call to `g_file_query_exists()` returns `FALSE` also when the `repodir` `GFile` exists, but the `cancellable ` is cancelled.

This exhibits the most with empty installations, which have no refs installed nor any remote configured, because (it seems, though I did not check it in the code) the FlatpakDir is freed early when the installation is completely empty (like my `--user` installation here). Having there at least a remote configured the `FlatpakDir` is not freed early, thus it's not recreated on demand.

The first commit adds a test to not call `flatpak_dir_mark_changed()` when the file already exists. The second commit adds checks for the cancelled state of the cancellable, which can stop the function earlier. As it's not assured when exactly the other thread can cancel the cancellable, I added it into multiple places.

One such place, where the FlatpakDir instance is periodically recreated, is when calling `flatpak_installation_list_remotes()`, as shown in the following backtrace snippet:
```
	   _flatpak_dir_ensure_repo() at flatpak-dir.c:4096
	   flatpak_dir_maybe_ensure_repo() at flatpak-dir.c:4284
	   flatpak_installation_list_remotes_by_type() at flatpak-installation.c:1263
	   flatpak_installation_list_remotes() at flatpak-installation.c:1312
```

The false "changed" notifications are wrong for the gnome-software, because there is no granularity on the signal (having a set of flags for "app/remote $ID added/removed/updated" would be a great improvement), the gnome-software simply reloads everything in the GUI, which can take its time and which is pretty bad user experience, but as there's currently no easy way to recognize what precisely changed, then there's no better option either.