### PR TITLE
Always allow app to inherit redirected fds from flatpak-run(1)

### DIFF
--- a/common/flatpak-bwrap-private.h
+++ b/common/flatpak-bwrap-private.h
@@ -90,6 +90,7 @@ void          flatpak_bwrap_populate_runtime_dir (FlatpakBwrap *bwrap,
                                                   const char *shared_xdg_runtime_dir);
 
 void          flatpak_bwrap_child_setup_cb (gpointer user_data);
+void          flatpak_bwrap_child_setup_inherit_fds_cb (gpointer user_data);
 void          flatpak_bwrap_child_setup (GArray *fd_array,
                                          gboolean close_fd_workaround);
 

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -530,6 +530,16 @@ flatpak_bwrap_child_setup_cb (gpointer user_data)
   flatpak_bwrap_child_setup (fd_array, TRUE);
 }
 
+/* Unset FD_CLOEXEC on the array of fds passed in @user_data,
+ * but do not set FD_CLOEXEC on all other fds */
+void
+flatpak_bwrap_child_setup_inherit_fds_cb (gpointer user_data)
+{
+  GArray *fd_array = user_data;
+
+  flatpak_bwrap_child_setup (fd_array, FALSE);
+}
+
 /* Add a --sync-fd argument for bwrap(1). Returns the write end of the pipe on
  * success, or -1 on error. */
 int

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..20"
+echo "1..21"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -75,6 +75,13 @@ run org.test.Hello &> hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ok "hello"
+
+true > value-in-sandbox
+head value-in-sandbox >&2
+run_sh org.test.Hello 'echo fd passthrough >&5' 5>value-in-sandbox
+assert_file_has_content value-in-sandbox '^fd passthrough$'
+
+ok "redirected fds can pass through to the app"
 
 # XDG_RUNTIME_DIR is set to <temp directory>/runtime by libtest.sh,
 # so we always have the necessary setup to reproduce #4372


### PR DESCRIPTION
* Always allow app to inherit redirected fds from flatpak-run(1)
    
    As noticed on #5615, under normal circumstances, flatpak-run(1) replaces itself with the bwrap process via execve(), and does not close any fds that it might have inherited from its parent. This allows for patterns like:
    
        flatpak run com.example.App --in-fd=3 --out-fd=5 3<foo 5>bar
    
    However, using execve() is annoying when trying to analyze code coverage, because the coverage instrumentation does not get the opportunity to write out its data during exit, so it is possible to set FLATPAK_TEST_COVERAGE=1 to make flatpak run the app as a child process and wait for it. This puts us on the code path normally used for apps launched in the background by flatpak_installation_launch_full(), which *don't* inherit arbitrary fds from their parent.
    
    Detect this situation and use a different child setup function, avoiding closing fds that we were meant to inherit.
    
    Fixes: 88a928ea "run: Avoid execve() when measuring test coverage"

* test-run.sh: Assert that fd redirections pass through into the app

    Before the previous commit, this would normally work, but would fail if we had FLATPAK_TEST_COVERAGE=1 in the environment.