### PR TITLE
feat(flatpak override) add override path

### DIFF
--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -51,6 +51,9 @@
             <command>flatpak override</command>.
         </para>
         <para>
+            The application overrides are saved in text files residing in $XDG_DATA_HOME/flatpak/overrides in user mode. 
+        </para>
+        <para>
             If the application ID <arg choice="plain">APP</arg> is not specified
             then the overrides affect all applications,
             but the per-application overrides can override the global overrides.


### PR DESCRIPTION
This addition includes the override path in Flatpak override command documentation.

This is similar to #401. This pull request modifies the file [doc/flatpak-override.xml](https://github.com/flatpak/flatpak/blob/main/doc/flatpak-override.xml). 

