### PR TITLE
ci: trigger differential-shellcheck workflow on push

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -4,6 +4,8 @@
 
 name: Differential ShellCheck
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -16,7 +18,6 @@ jobs:
 
     permissions:
       security-events: write
-      pull-requests: write
 
     steps:
       - name: Repository checkout
@@ -25,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v3
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also, update `differential-shellcheck` to the latest version (`v4.0.2`) - https://github.com/redhat-plumbers-in-action/differential-shellcheck/releases Push events are supported since `v4.0.0`.

Fixes: https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/215

This should get rid of annoying messages from the `github-code-scanning` bot.

![Screenshot from 2023-03-22 07-00-32](https://user-images.githubusercontent.com/2879818/226815668-36272095-4f1d-4465-a0e8-f317b0abfc52.png)