### PR TITLE
[1.14.x.] Backport various smaller changes from main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -214,6 +214,7 @@ jobs:
     name: Run tests in valgrind
     needs: check # Don't run expensive test if main check fails
     runs-on: ubuntu-20.04 # Might as well test with a different one too
+    if: ${{ false }} # Currently Valgrind takes too long and always fails
     steps:
     - name: Install Dependencies
       run: |

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,26 @@
+Changes in 1.14.2
+~~~~~~~~~~~~~~~~~
+Released: not yet
+
+Bug fixes:
+
+* Display the intended messages for `flatpak repair` (#5204)
+* Exporting an app to an existing repository on a CIFS filesystem
+  now works as intended (#5257)
+* Unset $GIO_EXTRA_MODULES for apps, avoiding misbehaviour in some GLib
+  apps when set to a path on the host (#5206)
+* Unset $XKB_CONFIG_ROOT for apps, avoiding crashes in GTK and Qt apps
+  under Wayland when this variable is set to a path not available in the
+  sandbox (#5194)
+* Unset $KRB5CCNAME for apps
+* When using the fish shell, avoid duplicate XDG_DATA_DIRS entries if the
+  profile script is sourced more than once (#5198)
+
+Internal changes:
+
+* The INFO log level is now treated the same as the DEBUG log level
+  by `flatpak -v`, to make backports from 1.15.x simpler
+
 Changes in 1.14.1
 ~~~~~~~~~~~~~~~~~
 Released: 2022-11-18

--- a/app/flatpak-builtins-repair.c
+++ b/app/flatpak-builtins-repair.c
@@ -415,7 +415,7 @@ flatpak_builtin_repair (int argc, char **argv, GCancellable *cancellable, GError
 
        This does also mean that other areas of this code section that print errors will need to print a trailing
        newline as well, otherwise the output will overwrite any errors. */
-    if (flatpak_fancy_output ())
+    if (flatpak_fancy_output () && i != 1)
       g_print ("\033[A\r\033[K");
 
     g_print (_("[%d/%d] Verifying %s…\n"), i, g_hash_table_size (all_refs), refspec);

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -358,12 +358,12 @@ flatpak_option_context_parse (GOptionContext     *context,
   else
     {
       if (opt_verbose > 0)
-        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+        g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
       if (opt_verbose > 1)
-        g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+        g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
       if (opt_ostree_verbose)
-        g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+        g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
       if (opt_verbose > 0 || opt_ostree_verbose)
         flatpak_disable_fancy_output ();

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1898,6 +1898,7 @@ static const ExportData default_exports[] = {
   {"GST_INSTALL_PLUGINS_HELPER", NULL},
   {"KRB5CCNAME", NULL},
   {"XKB_CONFIG_ROOT", NULL},
+  {"GIO_EXTRA_MODULES", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1878,7 +1878,8 @@ static const ExportData default_exports[] = {
   {"XDG_RUNTIME_DIR", NULL},
 
   /* Some env vars are common enough and will affect the sandbox badly
-     if set on the host. We clear these always. */
+     if set on the host. We clear these always. If updating this list,
+     also update the list in flatpak-run.xml. */
   {"PYTHONPATH", NULL},
   {"PERLLIB", NULL},
   {"PERL5LIB", NULL},
@@ -1895,6 +1896,7 @@ static const ExportData default_exports[] = {
   {"GST_PTP_HELPER", NULL},
   {"GST_PTP_HELPER_1_0", NULL},
   {"GST_INSTALL_PLUGINS_HELPER", NULL},
+  {"KRB5CCNAME", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1897,6 +1897,7 @@ static const ExportData default_exports[] = {
   {"GST_PTP_HELPER_1_0", NULL},
   {"GST_INSTALL_PLUGINS_HELPER", NULL},
   {"KRB5CCNAME", NULL},
+  {"XKB_CONFIG_ROOT", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -4979,6 +4979,10 @@ flatpak_repo_update (OstreeRepo   *repo,
                                                     g_variant_get_data (old_index),
                                                     g_variant_get_size (old_index));
 
+  /* Release the memory-mapped summary index file before replacing it,
+     to avoid failure on filesystems like cifs */
+  g_clear_pointer (&old_index, g_variant_unref);
+
   if (!flatpak_repo_save_summary_index (repo, summary_index, index_digest, index_sig, cancellable, error))
     return FALSE;
 

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -101,6 +101,7 @@
             <member>PERL5LIB</member>
             <member>XCURSOR_PATH</member>
             <member>KRB5CCNAME</member>
+            <member>XKB_CONFIG_ROOT</member>
         </simplelist>
         <para>
             Also several environment variables with the prefix "GST_" that are used by gstreamer

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -102,6 +102,7 @@
             <member>XCURSOR_PATH</member>
             <member>KRB5CCNAME</member>
             <member>XKB_CONFIG_ROOT</member>
+            <member>GIO_EXTRA_MODULES</member>
         </simplelist>
         <para>
             Also several environment variables with the prefix "GST_" that are used by gstreamer

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -100,6 +100,7 @@
             <member>PERLLIB</member>
             <member>PERL5LIB</member>
             <member>XCURSOR_PATH</member>
+            <member>KRB5CCNAME</member>
         </simplelist>
         <para>
             Also several environment variables with the prefix "GST_" that are used by gstreamer

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -692,7 +692,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -765,7 +765,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   g_debug ("Started flatpak-authenticator");
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -2967,7 +2967,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -3037,7 +3037,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   client_pid_data_hash = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) pid_data_free);
 

--- a/profile/flatpak.fish
+++ b/profile/flatpak.fish
@@ -13,5 +13,9 @@ if type -q flatpak
         set installations $installations (flatpak --installations)
     end
 
-    set XDG_DATA_DIRS {$installations}/exports/share $XDG_DATA_DIRS
+    for dir in {$installations[-1..1]}/exports/share
+        if not contains $dir $XDG_DATA_DIRS
+            set -p XDG_DATA_DIRS $dir
+        end
+    end
 end

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -680,7 +680,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -826,7 +826,7 @@ main (int    argc,
     }
 
   if (verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   client_pid_data_hash = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) pid_data_free);
 

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -2289,7 +2289,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("FH: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -2373,12 +2373,12 @@ main (int    argc,
   flatpak_disable_fancy_output ();
 
   if (opt_verbose > 0)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
   if (opt_verbose > 1)
-    g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN "2", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   if (opt_ostree_verbose)
-    g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler ("OSTree", G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   if (!on_session_bus)
     {

--- a/tests/test-authenticator.c
+++ b/tests/test-authenticator.c
@@ -322,7 +322,7 @@ message_handler (const gchar   *log_domain,
                  gpointer       user_data)
 {
   /* Make this look like normal console output */
-  if (log_level & G_LOG_LEVEL_DEBUG)
+  if (log_level & (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO))
     g_printerr ("F: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
@@ -372,7 +372,7 @@ main (int    argc,
     }
 
   if (opt_verbose)
-    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, message_handler, NULL);
+    g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO, message_handler, NULL);
 
   g_debug ("Started test-authenticator");
 


### PR DESCRIPTION
* #5257 
* #5198 
* #5206 
* #5194 
* #5204 
* Don't allow `KRB5CCNAME` to inherit into sandbox (part of #4914, I don't intend to backport the rest)
* Treat `g_info()` as equivalent to `g_debug()` to make backports from 1.15.x more straightforward (part of #5001, I don't intend to backport the rest)