### PR TITLE
flatpak-run: Unset VK_DRIVER_FILES and VK_ICD_FILENAMES

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -558,6 +558,8 @@ static const ExportData default_exports[] = {
   {"XKB_CONFIG_ROOT", NULL},
   {"GIO_EXTRA_MODULES", NULL},
   {"GDK_BACKEND", NULL},
+  {"VK_DRIVER_FILES", NULL},
+  {"VK_ICD_FILENAMES", NULL},
 };
 
 static const ExportData no_ld_so_cache_exports[] = {

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -104,6 +104,8 @@
             <member>XKB_CONFIG_ROOT</member>
             <member>GIO_EXTRA_MODULES</member>
             <member>GDK_BACKEND</member>
+            <member>VK_DRIVER_FILES</member>
+            <member>VK_ICD_FILENAMES</member>
         </simplelist>
         <para>
             Also several environment variables with the prefix "GST_" that are used by gstreamer


### PR DESCRIPTION
These environment variables inform the Vulkan loader on where to find driver files. Since they typically point to locations on the host filesystem, any application that attempts to load Vulkan within the flatpak sandbox would break with these set.

Anyone who explicitly wishes to point toward a Vulkan driver within the flatpak sandbox can do so using the `--env` parameter.