### PR TITLE
utils-base: Use close_range(..., CLOSE_RANGE_CLOEXEC) if possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,6 +214,9 @@ LIBGLNX_CONFIGURE
 AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
 AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])
 
+AC_CHECK_FUNCS_ONCE([close_range])
+AC_CHECK_HEADERS_ONCE([linux/close_range.h])
+
 AC_SUBST([GLIB_MKENUMS], [`$PKG_CONFIG --variable glib_mkenums glib-2.0`])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])

--- a/meson.build
+++ b/meson.build
@@ -415,6 +415,20 @@ if build_system_helper
   cdata.set('USE_SYSTEM_HELPER', '1')
 endif
 
+foreach function : [
+  'close_range',
+]
+  macro = 'HAVE_' + function.underscorify().to_upper()
+  config.set(macro, cc.has_function(function) ? 1 : false)
+endforeach
+
+foreach header : [
+  'linux/close_range.h',
+]
+  macro = 'HAVE_' + header.underscorify().to_upper()
+  config.set(macro, cc.has_header(header) ? 1 : false)
+endforeach
+
 configure_file(
   output : 'config.h',
   configuration : cdata,


### PR DESCRIPTION
This is a more correct and more efficient version of what we were doing with sysconf() and fcntl(..., FD_CLOEXEC) before.