### PR TITLE
tests: Make sure FUSERMOUNT gets set for "as-installed" tests

### DIFF
--- a/tests/installed-tests.sh.in
+++ b/tests/installed-tests.sh.in
@@ -1,0 +1,4 @@
+# Copyright 2024 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+FUSERMOUNT='@FUSERMOUNT@'

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -38,6 +38,10 @@ else
     test_builddir=$(dirname $0)
 fi
 
+if [ -e "$test_srcdir/installed-tests.sh" ]; then
+    . "$test_srcdir/installed-tests.sh"
+fi
+
 # All the asserts and ok functions below are wrapped such that they
 # don't output any set -x traces of their internals (but still echo
 # errors to stderr). This way the log output focuses on tracing what

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -40,6 +40,17 @@ else
   tests_environment.set('FLATPAK_DBUSPROXY', get_option('system_dbus_proxy'))
 endif
 
+if get_option('installed_tests')
+  configure_file(
+    input : 'installed-tests.sh.in',
+    output : 'installed-tests.sh',
+    configuration : {
+      'FUSERMOUNT' : fusermount,
+    },
+    install_dir : installed_testdir,
+  )
+endif
+
 # Explicitly doing a find_program() for this avoids lots of output with
 # older Meson versions
 tap_test = find_program(


### PR DESCRIPTION
Otherwise, tests for OCI and the update portal fail with:

    /usr/libexec/installed-tests/Flatpak/libtest.sh: line 611: FUSERMOUNT: unbound variable

Fixes: 2cb17b4e "Do not hard-code fusermount, add option or auto-detect instead"