### PR TITLE
Start p11-kit server with opensc provider when available.

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -708,17 +708,46 @@ start_p11_kit_server (const char *flatpak_dir)
     "pkcs11:model=p11-kit-trust?write-protected=yes",
     NULL
   };
+char *p11_opensc_argv[] = {
+    "p11-kit", "server",
+    /* We explicitly request --sh here, because we then fail on earlier versions that doesn't support
+     * this flag. This is good, because those earlier versions did not properly daemonize and caused
+     * the spawn_sync to hang forever, waiting for the pipe to close.
+     */
+    "--sh",
+    "-n", socket_path,
+    "--provider",  "p11-kit-trust.so",
+    "pkcs11:model=p11-kit-trust?write-protected=yes",
+    "--provider", "opensc-pkcs11.so",
+    "pkcs11:?library-manufacturer=OpenSC%20Project%26type=cert",
+    NULL
+  };
 
-  g_info ("starting p11-kit server");
-
-  if (!g_spawn_sync (NULL,
-                     p11_argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_STDERR_TO_DEV_NULL,
-                     NULL, NULL,
-                     &p11_kit_stdout, NULL,
-                     &exit_status, &local_error))
+  if (g_find_program_in_path("opensc-tool"))
     {
-      g_warning ("Unable to start p11-kit server: %s", local_error->message);
-      return;
+      g_info ("starting p11-kit server with opensc");
+      if (!g_spawn_sync (NULL,
+                        p11_opensc_argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_STDERR_TO_DEV_NULL,
+                        NULL, NULL,
+                        &p11_kit_stdout, NULL,
+                        &exit_status, &local_error))
+        {
+          g_warning ("Unable to start p11-kit server: %s", local_error->message);
+          return;
+        }
+    }
+  else
+    {
+      g_info ("starting p11-kit server");
+      if (!g_spawn_sync (NULL,
+                        p11_argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_STDERR_TO_DEV_NULL,
+                        NULL, NULL,
+                        &p11_kit_stdout, NULL,
+                        &exit_status, &local_error))
+        {
+          g_warning ("Unable to start p11-kit server: %s", local_error->message);
+          return;
+        }
     }
 
   if (!g_spawn_check_exit_status (exit_status, &local_error))


### PR DESCRIPTION
The purpose of the p11-kit server session helper is to make host trusted certificates available in the sandbox. If the opensc module is available (checked by presence of `opensc-tool` in path) then start the p11-kit server with the opensc-pkcs11.so provider and pkcs11 uri set.

Ths pkcs11 uri for opensc has a query of: `library-manufacturer=OpenSC Project` & `type=cert` to ensure that it only provides objects of type "certificate" provided by the "OpenSC Project" library.

The pkcs11 uri is defined in [RFC 7512](https://datatracker.ietf.org/doc/html/rfc7512)

The purpose and driver for adding this change is to get US Government PIV cards (CAC) to work with the various flatpak'd web browsers such as chromium and all chromium based browsers such as Edge, and Firefox. Some info on the US PIV can be found on the OpenSC project [here](https://github.com/OpenSC/OpenSC/wiki/US-PIV)