### PR TITLE
Use an overlayfs on /etc to keep monitored files updated

### DIFF
--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -73,6 +73,12 @@ gboolean      flatpak_bwrap_add_args_data (FlatpakBwrap *bwrap,
                                            gssize        content_size,
                                            const char   *path,
                                            GError      **error);
+gboolean      flatpak_bwrap_add_args_file (FlatpakBwrap *bwrap,
+                                           const char   *name,
+                                           const char   *content,
+                                           gssize        content_size,
+                                           const char   *path,
+                                           GError      **error);
 void          flatpak_bwrap_add_bind_arg (FlatpakBwrap *bwrap,
                                           const char   *type,
                                           const char   *src,

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -275,6 +275,23 @@ flatpak_bwrap_add_args_data (FlatpakBwrap *bwrap,
   return TRUE;
 }
 
+gboolean
+flatpak_bwrap_add_args_file (FlatpakBwrap *bwrap,
+                             const char   *name,
+                             const char   *content,
+                             gssize        content_size,
+                             const char   *path,
+                             GError      **error)
+{
+  g_auto(GLnxTmpfile) args_tmpf  = { 0, };
+
+  if (!flatpak_buffer_to_sealed_memfd_or_tmpfile (&args_tmpf, name, content, content_size, error))
+    return FALSE;
+
+  flatpak_bwrap_add_args_data_fd (bwrap, "--file", g_steal_fd (&args_tmpf.fd), path);
+  return TRUE;
+}
+
 /* This resolves the target here rather than in bwrap, because it may
  * not resolve in bwrap setup due to absolute symlinks conflicting
  * with /newroot root. For example, dest could be inside


### PR DESCRIPTION
Currently the monitored files are mounted in `/run/host/monitor/` and individual files are symlinked there from `/etc`.  If the file in `/etc` must be a symlink itself this approach is failing (#5514).

This patch sets up an overlayfs with `/run/host/monitor/`  as the upper layer and `/etc` as the lower layer and mount target. `/etc` itself is bind mounted instead of the individual files and folders which makes the whole dir read-only but we provide another overlay layer, `/run/etc-overlay` is created to make it possible to override files in `/etc` per-container.

Everything seems to work. The implementation assumes that bwrap always supports `--overlay`. A real implementation would have to support the current code paths and the overlay stuff at the same time.