### PR TITLE
utils: Drop stripping .desktop suffixes from appstream component ids

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -5308,9 +5308,6 @@ extract_appstream (OstreeRepo        *repo,
               continue;
             }
 
-          if (g_str_has_suffix (component_id_suffix, ".desktop"))
-            component_id_suffix[strlen (component_id_suffix) - strlen (".desktop")] = 0;
-
           if (!copy_icon (component_id_text, icons_dir, repo, size1_mtree, "64x64", &my_error))
             {
               g_print (_("Error copying 64x64 icon for component %s: %s\n"), component_id_text, my_error->message);


### PR DESCRIPTION
This will pass the exact appstream component ID to copy_icon

This was introduced in https://github.com/flatpak/flatpak/commit/7dd92d8a9be2e14313e2cda7dea44298fbb005a4 to handle appstream component IDs that ended in two `.desktop` suffixes. Recent analysis of appstream data shows that on Flathub no such appstream cid exists anymore and Telegram has component ID `com.telegram.desktop` now.

With the switch to libappstream, appstreamcli-compose produces icons in `share/app-info/flatpak` named by the appstream component ID instead of the `$FLATPAK_ID` used by appstream-glib. This causes applications whose `$FLATPAK_ID` does not end with `.desktop` but their appstream-component ID ends in `.desktop` ie. `$FLATPAK_ID != appstream-cid` to loose icons from the appstream ostree ref as `copy_icon` was being fed the id without `.desktop` but icons were created by appstreamcli with `.desktop` in them.

This will avoid adding anymore ID heuristics/workarounds on either side, per the discussion in https://github.com/flathub/flathub/issues/4222

An application with `$FLATPAK_ID` `com.telegram.desktop` and appstream ID `com.telegram.desktop.desktop` will be broken with this change but such dual `.desktop` IDs are non existent and should be fixed individually or be blocked on an app store level.