### PR TITLE
tests: Add macros to assert that a copied string has a desired value

### DIFF
--- a/tests/testlib.h
+++ b/tests/testlib.h
@@ -46,4 +46,52 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (TestsStdoutToStderr, tests_stdout_to_stderr_end);
 #define TESTS_SCOPED_STDOUT_TO_STDERR \
   G_GNUC_UNUSED g_autoptr(TestsStdoutToStderr) _tests_stdout_to_stderr = tests_stdout_to_stderr_begin ()
 
+/*
+ * assert_cmpstr_free_lhs:
+ * @lhs: (transfer full): An expression returning an owned string,
+ *  which will be freed
+ * @op: Either `==`, `!=`, `<=`, `<`, `>` or `>=`
+ * @rhs: (transfer none): An expression returning an unowned string
+ *
+ * Assert that @lhs has the given relationship with @rhs, then free @lhs.
+ */
+#define assert_cmpstr_free_lhs(lhs, op, rhs) \
+  do { \
+    g_autofree char *free_lhs = NULL; \
+    g_assert_cmpstr ((free_lhs = (lhs)), op, (rhs)); \
+  } while (0)
+
+/*
+ * assert_cmpstr_free_rhs:
+ * @lhs: (transfer none): An expression returning an unowned string
+ * @op: Either `==`, `!=`, `<=`, `<`, `>` or `>=`
+ * @rhs: (transfer full): An expression returning an owned string,
+ *  which will be freed
+ *
+ * Assert that @lhs has the given relationship with @rhs, then free @rhs.
+ */
+#define assert_cmpstr_free_rhs(lhs, op, rhs) \
+  do { \
+    g_autofree char *free_rhs = NULL; \
+    g_assert_cmpstr ((lhs), op, (free_rhs = (rhs))); \
+  } while (0)
+
+/*
+ * assert_cmpstr_free_both:
+ * @lhs: (transfer full): An expression returning an owned string,
+ *  which will be freed
+ * @op: Either `==`, `!=`, `<=`, `<`, `>` or `>=`
+ * @rhs: (transfer full): An expression returning an owned string,
+ *  which will be freed
+ *
+ * Assert that @lhs has the given relationship with @rhs, then free both
+ * strings.
+ */
+#define assert_cmpstr_free_both(lhs, op, rhs) \
+  do { \
+    g_autofree char *free_lhs = NULL; \
+    g_autofree char *free_rhs = NULL; \
+    g_assert_cmpstr ((free_lhs = (lhs)), op, (free_rhs = (rhs))); \
+  } while (0)
+
 #endif


### PR DESCRIPTION
* tests: Add macros to assert that a copied string has a desired value
    
    Suggested by Patrick during review of #5691.

* testlibrary: Make use of assert_cmpstr_free_lhs(), etc.