### PR TITLE
[1.14.x] Avoid exporting reserved directories

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,14 @@ Released: not yet
 Bug fixes:
 
 * Fix a crash when --socket=gpg-agent is used (#5095)
+* Never try to export a parent of reserved directories as a --filesystem,
+  for example /run, which would prevent the app from starting (#5205, #5207)
+* Never try to export a --filesystem below /run/flatpak or /run/host,
+  which could similarly prevent the app from starting
+* The above change also fixes apps not starting if a --filesystem is a
+  symlink to the root directory (#1357)
+* Show a warning when the --filesystem exists but cannot be shared with
+  the sandbox (#1357, #5035, #5205, #5207)
 
 Changes in 1.14.2
 ~~~~~~~~~~~~~~~~~

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2580,8 +2580,12 @@ flatpak_context_export (FlatpakContext *context,
 
       if (!flatpak_exports_add_path_expose (exports, MAX (home_mode, fs_mode), g_get_home_dir (), &local_error))
         {
-          log_cannot_export_error (MAX (home_mode, fs_mode), g_get_home_dir (),
-                                   local_error);
+          /* Even if the error is one that we would normally silence, like
+           * the path not existing, it seems reasonable to make more of a fuss
+           * about the home directory not existing or otherwise being unusable,
+           * so this is intentionally not using cannot_export() */
+          g_warning (_("Not allowing home directory access: %s"),
+                     local_error->message);
           g_clear_error (&local_error);
         }
     }
@@ -2799,8 +2803,8 @@ flatpak_context_get_exports_full (FlatpakContext *context,
       /* Ensure we always have a homedir */
       if (!flatpak_exports_add_path_dir (exports, g_get_home_dir (), &local_error))
         {
-          g_debug ("Unable to provide a temporary home directory in the sandbox: %s",
-                   local_error->message);
+          g_warning (_("Unable to provide a temporary home directory in the sandbox: %s"),
+                     local_error->message);
           g_clear_error (&local_error);
         }
     }

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2435,8 +2435,26 @@ flatpak_context_make_sandboxed (FlatpakContext *context)
 }
 
 const char *dont_mount_in_root[] = {
-  ".", "..", "lib", "lib32", "lib64", "bin", "sbin", "usr", "boot", "efi",
-  "root", "tmp", "etc", "app", "run", "proc", "sys", "dev", "var", NULL
+  ".",
+  "..",
+  "app",
+  "bin",
+  "boot",
+  "dev",
+  "efi",
+  "etc",
+  "lib",
+  "lib32",
+  "lib64",
+  "proc",
+  "root",
+  "run",
+  "sbin",
+  "sys",
+  "tmp",
+  "usr",
+  "var",
+  NULL
 };
 
 static void

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -43,16 +43,20 @@ void flatpak_exports_add_host_etc_expose (FlatpakExports       *exports,
                                           FlatpakFilesystemMode mode);
 void flatpak_exports_add_host_os_expose (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode);
-void flatpak_exports_add_path_expose (FlatpakExports       *exports,
-                                      FlatpakFilesystemMode mode,
-                                      const char           *path);
-void flatpak_exports_add_path_tmpfs (FlatpakExports *exports,
-                                     const char     *path);
-void flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
-                                              FlatpakFilesystemMode mode,
-                                              const char           *path);
-void flatpak_exports_add_path_dir (FlatpakExports *exports,
-                                   const char     *path);
+gboolean flatpak_exports_add_path_expose (FlatpakExports         *exports,
+                                          FlatpakFilesystemMode   mode,
+                                          const char             *path,
+                                          GError                **error);
+gboolean flatpak_exports_add_path_tmpfs (FlatpakExports  *exports,
+                                         const char      *path,
+                                         GError         **error);
+gboolean flatpak_exports_add_path_expose_or_hide (FlatpakExports         *exports,
+                                                  FlatpakFilesystemMode   mode,
+                                                  const char             *path,
+                                                  GError                **error);
+gboolean flatpak_exports_add_path_dir (FlatpakExports  *exports,
+                                       const char      *path,
+                                       GError         **error);
 
 gboolean flatpak_exports_path_is_visible (FlatpakExports *exports,
                                           const char     *path);

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -52,6 +52,7 @@
    flatpak_abs_usrmerged_dirs get the same treatment without having to be listed
    here. */
 const char *dont_export_in[] = {
+  "/.flatpak-info",
   "/app",
   "/dev",
   "/etc",

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -52,7 +52,12 @@
    flatpak_abs_usrmerged_dirs get the same treatment without having to be listed
    here. */
 const char *dont_export_in[] = {
-  "/usr", "/etc", "/app", "/dev", "/proc", NULL
+  "/app",
+  "/dev",
+  "/etc",
+  "/proc",
+  "/usr",
+  NULL
 };
 
 static char *

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -1050,55 +1050,46 @@ _exports_path_expose (FlatpakExports *exports,
   return TRUE;
 }
 
-void
-flatpak_exports_add_path_expose (FlatpakExports       *exports,
-                                 FlatpakFilesystemMode mode,
-                                 const char           *path)
+gboolean
+flatpak_exports_add_path_expose (FlatpakExports         *exports,
+                                 FlatpakFilesystemMode   mode,
+                                 const char             *path,
+                                 GError                **error)
 {
-  g_autoptr(GError) local_error = NULL;
-
-  g_return_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE);
-  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
-
-  if (!_exports_path_expose (exports, mode, path, 0, &local_error))
-    g_debug ("Unable to %s: \"%s\": %s",
-             export_mode_to_verb (mode), path, local_error->message);
+  g_return_val_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE, FALSE);
+  g_return_val_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST, FALSE);
+  return _exports_path_expose (exports, mode, path, 0, error);
 }
 
-void
-flatpak_exports_add_path_tmpfs (FlatpakExports *exports,
-                                const char     *path)
+gboolean
+flatpak_exports_add_path_tmpfs (FlatpakExports  *exports,
+                                const char      *path,
+                                GError         **error)
 {
-  g_autoptr(GError) local_error = NULL;
-
-  if (!_exports_path_expose (exports, FAKE_MODE_TMPFS, path, 0, &local_error))
-    g_debug ("Unable to %s: \"%s\": %s",
-             export_mode_to_verb (FAKE_MODE_TMPFS), path, local_error->message);
+  return _exports_path_expose (exports, FAKE_MODE_TMPFS, path, 0, error);
 }
 
-void
-flatpak_exports_add_path_expose_or_hide (FlatpakExports       *exports,
-                                         FlatpakFilesystemMode mode,
-                                         const char           *path)
+gboolean
+flatpak_exports_add_path_expose_or_hide (FlatpakExports        *exports,
+                                         FlatpakFilesystemMode  mode,
+                                         const char            *path,
+                                         GError               **error)
 {
-  g_return_if_fail (mode >= FLATPAK_FILESYSTEM_MODE_NONE);
-  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
+  g_return_val_if_fail (mode >= FLATPAK_FILESYSTEM_MODE_NONE, FALSE);
+  g_return_val_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST, FALSE);
 
   if (mode == FLATPAK_FILESYSTEM_MODE_NONE)
-    flatpak_exports_add_path_tmpfs (exports, path);
+    return flatpak_exports_add_path_tmpfs (exports, path, error);
   else
-    flatpak_exports_add_path_expose (exports, mode, path);
+    return flatpak_exports_add_path_expose (exports, mode, path, error);
 }
 
-void
-flatpak_exports_add_path_dir (FlatpakExports *exports,
-                              const char     *path)
+gboolean
+flatpak_exports_add_path_dir (FlatpakExports  *exports,
+                              const char      *path,
+                              GError         **error)
 {
-  g_autoptr(GError) local_error = NULL;
-
-  if (!_exports_path_expose (exports, FAKE_MODE_DIR, path, 0, &local_error))
-    g_debug ("Unable to %s: \"%s\": %s",
-             export_mode_to_verb (FAKE_MODE_DIR), path, local_error->message);
+  return _exports_path_expose (exports, FAKE_MODE_DIR, path, 0, error);
 }
 
 void

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -972,6 +972,19 @@ _exports_path_expose (FlatpakExports *exports,
                        dont_export_in[i]);
           return FALSE;
         }
+
+      /* Also don't expose directories that are a parent of a directory
+       * that is "owned" by the sandboxing framework. For example, because
+       * Flatpak controls /run/host and /run/flatpak, we cannot allow
+       * --filesystem=/run, which would prevent us from creating the
+       * contents of /run/host and /run/flatpak. */
+      if (flatpak_has_path_prefix (dont_export_in[i], path))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_MOUNTABLE_FILE,
+                       _("Path \"%s\" is reserved by Flatpak"),
+                       dont_export_in[i]);
+          return FALSE;
+        }
     }
 
   for (i = 0; flatpak_abs_usrmerged_dirs[i] != NULL; i++)

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -56,6 +56,8 @@ const char *dont_export_in[] = {
   "/dev",
   "/etc",
   "/proc",
+  "/run/flatpak",
+  "/run/host",
   "/usr",
   NULL
 };

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -50,6 +50,7 @@ app/flatpak-quiet-transaction.c
 common/flatpak-auth.c
 common/flatpak-context.c
 common/flatpak-dir.c
+common/flatpak-exports.c
 common/flatpak-installation.c
 common/flatpak-instance.c
 common/flatpak-oci-registry.c

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1266,6 +1266,8 @@ static const struct
 }
 reserved_filesystems[] =
 {
+  { "/", "/.flatpak-info" },
+  { "/.flatpak-info", "/.flatpak-info" },
   { "/app", "/app" },
   { "/app/foo", "/app" },
   { "/bin", "/bin" },
@@ -1280,6 +1282,9 @@ reserved_filesystems[] =
   { "/proc", "/proc" },
   { "/proc/1", "/proc" },
   { "/proc/sys/net", "/proc" },
+  { "/run", "/run/flatpak" },
+  { "/run/flatpak/foo/bar", "/run/flatpak" },
+  { "/run/host/foo", "/run/host" },
   { "/sbin", "/sbin" },
   { "/sbin/ldconfig", "/sbin" },
   { "/usr", "/usr" },

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1360,6 +1360,7 @@ test_exports_unusual (void)
     { "home", FAKE_SYMLINK, "var/home" },
     { "lib", FAKE_SYMLINK, "usr/lib" },
     { "recursion", FAKE_SYMLINK, "recursion" },
+    { "symlink-to-root", FAKE_SYMLINK, "." },
     { "tmp", FAKE_SYMLINK, "TMP" },
     { "usr/bin", FAKE_DIR },
     { "usr/lib", FAKE_DIR },
@@ -1414,6 +1415,14 @@ test_exports_unusual (void)
                                         "/recursion", &error);
   g_assert_error (error, G_IO_ERROR, G_IO_ERROR_TOO_MANY_LINKS);
   g_test_message ("attempting to export /recursion: %s", error->message);
+  g_assert_false (ok);
+  g_clear_error (&error);
+
+  ok = flatpak_exports_add_path_expose (exports,
+                                        FLATPAK_FILESYSTEM_MODE_READ_ONLY,
+                                        "/symlink-to-root", &error);
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_MOUNTABLE_FILE);
+  g_test_message ("attempting to export /symlink-to-root: %s", error->message);
   g_assert_false (ok);
   g_clear_error (&error);
 


### PR DESCRIPTION
Backport of #5213 to 1.14.x. What do other maintainers think? Good for 1.14.x, or too intrusive?

* exports, context: List unexported paths one per line in sorted order
    
    This will reduce conflicts when new entries are added.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Never try to export paths below /run/flatpak or /run/host
    
    These directories are reserved for Flatpak's own use.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Never try to export /.flatpak-info
    
    Just for completeness, in practice the host system will not have this.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Make _exports_path_expose produce a GError on failure
    
    This is a step towards allowing its direct and indirect callers to decide
    how serious the failure is, and debug or warn accordingly.
    
    Helps: https://github.com/flatpak/flatpak/issues/5205

* exports: Move error handling up into caller
    
    This lets flatpak_context_export() or other callers decide how they want
    to handle failure to export each path. For now, the callers in
    FlatpakExports are still using g_debug() unconditionally, but we can now
    have somewhat better test coverage.
    
    Helps: https://github.com/flatpak/flatpak/issues/1357  
    Helps: https://github.com/flatpak/flatpak/issues/5035  
    Helps: https://github.com/flatpak/flatpak/issues/5205  
    Helps: https://github.com/flatpak/flatpak/issues/5207

* context: Show a warning when --filesystem exists but can't be shared
    
    If the user gives us a override or command-line argument that we cannot
    obey, like --filesystem=/usr/share/whatever or
    --filesystem=/run/flatpak/whatever, then it's confusing that we silently
    ignore it. We should give them an opportunity to see that their override
    was ineffective.
    
    However, there are a few situations where we still want to keep quiet.
    If there is a --filesystem argument for something that simply doesn't
    exist, we don't diagnose the failure to share it: that avoids creating
    unnecessary noise for apps that opportunistically share locations that
    might or might not exist, like the way the Steam app on Flathub asks
    for access to $XDG_RUNTIME_DIR/app/com.discordapp.Discord.
    
    Similarly, if we have been asked for --filesystem=host, the root
    directory is very likely to contain symlinks into a reserved path, like
    /lib -> usr/lib. We don't need a user-visible warning for that.
    
    We actually use the equivalent of g_message() rather than g_warning(),
    to avoid this being fatal during unit testing (in particular when we
    do a `flatpak info` on an app that has never been run, which will
    be unable to share its `.var/app` subdirectory). `app/flatpak-main.c`
    currently displays them as equivalent to each other anyway.

* context: Show a warning if we cannot provide any $HOME
    
    If $HOME is below a reserved path (for example `/usr/home/thompson`
    for Unix traditionalists) or otherwise cannot be shared, or is a
    symbolic link to somewhere that cannot be shared, then we will end
    up running the app with $HOME not existing. This is unexpected, so
    we should make more noise about it.
    
    There are two situations here, both of which get a warning: if we have
    --filesystem=home or --filesystem=host then we are trying to share the
    real $HOME with the application, and if we do not, then we are trying
    to create a directory at the location of the real $HOME and replicate
    the chain of symlinks (if any) leading from $HOME to that location.
    
    Unlike the previous commit, this is not expected to happen during unit
    testing, so we do not use a g_warning() for this.
    
    Diagnoses: https://github.com/flatpak/flatpak/issues/5035

* exports: Don't export parent or ancestor of reserved directories
    
    Previously, --filesystem=/run would prevent apps from starting by
    breaking our ability to set up /run/flatpak and /run/host. Now it is
    ignored, with a diagnostic message, resolving #5205 and #5207.
    
    Similarly, --filesystem=/symlink-to-root (or --filesystem=host) would
    have prevented apps from starting if a symlink like
    `/symlink-to-root -> /` or `/symlink-to-root -> .` exists, and refusing
    to export the target of that symlink avoids that failure mode,
    resolving #1357.
    
    Resolves: https://github.com/flatpak/flatpak/issues/1357  
    Resolves: https://github.com/flatpak/flatpak/issues/5205  
    Resolves: https://github.com/flatpak/flatpak/issues/5207

* exports: Assert that recently-excluded paths are excluded
    
    Reproduces: https://github.com/flatpak/flatpak/issues/5205  
    Reproduces: https://github.com/flatpak/flatpak/issues/5207

* exports: Test that a symlink to the root directory is rejected
    
    Reproduces: https://github.com/flatpak/flatpak/issues/1357

* Update NEWS for backport of #5213