### PR TITLE
flatpak-prune: Make sure to calculate hash in the unsigned domain

### DIFF
--- a/common/flatpak-prune.c
+++ b/common/flatpak-prune.c
@@ -381,10 +381,10 @@ flatpak_ostree_object_name_hash (gconstpointer a)
      those are the ones that will be first compared on a hash collision,
      so if they were always the same that would waste 4 comparisons. */
   return
-    data[32] |
-    data[31] << 8 |
-    data[30] << 16 |
-    data[29] << 24;
+    ((guint32) data[32]) |
+    ((guint32) data[31]) << 8 |
+    ((guint32) data[30]) << 16 |
+    ((guint32) data[29]) << 24;
 }
 
 static gboolean


### PR DESCRIPTION
Otherwise, an out-of-bounds left shift can occur, as diagnosed by UBSan here:

    ../../../../src/flatpak/common/flatpak-prune.c:387:14: runtime error: left shift of 253 by 24 places cannot be represented in type 'int'