### PR TITLE
tests: Fix a misleading comment

### DIFF
--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -77,7 +77,7 @@ assert_file_has_content hello_out '^Hello world, from a sandbox$'
 ok "hello"
 
 # This should try and fail to run e.g. /usr/bin/--tmpfs, which will
-# exit with status 127 because there is no such executable.
+# exit with a nonzero status because there is no such executable.
 # It should not pass "--tmpfs /blah hello.sh" as bwrap options.
 exit_status=0
 run --command=--tmpfs org.test.Hello /blah hello.sh >&2 || exit_status=$?


### PR DESCRIPTION
Arguably bwrap should exit with status 127 if it can't find the executable, but right now it exits 1, so we accept any nonzero status. The implementation was correct, but the comment was wrong.

Fixes: 84984e49 "test-run: Add a reproducer for CVE-2024-32462"