### PR TITLE
Fix missing declaration for g_fdwalk_set_cloexec() with GLib 2.80.x

### DIFF
--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -34,6 +34,7 @@
 
 #include <glib/gi18n-lib.h>
 
+#include <glib-unix.h>
 #include <gio/gio.h>
 #include "libglnx.h"
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include <glib-unix.h>
 #include <glib/gi18n-lib.h>
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -34,6 +34,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <glib-unix.h>
+
 #include "flatpak-dbus-generated.h"
 #include "flatpak-dir-private.h"
 #include "flatpak-error.h"


### PR DESCRIPTION
With older GLib, it's provided by libglnx, but with newer GLib, we need to include the correct header.

Fixes: 7b1cd206 "Replace flatpak_close_fds_workaround() with g_fdwalk_set_cloexec()"