### PR TITLE
profile: Install flatpak.csh

### DIFF
--- a/profile/meson.build
+++ b/profile/meson.build
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 install_data(
+  'flatpak.csh',
   'flatpak.sh',
   install_dir : profile_dir,
 )


### PR DESCRIPTION
I don't know if there's a reason this wasn't being installed, but it does seem to work correctly in a quick test with tcsh. I don't see any evidence it was ever installed in autotools either.