### PR TITLE
ps: Add gnome to background portal backend list

### DIFF
--- a/app/flatpak-builtins-ps.c
+++ b/app/flatpak-builtins-ps.c
@@ -72,6 +72,8 @@ get_compositor_apps (void)
   g_autoptr(GVariant) ret = NULL;
   GVariant *list = NULL;
   const char *backends[] = {
+    "org.freedesktop.impl.portal.desktop.gnome",
+    /* Background portal was removed in 1.15.0, retained for compatibility */
     "org.freedesktop.impl.portal.desktop.gtk",
     "org.freedesktop.impl.portal.desktop.kde",
     NULL


### PR DESCRIPTION
This is used for the active and background columns.

There still doesn't appear to be any way to find the backend for a portal, as mentioned in the original commit: https://github.com/flatpak/flatpak/commit/5ec73b9a9af8d3b9c3d4479fcee05e5eef94ee6a