### PR TITLE
Don't crash on malformed overrides

### DIFF
--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -154,6 +154,7 @@ print_table_for_refs (gboolean      print_apps,
           const char *repo = NULL;
           g_autoptr(FlatpakDeploy) deploy = NULL;
           g_autoptr(GBytes) deploy_data = NULL;
+          g_autoptr(GError) local_error = NULL;
           const char *active;
           const char *alt_id;
           const char *eol;
@@ -171,7 +172,16 @@ print_table_for_refs (gboolean      print_apps,
           if (arch != NULL && !flatpak_decomposed_is_arch (ref, arch))
             continue;
 
-          deploy = flatpak_dir_load_deployed (dir, ref, NULL, cancellable, NULL);
+          deploy = flatpak_dir_load_deployed (dir, ref, NULL, cancellable, &local_error);
+
+          if (deploy == NULL)
+            {
+              g_warning (_("Unable to load details of %s: %s"),
+                         partial_ref, local_error->message);
+              g_clear_error (&local_error);
+              continue;
+            }
+
           deploy_data = flatpak_deploy_get_deploy_data (deploy, FLATPAK_DEPLOY_VERSION_CURRENT, cancellable, NULL);
           if (deploy_data == NULL)
             continue;

--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -182,9 +182,15 @@ print_table_for_refs (gboolean      print_apps,
               continue;
             }
 
-          deploy_data = flatpak_deploy_get_deploy_data (deploy, FLATPAK_DEPLOY_VERSION_CURRENT, cancellable, NULL);
+          deploy_data = flatpak_deploy_get_deploy_data (deploy, FLATPAK_DEPLOY_VERSION_CURRENT, cancellable, &local_error);
+
           if (deploy_data == NULL)
-            continue;
+            {
+              g_warning (_("Unable to inspect current version of %s: %s"),
+                         partial_ref, local_error->message);
+              g_clear_error (&local_error);
+              continue;
+            }
 
           runtime = flatpak_deploy_data_get_runtime (deploy_data);
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -562,6 +562,7 @@ FlatpakDeploy *       flatpak_dir_load_deployed                             (Fla
 char *                flatpak_dir_load_override                             (FlatpakDir                    *dir,
                                                                              const char                    *app_id,
                                                                              gsize                         *length,
+                                                                             GFile                        **file_out,
                                                                              GError                       **error);
 OstreeRepo *          flatpak_dir_get_repo                                  (FlatpakDir                    *self);
 gboolean              flatpak_dir_ensure_path                               (FlatpakDir                    *self,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2983,7 +2983,7 @@ flatpak_dir_load_deployed (FlatpakDir        *self,
 
   metakey = g_key_file_new ();
   if (!g_key_file_load_from_data (metakey, metadata_contents, metadata_size, 0, error))
-    return NULL;
+    return glnx_prefix_error_null (error, "%s", flatpak_file_get_path_cached (metadata));
 
   deploy = flatpak_deploy_new (deploy_dir, ref, metakey, self->repo);
 
@@ -3633,7 +3633,7 @@ upgrade_deploy_data (GBytes             *deploy_data,
                                  &metadata_contents, &metadata_size, NULL, error))
         return NULL;
       if (!g_key_file_load_from_data (keyfile, metadata_contents, metadata_size, 0, error))
-        return NULL;
+        return glnx_prefix_error_null (error, "%s", flatpak_file_get_path_cached (metadata_file));
       add_metadata_to_deploy_data (&metadata_dict, keyfile);
 
       /* Add fields from appdata to deploy, since appdata-content-rating wasn't

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1714,7 +1714,7 @@ flatpak_installation_load_app_overrides (FlatpakInstallation *self,
   if (dir == NULL)
     return NULL;
 
-  metadata_contents = flatpak_dir_load_override (dir, app_id, &metadata_size, error);
+  metadata_contents = flatpak_dir_load_override (dir, app_id, &metadata_size, NULL, error);
   if (metadata_contents == NULL)
     return NULL;
 


### PR DESCRIPTION
* list: Handle error in flatpak_dir_load_deployed()
    
    flatpak_dir_load_deployed() can fail and return NULL. If that happens,
    there is a semi-installed but broken app, and we should show a warning
    rather than crashing.
    
    Resolves: https://github.com/flatpak/flatpak/issues/5293

* list: Show a warning if we can't load the current version
    
    Conceptually similar to the previous commit, except it didn't crash
    before, just didn't display anything.

* dir: If overrides are syntactically invalid, include path in error message
    
    It's unhelpful to say something like "Key file contains line “x” which is
    not a key-value pair, group, or comment" without specifying which file
    we are talking about.

* dir: If metadata is syntactically invalid, say which file is the problem
    
    Similar to the previous commit, but for metadata.

---

With these changes, reproducing #5293 via the recipe in #5292 produces:

```
F: Unable to load details of org.gnome.Recipes/x86_64/stable: /home/smcv/.local/share/flatpak/overrides/org.gnome.Recipes: Key file contains line “x” which is not a key-value pair, group, or comment
F: Unable to load details of org.gnome.Recipes/x86_64/stable: /home/smcv/.local/share/flatpak/overrides/org.gnome.Recipes: Key file contains line “x” which is not a key-value pair, group, or comment
Name                       Application ID                       Version                            Branch Origin           Installation
...
```

which seems much better.

Maybe it would be possible to display the broken/non-working app in the table without parsing its overrides, but I'll leave that to someone with a better understanding of the "package management" layer of Flatpak (I mostly concentrate on the sandboxing layer).
```