### PR TITLE
Update libglnx submodule

### DIFF
--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -271,7 +271,7 @@ flatpak_bwrap_add_args_data (FlatpakBwrap *bwrap,
   if (!flatpak_buffer_to_sealed_memfd_or_tmpfile (&args_tmpf, name, content, content_size, error))
     return FALSE;
 
-  flatpak_bwrap_add_args_data_fd (bwrap, "--ro-bind-data", glnx_steal_fd (&args_tmpf.fd), path);
+  flatpak_bwrap_add_args_data_fd (bwrap, "--ro-bind-data", g_steal_fd (&args_tmpf.fd), path);
   return TRUE;
 }
 
@@ -373,7 +373,7 @@ flatpak_bwrap_bundle_args (FlatpakBwrap *bwrap,
   if (!flatpak_buffer_to_sealed_memfd_or_tmpfile (&args_tmpf, "bwrap-args", data, data_len, error))
     return FALSE;
 
-  fd = glnx_steal_fd (&args_tmpf.fd);
+  fd = g_steal_fd (&args_tmpf.fd);
 
   g_debug ("bwrap --args %d = ...", fd);
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -10299,26 +10299,15 @@ flatpak_dir_install_bundle (FlatpakDir         *self,
 }
 
 static gboolean
-_g_strv_equal0 (gchar **a, gchar **b)
+_g_strv_equal0 (const char * const *a, const char * const *b)
 {
-  gboolean ret = FALSE;
-  guint n;
-
   if (a == NULL && b == NULL)
-    {
-      ret = TRUE;
-      goto out;
-    }
+    return TRUE;
+
   if (a == NULL || b == NULL)
-    goto out;
-  if (g_strv_length (a) != g_strv_length (b))
-    goto out;
-  for (n = 0; a[n] != NULL; n++)
-    if (g_strcmp0 (a[n], b[n]) != 0)
-      goto out;
-  ret = TRUE;
-out:
-  return ret;
+    return FALSE;
+
+  return g_strv_equal (a, b);
 }
 
 gboolean
@@ -10381,7 +10370,7 @@ flatpak_dir_needs_update_for_commit_and_subpaths (FlatpakDir        *self,
   /* target commit is the same as current, but maybe something else that is different? */
 
   /* Same commit, but different subpaths => update */
-  if (!_g_strv_equal0 ((char **) subpaths, (char **) old_subpaths))
+  if (!_g_strv_equal0 (subpaths, old_subpaths))
     return TRUE;
 
   /* Same subpaths and commit, no need to update */

--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -530,7 +530,7 @@ flatpak_instance_ensure_per_app_dir (const char *app_id,
                                     _("Unable to lock %s"),
                                     lock_path);
 
-  *lock_fd_out = glnx_steal_fd (&lock_fd);
+  *lock_fd_out = g_steal_fd (&lock_fd);
   *lock_path_out = g_steal_pointer (&lock_path);
   return TRUE;
 }
@@ -767,7 +767,7 @@ flatpak_instance_allocate_id (char **host_dir_out,
              We work around that by only gc:ing "old" .ref files */
           if (lock_fd != -1 && fcntl (lock_fd, F_SETLK, &l) == 0)
             {
-              *lock_fd_out = glnx_steal_fd (&lock_fd);
+              *lock_fd_out = g_steal_fd (&lock_fd);
               g_info ("Allocated instance id %s", instance_id);
               *host_dir_out = g_steal_pointer (&instance_dir);
               return g_steal_pointer (&instance_id);

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -300,7 +300,7 @@ local_open_file (int           dfd,
       return -1;
     }
 
-  return glnx_steal_fd (&fd);
+  return g_steal_fd (&fd);
 }
 
 static GBytes *
@@ -528,7 +528,7 @@ flatpak_oci_registry_ensure_local (FlatpakOciRegistry *self,
     }
 
   if (self->dfd == -1 && local_dfd != -1)
-    self->dfd = glnx_steal_fd (&local_dfd);
+    self->dfd = g_steal_fd (&local_dfd);
 
   return TRUE;
 }
@@ -841,7 +841,7 @@ flatpak_oci_registry_download_blob (FlatpakOciRegistry    *self,
       lseek (fd, 0, SEEK_SET);
     }
 
-  return glnx_steal_fd (&fd);
+  return g_steal_fd (&fd);
 }
 
 gboolean
@@ -1994,7 +1994,7 @@ flatpak_oci_registry_apply_delta (FlatpakOciRegistry    *self,
   if (!flatpak_oci_registry_apply_delta_stream (self, delta_fd, content_dir, out, cancellable, error))
     return -1;
 
-  return glnx_steal_fd (&fd);
+  return g_steal_fd (&fd);
 }
 
 char *

--- a/common/flatpak-prune.c
+++ b/common/flatpak-prune.c
@@ -201,7 +201,7 @@ get_repo_lock (OstreeRepo          *repo,
   if (!do_repo_lock (lock_fd, flags))
     return glnx_throw_errno_prefix (error, "Locking repo failed (%s)", (flags & LOCK_EX) != 0 ? "exclusive" : "shared");
 
-  *out_lock_fd = glnx_steal_fd (&lock_fd);
+  *out_lock_fd = g_steal_fd (&lock_fd);
   return TRUE;
 }
 

--- a/common/flatpak-run-dbus.c
+++ b/common/flatpak-run-dbus.c
@@ -99,7 +99,7 @@ add_bwrap_wrapper (FlatpakBwrap *bwrap,
   /* This is a file rather than a bind mount, because it will then
      not be unmounted from the namespace when the namespace dies. */
   flatpak_bwrap_add_args (bwrap, "--perms", "0600", NULL);
-  flatpak_bwrap_add_args_data_fd (bwrap, "--file", glnx_steal_fd (&app_info_fd), "/.flatpak-info");
+  flatpak_bwrap_add_args_data_fd (bwrap, "--file", g_steal_fd (&app_info_fd), "/.flatpak-info");
 
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return FALSE;

--- a/common/flatpak-run-x11.c
+++ b/common/flatpak-run-x11.c
@@ -307,7 +307,7 @@ flatpak_run_add_x11_args (FlatpakBwrap         *bwrap,
           if (output != NULL)
             {
               /* fd is now owned by output, steal it from the tmpfile */
-              int tmp_fd = dup (glnx_steal_fd (&xauth_tmpf.fd));
+              int tmp_fd = dup (g_steal_fd (&xauth_tmpf.fd));
               if (tmp_fd != -1)
                 {
                   static const char dest[] = "/run/flatpak/Xauthority";

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1304,7 +1304,7 @@ flatpak_run_add_app_info_args (FlatpakBwrap       *bwrap,
                           NULL);
   flatpak_bwrap_add_runtime_dir_member (bwrap, ".flatpak");
   /* Keep the .ref lock held until we've started bwrap to avoid races */
-  flatpak_bwrap_add_noinherit_fd (bwrap, glnx_steal_fd (&lock_fd));
+  flatpak_bwrap_add_noinherit_fd (bwrap, g_steal_fd (&lock_fd));
 
   info_path = g_build_filename (instance_id_host_dir, "info", NULL);
 
@@ -2036,7 +2036,7 @@ setup_seccomp (FlatpakBwrap   *bwrap,
   lseek (seccomp_tmpf.fd, 0, SEEK_SET);
 
   flatpak_bwrap_add_args_data_fd (bwrap,
-                                  "--seccomp", glnx_steal_fd (&seccomp_tmpf.fd), NULL);
+                                  "--seccomp", g_steal_fd (&seccomp_tmpf.fd), NULL);
 
   return TRUE;
 }
@@ -2530,7 +2530,7 @@ regenerate_ld_cache (GPtrArray    *base_argv_array,
   ld_so_cache = g_file_get_child (ld_so_dir, checksum);
   ld_so_fd = open (flatpak_file_get_path_cached (ld_so_cache), O_RDONLY);
   if (ld_so_fd >= 0)
-    return glnx_steal_fd (&ld_so_fd);
+    return g_steal_fd (&ld_so_fd);
 
   g_info ("Regenerating ld.so.cache %s", flatpak_file_get_path_cached (ld_so_cache));
 
@@ -2634,7 +2634,7 @@ regenerate_ld_cache (GPtrArray    *base_argv_array,
         return -1;
     }
 
-  return glnx_steal_fd (&ld_so_fd);
+  return g_steal_fd (&ld_so_fd);
 }
 
 /* Check that this user is actually allowed to run this app. When running
@@ -3347,7 +3347,7 @@ flatpak_run_app (FlatpakDecomposed *app_ref,
     return FALSE;
 
   /* Hold onto the lock until we execute bwrap */
-  flatpak_bwrap_add_noinherit_fd (bwrap, glnx_steal_fd (&per_app_dir_lock_fd));
+  flatpak_bwrap_add_noinherit_fd (bwrap, g_steal_fd (&per_app_dir_lock_fd));
 
   flatpak_bwrap_finish (bwrap);
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -1857,7 +1857,7 @@ flatpak_buffer_to_sealed_memfd_or_tmpfile (GLnxTmpfile *tmpf,
           fcntl (memfd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_SEAL) < 0)
         return glnx_throw_errno_prefix (error, "fcntl(F_ADD_SEALS)");
       /* The other values can stay default */
-      tmpf->fd = glnx_steal_fd (&memfd);
+      tmpf->fd = g_steal_fd (&memfd);
       tmpf->initialized = TRUE;
     }
   return TRUE;
@@ -7074,7 +7074,7 @@ flatpak_pull_from_oci (OstreeRepo            *repo,
         }
       else
         {
-          layer_fd = glnx_steal_fd (&blob_fd);
+          layer_fd = g_steal_fd (&blob_fd);
           expected_digest = layer->digest;
         }
 
@@ -7113,7 +7113,7 @@ flatpak_pull_from_oci (OstreeRepo            *repo,
         }
       else
         {
-          layer_fd = glnx_steal_fd (&blob_fd);
+          layer_fd = g_steal_fd (&blob_fd);
         }
 
       a = archive_read_new ();
@@ -7268,7 +7268,7 @@ flatpak_allocate_tmpdir (int           tmpdir_dfd,
 
       /* We found an existing tmpdir which we managed to lock */
       tmpdir_name = g_strdup (dent->d_name);
-      tmpdir_fd = glnx_steal_fd (&existing_tmpdir_fd);
+      tmpdir_fd = g_steal_fd (&existing_tmpdir_fd);
       reusing_dir = TRUE;
     }
 
@@ -7312,7 +7312,7 @@ flatpak_allocate_tmpdir (int           tmpdir_dfd,
     *tmpdir_name_out = g_steal_pointer (&tmpdir_name);
 
   if (tmpdir_fd_out)
-    *tmpdir_fd_out = glnx_steal_fd (&tmpdir_fd);
+    *tmpdir_fd_out = g_steal_fd (&tmpdir_fd);
 
   if (reusing_dir_out)
     *reusing_dir_out = reusing_dir;

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1125,7 +1125,7 @@ handle_spawn (PortalFlatpak         *object,
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      env_fd = glnx_steal_fd (&env_tmpf.fd);
+      env_fd = g_steal_fd (&env_tmpf.fd);
 
       /* Use a fd that hasn't been used yet. We might have to reshuffle
        * fd_map_entry.to, a bit later. */

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -1008,7 +1008,7 @@ test_host_exports_setup (const FakeFile *files,
   glnx_openat_rdonly (AT_FDCWD, host, TRUE, &fd, &error);
   g_assert_no_error (error);
   g_assert_cmpint (fd, >=, 0);
-  flatpak_exports_take_host_fd (exports, glnx_steal_fd (&fd));
+  flatpak_exports_take_host_fd (exports, g_steal_fd (&fd));
 
   if (etc_mode > FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_host_etc_expose (exports, etc_mode);

--- a/tests/test-portal.c
+++ b/tests/test-portal.c
@@ -78,7 +78,7 @@ launcher_stdout_to_our_stderr (GSubprocessLauncher *launcher)
   stderr_copy = dup (STDERR_FILENO);
   g_assert_no_errno (stderr_copy);
   g_assert_no_errno (fcntl (stderr_copy, F_SETFD, FD_CLOEXEC));
-  g_subprocess_launcher_take_stdout_fd (launcher, glnx_steal_fd (&stderr_copy));
+  g_subprocess_launcher_take_stdout_fd (launcher, g_steal_fd (&stderr_copy));
 }
 
 static GSubprocessLauncher *


### PR DESCRIPTION
* Update submodule: libglnx 2023-08-29 ([changes](https://gitlab.gnome.org/GNOME/libglnx/-/compare/4e44fd...54ad67?from_project_id=1636&straight=false))
    
    * Add g_steal_fd() backport
    * Add g_strv_equal() backport
    * Disable crash reporting when testing assertions

* Use g_steal_fd()
    
    This was new in GLib 2.70, but libglnx now provides a backport, so we
    can use it unconditionally.

* dir: Use g_strv_equal()
    
    This was new in GLib 2.60, but libglnx now provides a backport, so we
    can use it unconditionally.
    
    We still need a wrapper because g_strv_equal() is not NULL-safe, but
    it's a very thin wrapper now.