### PR TITLE
Use `glnx_opendirat()` and `glnx_opendirat_with_errno()` where possible

### DIFF
--- a/portal/flatpak-portal-app-info.c
+++ b/portal/flatpak-portal-app-info.c
@@ -80,13 +80,14 @@ parse_app_id_from_fileinfo (int pid)
   g_autoptr(GKeyFile) metadata = NULL;
 
   root_path = g_strdup_printf ("/proc/%u/root", pid);
-  root_fd = openat (AT_FDCWD, root_path, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
-  if (root_fd == -1)
+  if (!glnx_opendirat (AT_FDCWD, root_path, TRUE,
+                       &root_fd,
+                       &local_error))
     {
       /* Not able to open the root dir shouldn't happen. Probably the app died and
        * we're failing due to /proc/$pid not existing. In that case fail instead
          of treating this as privileged. */
-      g_info ("Unable to open %s", root_path);
+      g_info ("Unable to open process root directory: %s", local_error->message);
       return NULL;
     }
 

--- a/revokefs/main.c
+++ b/revokefs/main.c
@@ -123,7 +123,7 @@ callback_readdir (const char *path, void *buf, fuse_fill_dir_t filler,
     }
   else
     {
-      dfd = openat (basefd, path, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
+      dfd = glnx_opendirat_with_errno (basefd, path, TRUE);
       if (dfd == -1)
         return -errno;
     }
@@ -562,7 +562,7 @@ main (int argc, char *argv[])
       exit (EXIT_FAILURE);
     }
 
-  basefd = openat (AT_FDCWD, base_path, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
+  basefd = glnx_opendirat_with_errno (AT_FDCWD, base_path, TRUE);
   if (basefd == -1)
     {
       perror ("opening basepath: ");


### PR DESCRIPTION
Follow-up to https://github.com/flatpak/flatpak/pull/5510#discussion_r1321752302. Only build-tested.

CC: @smcv

---

* instance: Use glnx_opendirat() where possible

  Doing so adds the following flags to the openat() call:
  O_RDONLY | O_NONBLOCK | O_NOCTTY
  
  And removes the following flag: O_PATH
  
  Also let libglnx handle the error message formatting.

* portal: Use glnx_opendirat()

  Also print error message in case the operation fails.
  
  No change in behavior apart from printing the error message.

* revokefs: Use glnx_opendirat_with_errno()

  No change in behavior.