### PR TITLE
FlatpakBwrap: Don't leak array of $XDG_RUNTIME_DIR members

### DIFF
--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -79,6 +79,7 @@ void
 flatpak_bwrap_free (FlatpakBwrap *bwrap)
 {
   g_ptr_array_unref (bwrap->argv);
+  g_clear_pointer (&bwrap->runtime_dir_members, g_ptr_array_unref);
   g_array_unref (bwrap->noinherit_fds);
   g_array_unref (bwrap->fds);
   g_strfreev (bwrap->envp);


### PR DESCRIPTION
Origin: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/commit/0f51a22e95ccf37eb5d4ea552387e49d0f62bae3

---

Originally a bug fix in Steam's pressure-vessel tool, some of which is derived from Flatpak's `common/`, but I didn't get round to upstreaming it to Flatpak until now.