### PR TITLE
tests: Check if program exists before using it

### DIFF
--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -47,6 +47,12 @@ add_bin() {
     local f=$1
     shift
 
+    # Check if the program is installed
+    if ! command -v "${f}" &> /dev/null; then
+        echo "${f} not found"
+        exit 1
+    fi
+
     if grep -qFe "${f}" $BINS; then
         # Already handled
         return 0


### PR DESCRIPTION
The tests/make-test-runtime.sh scripts sets '-e' in lieu of implementing useful error checking, but doesn't actually check if the programs it uses exist in the first place; and aborts silently when they're not available.

It is more useful to warn about them, and stop execution earlier. This leaves some leftover files, but arguably that's better than leaving leftover files AND people scratching their heads.

Warn about missing required programs.

Related: https://github.com/flatpak/flatpak/issues/5020