### PR TITLE
testlibrary: Initialize autofree variable to silence a compiler warning

### DIFF
--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -207,7 +207,7 @@ test_installation_config (void)
   g_autofree char *path = NULL;
   g_autoptr(GFile) file = NULL;
   g_autoptr(GError) error = NULL;
-  g_autofree char *value;
+  g_autofree char *value = NULL;
   gboolean res;
   guint64 bytes;
 


### PR DESCRIPTION
As with commit 43085c0e "dir: Consistently initialize g_autofree variables", this is currently harmless because we never actually early-return or goto out of the region between declaration and initialization, but some compiler versions log a warning here anyway.