### PR TITLE
[1.14.x] run: Avoid double-free of gpgconf stdout stream

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Changes in 1.14.3
+~~~~~~~~~~~~~~~~~
+Released: not yet
+
+Bug fixes:
+
+* Fix a crash when --socket=gpg-agent is used (#5095)
+
 Changes in 1.14.2
 ~~~~~~~~~~~~~~~~~
 Released: 2023-02-06

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -608,7 +608,7 @@ flatpak_run_add_gpg_agent_args (FlatpakBwrap *bwrap)
   g_autofree char * sandbox_agent_socket = NULL;
   g_autoptr(GError) gpgconf_error = NULL;
   g_autoptr(GSubprocess) process = NULL;
-  g_autoptr(GInputStream) base_stream = NULL;
+  GInputStream *base_stream = NULL;
   g_autoptr(GDataInputStream) data_stream = NULL;
 
   process = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE,


### PR DESCRIPTION
Trivial backport of #5286 