### PR TITLE
run: Ignore leftover eol-rebase data dir symlink

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3091,6 +3091,12 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
             {
               do_migrate = FALSE; /* Don't migrate older things, they are likely symlinks to this dir */
 
+              /* Don't migrate a symlink pointing to the new data dir. It was likely left over
+               * from a previous migration and would end up pointing to itself */
+              if (g_file_info_get_is_symlink (previous_app_id_dir_info) &&
+                  g_strcmp0 (g_file_info_get_symlink_target (previous_app_id_dir_info), app_id) == 0)
+                break;
+
               if (!flatpak_file_rename (previous_app_id_dir, real_app_id_dir, cancellable, &local_error))
                 {
                   g_warning (_("Failed to migrate old app data directory %s to new name %s: %s"),

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -486,6 +486,14 @@ assert_has_symlink $HOME/.var/app/org.test.Hello
 assert_has_file $HOME/.var/app/org.test.Hello/data/a-file
 assert_has_file $HOME/.var/app/org.test.Hello/data/another-file
 
+# Simulate removal of app data dir
+rm -rf $HOME/.var/app/org.test.NewHello
+
+${FLATPAK} run org.test.NewHello >&2
+
+# Ensure the data dir is re-created instead of migrating the symlink
+assert_has_dir $HOME/.var/app/org.test.NewHello
+
 ${FLATPAK} ${U} uninstall -y org.test.NewHello org.test.Platform >&2
 
 ok "eol-rebase"


### PR DESCRIPTION
If the current app data dir is removed, flatpak would try to migrate the
symlink that it had previously created, creating a symlink loop.

Fixes: #5668

I had considered also making `uninstall --delete-data` remove the leftover symlinks, but that turns out to be a larger project than anticipated. The delete-data implementation is in the app, not libflatpak, so the same change would need to be made in the other frontends for consistency. A more sophisticated implementation could be added to the library, but I don't know if it's worth the effort, given that the symlinks should be harmless with this change in place.