### PR TITLE
install, uninstall: Fail if non-interactive and multiple refs match

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -568,6 +568,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
             g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, _("Nothing matches %s in remote %s"), id, remote);
           return FALSE;
         }
+      else if (refs->len >= 2 && opt_noninteractive)
+        return flatpak_fail (error, _("Multiple refs match '%s', unable to proceed in non-interactive mode"), argv[1]);
 
       if (!flatpak_resolve_matching_refs (remote, dir, opt_yes, refs, id, &ref, error))
         return FALSE;

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -456,6 +456,8 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
               g_printerr (_("Warning: %s is not installed\n"), pref);
               continue;
             }
+          else if (ref_dir_pairs->len >= 2 && opt_noninteractive)
+            return flatpak_fail (error, _("Multiple refs match '%s', unable to proceed in non-interactive mode"), argv[1]);
 
           /* Don't show fuzzy matches if an exact match was found in any installation */
           if (found_exact_name_match)


### PR DESCRIPTION
Related to issue #3848

When non-interactive mode is enabled, install and uninstall commands still prompted you if multiple refs match. In my PR, these commands fail if the argument turns out to be ambiguous.

To prevent this error, scripts should specify the repo and the exact name of needed app/runtime: `flatpak install --noninteractive flathub app/org.videolan.VLC/x86_64/stable`. In case there is any ambiguity, an error like this is printed:

```
$ flatpak install --noninteractive doom
error: Multiple refs match 'doom', unable to proceed in non-interactive mode
```

When multiple refs with the substring "doom" are installed:
```
$ flatpak uninstall --noninteractive doom
error: Multiple refs match 'doom', unable to proceed in non-interactive mode
```