### PR TITLE
utils: Refactoring

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -36,6 +36,7 @@
 #include "flatpak-transaction-private.h"
 #include "flatpak-cli-transaction.h"
 #include "flatpak-quiet-transaction.h"
+#include "flatpak-utils-http-private.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-error.h"
 #include "flatpak-chain-input-stream-private.h"

--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -31,6 +31,7 @@
 
 #include "flatpak-builtins.h"
 #include "flatpak-builtins-utils.h"
+#include "flatpak-utils-http-private.h"
 #include "flatpak-utils-private.h"
 
 static gboolean opt_no_gpg_verify;

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -147,6 +147,7 @@ libflatpak_common_la_SOURCES = \
 	common/flatpak-json-oci.c \
 	common/flatpak-json-private.h \
 	common/flatpak-json.c \
+	common/flatpak-metadata-private.h \
 	common/flatpak-oci-registry-private.h \
 	common/flatpak-oci-registry.c \
 	common/flatpak-portal-error.c \

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -168,4 +168,7 @@ gboolean flatpak_context_parse_env_fd (FlatpakContext *context,
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakContext, flatpak_context_free)
 
+GFile *flatpak_get_user_base_dir_location (void);
+GFile *flatpak_get_data_dir (const char *app_id);
+
 #endif /* __FLATPAK_CONTEXT_H__ */

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -19,6 +19,7 @@
  */
 
 #include "config.h"
+#include "flatpak-context-private.h"
 
 #include <string.h>
 #include <fcntl.h>

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -398,7 +398,6 @@ GQuark       flatpak_dir_error_quark (void);
 GPtrArray *flatpak_get_system_base_dir_locations        (GCancellable  *cancellable,
                                                          GError       **error);
 GFile *    flatpak_get_system_default_base_dir_location (void);
-GFile *    flatpak_get_user_base_dir_location           (void);
 
 GKeyFile *      flatpak_load_override_keyfile   (const char  *app_id,
                                                  gboolean     user,

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -82,4 +82,6 @@ void flatpak_exports_take_host_fd (FlatpakExports *exports,
 void flatpak_exports_set_test_flags (FlatpakExports *exports,
                                      FlatpakExportsTestFlags flags);
 
+extern const char * const *flatpak_abs_usrmerged_dirs;
+
 #endif /* __FLATPAK_EXPORTS_H__ */

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -47,6 +47,17 @@
 #include "flatpak-systemd-dbus-generated.h"
 #include "flatpak-error.h"
 
+static const char * const abs_usrmerged_dirs[] =
+{
+  "/bin",
+  "/lib",
+  "/lib32",
+  "/lib64",
+  "/sbin",
+  NULL
+};
+const char * const *flatpak_abs_usrmerged_dirs = abs_usrmerged_dirs;
+
 /* We don't want to export paths pointing into these, because they are readonly
    (so we can't create mountpoints there) and don't match what's on the host anyway.
    flatpak_abs_usrmerged_dirs get the same treatment without having to be listed

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -41,8 +41,9 @@
 #include "libglnx.h"
 
 #include "flatpak-exports-private.h"
-#include "flatpak-run-private.h"
+#include "flatpak-metadata-private.h"
 #include "flatpak-utils-base-private.h"
+#include "flatpak-utils-private.h"
 #include "flatpak-dir-private.h"
 #include "flatpak-systemd-dbus-generated.h"
 #include "flatpak-error.h"

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -24,9 +24,9 @@
 #include <unistd.h>
 
 #include "flatpak-json-backports-private.h"
+#include "flatpak-metadata-private.h"
 #include "flatpak-utils-base-private.h"
 #include "flatpak-utils-private.h"
-#include "flatpak-run-private.h"
 #include "flatpak-instance.h"
 #include "flatpak-instance-private.h"
 #include "flatpak-enum-types.h"

--- a/common/flatpak-metadata-private.h
+++ b/common/flatpak-metadata-private.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014 Red Hat, Inc
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libglnx.h"
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/* See flatpak-metadata(5) */
+
+#define FLATPAK_METADATA_GROUP_APPLICATION "Application"
+#define FLATPAK_METADATA_GROUP_RUNTIME "Runtime"
+#define FLATPAK_METADATA_KEY_COMMAND "command"
+#define FLATPAK_METADATA_KEY_NAME "name"
+#define FLATPAK_METADATA_KEY_REQUIRED_FLATPAK "required-flatpak"
+#define FLATPAK_METADATA_KEY_RUNTIME "runtime"
+#define FLATPAK_METADATA_KEY_SDK "sdk"
+#define FLATPAK_METADATA_KEY_TAGS "tags"
+
+#define FLATPAK_METADATA_GROUP_CONTEXT "Context"
+#define FLATPAK_METADATA_KEY_SHARED "shared"
+#define FLATPAK_METADATA_KEY_SOCKETS "sockets"
+#define FLATPAK_METADATA_KEY_FILESYSTEMS "filesystems"
+#define FLATPAK_METADATA_KEY_PERSISTENT "persistent"
+#define FLATPAK_METADATA_KEY_DEVICES "devices"
+#define FLATPAK_METADATA_KEY_FEATURES "features"
+#define FLATPAK_METADATA_KEY_UNSET_ENVIRONMENT "unset-environment"
+
+#define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
+#define FLATPAK_METADATA_KEY_INSTANCE_PATH "instance-path"
+#define FLATPAK_METADATA_KEY_INSTANCE_ID "instance-id"
+#define FLATPAK_METADATA_KEY_ORIGINAL_APP_PATH "original-app-path"
+#define FLATPAK_METADATA_KEY_APP_PATH "app-path"
+#define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
+#define FLATPAK_METADATA_KEY_APP_EXTENSIONS "app-extensions"
+#define FLATPAK_METADATA_KEY_ARCH "arch"
+#define FLATPAK_METADATA_KEY_BRANCH "branch"
+#define FLATPAK_METADATA_KEY_FLATPAK_VERSION "flatpak-version"
+#define FLATPAK_METADATA_KEY_ORIGINAL_RUNTIME_PATH "original-runtime-path"
+#define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
+#define FLATPAK_METADATA_KEY_RUNTIME_COMMIT "runtime-commit"
+#define FLATPAK_METADATA_KEY_RUNTIME_EXTENSIONS "runtime-extensions"
+#define FLATPAK_METADATA_KEY_SESSION_BUS_PROXY "session-bus-proxy"
+#define FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY "system-bus-proxy"
+#define FLATPAK_METADATA_KEY_EXTRA_ARGS "extra-args"
+#define FLATPAK_METADATA_KEY_SANDBOX "sandbox"
+#define FLATPAK_METADATA_KEY_BUILD "build"
+#define FLATPAK_METADATA_KEY_DEVEL "devel"
+
+#define FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY "Session Bus Policy"
+#define FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY "System Bus Policy"
+#define FLATPAK_METADATA_GROUP_PREFIX_POLICY "Policy "
+#define FLATPAK_METADATA_GROUP_ENVIRONMENT "Environment"
+
+#define FLATPAK_METADATA_GROUP_PREFIX_EXTENSION "Extension "
+#define FLATPAK_METADATA_KEY_ADD_LD_PATH "add-ld-path"
+#define FLATPAK_METADATA_KEY_AUTODELETE "autodelete"
+#define FLATPAK_METADATA_KEY_DIRECTORY "directory"
+#define FLATPAK_METADATA_KEY_DOWNLOAD_IF "download-if"
+#define FLATPAK_METADATA_KEY_ENABLE_IF "enable-if"
+#define FLATPAK_METADATA_KEY_AUTOPRUNE_UNLESS "autoprune-unless"
+#define FLATPAK_METADATA_KEY_MERGE_DIRS "merge-dirs"
+#define FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD "no-autodownload"
+#define FLATPAK_METADATA_KEY_SUBDIRECTORIES "subdirectories"
+#define FLATPAK_METADATA_KEY_SUBDIRECTORY_SUFFIX "subdirectory-suffix"
+#define FLATPAK_METADATA_KEY_LOCALE_SUBSET "locale-subset"
+#define FLATPAK_METADATA_KEY_VERSION "version"
+#define FLATPAK_METADATA_KEY_VERSIONS "versions"
+
+#define FLATPAK_METADATA_KEY_COLLECTION_ID "collection-id"
+
+#define FLATPAK_METADATA_GROUP_EXTRA_DATA "Extra Data"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_CHECKSUM "checksum"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_INSTALLED_SIZE "installed-size"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_NAME "name"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_SIZE "size"
+#define FLATPAK_METADATA_KEY_EXTRA_DATA_URI "uri"
+#define FLATPAK_METADATA_KEY_NO_RUNTIME "NoRuntime"
+
+#define FLATPAK_METADATA_GROUP_EXTENSION_OF "ExtensionOf"
+#define FLATPAK_METADATA_KEY_PRIORITY "priority"
+#define FLATPAK_METADATA_KEY_REF "ref"
+#define FLATPAK_METADATA_KEY_TAG "tag"
+
+#define FLATPAK_METADATA_GROUP_DCONF "X-DConf"
+#define FLATPAK_METADATA_KEY_DCONF_PATHS "paths"
+#define FLATPAK_METADATA_KEY_DCONF_MIGRATE_PATH "migrate-path"
+
+G_END_DECLS

--- a/common/flatpak-oci-registry-private.h
+++ b/common/flatpak-oci-registry-private.h
@@ -27,6 +27,7 @@
 #include <gio/gio.h>
 #include <archive.h>
 #include "flatpak-json-oci-private.h"
+#include "flatpak-utils-http-private.h"
 #include "flatpak-utils-private.h"
 
 #define FLATPAK_TYPE_OCI_REGISTRY flatpak_oci_registry_get_type ()

--- a/common/flatpak-ref-utils-private.h
+++ b/common/flatpak-ref-utils-private.h
@@ -45,7 +45,6 @@ gboolean flatpak_id_has_subref_suffix (const char *id,
 
 gboolean flatpak_is_app_runtime_or_appstream_ref (const char *ref);
 char * flatpak_get_arch_for_ref (const char *ref);
-const char *flatpak_get_compat_arch_reverse (const char *compat_arch);
 
 FlatpakKinds flatpak_kinds_from_kind (FlatpakRefKind kind);
 

--- a/common/flatpak-ref-utils.c
+++ b/common/flatpak-ref-utils.c
@@ -27,8 +27,9 @@
 
 #include <glib.h>
 #include "flatpak-ref-utils-private.h"
-#include "flatpak-run-private.h"
+
 #include "flatpak-error.h"
+#include "flatpak-metadata-private.h"
 #include "flatpak-utils-private.h"
 
 FlatpakKinds

--- a/common/flatpak-ref-utils.c
+++ b/common/flatpak-ref-utils.c
@@ -1687,3 +1687,12 @@ flatpak_build_app_ref (const char *app,
   return g_build_filename ("app", app, arch, branch, NULL);
 }
 
+gboolean
+flatpak_is_app_runtime_or_appstream_ref (const char *ref)
+{
+  return
+    g_str_has_prefix (ref, "appstream/") ||
+    g_str_has_prefix (ref, "appstream2/") ||
+    g_str_has_prefix (ref, "app/") ||
+    g_str_has_prefix (ref, "runtime/");
+}

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -198,6 +198,4 @@ gboolean flatpak_run_app (FlatpakDecomposed  *app_ref,
                           GCancellable       *cancellable,
                           GError            **error);
 
-extern const char * const *flatpak_abs_usrmerged_dirs;
-
 #endif /* __FLATPAK_RUN_H__ */

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -59,14 +59,11 @@ char **  flatpak_run_get_minimal_env (gboolean devel,
                                       gboolean use_ld_so_cache);
 void     flatpak_run_apply_env_default (FlatpakBwrap *bwrap,
                                         gboolean      use_ld_so_cache);
-void     flatpak_run_apply_env_appid (FlatpakBwrap *bwrap,
-                                      GFile        *app_dir);
 void      flatpak_run_apply_env_vars (FlatpakBwrap   *bwrap,
                                       FlatpakContext *context);
 FlatpakContext *flatpak_app_compute_permissions (GKeyFile *app_metadata,
                                                  GKeyFile *runtime_metadata,
                                                  GError  **error);
-GFile *flatpak_get_data_dir (const char *app_id);
 gboolean flatpak_ensure_data_dir (GFile        *app_id_dir,
                                   GCancellable *cancellable,
                                   GError      **error);

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -25,91 +25,12 @@
 #include "flatpak-common-types-private.h"
 #include "flatpak-context-private.h"
 #include "flatpak-bwrap-private.h"
+#include "flatpak-metadata-private.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-exports-private.h"
 
 gboolean flatpak_run_in_transient_unit (const char *app_id,
                                         GError    **error);
-
-/* See flatpak-metadata(5) */
-
-#define FLATPAK_METADATA_GROUP_APPLICATION "Application"
-#define FLATPAK_METADATA_GROUP_RUNTIME "Runtime"
-#define FLATPAK_METADATA_KEY_COMMAND "command"
-#define FLATPAK_METADATA_KEY_NAME "name"
-#define FLATPAK_METADATA_KEY_REQUIRED_FLATPAK "required-flatpak"
-#define FLATPAK_METADATA_KEY_RUNTIME "runtime"
-#define FLATPAK_METADATA_KEY_SDK "sdk"
-#define FLATPAK_METADATA_KEY_TAGS "tags"
-
-#define FLATPAK_METADATA_GROUP_CONTEXT "Context"
-#define FLATPAK_METADATA_KEY_SHARED "shared"
-#define FLATPAK_METADATA_KEY_SOCKETS "sockets"
-#define FLATPAK_METADATA_KEY_FILESYSTEMS "filesystems"
-#define FLATPAK_METADATA_KEY_PERSISTENT "persistent"
-#define FLATPAK_METADATA_KEY_DEVICES "devices"
-#define FLATPAK_METADATA_KEY_FEATURES "features"
-#define FLATPAK_METADATA_KEY_UNSET_ENVIRONMENT "unset-environment"
-
-#define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
-#define FLATPAK_METADATA_KEY_INSTANCE_PATH "instance-path"
-#define FLATPAK_METADATA_KEY_INSTANCE_ID "instance-id"
-#define FLATPAK_METADATA_KEY_ORIGINAL_APP_PATH "original-app-path"
-#define FLATPAK_METADATA_KEY_APP_PATH "app-path"
-#define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
-#define FLATPAK_METADATA_KEY_APP_EXTENSIONS "app-extensions"
-#define FLATPAK_METADATA_KEY_ARCH "arch"
-#define FLATPAK_METADATA_KEY_BRANCH "branch"
-#define FLATPAK_METADATA_KEY_FLATPAK_VERSION "flatpak-version"
-#define FLATPAK_METADATA_KEY_ORIGINAL_RUNTIME_PATH "original-runtime-path"
-#define FLATPAK_METADATA_KEY_RUNTIME_PATH "runtime-path"
-#define FLATPAK_METADATA_KEY_RUNTIME_COMMIT "runtime-commit"
-#define FLATPAK_METADATA_KEY_RUNTIME_EXTENSIONS "runtime-extensions"
-#define FLATPAK_METADATA_KEY_SESSION_BUS_PROXY "session-bus-proxy"
-#define FLATPAK_METADATA_KEY_SYSTEM_BUS_PROXY "system-bus-proxy"
-#define FLATPAK_METADATA_KEY_EXTRA_ARGS "extra-args"
-#define FLATPAK_METADATA_KEY_SANDBOX "sandbox"
-#define FLATPAK_METADATA_KEY_BUILD "build"
-#define FLATPAK_METADATA_KEY_DEVEL "devel"
-
-#define FLATPAK_METADATA_GROUP_SESSION_BUS_POLICY "Session Bus Policy"
-#define FLATPAK_METADATA_GROUP_SYSTEM_BUS_POLICY "System Bus Policy"
-#define FLATPAK_METADATA_GROUP_PREFIX_POLICY "Policy "
-#define FLATPAK_METADATA_GROUP_ENVIRONMENT "Environment"
-
-#define FLATPAK_METADATA_GROUP_PREFIX_EXTENSION "Extension "
-#define FLATPAK_METADATA_KEY_ADD_LD_PATH "add-ld-path"
-#define FLATPAK_METADATA_KEY_AUTODELETE "autodelete"
-#define FLATPAK_METADATA_KEY_DIRECTORY "directory"
-#define FLATPAK_METADATA_KEY_DOWNLOAD_IF "download-if"
-#define FLATPAK_METADATA_KEY_ENABLE_IF "enable-if"
-#define FLATPAK_METADATA_KEY_AUTOPRUNE_UNLESS "autoprune-unless"
-#define FLATPAK_METADATA_KEY_MERGE_DIRS "merge-dirs"
-#define FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD "no-autodownload"
-#define FLATPAK_METADATA_KEY_SUBDIRECTORIES "subdirectories"
-#define FLATPAK_METADATA_KEY_SUBDIRECTORY_SUFFIX "subdirectory-suffix"
-#define FLATPAK_METADATA_KEY_LOCALE_SUBSET "locale-subset"
-#define FLATPAK_METADATA_KEY_VERSION "version"
-#define FLATPAK_METADATA_KEY_VERSIONS "versions"
-
-#define FLATPAK_METADATA_KEY_COLLECTION_ID "collection-id"
-
-#define FLATPAK_METADATA_GROUP_EXTRA_DATA "Extra Data"
-#define FLATPAK_METADATA_KEY_EXTRA_DATA_CHECKSUM "checksum"
-#define FLATPAK_METADATA_KEY_EXTRA_DATA_INSTALLED_SIZE "installed-size"
-#define FLATPAK_METADATA_KEY_EXTRA_DATA_NAME "name"
-#define FLATPAK_METADATA_KEY_EXTRA_DATA_SIZE "size"
-#define FLATPAK_METADATA_KEY_EXTRA_DATA_URI "uri"
-#define FLATPAK_METADATA_KEY_NO_RUNTIME "NoRuntime"
-
-#define FLATPAK_METADATA_GROUP_EXTENSION_OF "ExtensionOf"
-#define FLATPAK_METADATA_KEY_PRIORITY "priority"
-#define FLATPAK_METADATA_KEY_REF "ref"
-#define FLATPAK_METADATA_KEY_TAG "tag"
-
-#define FLATPAK_METADATA_GROUP_DCONF "X-DConf"
-#define FLATPAK_METADATA_KEY_DCONF_PATHS "paths"
-#define FLATPAK_METADATA_KEY_DCONF_MIGRATE_PATH "migrate-path"
 
 void     flatpak_run_extend_ld_path       (FlatpakBwrap       *bwrap,
                                            const char         *prepend,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -66,17 +66,6 @@
 
 #define DEFAULT_SHELL "/bin/sh"
 
-const char * const abs_usrmerged_dirs[] =
-{
-  "/bin",
-  "/lib",
-  "/lib32",
-  "/lib64",
-  "/sbin",
-  NULL
-};
-const char * const *flatpak_abs_usrmerged_dirs = abs_usrmerged_dirs;
-
 static int
 flatpak_extension_compare_by_path (gconstpointer _a,
                                    gconstpointer _b)

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -687,37 +687,6 @@ flatpak_run_apply_env_prompt (FlatpakBwrap *bwrap, const char *app_id)
 }
 
 void
-flatpak_run_apply_env_appid (FlatpakBwrap *bwrap,
-                             GFile        *app_dir)
-{
-  g_autoptr(GFile) app_dir_data = NULL;
-  g_autoptr(GFile) app_dir_config = NULL;
-  g_autoptr(GFile) app_dir_cache = NULL;
-  g_autoptr(GFile) app_dir_state = NULL;
-
-  app_dir_data = g_file_get_child (app_dir, "data");
-  app_dir_config = g_file_get_child (app_dir, "config");
-  app_dir_cache = g_file_get_child (app_dir, "cache");
-  /* Yes, this is inconsistent with data, config and cache. However, using
-   * this path lets apps provide backwards-compatibility with older Flatpak
-   * versions by using `--persist=.local/state --unset-env=XDG_STATE_DIR`. */
-  app_dir_state = g_file_get_child (app_dir, ".local/state");
-  flatpak_bwrap_set_env (bwrap, "XDG_DATA_HOME", flatpak_file_get_path_cached (app_dir_data), TRUE);
-  flatpak_bwrap_set_env (bwrap, "XDG_CONFIG_HOME", flatpak_file_get_path_cached (app_dir_config), TRUE);
-  flatpak_bwrap_set_env (bwrap, "XDG_CACHE_HOME", flatpak_file_get_path_cached (app_dir_cache), TRUE);
-  flatpak_bwrap_set_env (bwrap, "XDG_STATE_HOME", flatpak_file_get_path_cached (app_dir_state), TRUE);
-
-  if (g_getenv ("XDG_DATA_HOME"))
-    flatpak_bwrap_set_env (bwrap, "HOST_XDG_DATA_HOME", g_getenv ("XDG_DATA_HOME"), TRUE);
-  if (g_getenv ("XDG_CONFIG_HOME"))
-    flatpak_bwrap_set_env (bwrap, "HOST_XDG_CONFIG_HOME", g_getenv ("XDG_CONFIG_HOME"), TRUE);
-  if (g_getenv ("XDG_CACHE_HOME"))
-    flatpak_bwrap_set_env (bwrap, "HOST_XDG_CACHE_HOME", g_getenv ("XDG_CACHE_HOME"), TRUE);
-  if (g_getenv ("XDG_STATE_HOME"))
-    flatpak_bwrap_set_env (bwrap, "HOST_XDG_STATE_HOME", g_getenv ("XDG_STATE_HOME"), TRUE);
-}
-
-void
 flatpak_run_apply_env_vars (FlatpakBwrap *bwrap, FlatpakContext *context)
 {
   GHashTableIter iter;
@@ -734,15 +703,6 @@ flatpak_run_apply_env_vars (FlatpakBwrap *bwrap, FlatpakContext *context)
       else
         flatpak_bwrap_unset_env (bwrap, var);
     }
-}
-
-GFile *
-flatpak_get_data_dir (const char *app_id)
-{
-  g_autoptr(GFile) home = g_file_new_for_path (g_get_home_dir ());
-  g_autoptr(GFile) var_app = g_file_resolve_relative_path (home, ".var/app");
-
-  return g_file_get_child (var_app, app_id);
 }
 
 gboolean

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -28,6 +28,7 @@
 #include "flatpak-installation-private.h"
 #include "flatpak-progress-private.h"
 #include "flatpak-transaction-private.h"
+#include "flatpak-utils-http-private.h"
 #include "flatpak-utils-private.h"
 #include "flatpak-uri-private.h"
 #include "flatpak-variant-impl-private.h"

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -142,23 +142,6 @@ const char * const *flatpak_get_locale_categories (void);
 char *flatpak_get_lang_from_locale (const char *locale);
 char **flatpak_get_current_locale_langs (void);
 
-gboolean flatpak_write_update_checksum (GOutputStream *out,
-                                        gconstpointer  data,
-                                        gsize          len,
-                                        gsize         *out_bytes_written,
-                                        GChecksum     *checksum,
-                                        GCancellable  *cancellable,
-                                        GError       **error);
-
-
-gboolean flatpak_splice_update_checksum (GOutputStream         * out,
-                                         GInputStream          *in,
-                                         GChecksum             *checksum,
-                                         FlatpakLoadUriProgress progress,
-                                         gpointer progress_data,
-                                         GCancellable          *cancellable,
-                                         GError               **error);
-
 GBytes * flatpak_read_stream (GInputStream * in,
                               gboolean null_terminate,
                               GError      **error);

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -122,6 +122,7 @@ gboolean flatpak_fancy_output (void);
 const char * flatpak_get_arch (void);
 const char ** flatpak_get_arches (void);
 gboolean flatpak_is_linux32_arch (const char *arch);
+const char *flatpak_get_compat_arch_reverse (const char *compat_arch);
 
 const char ** flatpak_get_gl_drivers (void);
 gboolean flatpak_extension_matches_reason (const char *extension_id,

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -32,7 +32,6 @@
 #include "flatpak-context-private.h"
 #include "flatpak-error.h"
 #include "flatpak-glib-backports-private.h"
-#include "flatpak-utils-http-private.h"
 #include "flatpak-variant-private.h"
 #include "flatpak-dir-private.h"
 #include <ostree.h>

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3261,16 +3261,6 @@ flatpak_repo_save_digested_summary_delta (OstreeRepo   *repo,
 }
 
 
-gboolean
-flatpak_is_app_runtime_or_appstream_ref (const char *ref)
-{
-  return
-    g_str_has_prefix (ref, "appstream/") ||
-    g_str_has_prefix (ref, "appstream2/") ||
-    g_str_has_prefix (ref, "app/") ||
-    g_str_has_prefix (ref, "runtime/");
-}
-
 typedef struct
 {
   guint64    installed_size;

--- a/portal/flatpak-portal-app-info.h
+++ b/portal/flatpak-portal-app-info.h
@@ -21,23 +21,7 @@
 #ifndef __FLATPAK_PORTAL_APP_INFO_H__
 #define __FLATPAK_PORTAL_APP_INFO_H__
 
-#define FLATPAK_METADATA_GROUP_APPLICATION "Application"
-#define FLATPAK_METADATA_GROUP_RUNTIME "Runtime"
-#define FLATPAK_METADATA_GROUP_INSTANCE "Instance"
-#define FLATPAK_METADATA_GROUP_CONTEXT "Context"
-#define FLATPAK_METADATA_KEY_NAME "name"
-#define FLATPAK_METADATA_KEY_ARCH "arch"
-#define FLATPAK_METADATA_KEY_RUNTIME "runtime"
-#define FLATPAK_METADATA_KEY_BRANCH "branch"
-#define FLATPAK_METADATA_KEY_EXTRA_ARGS "extra-args"
-#define FLATPAK_METADATA_KEY_APP_COMMIT "app-commit"
-#define FLATPAK_METADATA_KEY_RUNTIME_COMMIT "runtime-commit"
-#define FLATPAK_METADATA_KEY_SHARED "shared"
-#define FLATPAK_METADATA_KEY_SOCKETS "sockets"
-#define FLATPAK_METADATA_KEY_DEVICES "devices"
-#define FLATPAK_METADATA_KEY_DEVEL "devel"
-#define FLATPAK_METADATA_KEY_INSTANCE_PATH "instance-path"
-#define FLATPAK_METADATA_KEY_INSTANCE_ID "instance-id"
+#include "flatpak-metadata-private.h"
 
 GKeyFile * flatpak_invocation_lookup_app_info (GDBusMethodInvocation *invocation,
                                                GCancellable          *cancellable,

--- a/tests/httpcache.c
+++ b/tests/httpcache.c
@@ -1,3 +1,5 @@
+#include "libglnx.h"
+#include "common/flatpak-utils-http-private.h"
 #include "common/flatpak-utils-private.h"
 
 int

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -22,7 +22,7 @@
 #include <glib.h>
 #include "flatpak.h"
 #include "flatpak-context-private.h"
-#include "flatpak-run-private.h"
+#include "flatpak-metadata-private.h"
 #include "flatpak-utils-private.h"
 
 #include "tests/testlib.h"

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -26,8 +26,9 @@
 #include "flatpak-bwrap-private.h"
 #include "flatpak-context-private.h"
 #include "flatpak-exports-private.h"
-#include "flatpak-run-private.h"
+#include "flatpak-metadata-private.h"
 #include "flatpak-utils-base-private.h"
+#include "flatpak-utils-private.h"
 
 #include "tests/testlib.h"
 

--- a/tests/test-instance.c
+++ b/tests/test-instance.c
@@ -30,7 +30,7 @@
 
 #include "flatpak.h"
 #include "flatpak-instance-private.h"
-#include "flatpak-run-private.h"
+#include "flatpak-metadata-private.h"
 
 #include "libglnx.h"
 #include "tests/libglnx-testlib.h"


### PR DESCRIPTION
Various smaller refactors in preparation for #5409.

* common: Move declaration of get_compat_arch_reverse back to -utils
    
    The implementation never actually moved to -ref-utils.

* common: Move flatpak_abs_usrmerged_dirs to FlatpakExports
    
    This will help to break circular dependencies between FlatpakExports
    and flatpak-run.

* common: Move flatpak_is_app_runtime_or_appstream_ref to ref-utils
    
    This matches where it was declared.

* common: Remove unused functions

* common: Stop including utils-http in utils
    
    utils-http is conceptually larger than utils.

* common: Explicitly include context's own header
    
    Previously we were relying on flatpak-utils-private.h having a circular
    dependency on this, but I'm intending to remove that during future
    refactoring.

* common: Move metadata to its own header
    
    This cuts more circular dependencies between flatpak-run and
    flatpak-exports.

* common: Break circular dependency between context and dir/run
    
    By giving the context a bit more knowledge of which directories Flatpak
    uses for what, we can stop it from depending on the dir/run modules,
    which themselves depend on FlatpakContext.