### PR TITLE
utils-http: Add transfer speed timeout for libcurl HTTP downloads

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -407,7 +407,15 @@ flatpak_create_http_session (const char *user_agent)
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _write_cb);
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, _header_cb);
 
+  /* Abort the connection if connecting to the server takes too long. This
+   * timeout has no effect after a connection is established. */
   curl_easy_setopt (curl, CURLOPT_CONNECTTIMEOUT, (long)FLATPAK_HTTP_TIMEOUT_SECS);
+
+  /* Abort the download if it’s slower than 10KB/sec for 60 seconds. An example
+   * compressed summary file is 1.5MB in size, so anything slower than this rate
+   * will mean it takes over 2.5 minutes to download just the summary file. */
+  curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, (long)FLATPAK_HTTP_TIMEOUT_SECS);
+  curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 10000L);
 
   return session;
 }


### PR DESCRIPTION
There was already a timeout set using `CURLOPT_CONNECTTIMEOUT`, but that only affects the initial connection. Once a HTTP connection is established, the timeout is ineffective.

That means that once a HTTP connection is established, there is no bound on the length of time a download can take. Sometimes, downloads drop to very low speeds (for Networking Reasons) and we need a way to give up on a download if that happens.

So, set a low speed limit of 10KB/s for 60s. If a curl download goes more slowly than this, it will be considered timed out, and the `CURLE_OPERATION_TIMEDOUT` code path will be taken.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: https://github.com/flatpak/flatpak/issues/5519