### PR TITLE
tests: Skip more tests when FUSE isn't available

### DIFF
--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_revokefs_without_fuse
 
 echo "1..8"
 

--- a/tests/test-update-portal.sh
+++ b/tests/test-update-portal.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 skip_without_bwrap
+skip_revokefs_without_fuse
 
 echo "1..6"
 


### PR DESCRIPTION
These tests try to install flatpaks, which fails in the system case when FUSE isn't available to mount revokefs-fuse.