### PR TITLE
dir: Fix glib criticals

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -11546,7 +11546,7 @@ flatpak_dir_get_unmaintained_extension_dir_if_exists (FlatpakDir   *self,
   extension_dir = flatpak_dir_get_unmaintained_extension_dir (self, name, arch, branch);
 
   extension_dir_info = g_file_query_info (extension_dir,
-                                          G_FILE_ATTRIBUTE_STANDARD_SYMLINK_TARGET,
+                                          G_FILE_ATTRIBUTE_STANDARD_SYMLINK_TARGET "," G_FILE_ATTRIBUTE_STANDARD_IS_SYMLINK,
                                           G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
                                           cancellable,
                                           NULL);


### PR DESCRIPTION
```
(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:11.938: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:11.938: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:11.957: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:11.957: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:11.979: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:11.979: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.000: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.000: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.019: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.019: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.042: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.042: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.063: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.063: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.081: GFileInfo created without standard::is-symlink

(flatpak update:8279): GLib-GIO-CRITICAL **: 15:50:12.081: file ../gio/gfileinfo.c: line 1677 (g_file_info_get_is_symlink): should not be reached
```