### PR TITLE
Do not hard-code fusermount, add option or auto-detect instead

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2110,8 +2110,7 @@ flatpak_dir_revokefs_fuse_unmount (OstreeRepo **repo,
 
   fusermount = g_subprocess_new (G_SUBPROCESS_FLAGS_NONE,
                                  error,
-                                 "fusermount", "-u", "-z", mnt_dir,
-                                 NULL);
+                                 FUSERMOUNT, "-u", "-z", mnt_dir, NULL);
   if (g_subprocess_wait_check (fusermount, NULL, error))
     {
       g_autoptr(GFile) mnt_dir_file = g_file_new_for_path (mnt_dir);

--- a/meson.build
+++ b/meson.build
@@ -188,12 +188,25 @@ polkit_agent_dep = dependency('polkit-agent-1', version : '>=0.98', required : g
 build_system_helper = polkit_agent_dep.found()
 
 fuse_dep = dependency('fuse3', version : '>=3.1.1', required : false)
-
 if fuse_dep.found()
   fuse_api = 31
 else
   fuse_dep = dependency('fuse', version : '>=2.9.2')
   fuse_api = 26
+endif
+
+fusermount = get_option('system_fusermount')
+if fusermount == ''
+  if fuse_api >= 30
+    fusermount_program = find_program('fusermount3', required: true)
+  else
+    fusermount_program = find_program('fusermount', required: true)
+  endif
+  if meson.version().version_compare('>=0.55')
+    fusermount = fusermount_program.full_path()
+  else
+    fusermount = fusermount_program.path()
+  endif
 endif
 
 xau_dep = dependency('xau', required : get_option('xauth'))
@@ -347,6 +360,7 @@ cdata.set_quoted(
 cdata.set_quoted('G_LOG_DOMAIN', 'flatpak')
 cdata.set_quoted('GETTEXT_PACKAGE', 'flatpak')
 cdata.set('FUSE_USE_VERSION', fuse_api)
+cdata.set_quoted('FUSERMOUNT', fusermount)
 
 if get_option('system_bubblewrap') == ''
   cdata.set_quoted('HELPER', get_option('prefix') / get_option('libexecdir') / 'flatpak-bwrap')
@@ -433,6 +447,7 @@ summary(
     'Build selinux module' : build_selinux_module,
     'Build bubblewrap' : (get_option('system_bubblewrap') == ''),
     'Build dbus-proxy' : (get_option('system_dbus_proxy') == ''),
+    'fusermount executable' : fusermount,
     'Use sandboxed triggers' : get_option('sandboxed_triggers'),
     'Use seccomp' : libseccomp_dep.found(),
     'Privileged group' : get_option('privileged_group'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -141,6 +141,12 @@ option(
   value : '',
 )
 option(
+  'system_fusermount',
+  type : 'string',
+  description : 'system fusermount executable, or empty string to auto-select based on fuse version',
+  value : '',
+)
+option(
   'system_font_cache_dirs',
   type : 'array',
   description : 'directory where the system font cache is',

--- a/tests/can-use-fuse.c
+++ b/tests/can-use-fuse.c
@@ -53,7 +53,7 @@ check_fuse (void)
       return FALSE;
     }
 
-  fusermount = g_find_program_in_path ("fusermount");
+  fusermount = g_find_program_in_path (FUSERMOUNT);
 
   if (fusermount == NULL)
     {

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -542,7 +542,7 @@ skip_one_without_bwrap () {
 }
 
 skip_without_fuse () {
-    fusermount --version >/dev/null 2>&1 || skip "no fusermount"
+    "${FUSERMOUNT}" --version >/dev/null 2>&1 || skip "no fusermount"
 
     capsh --print | grep -q 'Bounding set.*[^a-z]cap_sys_admin' || \
         skip "No cap_sys_admin in bounding set, can't use FUSE"
@@ -608,7 +608,7 @@ commit_to_path () {
 cleanup () {
     /bin/kill -9 $DBUS_SESSION_BUS_PID
     gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye >&2 || true
-    fusermount -u $XDG_RUNTIME_DIR/doc >&2 || :
+    "${FUSERMOUNT}" -u $XDG_RUNTIME_DIR/doc >&2 || :
     kill $(jobs -p) &> /dev/null || true
     if test -n "${TEST_SKIP_CLEANUP:-}"; then
         echo "# Skipping cleanup of ${TEST_DATA_DIR}"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,6 +21,7 @@ tests_environment.set(
   'FLATPAK_VALIDATE_ICON',
   project_build_root / 'icon-validator' / 'flatpak-validate-icon',
 )
+tests_environment.set('FUSERMOUNT', fusermount)
 tests_environment.set('G_TEST_BUILDDIR', meson.current_build_dir())
 tests_environment.set('G_TEST_SRCDIR', meson.current_source_dir())
 tests_environment.prepend('GI_TYPELIB_PATH', project_build_root / 'common')


### PR DESCRIPTION
The hard-coding is not appropriate. According to libfuse 3.0.0 release notes: "The fusermount and mount.fuse binaries have been renamed to fusermount3 and mount.fuse3 to allow co-installation of libfuse 2.x and 3.x". Some distributions seem to install a symlink, but this is not upstream's default behavior.

In addition, fusermount might be provided from non-distro sources. So a build-time option takes precedence over auto-detection logic.

Fixes #5104

Fixes #5694

`executable.path()` is deprecated in meson, but `full_path` was only available in 0.55, and the minimum version is 0.53. So I guess this introduces a bit of technical debt...

@smcv as promised