### PR TITLE
utils: Unmap the old summary.idx file before trying to replace it

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4980,6 +4980,10 @@ flatpak_repo_update (OstreeRepo   *repo,
                                                     g_variant_get_data (old_index),
                                                     g_variant_get_size (old_index));
 
+  /* Release the memory-mapped summary index file before replacing it,
+     to avoid failure on filesystems like cifs */
+  g_clear_pointer (&old_index, g_variant_unref);
+
   if (!flatpak_repo_save_summary_index (repo, summary_index, index_digest, index_sig, cancellable, error))
     return FALSE;
 


### PR DESCRIPTION
Exporting to an existing repo on a Samba filesystem failed with EACCES when libglnx called renameat() to replace the old summary.idx file.

    error: renameat: Permission denied

This occurred even when the user had appropriate permissions to the file and its ancestor directories.

The problem was that flatpak had mapped the old file into memory for reading, and still held a reference to that mapping when attempting to replace the underlying file. Apparently this works on some filesystems, but not on cifs.

We therefore release the memory mapping before replacing the underlying file.

Fixes #5257