### PR TITLE
[1.14.x] transaction: Ignore uninstall operations for no deploy

### DIFF
--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -439,6 +439,13 @@ ${FLATPAK} build-commit-from --no-update-summary --end-of-life-rebase=org.test.H
 GPGARGS="${FL_GPGARGS}" $(dirname $0)/make-test-app.sh repos/test-rebase org.test.NewHello master "${REBASE_COLLECTION_ID}" "NEW" > /dev/null
 update_repo test-rebase
 
+# First do a --no-deploy update and check the old version is still installed
+${FLATPAK} ${U} update -y --no-deploy org.test.Hello >&2
+
+assert_has_dir $HOME/.var/app/org.test.Hello
+assert_has_file $HOME/.var/app/org.test.Hello/data/a-file
+assert_not_has_dir $HOME/.var/app/org.test.NewHello
+
 ${FLATPAK} ${U} update -y org.test.Hello >&2
 
 # Make sure we got the new version installed
@@ -491,6 +498,12 @@ assert_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
 make_updated_runtime "" "" "mainline" ""
 make_updated_app "" "" "" "UPDATED99" "" "mainline"
 
+# First update with --no-deploy and check the old runtime is still installed
+${FLATPAK} ${U} update -y --no-deploy org.test.Hello >&2
+
+assert_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
+assert_not_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/mainline/active/files
+
 ${FLATPAK} ${U} update -y org.test.Hello >&2
 
 # The previous runtime should have been removed during the update
@@ -518,7 +531,11 @@ ${FLATPAK} ${U} update -y org.test.Platform >&2
 ${FLATPAK} ${U} info org.test.Platform > info-log
 assert_file_has_content info-log "End-of-life: Reason4"
 
-# Now that the runtime is EOL and unused it should be uninstalled by the update command
+# Now that the runtime is EOL and unused it should be uninstalled by the
+# update command. Check first that it's not uninstalled with --no-deploy.
+${FLATPAK} ${U} update -y --no-deploy >&2
+assert_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
+
 ${FLATPAK} ${U} update -y >&2
 assert_not_has_dir $FL_DIR/runtime/org.test.Platform/$ARCH/master/active/files
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -3269,6 +3269,28 @@ test_transaction_install_uninstall (void)
 
   g_clear_object (&transaction);
 
+  /* uninstall org.test.Hello with no_deploy set to TRUE. This should be a
+   * no-op.
+   */
+  transaction = flatpak_transaction_new_for_installation (inst, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (transaction);
+
+  flatpak_transaction_set_no_deploy (transaction, TRUE);
+  g_assert_true (flatpak_transaction_get_no_deploy (transaction));
+
+  res = flatpak_transaction_add_uninstall (transaction, app, &error);
+  g_assert_no_error (error);
+  g_assert_true (res);
+
+  g_assert_true (flatpak_transaction_is_empty (transaction));
+
+  list = flatpak_transaction_get_operations (transaction);
+  g_assert_cmpint (g_list_length (list), ==, 0);
+  g_list_free (list);
+
+  g_clear_object (&transaction);
+
   /* uninstall org.test.Hello, we expect org.test.Hello.Locale to be
    * removed with it, but org.test.Platform to stay
    */


### PR DESCRIPTION
From: @dbnicholson 

If `no_deploy` has been set to `TRUE` in a transaction, then the intention is that no changes will be made to the installed flatpaks. Currently that's not the case for explicitly or implicitly added uninstall operations. That's particularly bad for eol-rebase flatpaks since they old version will be automatically removed without the new version being installed. To address this, prevent uninstall operations from being added for no deploy transactions.

Closes: #5172
(cherry picked from commit fba3a7d35e7739a6b923f74596d388a3ae7a2cfa)

---

cc @pwithnall @wjt 

Cherry-pick from 1.15.3, and I hope this is equivalent to what you're shipping in your Flatpak builds?