### PR TITLE
dir: search for repositories also under FLATPAK_BASEDIR

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3951,11 +3951,10 @@ _flatpak_dir_find_new_flatpakrepos (FlatpakDir *self, OstreeRepo *repo)
   while (TRUE)
     {
       GFileInfo *file_info;
-      GFile *path;
       const char *name;
       guint32 type;
 
-      if (!g_file_enumerator_iterate (dir_enum, &file_info, &path,
+      if (!g_file_enumerator_iterate (dir_enum, &file_info, NULL,
                                       NULL, &my_error))
         {
           g_info ("Unexpected error reading file in %s: %s",

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3922,7 +3922,6 @@ _flatpak_dir_scan_new_flatpakrepos (const char          *dir_str,
 {
   g_autoptr(GFile) dir = NULL;
   g_autoptr(GFileEnumerator) dir_enum = NULL;
-  g_autoptr(GError) my_error = NULL;
 
   g_return_if_fail (dir_str != NULL);
   g_return_if_fail (flatpakrepos != NULL);
@@ -3931,8 +3930,8 @@ _flatpak_dir_scan_new_flatpakrepos (const char          *dir_str,
   dir_enum = g_file_enumerate_children (dir,
                                         G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_STANDARD_TYPE,
                                         G_FILE_QUERY_INFO_NONE,
-                                        NULL, &my_error);
-  if (my_error != NULL)
+                                        NULL, NULL);
+  if (dir_enum == NULL)
     return;
 
   while (TRUE)
@@ -3940,12 +3939,13 @@ _flatpak_dir_scan_new_flatpakrepos (const char          *dir_str,
       GFileInfo *file_info;
       const char *name;
       guint32 type;
+      g_autoptr(GError) local_error = NULL;
 
       if (!g_file_enumerator_iterate (dir_enum, &file_info, NULL,
-                                      NULL, &my_error))
+                                      NULL, &local_error))
         {
           g_info ("Unexpected error reading file in %s: %s",
-                  dir_str, my_error->message);
+                  dir_str, local_error->message);
           break;
         }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -3921,7 +3921,7 @@ _flatpak_dir_find_new_flatpakrepos (FlatpakDir *self, OstreeRepo *repo)
   g_autoptr(GFile) conf_dir = NULL;
   g_autoptr(GFileEnumerator) dir_enum = NULL;
   g_autoptr(GError) my_error = NULL;
-  g_autofree char *config_dir = NULL;
+  g_autofree char *conf_dir_str = NULL;
   g_auto(GStrv) remotes = NULL;
   g_auto(GStrv) applied_remotes = NULL;
 
@@ -3933,10 +3933,10 @@ _flatpak_dir_find_new_flatpakrepos (FlatpakDir *self, OstreeRepo *repo)
        strcmp (self->extra_data->id, SYSTEM_DIR_DEFAULT_ID) != 0))
     return NULL;
 
-  config_dir = g_strdup_printf ("%s/%s",
+  conf_dir_str = g_strdup_printf ("%s/%s",
                                 get_config_dir_location (),
                                 SYSCONF_REMOTES_DIR);
-  conf_dir = g_file_new_for_path (config_dir);
+  conf_dir = g_file_new_for_path (conf_dir_str);
   dir_enum = g_file_enumerate_children (conf_dir,
                                         G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_STANDARD_TYPE,
                                         G_FILE_QUERY_INFO_NONE,
@@ -3959,7 +3959,7 @@ _flatpak_dir_find_new_flatpakrepos (FlatpakDir *self, OstreeRepo *repo)
                                       NULL, &my_error))
         {
           g_info ("Unexpected error reading file in %s: %s",
-                  config_dir, my_error->message);
+                  conf_dir_str, my_error->message);
           break;
         }
 

--- a/doc/flatpak-remote.xml
+++ b/doc/flatpak-remote.xml
@@ -46,7 +46,11 @@
 
        <para>
             System-wide remotes can be statically preconfigured by dropping
-            <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
+            <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+            files into <filename>/usr/share/flatpak/remotes.d/</filename> and
+            <filename>/etc/flatpak/remotes.d/</filename>. Ifa file with
+            the same name exists in both, the file under
+            <filename>/etc</filename> will take precedence.
        </para>
 
     </refsect1>

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -60,7 +60,11 @@
 
        <para>
             System-wide remotes can be statically preconfigured by dropping
-            <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry> files into <filename>/etc/flatpak/remotes.d/</filename>.
+            <citerefentry><refentrytitle>flatpakrepo</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+            files into <filename>/usr/share/flatpak/remotes.d/</filename> and
+            <filename>/etc/flatpak/remotes.d/</filename>. If a file with
+            the same name exists in both, the file under
+            <filename>/etc</filename> will take precedence.
        </para>
 
         <para>

--- a/doc/flatpakrepo.xml
+++ b/doc/flatpakrepo.xml
@@ -48,9 +48,13 @@
         </para>
 
         <para>
-           flatpakrepo files can also be placed in <filename>/etc/flatpak/remotes.d/</filename>
-           to statically preconfigure system-wide remotes. Such files must use the
-           <filename>.flatpakrepo</filename> extension.
+          flatpakrepo files can also be placed in
+          <filename>/usr/share/flatpak/remotes.d/</filename> and
+          <filename>/etc/flatpak/remotes.d/</filename>
+          to statically preconfigure system-wide remotes. Such files must use the
+          <filename>.flatpakrepo</filename> extension. If a file with the
+          same name exists in both, the file under <filename>/etc</filename> will
+          take precedence.
         </para>
 
     </refsect1>


### PR DESCRIPTION
This is more compliant with FHS specification. Most remarkably, /etc
is not appropriate to hold distro configuration, which is a common
use for the remotes.d feature. It is better practice to put things
under /usr/share, and let the system administrator modify /etc to
their will, of course giving them priority.

In the process, fix a couple of leaks. 

I know that FHS might not be the most up-to-date standard. But luckily the purpose of /etc hasn't really changed. FHS states: ` /etc : Host-specific system configuration`. So not feasible for distributions to put their configuration.