### PR TITLE
DRAFT: run: add --host-share-pids to reuse host pid namespace

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -44,6 +44,7 @@ static gboolean opt_log_system_bus;
 static gboolean opt_die_with_parent;
 static gboolean opt_with_appdir;
 static gboolean opt_readonly;
+static gboolean opt_host_share_pids;
 
 static GOptionEntry options[] = {
   { "runtime", 'r', 0, G_OPTION_ARG_NONE, &opt_runtime, N_("Use Platform runtime rather than Sdk"), NULL },
@@ -56,6 +57,7 @@ static GOptionEntry options[] = {
   { "with-appdir", 0, 0, G_OPTION_ARG_NONE, &opt_with_appdir, N_("Export application homedir directory to build"), NULL },
   { "log-session-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_session_bus, N_("Log session bus calls"), NULL },
   { "log-system-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_system_bus, N_("Log system bus calls"), NULL },
+  { "host-share-pids", 0, 0, G_OPTION_ARG_NONE, &opt_host_share_pids, N_("Share process ID namespace with host"), NULL },
   { NULL }
 };
 
@@ -453,6 +455,9 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
 
   if (opt_log_system_bus)
     run_flags |= FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS;
+
+  if (opt_host_share_pids)
+    run_flags |= FLATPAK_RUN_FLAG_HOST_SHARE_PIDS;
 
   /* Never set up an a11y bus for builds */
   run_flags |= FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY;

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -58,6 +58,7 @@ static char *opt_runtime_commit;
 static int opt_parent_pid;
 static gboolean opt_parent_expose_pids;
 static gboolean opt_parent_share_pids;
+static gboolean opt_host_share_pids;
 static int opt_instance_id_fd = -1;
 static char *opt_app_path;
 static char *opt_usr_path;
@@ -86,6 +87,7 @@ static GOptionEntry options[] = {
   { "parent-pid", 0, 0, G_OPTION_ARG_INT, &opt_parent_pid, N_("Use PID as parent pid for sharing namespaces"), N_("PID") },
   { "parent-expose-pids", 0, 0, G_OPTION_ARG_NONE, &opt_parent_expose_pids, N_("Make processes visible in parent namespace"), NULL },
   { "parent-share-pids", 0, 0, G_OPTION_ARG_NONE, &opt_parent_share_pids, N_("Share process ID namespace with parent"), NULL },
+  { "host-share-pids", 0, 0, G_OPTION_ARG_NONE, &opt_host_share_pids, N_("Share process ID namespace with host"), NULL },
   { "instance-id-fd", 0, 0, G_OPTION_ARG_INT, &opt_instance_id_fd, N_("Write the instance ID to the given file descriptor"), NULL },
   { "app-path", 0, 0, G_OPTION_ARG_FILENAME, &opt_app_path, N_("Use PATH instead of the app's /app"), N_("PATH") },
   { "usr-path", 0, 0, G_OPTION_ARG_FILENAME, &opt_usr_path, N_("Use PATH instead of the runtime's /usr"), N_("PATH") },
@@ -301,6 +303,8 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
     flags |= FLATPAK_RUN_FLAG_PARENT_EXPOSE_PIDS;
   if (opt_parent_share_pids)
     flags |= FLATPAK_RUN_FLAG_PARENT_SHARE_PIDS;
+  if (opt_host_share_pids)
+    flags |= FLATPAK_RUN_FLAG_HOST_SHARE_PIDS;
   if (!opt_a11y_bus)
     flags |= FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY;
   if (!opt_session_bus)

--- a/common/flatpak-common-types-private.h
+++ b/common/flatpak-common-types-private.h
@@ -49,6 +49,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_NO_PROC            = (1 << 19),
   FLATPAK_RUN_FLAG_PARENT_EXPOSE_PIDS = (1 << 20),
   FLATPAK_RUN_FLAG_PARENT_SHARE_PIDS  = (1 << 21),
+  FLATPAK_RUN_FLAG_HOST_SHARE_PIDS    = (1 << 22),
 } FlatpakRunFlags;
 
 typedef struct FlatpakDir          FlatpakDir;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2147,6 +2147,7 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
   g_autoptr(GFile) etc = NULL;
   gboolean parent_expose_pids = (flags & FLATPAK_RUN_FLAG_PARENT_EXPOSE_PIDS) != 0;
   gboolean parent_share_pids = (flags & FLATPAK_RUN_FLAG_PARENT_SHARE_PIDS) != 0;
+  gboolean host_share_pids = (flags & FLATPAK_RUN_FLAG_HOST_SHARE_PIDS) != 0;
   gboolean bwrap_unprivileged = flatpak_bwrap_is_unprivileged ();
 
   /* Disable recursive userns for all flatpak processes, as we need this
@@ -2206,7 +2207,7 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
                             "--proc", "/proc",
                             NULL);
 
-  if (!(flags & FLATPAK_RUN_FLAG_PARENT_SHARE_PIDS))
+  if (!host_share_pids && !(flags & FLATPAK_RUN_FLAG_PARENT_SHARE_PIDS))
     flatpak_bwrap_add_arg (bwrap, "--unshare-pid");
 
   flatpak_bwrap_add_args (bwrap,


### PR DESCRIPTION
This allows exposing a process to the PID namespace of the host. That can be useful when you need to expose tooling that will process various /proc information such as profilers and systems tooling.

Typically this is not enabled because once you do, processes can use ptrace on each other and generally circumvent the sandbox.

This is mostly a draft as it really depends on what we'd like to do with https://github.com/flatpak/flatpak/issues/3922

If we decide to go ahead, I can take care of adding documentation, etc.