### PR TITLE
meson: Properly install tmpfiles.d config

### DIFF
--- a/sideload-repos-systemd/meson.build
+++ b/sideload-repos-systemd/meson.build
@@ -22,6 +22,6 @@ configure_file(
 )
 
 install_data(
-  'flatpak-sideload-repos.conf',
+  'tmpfiles.d/flatpak-sideload-repos.conf',
   install_dir : 'lib/tmpfiles.d',
 )


### PR DESCRIPTION
Previously, the meson build just didn't work