### PR TITLE
meson.build: require native wayland-scanner

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -207,7 +207,7 @@ gtkdoc_dep = dependency('gtk-doc', required : get_option('gtkdoc'))
 build_gtk_doc = gtkdoc_dep.found()
 
 wayland_client = dependency('wayland-client', required : get_option('wayland_security_context'))
-wayland_scanner = dependency('wayland-scanner', version : '>= 1.15', required : get_option('wayland_security_context'))
+wayland_scanner = dependency('wayland-scanner', version : '>= 1.15', required : get_option('wayland_security_context'), native : true)
 wayland_protocols = dependency('wayland-protocols', version : '>= 1.32', required : get_option('wayland_security_context'))
 build_wayland_security_context = wayland_client.found() and wayland_scanner.found() and wayland_protocols.found()
 


### PR DESCRIPTION
This fixes:
| Program /usr/bin/wayland-scanner found: NO
|
| ../git/common/meson.build:123:25: ERROR: Program '/usr/bin/wayland-scanner' not found or not executable |
| A full log can be found at /home/flk/poky/build/tmp/work/corei7-64-poky-linux/flatpak/1.15.6/build/meson-logs/meson-log.txt | ERROR: meson failed

At least for the openembedded build environment