### PR TITLE
run: Don't inherit LD_PRELOAD/LD_AUDIT from the host

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -518,10 +518,13 @@ typedef struct
 
 static const ExportData default_exports[] = {
   {"PATH", "/app/bin:/usr/bin"},
-  /* We always want to unset LD_LIBRARY_PATH to avoid inheriting weird
-   * dependencies from the host. But if not using ld.so.cache this is
-   * later set. */
+  /* We always want to unset LD variables to avoid inheriting weird
+   * dependencies from the host. But if not using ld.so.cache LD_LIBRARY_PATH
+   is later set. */
   {"LD_LIBRARY_PATH", NULL},
+  {"LD_PRELOAD", NULL},
+  {"LD_AUDIT", NULL},
+
   {"XDG_CONFIG_DIRS", "/app/etc/xdg:/etc/xdg"},
   {"XDG_DATA_DIRS", "/app/share:/usr/share"},
   {"SHELL", "/bin/sh"},

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -88,6 +88,8 @@
         <simplelist>
             <member>PATH</member>
             <member>LD_LIBRARY_PATH</member>
+            <member>LD_PRELOAD</member>
+            <member>LD_AUDIT</member>
             <member>XDG_CONFIG_DIRS</member>
             <member>XDG_DATA_DIRS</member>
             <member>XDG_RUNTIME_DIR</member>


### PR DESCRIPTION
I don't think this env var makes much sense to pass into the sandbox for similar reasons to LD_LIBRARY_PATH. Libraries from the host just aren't relevant.

Users can still pass `--env=LD_PRELOAD=/foo` to use this functionality.