### PR TITLE
Set size of file info for symlinks to 0

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5056,6 +5056,7 @@ flatpak_mtree_create_symlink (OstreeRepo         *repo,
 
   g_file_info_set_name (file_info, filename);
   g_file_info_set_file_type (file_info, G_FILE_TYPE_SYMBOLIC_LINK);
+  g_file_info_set_size (file_info, 0);
   g_file_info_set_attribute_uint32 (file_info, "unix::uid", 0);
   g_file_info_set_attribute_uint32 (file_info, "unix::gid", 0);
   g_file_info_set_attribute_uint32 (file_info, "unix::mode", S_IFLNK | 0777);


### PR DESCRIPTION
`ostree_raw_file_to_content_stream` will try to read it, causing a critical warning with GLib 2.76 causing tests to fail.

Ostree probably shouldn't try to use the size of a symlink, but that seems to be more complicated than a single line.