### PR TITLE
revokefs: Always bypass page cache for backend requests

### DIFF
--- a/revokefs/main.c
+++ b/revokefs/main.c
@@ -297,6 +297,10 @@ do_open (const char *path, mode_t mode, struct fuse_file_info *finfo)
         return fd;
 
       finfo->fh = fd + REMOTE_FD_OFFSET;
+
+      /* Ensure all I/O requests bypass the page cache and are sent to
+       * the backend. */
+      finfo->direct_io = 1;
     }
 
   return 0;


### PR DESCRIPTION
By default, FUSE runs in cached I/O mode[1]. That means some I/O responses will be taken from the page cache instead of being handled by the FUSE process. For files opened for reading that's not a problem as all the requests are just passed through.

However, that is problematic for files opened for writing since those requests need to be handled by the backend. It's particularly bad for a file opened `O_RDWR` since `read` responses from the page cache are likely to be wrong. Instruct FUSE to use `direct-io` for those files so that the page cache is bypassed.

1. https://docs.kernel.org/filesystems/fuse-io.html

Fixes: #5452