### PR TITLE
app: Improve table ellipsization

### DIFF
--- a/app/flatpak-builtins-list.c
+++ b/app/flatpak-builtins-list.c
@@ -112,7 +112,6 @@ print_table_for_refs (gboolean      print_apps,
   g_autofree char *match_id = NULL;
   g_autofree char *match_arch = NULL;
   g_autofree char *match_branch = NULL;
-  int rows, cols;
 
   if (columns[0].name == NULL)
     return TRUE;
@@ -356,9 +355,7 @@ print_table_for_refs (gboolean      print_apps,
 
   if (flatpak_table_printer_get_current_row (printer) > 0)
     {
-      flatpak_get_window_size (&rows, &cols);
-      flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
-      g_print ("\n");
+      flatpak_table_printer_print (printer);
     }
 
   return TRUE;

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -130,7 +130,6 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
   g_autofree char *match_branch = NULL;
   gboolean need_cache_data = FALSE;
   gboolean need_appstream_data = FALSE;
-  int rows, cols;
 
   printer = flatpak_table_printer_new ();
 
@@ -368,9 +367,7 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
 
   if (flatpak_table_printer_get_current_row (printer) > 0)
     {
-      flatpak_get_window_size (&rows, &cols);
-      flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
-      g_print ("\n");
+      flatpak_table_printer_print (printer);
     }
 
   return TRUE;

--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -218,7 +218,6 @@ static void
 print_matches (Column *columns, GSList *matches)
 {
   g_autoptr(FlatpakTablePrinter) printer = NULL;
-  int rows, cols;
   GSList *s;
 
   printer = flatpak_table_printer_new ();
@@ -231,9 +230,7 @@ print_matches (Column *columns, GSList *matches)
       print_app (columns, res, printer);
     }
 
-  flatpak_get_window_size (&rows, &cols);
-  flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
-  g_print ("\n");
+  flatpak_table_printer_print (printer);
 }
 
 gboolean

--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -717,7 +717,10 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
 void
 flatpak_table_printer_print (FlatpakTablePrinter *printer)
 {
-  flatpak_table_printer_print_full (printer, 0, 80, NULL, NULL);
+  int rows, cols;
+
+  flatpak_get_window_size (&rows, &cols);
+  flatpak_table_printer_print_full (printer, 0, cols, NULL, NULL);
   g_print ("\n");
 }
 


### PR DESCRIPTION
Instead of having each command call `flatpak_get_window_size()`, do it by default in `flatpak_table_printer_print()`. This fixes the display of ellipsized columns in `flatpak remotes -d` with wide terminals.

If preferred, I can fix the remotes command instead, but this seemed a better option.