### PR TITLE
doc: improvements for /etc/flatpak/remotes.d

### DIFF
--- a/doc/flatpak-flatpakrepo.xml
+++ b/doc/flatpak-flatpakrepo.xml
@@ -47,6 +47,12 @@
            The filename extension commonly used for flatpakrepo files is <filename>.flatpakrepo</filename>.
         </para>
 
+        <para>
+           flatpakrepo files can also be placed in <filename>/etc/flatpak/remotes.d/</filename>
+           to statically preconfigure system-wide remotes. Such files must use the
+           <filename>.flatpakrepo</filename> extension.
+        </para>
+
     </refsect1>
 
     <refsect1>

--- a/doc/flatpak-remote.xml
+++ b/doc/flatpak-remote.xml
@@ -46,7 +46,7 @@
 
        <para>
             System-wide remotes can be statically preconfigured by dropping
-            flatpakref files into <filename>/etc/flatpak/remotes.d/</filename>.
+            <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
        </para>
 
     </refsect1>

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -60,7 +60,7 @@
 
        <para>
             System-wide remotes can be statically preconfigured by dropping
-            flatpakrepo files into <filename>/etc/flatpak/remotes.d/</filename>.
+            <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
        </para>
 
         <para>


### PR DESCRIPTION
Helps https://github.com/flatpak/flatpak/issues/5654

As a further change, I'd like to rename `flatpak-flatpakrepo(5)` and `flatpak-flatpakref(5)`, dropping the redundant `flatpak-` prefix. They're already named that way in the manpage headers. Is there any reason why that's a bad idea or otherwise infeasible? My understanding is that we can add compatibility symlinks  to keep the original names working.