### PR TITLE
Improve libappstream version detection, and use newer APIs if available

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1130,7 +1130,12 @@ flatpak_dir_load_appstream_store (FlatpakDir   *self,
                                        NULL);
 
   appstream_file = g_file_new_for_path (appstream_path);
+#if AS_CHECK_VERSION(0, 16, 0)
+  as_metadata_set_format_style (mdata, AS_FORMAT_STYLE_CATALOG);
+#else
+  /* Deprecated name for the same thing */
   as_metadata_set_format_style (mdata, AS_FORMAT_STYLE_COLLECTION);
+#endif
 #if AS_CHECK_VERSION(0, 14, 0)
   success = as_metadata_parse_file (mdata, appstream_file, AS_FORMAT_KIND_XML, &local_error);
 #else

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1131,7 +1131,7 @@ flatpak_dir_load_appstream_store (FlatpakDir   *self,
 
   appstream_file = g_file_new_for_path (appstream_path);
   as_metadata_set_format_style (mdata, AS_FORMAT_STYLE_COLLECTION);
-#ifdef HAVE_APPSTREAM_0_14_0
+#if AS_CHECK_VERSION(0, 14, 0)
   success = as_metadata_parse_file (mdata, appstream_file, AS_FORMAT_KIND_XML, &local_error);
 #else
   as_metadata_parse_file (mdata, appstream_file, AS_FORMAT_KIND_XML, &local_error);

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -28,6 +28,12 @@
 #include "flatpak-dir-private.h"
 #include "flatpak-permission-dbus-generated.h"
 
+/* AS_CHECK_VERSION was introduced in 0.14.0; we still support 0.12.0, so
+ * behave as though versions without this macro are arbitrarily old */
+#ifndef AS_CHECK_VERSION
+#define AS_CHECK_VERSION(major, minor, micro) (0)
+#endif
+
 /* Appstream data expires after a day */
 #define FLATPAK_APPSTREAM_TTL 86400
 

--- a/configure.ac
+++ b/configure.ac
@@ -362,9 +362,6 @@ PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
 PKG_CHECK_MODULES(JSON, [json-glib-1.0])
 
 PKG_CHECK_MODULES(APPSTREAM, [appstream >= 0.12.0])
-PKG_CHECK_MODULES(APPSTREAM_0_14_0, appstream >= 0.14.0,
-                  [AC_DEFINE([HAVE_APPSTREAM_0_14_0], [1], [Define if appstream >= 0.14.0 is available])],
-                  [true])
 
 PKG_CHECK_MODULES(GDK_PIXBUF, [gdk-pixbuf-2.0])
 

--- a/meson.build
+++ b/meson.build
@@ -363,10 +363,6 @@ if glib_dep.version().version_compare('>=2.60')
   cdata.set('GLIB_VERSION_MIN_REQUIRED', 'GLIB_VERSION_2_60')
 endif
 
-if appstream_dep.version().version_compare('>=0.14.0')
-  cdata.set('HAVE_APPSTREAM_0_14_0', 1)
-endif
-
 if dconf_dep.found()
   cdata.set('HAVE_DCONF', 1)
 endif


### PR DESCRIPTION
* app: Provide a stub implementation of AS_CHECK_VERSION if needed
    
    Our only code that is conditional on the libappstream version wants
    version 0.14.0, which conveniently is exactly the version that
    introduced AS_CHECK_VERSION.

* app: Use AS_FORMAT_STYLE_CATALOG if available
    
    AS_FORMAT_STYLE_COLLECTION is a deprecated alias for ..._CATALOG, and
    was removed entirely in appstream git main (presumably version 0.17
    or 1.0).
    
    Resolves: https://github.com/flatpak/flatpak/issues/5472

---

@Justinzobel, please try compiling flatpak with this change? It should fix #5472.