### PR TITLE
common: Fix use of deprecated libmalcontent symbols

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8444,7 +8444,7 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   gboolean authorized;
   gboolean repo_installation_allowed, app_is_appropriate;
   PolkitCheckAuthorizationFlags polkit_flags;
-  MctGetAppFilterFlags manager_flags;
+  MctManagerGetValueFlags manager_flags;
 
   /* Assume that root is allowed to install any ref and shouldn't have any
    * parental controls restrictions applied to them. Note that this branch
@@ -8498,13 +8498,13 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
     }
 
   manager = mct_manager_new (dbus_connection);
-  manager_flags = MCT_GET_APP_FILTER_FLAGS_NONE;
+  manager_flags = MCT_MANAGER_GET_VALUE_FLAGS_NONE;
   if (!flatpak_dir_get_no_interaction (self))
-    manager_flags |= MCT_GET_APP_FILTER_FLAGS_INTERACTIVE;
+    manager_flags |= MCT_MANAGER_GET_VALUE_FLAGS_INTERACTIVE;
   app_filter = mct_manager_get_app_filter (manager, subject_uid,
                                            manager_flags,
                                            cancellable, &local_error);
-  if (g_error_matches (local_error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_DISABLED))
+  if (g_error_matches (local_error, MCT_MANAGER_ERROR, MCT_MANAGER_ERROR_DISABLED))
     {
       g_info ("Skipping parental controls check for %s since parental "
               "controls are disabled globally", ref);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2729,9 +2729,9 @@ check_parental_controls (FlatpakDecomposed *app_ref,
 
   manager = mct_manager_new (system_bus);
   app_filter = mct_manager_get_app_filter (manager, getuid (),
-                                           MCT_GET_APP_FILTER_FLAGS_INTERACTIVE,
+                                           MCT_MANAGER_GET_VALUE_FLAGS_INTERACTIVE,
                                            cancellable, &local_error);
-  if (g_error_matches (local_error, MCT_APP_FILTER_ERROR, MCT_APP_FILTER_ERROR_DISABLED))
+  if (g_error_matches (local_error, MCT_MANAGER_ERROR, MCT_MANAGER_ERROR_DISABLED))
     {
       g_info ("Skipping parental controls check for %s since parental "
               "controls are disabled globally", flatpak_decomposed_get_ref (app_ref));

--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,7 @@ if test "x$with_systemd" != "xno"; then
 else
   have_libsystemd=no
 fi
-PKG_CHECK_MODULES([MALCONTENT], [malcontent-0 >= 0.4.0], [have_libmalcontent=yes], [have_libmalcontent=no])
+PKG_CHECK_MODULES([MALCONTENT], [malcontent-0 >= 0.5.0], [have_libmalcontent=yes], [have_libmalcontent=no])
 AS_IF([test "$have_libmalcontent" = "yes"],[
   AC_DEFINE([HAVE_LIBMALCONTENT], [1], [Define if libmalcontent is available])
 ])

--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,7 @@ libxml_dep = dependency('libxml-2.0', version : '>=2.4')
 libzstd_dep = dependency('libzstd', version : '>=0.8.1', required : get_option('libzstd'))
 dconf_dep = dependency('dconf', version : '>=0.26', required : get_option('dconf'))
 libsystemd_dep = dependency('libsystemd', required : get_option('systemd'))
-malcontent_dep = dependency('malcontent-0', required : get_option('malcontent'))
+malcontent_dep = dependency('malcontent-0', version : '>=0.5.0', required : get_option('malcontent'))
 polkit_agent_dep = dependency('polkit-agent-1', version : '>=0.98', required : get_option('system_helper'))
 build_system_helper = polkit_agent_dep.found()
 


### PR DESCRIPTION
These symbols were soft-renamed in libmalcontent 0.5.0 (released in February 2020). We can probably now safely depend on that, and use the renamed versions.