### PR TITLE
workflows: Disable Microsoft-specific apt repository

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,10 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
+        head -v -n-0 /etc/apt/sources.list || :
+        head -v -n-0 /etc/apt/sources.list.d/* || :
+        # Workaround for https://github.com/orgs/community/discussions/120966
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install -y libglib2.0-dev attr gettext bison  dbus gtk-doc-tools \
         libfuse3-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \


### PR DESCRIPTION
* workflows: Disable Microsoft-specific apt repository

    We don't need anything from here, and its secure-apt signing is
    currently broken.
    
    Workaround-for: https://github.com/orgs/community/discussions/120966

---

If Github provided an image that was purely Ubuntu (rather than the "Ubuntu with Github and Microsoft additions" that they *actually* provide) then we wouldn't have to do this sort of thing every few months.