### PR TITLE
doc: rename man pages to flatpakref(5) and flatpakrepo(5)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -67,8 +67,8 @@ man1 = \
 
 man5 = \
 	flatpak-metadata.5		\
-	flatpak-flatpakrepo.5		\
-	flatpak-flatpakref.5		\
+	flatpakrepo.5			\
+	flatpakref.5			\
 	flatpak-remote.5		\
 	flatpak-installation.5		\
 	$(NULL)
@@ -96,6 +96,10 @@ DISTCLEANFILES = \
 	$(man_MANS)		\
 	flatpak-docs.xml	\
 	$(NULL)
+
+install-data-hook:
+	ln -sf flatpakrepo.5 $(DESTDIR)$(mandir)/man5/flatpak-flatpakrepo.5
+	ln -sf flatpakref.5 $(DESTDIR)$(mandir)/man5/flatpak-flatpakref.5
 
 if DOCBOOK_DOCS_ENABLED
 

--- a/doc/flatpak-docs.xml.in
+++ b/doc/flatpak-docs.xml.in
@@ -69,8 +69,8 @@
     </chapter>
     <chapter>
       <title>File Formats</title>
-      <xi:include href="@srcdir@/flatpak-flatpakrepo.xml"/>
-      <xi:include href="@srcdir@/flatpak-flatpakref.xml"/>
+      <xi:include href="@srcdir@/flatpakrepo.xml"/>
+      <xi:include href="@srcdir@/flatpakref.xml"/>
       <xi:include href="@srcdir@/flatpak-installation.xml"/>
       <xi:include href="@srcdir@/flatpak-metadata.xml"/>
       <xi:include href="@srcdir@/flatpak-remote.xml"/>

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -357,7 +357,7 @@
             <citerefentry><refentrytitle>flatpak-update</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-list</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-build-bundle</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-flatpakref</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpakref</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-make-current</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>ostree-find-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>
         </para>

--- a/doc/flatpak-remote-add.xml
+++ b/doc/flatpak-remote-add.xml
@@ -336,7 +336,7 @@ allow org.signal.Signal.*/*/stable
                 <citerefentry><refentrytitle>flatpak-remote-modify</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
                 <citerefentry><refentrytitle>flatpak-remote-delete</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
                 <citerefentry><refentrytitle>flatpak-remotes</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-                <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry>
             </para>
     </refsect1>
 

--- a/doc/flatpak-remote.xml
+++ b/doc/flatpak-remote.xml
@@ -46,7 +46,7 @@
 
        <para>
             System-wide remotes can be statically preconfigured by dropping
-            <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
+            <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
        </para>
 
     </refsect1>

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -60,7 +60,7 @@
 
        <para>
             System-wide remotes can be statically preconfigured by dropping
-            <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
+            <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
        </para>
 
         <para>
@@ -559,14 +559,14 @@
 
         <variablelist>
             <varlistentry>
-                <term><citerefentry><refentrytitle>flatpak-flatpakref</refentrytitle><manvolnum>5</manvolnum></citerefentry></term>
+                <term><citerefentry><refentrytitle>flatpakref</refentrytitle><manvolnum>5</manvolnum></citerefentry></term>
 
                 <listitem><para>
                     Reference to a remote for an application or runtime
                 </para></listitem>
             </varlistentry>
             <varlistentry>
-                <term><citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry></term>
+                <term><citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry></term>
 
                 <listitem><para>
                     Reference to a remote

--- a/doc/flatpakref.xml
+++ b/doc/flatpakref.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
     "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
-<refentry id="flatpak-flatpakref">
+<refentry id="flatpakref">
 
     <refentryinfo>
         <title>flatpakref</title>
@@ -24,7 +24,7 @@
     </refmeta>
 
     <refnamediv>
-        <refname>flatpak-flatpakref</refname>
+        <refname>flatpakref</refname>
         <refpurpose>Reference to a remote for an application or runtime</refpurpose>
     </refnamediv>
 
@@ -169,7 +169,7 @@ DeployCollectionID=org.gnome.Apps
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-install</refentrytitle><manvolnum>1</manvolnum></citerefentry>
-            <citerefentry><refentrytitle>flatpak-flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
+            <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
         </para>
 
     </refsect1>

--- a/doc/flatpakrepo.xml
+++ b/doc/flatpakrepo.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
     "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
-<refentry id="flatpak-flatpakrepo">
+<refentry id="flatpakrepo">
 
     <refentryinfo>
         <title>flatpakrepo</title>
@@ -24,7 +24,7 @@
     </refmeta>
 
     <refnamediv>
-        <refname>flatpak-flatpakrepo</refname>
+        <refname>flatpakrepo</refname>
         <refpurpose>Reference to a remote</refpurpose>
     </refnamediv>
 
@@ -167,7 +167,7 @@ DeployCollectionID=org.gnome.Apps
         <para>
             <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
             <citerefentry><refentrytitle>flatpak-remote-add</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-            <citerefentry><refentrytitle>flatpak-flatpakref</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+            <citerefentry><refentrytitle>flatpakref</refentrytitle><manvolnum>5</manvolnum></citerefentry>
         </para>
 
     </refsect1>

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -64,10 +64,15 @@ man1 = [
 
 man5 = [
   'flatpak-metadata',
-  'flatpak-flatpakrepo',
-  'flatpak-flatpakref',
+  'flatpakrepo',
+  'flatpakref',
   'flatpak-remote',
   'flatpak-installation',
+]
+
+man_compat_symlinks = [
+   ['flatpak-flatpakrepo', 'flatpakrepo', '5'],
+   ['flatpak-flatpakref', 'flatpakref', '5'],
 ]
 
 xml_files = []
@@ -97,6 +102,23 @@ foreach pair : [[man1, '1'], [man5, '5']]
       )
     endif
   endforeach
+endforeach
+
+foreach entry : man_compat_symlinks
+  name = entry[0]
+  target = entry[1]
+  section = entry[2]
+
+  if build_man_pages
+    #TODO: replace with install_symlink() when we can depend on meson 0.61
+    meson.add_install_script(
+      'sh', '-c', 'ln -sf @0@ $MESON_INSTALL_DESTDIR_PREFIX/@1@/@2@'.format(
+        target + '.' + section,
+        get_option('mandir') / ('man' + section),
+        name + '.' + section
+      )
+    )
+  endif
 endforeach
 
 if xmlto.found()


### PR DESCRIPTION
Added symlinks to preserve flatpak-prefixed names.

Also fixed section reference in flatpak-install(1).

Followup to https://github.com/flatpak/flatpak/pull/5659