### PR TITLE
Add --show-changelog flag to flatpak-info

### DIFF
--- a/app/flatpak-tty-utils-private.h
+++ b/app/flatpak-tty-utils-private.h
@@ -83,3 +83,5 @@ void flatpak_format_choices (const char **choices,
 
 void   flatpak_print_escaped_string (const char        *s,
                                      FlatpakEscapeFlags flags);
+
+void   flatpak_print_appstream_release_description_markup (const char *s);


### PR DESCRIPTION
This shows the latest changelog entry from the appstream data for a given app.

It looks something like this, with italics and lists:

![image](https://github.com/flatpak/flatpak/assets/798838/8c25c37b-85b9-4c8d-b713-249b58950c12)

TODO:

- [ ] Use correct remote for ref
- [ ] Maybe tweak formatting/wrapping like the other printed strings
- [ ] More helpful error messages

Closes #5561