### PR TITLE
Fix memory leaks detected by running testlibrary with AddressSanitizer

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -679,7 +679,7 @@ flatpak_run (int      argc,
 
   if (!command->fn)
     {
-      GOptionContext *context;
+      g_autoptr(GOptionContext) context = NULL;
       g_autofree char *hint = NULL;
       g_autofree char *msg = NULL;
 
@@ -814,8 +814,6 @@ flatpak_run (int      argc,
           else
             msg = g_strdup (_("No command specified"));
         }
-
-      g_option_context_free (context);
 
       g_set_error (&error, G_IO_ERROR, G_IO_ERROR_FAILED, "%s\n\n%s", msg, hint);
 

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -711,13 +711,13 @@ flatpak_run (int      argc,
               if (opt_version)
                 {
                   g_print ("%s\n", PACKAGE_STRING);
-                  exit (EXIT_SUCCESS);
+                  return EXIT_SUCCESS;
                 }
 
               if (opt_default_arch)
                 {
                   g_print ("%s\n", flatpak_get_arch ());
-                  exit (EXIT_SUCCESS);
+                  return EXIT_SUCCESS;
                 }
 
               if (opt_supported_arches)
@@ -726,7 +726,7 @@ flatpak_run (int      argc,
                   int i;
                   for (i = 0; arches[i] != NULL; i++)
                     g_print ("%s\n", arches[i]);
-                  exit (EXIT_SUCCESS);
+                  return EXIT_SUCCESS;
                 }
 
               if (opt_gl_drivers)
@@ -735,7 +735,7 @@ flatpak_run (int      argc,
                   int i;
                   for (i = 0; drivers[i] != NULL; i++)
                     g_print ("%s\n", drivers[i]);
-                  exit (EXIT_SUCCESS);
+                  return EXIT_SUCCESS;
                 }
 
               if (opt_list_installations)
@@ -751,7 +751,7 @@ flatpak_run (int      argc,
                           GFile *file = paths->pdata[i];
                           g_print ("%s\n", flatpak_file_get_path_cached (file));
                         }
-                      exit (EXIT_SUCCESS);
+                      return EXIT_SUCCESS;
                     }
                 }
 
@@ -777,7 +777,7 @@ flatpak_run (int      argc,
                   if (local_error != NULL)
                     {
                       g_printerr ("%s\n", local_error->message);
-                      exit (1);
+                      return 1;
                     }
 
                   for (gsize i = 0; i < system_installation_locations->len; i++)
@@ -805,7 +805,7 @@ flatpak_run (int      argc,
                   new_dirs_joined = g_strjoinv (":", (gchar **) new_dirs->pdata);
                   g_print ("XDG_DATA_DIRS=%s\n", new_dirs_joined);
 
-                  exit (EXIT_SUCCESS);
+                  return EXIT_SUCCESS;
                 }
             }
 

--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -81,6 +81,7 @@ flatpak_bwrap_free (FlatpakBwrap *bwrap)
   g_array_unref (bwrap->noinherit_fds);
   g_array_unref (bwrap->fds);
   g_strfreev (bwrap->envp);
+  g_clear_pointer (&bwrap->runtime_dir_members, g_ptr_array_unref);
   g_free (bwrap);
 }
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1842,16 +1842,16 @@ GPtrArray *
 flatpak_get_system_base_dir_locations (GCancellable *cancellable,
                                        GError      **error)
 {
-  static gsize array = 0;
+  static gsize initialized = 0;
+  static GPtrArray *array = NULL;
 
-  if (g_once_init_enter (&array))
+  if (g_once_init_enter (&initialized))
     {
-      gsize setup_value = 0;
-      setup_value = (gsize) get_system_locations (cancellable, error);
-      g_once_init_leave (&array, setup_value);
+      array = get_system_locations (cancellable, error);
+      g_once_init_leave (&initialized, 1);
     }
 
-  return (GPtrArray *) array;
+  return array;
 }
 
 GFile *

--- a/common/flatpak-remote.c
+++ b/common/flatpak-remote.c
@@ -1175,7 +1175,7 @@ flatpak_remote_commit_filter (FlatpakRemote *self,
   if (priv->local_filter_set &&
       !flatpak_dir_compare_remote_filter (dir, priv->name, priv->local_filter))
     {
-      GKeyFile *config = ostree_repo_copy_config (flatpak_dir_get_repo (dir));
+      g_autoptr(GKeyFile) config = ostree_repo_copy_config (flatpak_dir_get_repo (dir));
 
       g_key_file_set_string (config, group, "xa.filter", priv->local_filter ? priv->local_filter : "");
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3301,7 +3301,8 @@ populate_commit_data_cache (OstreeRepo *repo,
                     {
                       VarVariantRef v = var_metadata_entry_get_value (m);
                       GVariant *vv = var_variant_dup_to_gvariant (v);
-                      g_variant_builder_add (&sparse_builder, "{sv}", m_key, g_variant_get_child_value (vv, 0));
+                      g_autoptr(GVariant) child = g_variant_get_child_value (vv, 0);
+                      g_variant_builder_add (&sparse_builder, "{sv}", m_key, child);
                       has_sparse = TRUE;
                     }
                 }

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -3300,7 +3300,7 @@ populate_commit_data_cache (OstreeRepo *repo,
                       strcmp (m_key, "xa.data") != 0)
                     {
                       VarVariantRef v = var_metadata_entry_get_value (m);
-                      GVariant *vv = var_variant_dup_to_gvariant (v);
+                      g_autoptr(GVariant) vv = g_variant_ref_sink (var_variant_dup_to_gvariant (v));
                       g_autoptr(GVariant) child = g_variant_get_child_value (vv, 0);
                       g_variant_builder_add (&sparse_builder, "{sv}", m_key, child);
                       has_sparse = TRUE;

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -767,7 +767,7 @@ main (int    argc,
   gboolean replace;
   gboolean verbose;
   gboolean show_version;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   GBusNameOwnerFlags flags;
   g_autofree char *pk11_program = NULL;
   g_autofree char *flatpak_dir = NULL;
@@ -821,9 +821,10 @@ main (int    argc,
       g_printerr ("Try \"%s --help\" for more information.",
                   g_get_prgname ());
       g_printerr ("\n");
-      g_option_context_free (context);
       return 1;
     }
+
+  g_clear_pointer (&context, g_option_context_free);
 
   if (show_version)
     {

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -144,6 +144,7 @@ ongoing_pull_free (OngoingPull *pull)
   close (pull->client_socket);
   close (pull->backend_exit_socket);
 
+  g_clear_object (&pull->cancellable);
   g_slice_free (OngoingPull, pull);
 }
 


### PR DESCRIPTION
This PR just fixes leaks detected in the production code. A follow-up PR will get testlibrary passing.

---

* main: Use g_autoptr for the GOptionContext
    
    No functional change, but it will make it easier to avoid leaking it.

* main: Return from flatpak_run() instead of calling exit()
    
    This allows g_autoptr destructors to run, avoiding memory leaks being
    reported by AddressSanitizer; they would be harmless, since we're about
    to exit anyway, but AddressSanitizer can't tell the difference between
    an O(n) problem and an O(1) harmless "leak".

* dir: Don't store a pointer in a gsize
    
    This is, strictly speaking, not allowed. On uncommon architectures like
    CHERI, a pointer can be larger than a gsize.
    
    This might also help to avoid AddressSanitizer losing track of
    reachability, so that it won't think the array and its contents have
    been leaked.

* populate_commit_data_cache: Don't leak child value
    
    g_variant_get_child_value() returns a non-floating reference, so
    g_variant_builder_add() will not sink it.

* populate_commit_data_cache: Don't leak a floating GVariant
    
    var_variant_dup_to_gvariant() returns a floating GVariant, and
    g_variant_get_child_value() won't sink it, so we need to free it.

* session-helper: Don't leak the GOptionContext

* flatpak_remote_commit_filter: Don't leak config GKeyFile

* flatpak-bwrap: Don't leak runtime_dir_members

* system-helper: Don't leak the GCancellable for each OngoingPull