### PR TITLE
Fix export dynamic linker option

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -253,7 +253,7 @@ libflatpak = library(
   gnu_symbol_visibility : 'hidden',
   include_directories : [common_include_directories],
   install : true,
-  link_args : ['-export-dynamic'],
+  link_args : ['-Wl,--export-dynamic'],
   link_whole : [
     libflatpak_common_base,
     libflatpak_common,


### PR DESCRIPTION
As of LLVM/Clang 18 and LLD18 linker with the -export-dynamic option compilation ends with an error: cc: error: unknown argument: '-export-dynamic'

For GCC and the default compiler this is not a problem. The problem occurs in Clang/LLD 18.

Fix tested on Mandriva via https://github.com/OpenMandrivaAssociation/flatpak/commit/39f1c03e915ea20bb58ef9e8838823488f6a1e08