### PR TITLE
tests: Call g_test_init() before isolated_test_dir_global_setup()

### DIFF
--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1477,9 +1477,8 @@ main (int argc, char *argv[])
   /* Do not call setlocale() here: some tests look at untranslated error
    * messages. */
 
-  isolated_test_dir_global_setup ();
-
   g_test_init (&argc, &argv, NULL);
+  isolated_test_dir_global_setup ();
 
   g_test_add_func ("/context/empty", test_empty_context);
   g_test_add_func ("/context/filesystems", test_filesystems);

--- a/tests/test-instance.c
+++ b/tests/test-instance.c
@@ -491,9 +491,8 @@ main (int argc, char *argv[])
 {
   int res;
 
-  isolated_test_dir_global_setup ();
-
   g_test_init (&argc, &argv, NULL);
+  isolated_test_dir_global_setup ();
 
   g_test_add_func ("/instance/gc", test_gc);
   g_test_add_func ("/instance/claim-per-app-temp-directory",


### PR DESCRIPTION
g_test_init() is meant to be called before any other use of GTest APIs, and isolated_test_dir_global_setup() can call g_test_message(). GLib 2.76 makes this more of a practical problem.

(isolated_test_dir_global_setup() is essentially a reimplementation of G_TEST_OPTION_ISOLATE_DIRS, since we don't depend on GLib 2.60.)

Alternative to https://github.com/flatpak/flatpak/pull/5355.

---

As suggested by @pwithnall on #5355. @heftig, please could you try this?