### PR TITLE
Add --device=input permission

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -57,6 +57,7 @@ typedef enum {
   FLATPAK_CONTEXT_DEVICE_ALL         = 1 << 1,
   FLATPAK_CONTEXT_DEVICE_KVM         = 1 << 2,
   FLATPAK_CONTEXT_DEVICE_SHM         = 1 << 3,
+  FLATPAK_CONTEXT_DEVICE_INPUT       = 1 << 4,
 } FlatpakContextDevices;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -69,6 +69,7 @@ const char *flatpak_context_devices[] = {
   "all",
   "kvm",
   "shm",
+  "input",
   NULL
 };
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -408,6 +408,14 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
             }
         }
 
+      if (context->devices & FLATPAK_CONTEXT_DEVICE_INPUT)
+        {
+          g_info ("Allowing input device access. Note: raw and virtual input currently require --device=all");
+
+          if (g_file_test ("/dev/input", G_FILE_TEST_IS_DIR))
+              flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/input", "/dev/input", NULL);
+        }
+
       if (context->devices & FLATPAK_CONTEXT_DEVICE_KVM)
         {
           g_info ("Allowing kvm access");

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -162,7 +162,7 @@
                 <listitem><para>
                     Expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, shm, all.
+                    DEVICE must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -173,7 +173,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, shm, all.
+                    DEVICE must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -172,7 +172,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -183,7 +183,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -175,6 +175,12 @@
                                 Available since 0.3.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>input</option></term>
+                            <listitem><para>
+                                Input devices
+                                (<filename>/dev/input</filename>).
+                            </para></listitem></varlistentry>
+
                             <varlistentry><term><option>kvm</option></term>
                             <listitem><para>
                                 Virtualization

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -160,7 +160,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -171,7 +171,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -329,7 +329,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -340,7 +340,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This new permission exposes the host's /dev/input directory, providing
minimal game controller support without resorting to --device=all.

(It originally handled /dev/uinput and /dev/hidraw* as well, for the sake of motion controls, Steam Input, and similar advanced features, but that functionality has since been removed.)

I made this for my own use, but thought it might be a helpful contribution, since I've noticed multiple suggestions for something like it.

Ref:
https://github.com/flatpak/flatpak/issues/7
https://github.com/flatpak/flatpak/issues/4405#issuecomment-916792716