### PR TITLE
flatpak-run: Unset GDK_BACKEND

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1912,6 +1912,7 @@ static const ExportData default_exports[] = {
   {"KRB5CCNAME", NULL},
   {"XKB_CONFIG_ROOT", NULL},
   {"GIO_EXTRA_MODULES", NULL},
+  {"GDK_BACKEND", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -103,6 +103,7 @@
             <member>KRB5CCNAME</member>
             <member>XKB_CONFIG_ROOT</member>
             <member>GIO_EXTRA_MODULES</member>
+            <member>GDK_BACKEND</member>
         </simplelist>
         <para>
             Also several environment variables with the prefix "GST_" that are used by gstreamer


### PR DESCRIPTION
If the `GDK_BACKEND` environment variable is present and it's value does not match the Wayland and X11 socket configuration, then a GTK app will fail to run since it will only consider the display backend from the environment variable.

This should probably be extended to cover other display environment variables such as `QT_QPA_PLATFORM` for Qt and `SDL_VIDEODRIVER` for SDL. However, I've only tested this with GTK applications.