### PR TITLE
session-helper: use a more generic p11-kit server command for pkcs#11 tokens

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -704,8 +704,7 @@ start_p11_kit_server (const char *flatpak_dir)
      */
     "--sh",
     "-n", socket_path,
-    "--provider",  "p11-kit-trust.so",
-    "pkcs11:model=p11-kit-trust?write-protected=yes",
+    "pkcs11:?write-protected=yes",
     NULL
   };
 


### PR DESCRIPTION
This should close #4723 as the current p11-kit server command run by the session helper only exposes the p11-kit-trust module over the socket. This means that user configured p11-kit modules like opensc (for smart card tokens) are not available inside of the flatpak sandbox. The result is that packages must make [hideous workarounds][0] like adding pcsc-lite and opensc into the respective packages.

[0]: https://github.com/flathub/com.microsoft.Edge/pull/325