### PR TITLE
appdata: exclude <name> element inside <developer>

### DIFF
--- a/tests/make-test-app.sh
+++ b/tests/make-test-app.sh
@@ -130,6 +130,9 @@ cat <<EOF > ${DIR}/files/share/metainfo/${APP_ID}.metainfo.xml
     <name>Hello world test app: $APP_ID</name>
     <summary>Print a greeting</summary>
     <description><p>This is a test app.</p></description>
+    <developer>
+      <name>Developer name</name>
+    </developer>
     <categories>
       <category>Utility</category>
     </categories>

--- a/tests/test-info.sh
+++ b/tests/test-info.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 skip_revokefs_without_fuse
 
-echo "1..8"
+echo "1..9"
 
 INCLUDE_SPECIAL_CHARACTER=1 setup_repo
 install_repo
@@ -62,3 +62,9 @@ ${FLATPAK} info --file-access=home org.test.Hello > info
 assert_file_has_content info "^hidden$"
 
 ok "info --file-access"
+
+${FLATPAK} info org.test.Hello > info
+
+assert_file_has_content info "^Hello world test app: org\.test\.Hello - Print a greeting$"
+
+ok "info (name header)"


### PR DESCRIPTION
`<developer_name>` has been deprecated in favor of `<developer>` with a `<name>` child. We need to ensure that this developer name isn't parsed as the application name.

Fixes: #5700