### PR TITLE
docs: Clarify that an app can own its app-id as subname of MPRIS bus

### DIFF
--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -721,12 +721,14 @@
             </para>
             <para>
                 The default policy for the session bus only allows the
-                application to own its own application ID and
-                subnames. For instance if the app is called
-                "org.my.App", it can only own "org.my.App" and
-                "org.my.App.*". Its also only allowed to talk to the
-                bus itself (org.freedesktop.DBus) and the portal APIs
-                APIs (bus names of the form org.freedesktop.portal.*).
+                application to own its own application ID, its
+                subnames and its own application id as a subname of 
+                "org.mpris.MediaPlayer2". For instance if the app is called
+                "org.my.App", it can only own "org.my.App", "org.my.App.*"
+                and "org.mpris.MediaPlayer2.org.my.App".
+                It is only allowed to talk to names matching those patterns, plus
+                the bus itself (org.freedesktop.DBus)
+                and the portal APIs (bus names of the form org.freedesktop.portal.*).
             </para>
             <para>
                 Additionally the app is always allowed to reply to

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -63,7 +63,7 @@
             systemd unit files or application .desktop files.
         </para>
 
-        <refsect2>
+        <refsect2 id="application-runtime-metadata">
             <title>[Application] or [Runtime]</title>
 
             <para>
@@ -128,7 +128,7 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
-        <refsect2>
+        <refsect2 id="context-metadata">
             <title>[Context]</title>
             <para>
                 This group determines various system resources that may be shared
@@ -516,7 +516,7 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
-        <refsect2>
+        <refsect2 id="instance-metadata">
             <title>[Instance]</title>
             <para>
                 This group only appears in <filename>/.flatpak-info</filename>
@@ -713,7 +713,7 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
-        <refsect2>
+        <refsect2 id="session-bus-policy-metadata">
             <title>[Session Bus Policy]</title>
             <para>
                 If the <option>sockets</option> key is not allowing full access
@@ -780,7 +780,7 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
-        <refsect2>
+        <refsect2 id="system-bus-policy-metadata">
             <title>[System Bus Policy]</title>
             <para>
                 If the <option>sockets</option> key is not allowing full access
@@ -793,7 +793,7 @@
                 However, the app has no permissions by default.
             </para>
         </refsect2>
-        <refsect2>
+        <refsect2 id="environment-metadata">
             <title>[Environment]</title>
             <para>
                 The [Environment] group specifies environment variables to set
@@ -811,7 +811,7 @@
                 [Context] group.
               </para>
         </refsect2>
-        <refsect2>
+        <refsect2 id="extension-metadata">
             <title>[Extension NAME]</title>
             <para>
                 Runtimes and applications can define extension points, which allow
@@ -997,7 +997,7 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
-        <refsect2>
+        <refsect2 id="extension-of-metadata">
             <title>[ExtensionOf]</title>
             <para>
                 This optional group may be present if the runtime is an extension.
@@ -1036,7 +1036,7 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
-        <refsect2>
+        <refsect2 id="extra-data-metadata">
             <title>[Extra Data]</title>
             <para>
                 This optional group may be present if the runtime or application uses
@@ -1083,7 +1083,7 @@
                 </varlistentry>
             </variablelist>
         </refsect2>
-        <refsect2>
+        <refsect2 id="policy-metadata">
           <title>[Policy SUBSYSTEM]</title>
           <para>
             Subsystems can define their own policies to be placed in a group


### PR DESCRIPTION
It'd be nice if these sections could be referenced through a link, at most I can get a https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-metadata. I wanted to reference it in the flathub docs https://github.com/flathub/documentation/pull/112