### PR TITLE
dir: Uniformize two similar strings

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -741,7 +741,7 @@ flatpak_remote_state_lookup_ref (FlatpakRemoteState *self,
   if (!flatpak_remote_state_allow_ref (self, ref))
     {
       return flatpak_fail_error (error, FLATPAK_ERROR_REF_NOT_FOUND,
-                                 _("No entry for %s in remote '%s' summary flatpak cache "),
+                                 _("No entry for %s in remote %s summary flatpak cache"),
                                  ref, self->remote_name);
     }
 
@@ -878,7 +878,7 @@ flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
   summary_v = get_summary_for_ref (self, ref);
   if (summary_v == NULL)
     return flatpak_fail_error (error, FLATPAK_ERROR_REF_NOT_FOUND,
-                               _("No entry for %s in remote '%s' summary flatpak cache "),
+                               _("No entry for %s in remote %s summary flatpak cache"),
                                ref, self->remote_name);
 
 
@@ -907,7 +907,7 @@ flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
 
       if (!var_cache_lookup (cache, ref, &pos, &cache_data))
         return flatpak_fail_error (error, FLATPAK_ERROR_REF_NOT_FOUND,
-                                   _("No entry for %s in remote '%s' summary flatpak cache "),
+                                   _("No entry for %s in remote %s summary flatpak cache"),
                                    ref, self->remote_name);
     }
   else if (summary_version == 1)
@@ -919,7 +919,7 @@ flatpak_remote_state_lookup_cache (FlatpakRemoteState *self,
 
       if (!flatpak_var_ref_map_lookup_ref (ref_map, ref, &info))
         return flatpak_fail_error (error, FLATPAK_ERROR_REF_NOT_FOUND,
-                                   _("No entry for %s in remote '%s' summary cache "),
+                                   _("No entry for %s in remote %s summary flatpak cache"),
                                    ref, self->remote_name);
 
       commit_metadata = var_ref_info_get_metadata (info);


### PR DESCRIPTION
Related to issue #4746.

This makes these two strings:
1. `No entry for %s in remote '%s' summary flatpak cache `
2. `No entry for %s in remote '%s' summary cache `

look like this other string in the code:
`No entry for %s in remote %s summary flatpak sparse cache`

This technically removes the two strings and adds one new one: `No entry for %s in remote %s summary flatpak cache`. 
