### PR TITLE
[major, fix] workflows: bump actions version and remove unsupported runner 18.04

### DIFF
--- a/.github/workflows/block-autosquash-commits.yml
+++ b/.github/workflows/block-autosquash-commits.yml
@@ -10,6 +10,6 @@ jobs:
 
     steps:
       - name: Block Autosquash Commits
-        uses: xt0rted/block-autosquash-commits-action@v2.0.0
+        uses: xt0rted/block-autosquash-commits-action@v2.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -146,7 +146,6 @@ jobs:
     # https://gitlab.gnome.org/GNOME/glib/-/issues/1014
     - name: Upgrade GLib before running tests
       run: |
-        sudo add-apt-repository ppa:alexlarsson/glib260
         sudo apt-get install -y libglib2.0-dev
     - name: Run tests
       run: make -C _build check -j $(getconf _NPROCESSORS_ONLN)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,7 +92,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/meson-logs/* test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure() || cancelled()
       with:
         name: test logs
@@ -158,7 +158,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/tests/*.log test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure() || cancelled()
       with:
         name: test logs
@@ -258,7 +258,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/tests/*.log test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure() || cancelled()
       with:
         name: test logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -213,7 +213,7 @@ jobs:
   valgrind:
     name: Run tests in valgrind
     needs: check # Don't run expensive test if main check fails
-    runs-on: ubuntu-20.04 # Might as well test with a different one too
+    runs-on: ubuntu-22.04 # Might as well test with a different one too
     if: ${{ false }} # Currently Valgrind takes too long and always fails
     steps:
     - name: Install Dependencies

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Build appstream dependency # (We need at least 0.15.3 for the g_once fix)
@@ -105,7 +105,7 @@ jobs:
   # * Disable malcontent build-dependency
   check-alt2:
     name: Build with gcc and test (older)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Install Dependencies
       run: |
@@ -120,7 +120,7 @@ jobs:
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Create logs dir
@@ -169,7 +169,7 @@ jobs:
     permissions:
       security-events: write # for codeql
     name: Build with clang and analyze
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -198,7 +198,7 @@ jobs:
         libseccomp-dev libsoup2.4-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang e2fslibs-dev
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: configure
@@ -229,7 +229,7 @@ jobs:
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev \
         valgrind e2fslibs-dev
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Create logs dir


### PR DESCRIPTION
## Description

Recently on April 1st, Ubuntu 18.04 runners reached the unsupported state and will no longer be available in actions (More information here: https://github.com/actions/runner-images/issues/6002). This PR is to update not only for updating the runners but also for updating the related actions. I tested these changes before creating this PR in my fork's actions here https://github.com/kbdharun/flatpak/actions. Since this is a major change a thorough review is required. 

## Changes

- [check.yml: bump actions/checkout version and replace deprecated 18.04 runner with 20.04](https://github.com/flatpak/flatpak/commit/45b7df6d1ded5d23ec3779a79b1cf44b4c9c5625)
- [block-autosquash-commits.yml: bump block-autosquash-commits-action version to 2.2.0](https://github.com/flatpak/flatpak/commit/902cc6807db97c7f077d6d653b85dbe7ffeb2f74)
- [check.yml: remove glib260 ppa](https://github.com/flatpak/flatpak/commit/e5aa5697043927b266fa251fa69a4b7ed2682481) [As it is present in the Ubuntu repository directory, check commit message for more information]
- [check.yml: bump actions/upload-artifacts to v3](https://github.com/flatpak/flatpak/commit/7656d224380ea6145b8ecfa4b63b67d8d7cac715)
- [check.yml: bump Ubuntu runner to 22.04 for valgrind](https://github.com/flatpak/flatpak/commit/aa82435c1f872937f6bc3211493e7c9682574ba5) [~~Note: This check is being skipped in all my workflow runs~~, Update: I found out it is disabled since <https://github.com/flatpak/flatpak/commit/8daa975ab3e11e56b2c168dc62b30f029751dbd2>]