### PR TITLE
update: Make autopruned refs automatically removed

### DIFF
--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -345,7 +345,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
 
           udir = uninstall_dir_ensure (uninstall_dirs, dir);
 
-          unused = flatpak_dir_list_unused_refs (dir, opt_arch, NULL, NULL, NULL, FALSE, cancellable, error);
+          unused = flatpak_dir_list_unused_refs (dir, opt_arch, NULL, NULL, NULL, FLATPAK_DIR_FILTER_NONE, cancellable, error);
           if (unused == NULL)
             return FALSE;
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -361,6 +361,12 @@ typedef enum {
 } FlatpakDirStorageType;
 
 typedef enum {
+  FLATPAK_DIR_FILTER_NONE = 0,
+  FLATPAK_DIR_FILTER_EOL = 1 << 0,
+  FLATPAK_DIR_FILTER_AUTOPRUNE = 1 << 1,
+} FlatpakDirFilterFlags;
+
+typedef enum {
   FIND_MATCHING_REFS_FLAGS_NONE = 0,
   FIND_MATCHING_REFS_FLAGS_FUZZY = (1 << 0),
 } FindMatchingRefsFlags;
@@ -1049,7 +1055,7 @@ char **               flatpak_dir_list_unused_refs                          (Fla
                                                                              GHashTable                    *metadata_injection,
                                                                              GHashTable                    *eol_injection,
                                                                              const char * const            *refs_to_exclude,
-                                                                             gboolean                       filter_by_eol,
+                                                                             FlatpakDirFilterFlags          filter_flags,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -24,6 +24,7 @@
 #include <glib/gi18n-lib.h>
 
 #include "flatpak-auth-private.h"
+#include "flatpak-dir-private.h"
 #include "flatpak-error.h"
 #include "flatpak-installation-private.h"
 #include "flatpak-progress-private.h"
@@ -4999,7 +5000,7 @@ add_uninstall_unused_ops (FlatpakTransaction  *self,
                                                       NULL, /* metadata_injection */
                                                       NULL, /* eol_injection */
                                                       NULL, /* exclude_refs */
-                                                      TRUE, /* filter_by_eol */
+                                                      FLATPAK_DIR_FILTER_EOL | FLATPAK_DIR_FILTER_AUTOPRUNE,
                                                       cancellable, error);
       if (old_unused_refs == NULL)
         return FALSE;
@@ -5056,7 +5057,7 @@ add_uninstall_unused_ops (FlatpakTransaction  *self,
                                               metadata_injection,
                                               eol_injection,
                                               to_be_excluded_strv,
-                                              TRUE, /* filter_by_eol */
+                                              FLATPAK_DIR_FILTER_EOL | FLATPAK_DIR_FILTER_AUTOPRUNE,
                                               cancellable, error);
   if (unused_refs == NULL)
     return FALSE;

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -925,10 +925,10 @@
                     <term><option>autoprune-unless</option> (string)</term>
                     <listitem><para>
                         A condition that must be false for the extension to be considered unused when
-                        pruning. For example, <command>flatpak uninstall --unused</command> uses
-                        this information. The only currently recognized value is active-gl-driver,
-                        which is true if the name of the active GL driver matches the extension
-                        point basename. Available since 0.11.8.
+                        pruning. For example, <command>flatpak uninstall --unused</command> and
+                        <command>flatpak update</command> use this information. The only currently
+                        recognized value is active-gl-driver, which is true if the name of the active
+                        GL driver matches the extension point basename. Available since 0.11.8.
                     </para></listitem>
                 </varlistentry>
                 <varlistentry>

--- a/tests/list-unused.c
+++ b/tests/list-unused.c
@@ -4,10 +4,14 @@
 
 static char **opt_exclude_refs;
 static gboolean opt_user;
+static gboolean opt_filter_eol;
+static gboolean opt_filter_autoprune;
 
 static GOptionEntry options[] = {
   { "user", 0, 0, G_OPTION_ARG_NONE, &opt_user, "Work on the user installation", NULL },
   { "exclude", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_exclude_refs, "Exclude ref", "REF" },
+  { "filter-eol", 0, 0, G_OPTION_ARG_NONE, &opt_filter_eol, "Filter results to include end-of-life refs", NULL },
+  { "filter-autoprune", 0, 0, G_OPTION_ARG_NONE, &opt_filter_autoprune, "Filter results to include autopruned refs", NULL },
   { NULL }
 };
 
@@ -19,6 +23,7 @@ main (int argc, char *argv[])
   g_autoptr(GError) error = NULL;
   g_auto(GStrv) refs = NULL;
   g_autoptr(GOptionContext) context = NULL;
+  FlatpakDirFilterFlags filter_flags = FLATPAK_DIR_FILTER_NONE;
   int i;
 
   context = g_option_context_new ("");
@@ -35,7 +40,13 @@ main (int argc, char *argv[])
   else
     dir = flatpak_dir_get_system_default ();
 
-  refs = flatpak_dir_list_unused_refs (dir, NULL, NULL, NULL, (const char * const *)opt_exclude_refs, FALSE, NULL, &error);
+  if (opt_filter_eol)
+    filter_flags |= FLATPAK_DIR_FILTER_EOL;
+
+  if (opt_filter_autoprune)
+    filter_flags |= FLATPAK_DIR_FILTER_AUTOPRUNE;
+
+  refs = flatpak_dir_list_unused_refs (dir, NULL, NULL, NULL, (const char * const *)opt_exclude_refs, filter_flags, NULL, &error);
   g_assert_nonnull (refs);
   g_assert_no_error (error);
 

--- a/tests/test-unused.sh
+++ b/tests/test-unused.sh
@@ -27,7 +27,7 @@ export USE_SYSTEMDIR=yes
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..2"
+echo "1..3"
 
 setup_empty_repo &> /dev/null > /dev/null
 
@@ -305,6 +305,11 @@ verify_unused() {
     assert_not_file_has_content unused.txt "\.APP"
 }
 
+verify_autopruned() {
+    assert_file_has_content autopruned.txt "\.NONACTIVEGL"
+    assert_not_file_has_content autopruned.txt "PINNED_.\.NONACTIVEGL"
+}
+
 # This is used for the autoprune check
 export FLATPAK_GL_DRIVERS=ACTIVEGL
 
@@ -342,6 +347,9 @@ make_extension USED_G.ACTIVEGL
 runtime_add_autoprune_extension USED_G USED_G.ACTIVEGL
 make_extension UNUSED_G.NONACTIVEGL
 runtime_add_autoprune_extension USED_G UNUSED_G.NONACTIVEGL
+make_extension PINNED_G.NONACTIVEGL
+runtime_add_autoprune_extension USED_G PINNED_G.NONACTIVEGL
+pin_extension PINNED_G.NONACTIVEGL
 
 # unused runtime with autopruned extension
 make_runtime UNUSED_H
@@ -388,6 +396,12 @@ ${test_builddir}/list-unused | sed s@^app/@@g | sed s@^runtime/@@g | sort > unus
 verify_unused
 
 ok "list unused regular"
+
+${test_builddir}/list-unused --filter-autoprune | sed s@^app/@@g | sed s@^runtime/@@g | sort > autopruned.txt
+
+verify_autopruned
+
+ok "list autopruned"
 
 mv unused.txt old-unused.txt
 


### PR DESCRIPTION
In order to maintain a system over time update automatically removes any EOL runtimes that are unused.

This extends it to also remove any autopruned refs. In practice this means removing no longer used driver versions as the system is updated.

Closes #5261