### PR TITLE
common: Fix an uninitialized variable

### DIFF
--- a/common/flatpak-run-sockets.c
+++ b/common/flatpak-run-sockets.c
@@ -218,7 +218,7 @@ flatpak_run_add_socket_args_environment (FlatpakBwrap *bwrap,
                                          FlatpakContextShares shares,
                                          FlatpakContextSockets sockets)
 {
-  gboolean has_wayland;
+  gboolean has_wayland = FALSE;
   gboolean allow_x11;
 
   if (sockets & FLATPAK_CONTEXT_SOCKET_WAYLAND)


### PR DESCRIPTION
This could be uninitialized if the app has --socket=fallback-x11 but not --socket=wayland, although that's a combination that doesn't make a great deal of sense. Regression introduced during recent refactoring.

Fixes: db7a8bb5 "common: Split up socket setup from flatpak-run into multiple files"