### PR TITLE
Fix memory errors in testlibrary and other test code

### DIFF
--- a/tests/httpcache.c
+++ b/tests/httpcache.c
@@ -6,7 +6,7 @@ int
 main (int argc, char *argv[])
 {
   g_autoptr(FlatpakHttpSession) session = flatpak_create_http_session (PACKAGE_STRING);
-  GError *error = NULL;
+  g_autoptr(GError) error = NULL;
   const char *url, *dest;
   int flags = 0;
 

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -158,7 +158,7 @@ context_parse_args (FlatpakContext *context,
 
   oc = g_option_context_new ("");
   group = flatpak_context_get_options (context);
-  g_option_context_add_group (oc, group);
+  g_option_context_add_group (oc, g_steal_pointer (&group));
   g_option_context_parse_strv (oc, &argv, error);
 }
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1220,7 +1220,7 @@ test_update_installed_ref_if_missing_runtime (void)
   G_GNUC_END_IGNORE_DEPRECATIONS
   g_assert_no_error (error);
   g_assert_true (FLATPAK_IS_INSTALLED_REF (iref));
-  iref = NULL;
+  g_clear_object (&iref);
 
   /* Install the Locale extension */
   G_GNUC_BEGIN_IGNORE_DEPRECATIONS
@@ -1234,7 +1234,7 @@ test_update_installed_ref_if_missing_runtime (void)
   G_GNUC_END_IGNORE_DEPRECATIONS
   g_assert_no_error (error);
   g_assert_true (FLATPAK_IS_INSTALLED_REF (iref));
-  iref = NULL;
+  g_clear_object (&iref);
 
   updatable_refs = flatpak_installation_list_installed_refs_for_update (inst, NULL, &error);
   g_assert_cmpint (updatable_refs->len, ==, 1);
@@ -1259,6 +1259,7 @@ test_update_installed_ref_if_missing_runtime (void)
   iref = flatpak_installation_get_installed_ref (inst, FLATPAK_REF_KIND_RUNTIME, "org.test.Platform", NULL, NULL, NULL, &error);
   g_assert_nonnull (iref);
   g_assert_no_error (error);
+  g_clear_object (&iref);
 }
 
 static void
@@ -4486,12 +4487,14 @@ test_overrides (void)
   G_GNUC_END_IGNORE_DEPRECATIONS
   g_assert_no_error (error);
   g_assert_nonnull (ref);
+  g_clear_object (&ref);
 
   G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   ref = flatpak_installation_install (inst, repo_name, FLATPAK_REF_KIND_RUNTIME, "org.test.Platform", NULL, "master", NULL, NULL, NULL, &error);
   G_GNUC_END_IGNORE_DEPRECATIONS
   g_assert_no_error (error);
   g_assert_nonnull (ref);
+  g_clear_object (&ref);
 
   {
     TESTS_SCOPED_STDOUT_TO_STDERR;

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -4256,7 +4256,7 @@ test_instance (void)
   g_autoptr(GError) error = NULL;
   gboolean res;
   g_autoptr(GPtrArray) instances = NULL;
-  FlatpakInstance *instance;
+  g_autoptr(FlatpakInstance) instance = NULL;
   GKeyFile *info;
   g_autofree char *value = NULL;
   int i;

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -4746,6 +4746,8 @@ test_list_installed_related_refs (void)
   g_assert_true (g_strv_length ((char **) flatpak_related_ref_get_subpaths (ref)) == 1);
   g_assert_cmpstr (flatpak_related_ref_get_subpaths (ref)[0], ==, "/de");
 
+  g_clear_pointer (&refs, g_ptr_array_unref);
+
   // Make the test with extra-languages, instead of languages
   clean_languages();
   configure_extra_languages();

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1992,6 +1992,7 @@ mangle_deploy_file (FlatpakInstalledRef *ref)
   GVariantBuilder metadata_builder;
   g_autoptr(GError) error = NULL;
   const char * const previous_ids[] = { "net.example.Goodbye", NULL };
+  g_autofree const char **subpaths = NULL;
 
   dir = g_file_new_for_path (flatpak_installed_ref_get_deploy_dir (ref));
   data = flatpak_load_deploy_data (dir);
@@ -2002,9 +2003,10 @@ mangle_deploy_file (FlatpakInstalledRef *ref)
   g_variant_builder_add (&metadata_builder, "{s@v}", "previous-ids",
                          g_variant_new_variant (g_variant_new_strv (previous_ids, -1)));
 
+  subpaths = flatpak_deploy_data_get_subpaths (data);
   new_data = flatpak_dir_new_deploy_data (flatpak_deploy_data_get_origin (data),
                                           flatpak_deploy_data_get_commit (data),
-                                          (char **) flatpak_deploy_data_get_subpaths (data),
+                                          (char **) subpaths,
                                           flatpak_deploy_data_get_installed_size (data),
                                           g_variant_builder_end (&metadata_builder));
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -3429,6 +3429,8 @@ test_transaction_install_uninstall (void)
   g_assert_no_error (error);
   g_assert_true (res);
 
+  g_clear_object (&transaction);
+
   /* uninstall again, expect a not-installed error */
   transaction = flatpak_transaction_new_for_installation (inst, NULL, &error);
   g_assert_no_error (error);
@@ -3437,6 +3439,8 @@ test_transaction_install_uninstall (void)
   res = flatpak_transaction_add_uninstall (transaction, app, &error);
   g_assert_error (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_INSTALLED);
   g_assert_false (res);
+
+  g_clear_object (&transaction);
 }
 
 static int remote_added;

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -4606,9 +4606,11 @@ test_bundle (void)
   icon = flatpak_bundle_ref_get_icon (ref, 64);
   g_assert_nonnull (icon);
   /* FIXME verify format */
+  g_clear_pointer (&icon, g_bytes_unref);
 
   icon = flatpak_bundle_ref_get_icon (ref, 128);
   g_assert_null (icon);
+  g_clear_pointer (&icon, g_bytes_unref);
 
   g_clear_object (&file2);
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1464,6 +1464,7 @@ test_list_remote_related_refs (void)
   g_assert_true (should_download);
   g_assert_true (should_delete);
   g_assert_false (should_autoprune);
+  g_clear_pointer (&subpaths, g_strfreev);
 
   ref = g_ptr_array_index (refs, 1);
   g_assert_cmpstr (flatpak_ref_get_name (FLATPAK_REF (ref)), ==, "org.test.Hello.Plugin.fun");


### PR DESCRIPTION
Continuation of #5690, fixing bugs in the test itself. Detected by running tests compiled with AddressSanitizer.

This fixes testlibrary, plus a few issues in other tests that I found before reducing the scope of what I was trying to just testlibrary.

After this has been reviewed I'm intending to continue to clean up AddressSanitizer issues as time permits, but repeatedly running the tests under AddressSanitizer is rather time-consuming, so I'd prefer to land this a piece at a time.

---

* tests: Fix a double-free when exercising argument parsing
    
    g_option_context_add_group() takes ownership of the group that it's
    given, so we can't also free it.
    
    Fixes: fab0f8ed "test-context: Exercise some corner cases for merging filesystems"

* testlibrary: Don't leak transactions

* testlibrary: Don't leak several installed references

* testlibrary: Don't leak FlatpakInstance

* testlibrary: Don't leak icon data

* testlibrary: Don't leak an array of related refs

* testlibrary: Don't leak strings retrieved from remote
    
    All of these getters are (transfer full) (but note that
    flatpak_remote_get_name() isn't).

* test_list_remote_related_refs: Don't leak list of subpaths

* testlibrary: Don't leak list of subpaths
    
    flatpak_deploy_data_get_subpaths() returns a new array (of unowned
    strings) and flatpak_dir_new_deploy_data() doesn't take ownership.

* httpcache: Free the GError before exiting