### PR TITLE
doc: Add since version for --device=input

### DIFF
--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -179,6 +179,7 @@
                             <listitem><para>
                                 Input devices
                                 (<filename>/dev/input</filename>).
+                                Available since 1.15.6.
                             </para></listitem></varlistentry>
 
                             <varlistentry><term><option>kvm</option></term>


### PR DESCRIPTION
Follow-up to #5481

This is consistent with other places. 