### PR TITLE
cli-transaction: Do not double free transaction ops

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1467,10 +1467,7 @@ transaction_ready_pre_auth (FlatpakTransaction *transaction)
         ret = flatpak_yes_no_prompt (TRUE, _("Proceed with these changes to the %s?"), name);
 
       if (!ret)
-        {
-          g_list_free_full (ops, g_object_unref);
-          return FALSE;
-        }
+        return FALSE;
     }
   else
     g_print ("\n\n");


### PR DESCRIPTION
The transaction ops are a g_autolist(FlatpakTransactionOperation) which means the list gets freed automatically. Calling g_list_free_full without clearing the variable to NULL results in a double-free.