### PR TITLE
run: Avoid double-free of gpgconf stdout stream

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -608,7 +608,7 @@ flatpak_run_add_gpg_agent_args (FlatpakBwrap *bwrap)
   g_autofree char * sandbox_agent_socket = NULL;
   g_autoptr(GError) gpgconf_error = NULL;
   g_autoptr(GSubprocess) process = NULL;
-  g_autoptr(GInputStream) base_stream = NULL;
+  GInputStream *base_stream = NULL;
   g_autoptr(GDataInputStream) data_stream = NULL;
 
   process = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE,


### PR DESCRIPTION
g_subprocess_get_stdout_pipe() does not transfer ownership, so the stream still belongs to the GSubprocess and we must not unref it.

Fixes: 764e5a4d "Add --socket=gpg-agent"  
Resolves: https://github.com/flatpak/flatpak/issues/5095

cc @bl00mber 

---

Should be backported to 1.14.x once merged, but I'm not going to block on this for 1.14.2.