### PR TITLE
Clean up build system integration for Wayland security contexts

### DIFF
--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -83,7 +83,6 @@ common/security-context-v1-protocol.h: $(wl_security_context_xml)
 
 nodist_libflatpak_common_base_la_SOURCES = \
 	$(dbus_built_sources)		\
-	$(wayland_built_sources)	\
 	$(NULL)
 
 BUILT_SOURCES += $(nodist_libflatpak_common_base_la_SOURCES)
@@ -119,6 +118,7 @@ libflatpak_common_base_la_LIBADD = $(AM_LIBADD) $(BASE_LIBS)
 nodist_libflatpak_common_la_SOURCES = \
 	$(nodist_flatpakinclude_HEADERS)    \
 	$(systemd_dbus_built_sources)	\
+	$(wayland_built_sources)	\
 	$(xdp_dbus_built_sources) \
 	common/flatpak-enum-types.c \
 	common/flatpak-variant-private.h \

--- a/common/Makefile.am.inc
+++ b/common/Makefile.am.inc
@@ -76,7 +76,7 @@ endif
 wl_security_context_xml = $(WAYLAND_PROTOCOLS_DATADIR)/staging/security-context/security-context-v1.xml
 
 common/security-context-v1-protocol.c: $(wl_security_context_xml)
-	$(AM_V_GEN) $(WAYLAND_SCANNER) code $(wl_security_context_xml) $(builddir)/common/security-context-v1-protocol.c
+	$(AM_V_GEN) $(WAYLAND_SCANNER) private-code $(wl_security_context_xml) $(builddir)/common/security-context-v1-protocol.c
 
 common/security-context-v1-protocol.h: $(wl_security_context_xml)
 	$(AM_V_GEN) $(WAYLAND_SCANNER) client-header $(wl_security_context_xml) $(builddir)/common/security-context-v1-protocol.h

--- a/common/meson.build
+++ b/common/meson.build
@@ -116,6 +116,9 @@ built_headers = [
   flatpak_variant[1],
 ]
 
+libflatpak_common_deps = []
+built_sources = []
+
 if build_wayland_security_context
   wayland_scanner_prog = find_program(wayland_scanner.get_variable(pkgconfig: 'wayland_scanner'))
   wayland_protocols_dir = wayland_protocols.get_variable(pkgconfig: 'pkgdatadir')
@@ -135,8 +138,8 @@ if build_wayland_security_context
     ),
   ]
 
-  libflatpak_common_base_deps += [wayland_client]
-  libflatpak_common_base_sources += [wl_security_context]
+  libflatpak_common_deps += [wayland_client]
+  built_sources += [wl_security_context]
   built_headers += [wl_security_context[1]]
 endif
 
@@ -210,6 +213,7 @@ libflatpak_common = static_library(
     libarchive_dep,
     libcurl_dep,
     libflatpak_common_base_dep,
+    libflatpak_common_deps,
     libglnx_dep,
     libostree_dep,
     libseccomp_dep,
@@ -224,7 +228,7 @@ libflatpak_common = static_library(
   gnu_symbol_visibility : 'hidden',
   include_directories : [common_include_directories],
   install : false,
-  sources : enums + public_headers + sources + systemd_gdbus + [
+  sources : enums + public_headers + sources + built_sources + systemd_gdbus + [
     flatpak_variant[0],
     flatpak_variant[1],
   ],

--- a/common/meson.build
+++ b/common/meson.build
@@ -128,7 +128,7 @@ if build_wayland_security_context
       'security-context-v1-protocol.c',
       input : wl_security_context_xml,
       output : 'security-context-v1-protocol.c',
-      command : [wayland_scanner_prog, 'code', '@INPUT@', '@OUTPUT@'],
+      command : [wayland_scanner_prog, 'private-code', '@INPUT@', '@OUTPUT@'],
     ),
     custom_target(
       'security-context-v1-protocol.h',

--- a/configure.ac
+++ b/configure.ac
@@ -353,7 +353,7 @@ if test "x$with_wayland_security_context" != "xno"; then
                      [have_wayland_protocols=yes], [have_wayland_protocols=no])
    if test $have_wayland_protocols = yes; then
       PKG_CHECK_MODULES(WAYLAND_CLIENT, [wayland-client])
-      PKG_CHECK_MODULES(WAYLAND_SCANNER, [wayland-scanner])
+      PKG_CHECK_MODULES(WAYLAND_SCANNER, [wayland-scanner >= 1.15])
       wayland_scanner=`$PKG_CONFIG --variable=wayland_scanner wayland-scanner`
       AC_SUBST(WAYLAND_SCANNER, $wayland_scanner)
       wayland_protocols_pkgdatadir=`$PKG_CONFIG --variable=pkgdatadir wayland-protocols`

--- a/meson.build
+++ b/meson.build
@@ -207,7 +207,7 @@ gtkdoc_dep = dependency('gtk-doc', required : get_option('gtkdoc'))
 build_gtk_doc = gtkdoc_dep.found()
 
 wayland_client = dependency('wayland-client', required : get_option('wayland_security_context'))
-wayland_scanner = dependency('wayland-scanner', required : get_option('wayland_security_context'))
+wayland_scanner = dependency('wayland-scanner', version : '>= 1.15', required : get_option('wayland_security_context'))
 wayland_protocols = dependency('wayland-protocols', version : '>= 1.32', required : get_option('wayland_security_context'))
 build_wayland_security_context = wayland_client.found() and wayland_scanner.found() and wayland_protocols.found()
 


### PR DESCRIPTION
Follow-up for #4920. cc @emersion 

* build: Link Wayland code into full libflatpak-common only
    
    This is only needed in flatpak-run-wayland.c, so we don't need it when
    linking ancillary daemons that don't need any of flatpak-run, such as
    the portal, session helper, system helper and OCI authenticator.

* build: Generate Wayland glue code as private
    
    The `code` argument to wayland-scanner is deprecated in favour of
    `private-code`, which marks the symbols as private, avoiding them
    leaking into the ABI of `libflatpak.so.0`.
    
    `private-code` was new in wayland-scanner 1.15, which is available in
    relatively old LTS distributions like CentOS 7, Debian 10 and
    Ubuntu 18.04, and is much older than wayland-protocols 1.32.