### PR TITLE
Adjust to AppStream 1.0 API changes

### DIFF
--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -180,24 +180,24 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       int rows, cols;
       int width;
       g_autoptr(AsMetadata) mdata = as_metadata_new ();
-      AsComponent *app = NULL;
+      AsComponent *cpt = NULL;
       const char *version = NULL;
       const char *license = NULL;
       g_autofree char *arch = flatpak_decomposed_dup_arch (ref);
 
       flatpak_get_window_size (&rows, &cols);
 
-      flatpak_dir_load_appstream_store (preferred_dir, remote, arch, mdata, NULL, NULL);
-      app = as_store_find_app (mdata, flatpak_decomposed_get_ref (ref));
-      if (app)
+      flatpak_dir_load_appstream_data (preferred_dir, remote, arch, mdata, NULL, NULL);
+      cpt = metadata_find_component (mdata, flatpak_decomposed_get_ref (ref));
+      if (cpt)
         {
-          const char *name = as_component_get_name (app);
-          const char *comment = as_component_get_summary (app);
+          const char *name = as_component_get_name (cpt);
+          const char *comment = as_component_get_summary (cpt);
 
           print_wrapped (MIN (cols, 80), "\n%s - %s\n", name, comment);
 
-          version = as_app_get_version (app);
-          license = as_component_get_project_license (app);
+          version = component_get_version_latest (cpt);
+          license = as_component_get_project_license (cpt);
         }
 
       if (commit_v)

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -231,7 +231,7 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
       if (need_appstream_data)
         {
           mdata = as_metadata_new ();
-          flatpak_dir_load_appstream_store (dir, remote, NULL, mdata, NULL, NULL);
+          flatpak_dir_load_appstream_data (dir, remote, NULL, mdata, NULL, NULL);
         }
 
       keys = (FlatpakDecomposed **) g_hash_table_get_keys_as_array (names, &n_keys);
@@ -244,7 +244,7 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
           guint64 installed_size;
           guint64 download_size;
           g_autofree char *runtime = NULL;
-          AsComponent *app = NULL;
+          AsComponent *cpt = NULL;
           gboolean has_sparse_cache;
           VarMetadataRef sparse_cache;
           g_autofree char *id = flatpak_decomposed_dup_id (ref);
@@ -278,7 +278,7 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
             }
 
           if (need_appstream_data)
-            app = as_store_find_app (mdata, ref_str);
+            cpt = metadata_find_component (mdata, ref_str);
 
           if (app_runtime && runtime)
             {
@@ -296,8 +296,8 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
                   const char *name = NULL;
                   g_autofree char *readable_id = NULL;
 
-                  if (app)
-                    name = as_component_get_name (app);
+                  if (cpt)
+                    name = as_component_get_name (cpt);
 
                   if (name == NULL)
                     readable_id = flatpak_decomposed_dup_readable_id (ref);
@@ -307,13 +307,13 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
               else if (strcmp (columns[j].name, "description") == 0)
                 {
                   const char *comment = NULL;
-                  if (app)
-                      comment = as_component_get_summary (app);
+                  if (cpt)
+                      comment = as_component_get_summary (cpt);
 
                   flatpak_table_printer_add_column (printer, comment);
                 }
               else if (strcmp (columns[j].name, "version") == 0)
-                flatpak_table_printer_add_column (printer, app ? as_app_get_version (app) : "");
+                flatpak_table_printer_add_column (printer, cpt ? component_get_version_latest (cpt) : "");
               else if (strcmp (columns[j].name, "ref") == 0)
                 flatpak_table_printer_add_column (printer, ref_str);
               else if (strcmp (columns[j].name, "application") == 0)

--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1043,50 +1043,79 @@ ellipsize_string_full (const char *text, int len, FlatpakEllipsizeMode mode)
 }
 
 const char *
-as_app_get_version (AsComponent *app)
+component_get_version_latest (AsComponent *component)
 {
-  GPtrArray *releases = as_component_get_releases (app);
+#if AS_CHECK_VERSION(1, 0, 0)
+  AsReleaseList *releases = NULL;
+
+  /* load releases without network access, ignoring any errors */
+  as_component_load_releases (component, FALSE, NULL);
+
+  /* fetch default releases even if previous loading has failed */
+  releases = as_component_get_releases_plain (component);
+  if (releases != NULL && as_release_list_len (releases) > 0)
+    return as_release_get_version (as_release_list_index (releases, 0));
+#else
+  GPtrArray *releases = as_component_get_releases (component);
 
   if (releases != NULL && releases->len > 0)
     return as_release_get_version (AS_RELEASE (g_ptr_array_index (releases, 0)));
+#endif
 
   return NULL;
 }
 
 AsComponent *
-as_store_find_app (AsMetadata *mdata,
-                   const char *ref)
+metadata_find_component (AsMetadata *mdata,
+                         const char *ref)
 {
   g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
-  const char *appid = flatpak_ref_get_name (rref);
-  g_autofree char *desktopid = g_strconcat (appid, ".desktop", NULL);
-  int j;
+  const char *cid = flatpak_ref_get_name (rref);
+  g_autofree char *desktopid = g_strconcat (cid, ".desktop", NULL);
 
-  for (j = 0; j < 2; j++)
+  for (int j = 0; j < 2; j++)
     {
-      const char *id = j == 0 ? appid : desktopid;
+      const char *id = j == 0 ? cid : desktopid;
+#if AS_CHECK_VERSION(1, 0, 0)
+      AsComponentBox *cbox = as_metadata_get_components (mdata);
+
+      for (gsize i = 0; i < as_component_box_len (cbox); i++)
+        {
+          AsComponent *component = as_component_box_index (cbox, i);
+          AsBundle *bundle;
+
+          if (g_strcmp0 (as_component_get_id (component), id) != 0)
+            continue;
+
+          bundle = as_component_get_bundle (component, AS_BUNDLE_KIND_FLATPAK);
+          if (bundle &&
+              g_str_equal (as_bundle_get_id (bundle), ref))
+            return component;
+        }
+#else
       GPtrArray *components = as_metadata_get_components (mdata);
 
       for (gsize i = 0; i < components->len; i++)
         {
-          AsComponent *app = g_ptr_array_index (components, i);
+          AsComponent *component = g_ptr_array_index (components, i);
           AsBundle *bundle;
 
-          if (g_strcmp0 (as_component_get_id (app), id) != 0)
+          if (g_strcmp0 (as_component_get_id (component), id) != 0)
             continue;
 
-          bundle = as_component_get_bundle (app, AS_BUNDLE_KIND_FLATPAK);
+          bundle = as_component_get_bundle (component, AS_BUNDLE_KIND_FLATPAK);
           if (bundle &&
               g_str_equal (as_bundle_get_id (bundle), ref))
-            return app;
+            return component;
         }
+#endif
     }
 
   return NULL;
 }
 
 /**
- * flatpak_dir_load_appstream_store:
+ * flatpak_dir_load_appstream_data:
  * @self: a #FlatpakDir
  * @remote_name: name of the remote to load the AppStream data for
  * @arch: (nullable): name of the architecture to load the AppStream data for,
@@ -1104,12 +1133,12 @@ as_store_find_app (AsMetadata *mdata,
  *    otherwise
  */
 gboolean
-flatpak_dir_load_appstream_store (FlatpakDir   *self,
-                                  const gchar  *remote_name,
-                                  const gchar  *arch,
-                                  AsMetadata   *mdata,
-                                  GCancellable *cancellable,
-                                  GError      **error)
+flatpak_dir_load_appstream_data (FlatpakDir   *self,
+                                 const gchar  *remote_name,
+                                 const gchar  *arch,
+                                 AsMetadata   *mdata,
+                                 GCancellable *cancellable,
+                                 GError      **error)
 {
   const char *install_path = flatpak_file_get_path_cached (flatpak_dir_get_path (self));
   g_autoptr(GFile) appstream_file = NULL;

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -160,16 +160,16 @@ void print_aligned_take (int         len,
                          const char *title,
                          char       *value);
 
-AsComponent *as_store_find_app (AsMetadata *mdata,
-                                const char *ref);
-const char *as_app_get_version (AsComponent *component);
+AsComponent *metadata_find_component (AsMetadata *mdata,
+                                         const char *ref);
+const char *component_get_version_latest (AsComponent *component);
 
-gboolean    flatpak_dir_load_appstream_store (FlatpakDir   *self,
-                                              const gchar  *remote_name,
-                                              const gchar  *arch,
-                                              AsMetadata   *mdata,
-                                              GCancellable *cancellable,
-                                              GError      **error);
+gboolean    flatpak_dir_load_appstream_data (FlatpakDir   *self,
+                                             const gchar  *remote_name,
+                                             const gchar  *arch,
+                                             AsMetadata   *mdata,
+                                             GCancellable *cancellable,
+                                             GError      **error);
 
 int         cell_width (const char *text);
 const char *cell_advance (const char *text,


### PR DESCRIPTION
Hi!

This patch adjusts Flatpak to build with the currently in-development AppStream 1.0 series as well as the older 0.16.x series.
While AppStream 1.0 is not currently released yet, I also do not expect any major API changes to happen anymore (if everything goes well we will release it late this or early next month), so this patch should be safe to merge already, for future-proofing.

Cheers,
    Matthias
