### PR TITLE
Add initial support for preinstalling flatpaks

### DIFF
--- a/app/flatpak-builtins-preinstall.c
+++ b/app/flatpak-builtins-preinstall.c
@@ -1,0 +1,160 @@
+/* vi:set et sw=2 sts=2 cin cino=t0,f0,(0,{s,>2s,n-s,^-s,e-s:
+ * Copyright © 2024 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Kalev Lember <klember@redhat.com>
+ */
+
+#include "config.h"
+
+#include <locale.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#include <glib/gi18n.h>
+
+#include <gio/gunixinputstream.h>
+
+#include "libglnx.h"
+
+#include "flatpak-builtins.h"
+#include "flatpak-builtins-utils.h"
+#include "flatpak-transaction-private.h"
+#include "flatpak-cli-transaction.h"
+#include "flatpak-quiet-transaction.h"
+#include "flatpak-utils-http-private.h"
+#include "flatpak-utils-private.h"
+#include "flatpak-error.h"
+#include "flatpak-chain-input-stream-private.h"
+
+static char **opt_sideload_repos;
+static gboolean opt_no_pull;
+static gboolean opt_no_deploy;
+static gboolean opt_no_related;
+static gboolean opt_no_deps;
+static gboolean opt_no_static_deltas;
+static gboolean opt_include_sdk;
+static gboolean opt_include_debug;
+static gboolean opt_yes;
+static gboolean opt_reinstall;
+static gboolean opt_noninteractive;
+
+static GOptionEntry options[] = {
+  { "no-pull", 0, 0, G_OPTION_ARG_NONE, &opt_no_pull, N_("Don't pull, only install from local cache"), NULL },
+  { "no-deploy", 0, 0, G_OPTION_ARG_NONE, &opt_no_deploy, N_("Don't deploy, only download to local cache"), NULL },
+  { "no-related", 0, 0, G_OPTION_ARG_NONE, &opt_no_related, N_("Don't install related refs"), NULL },
+  { "no-deps", 0, 0, G_OPTION_ARG_NONE, &opt_no_deps, N_("Don't verify/install runtime dependencies"), NULL },
+  { "no-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_no_static_deltas, N_("Don't use static deltas"), NULL },
+  { "include-sdk", 0, 0, G_OPTION_ARG_NONE, &opt_include_sdk, N_("Additionally install the SDK used to build the given refs") },
+  { "include-debug", 0, 0, G_OPTION_ARG_NONE, &opt_include_debug, N_("Additionally install the debug info for the given refs and their dependencies") },
+  { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
+  { "reinstall", 0, 0, G_OPTION_ARG_NONE, &opt_reinstall, N_("Uninstall first if already installed"), NULL },
+  { "noninteractive", 0, 0, G_OPTION_ARG_NONE, &opt_noninteractive, N_("Produce minimal output and don't ask questions"), NULL },
+  /* Translators: A sideload is when you install from a local USB drive rather than the Internet. */
+  { "sideload-repo", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_sideload_repos, N_("Use this local repo for sideloads"), N_("PATH") },
+  { NULL }
+};
+
+gboolean
+flatpak_builtin_preinstall (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(GPtrArray) dirs = NULL;
+  g_autoptr(FlatpakDir) dir = NULL;
+  g_autoptr(FlatpakTransaction) transaction = NULL;
+
+  context = g_option_context_new (_("- Install flatpaks that are part of the operating system"));
+  g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
+
+  if (!flatpak_option_context_parse (context, options, &argc, &argv,
+                                     FLATPAK_BUILTIN_FLAG_ALL_DIRS | FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO,
+                                     &dirs, cancellable, error))
+    return FALSE;
+
+  /* Use the default dir */
+  dir = g_object_ref (g_ptr_array_index (dirs, 0));
+
+  if (opt_noninteractive)
+    opt_yes = TRUE; /* Implied */
+
+  if (!opt_noninteractive)
+    g_print (_("Syncing preinstalled flatpaks…\n"));
+
+  if (opt_noninteractive)
+    transaction = flatpak_quiet_transaction_new (dir, error);
+  else
+    transaction = flatpak_cli_transaction_new (dir, opt_yes, TRUE, FALSE, error);
+  if (transaction == NULL)
+    return FALSE;
+
+  flatpak_transaction_set_no_pull (transaction, opt_no_pull);
+  flatpak_transaction_set_no_deploy (transaction, opt_no_deploy);
+  flatpak_transaction_set_disable_static_deltas (transaction, opt_no_static_deltas);
+  flatpak_transaction_set_disable_dependencies (transaction, opt_no_deps);
+  flatpak_transaction_set_disable_related (transaction, opt_no_related);
+  flatpak_transaction_set_reinstall (transaction, opt_reinstall);
+  flatpak_transaction_set_auto_install_sdk (transaction, opt_include_sdk);
+  flatpak_transaction_set_auto_install_debug (transaction, opt_include_debug);
+
+  for (int i = 0; opt_sideload_repos != NULL && opt_sideload_repos[i] != NULL; i++)
+    flatpak_transaction_add_sideload_repo (transaction, opt_sideload_repos[i]);
+
+  if (!flatpak_transaction_add_sync_preinstalled (transaction, error))
+    return FALSE;
+
+  if (flatpak_transaction_is_empty (transaction))
+    {
+      g_print ("\n");
+      g_print (_("Nothing to do.\n"));
+
+      return TRUE;
+    }
+
+  if (!flatpak_transaction_run (transaction, cancellable, error))
+    {
+      if (g_error_matches (*error, FLATPAK_ERROR, FLATPAK_ERROR_ABORTED))
+        g_clear_error (error); /* Don't report on stderr */
+
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+gboolean
+flatpak_complete_preinstall (FlatpakCompletion *completion)
+{
+  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(GPtrArray) dirs = NULL;
+
+  context = g_option_context_new ("");
+  if (!flatpak_option_context_parse (context, options, &completion->argc, &completion->argv,
+                                     FLATPAK_BUILTIN_FLAG_ONE_DIR | FLATPAK_BUILTIN_FLAG_OPTIONAL_REPO,
+                                     &dirs, NULL, NULL))
+    return FALSE;
+
+  switch (completion->argc)
+    {
+    default: /* REF */
+      flatpak_complete_options (completion, global_entries);
+      flatpak_complete_options (completion, options);
+      flatpak_complete_options (completion, user_entries);
+      break;
+    }
+
+  return TRUE;
+}

--- a/app/flatpak-builtins.h
+++ b/app/flatpak-builtins.h
@@ -127,6 +127,7 @@ BUILTINPROTO (repair)
 BUILTINPROTO (create_usb)
 BUILTINPROTO (kill)
 BUILTINPROTO (history)
+BUILTINPROTO (preinstall)
 
 #undef BUILTINPROTO
 

--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -89,6 +89,7 @@ static FlatpakCommand commands[] = {
   { "config", N_("Configure flatpak"), flatpak_builtin_config, flatpak_complete_config },
   { "repair", N_("Repair flatpak installation"), flatpak_builtin_repair, flatpak_complete_repair },
   { "create-usb", N_("Put applications or runtimes onto removable media"), flatpak_builtin_create_usb, flatpak_complete_create_usb },
+  { "preinstall", N_("Install flatpaks that are part of the operating system"), flatpak_builtin_preinstall, flatpak_complete_preinstall },
 
   /* translators: please keep the leading newline and space */
   { N_("\n Find applications and runtimes") },

--- a/app/meson.build
+++ b/app/meson.build
@@ -100,6 +100,7 @@ sources = [
   'flatpak-builtins-permission-set.c',
   'flatpak-builtins-permission-show.c',
   'flatpak-builtins-pin.c',
+  'flatpak-builtins-preinstall.c',
   'flatpak-builtins-ps.c',
   'flatpak-builtins-remote-add.c',
   'flatpak-builtins-remote-delete.c',

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -180,6 +180,7 @@ typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_APP_HINT = 1 << 5,
   FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT = 1 << 6,
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED = 1 << 7,
+  FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PREINSTALLED = 1 << 8,
 } FlatpakHelperDeployFlags;
 
 #define FLATPAK_HELPER_DEPLOY_FLAGS_ALL (FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE | \
@@ -189,18 +190,21 @@ typedef enum {
                                          FLATPAK_HELPER_DEPLOY_FLAGS_NO_INTERACTION | \
                                          FLATPAK_HELPER_DEPLOY_FLAGS_APP_HINT | \
                                          FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT | \
-                                         FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED)
+                                         FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED | \
+                                         FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PREINSTALLED)
 
 typedef enum {
   FLATPAK_HELPER_UNINSTALL_FLAGS_NONE = 0,
   FLATPAK_HELPER_UNINSTALL_FLAGS_KEEP_REF = 1 << 0,
   FLATPAK_HELPER_UNINSTALL_FLAGS_FORCE_REMOVE = 1 << 1,
   FLATPAK_HELPER_UNINSTALL_FLAGS_NO_INTERACTION = 1 << 2,
+  FLATPAK_HELPER_UNINSTALL_FLAGS_UPDATE_PREINSTALLED = 1 << 3,
 } FlatpakHelperUninstallFlags;
 
 #define FLATPAK_HELPER_UNINSTALL_FLAGS_ALL (FLATPAK_HELPER_UNINSTALL_FLAGS_KEEP_REF | \
                                             FLATPAK_HELPER_UNINSTALL_FLAGS_FORCE_REMOVE | \
-                                            FLATPAK_HELPER_UNINSTALL_FLAGS_NO_INTERACTION)
+                                            FLATPAK_HELPER_UNINSTALL_FLAGS_NO_INTERACTION | \
+                                            FLATPAK_HELPER_UNINSTALL_FLAGS_UPDATE_PREINSTALLED)
 
 typedef enum {
   FLATPAK_HELPER_CONFIGURE_REMOTE_FLAGS_NONE = 0,
@@ -363,6 +367,14 @@ gboolean        flatpak_save_override_keyfile   (GKeyFile    *metakey,
 gboolean        flatpak_remove_override_keyfile (const char  *app_id,
                                                  gboolean     user,
                                                  GError     **error);
+
+char **  flatpak_get_preinstall_config_file_paths (GCancellable       *cancellable,
+                                                   GError            **error);
+gboolean flatpak_parse_preinstall_config_file     (const char         *file_path,
+                                                   const char         *default_arch,
+                                                   FlatpakDecomposed **ref_out,
+                                                   char              **collection_id_out,
+                                                   GError            **error);
 
 int          flatpak_deploy_data_get_version                     (GBytes *deploy_data);
 const char * flatpak_deploy_data_get_origin                      (GBytes *deploy_data);
@@ -679,6 +691,7 @@ gboolean              flatpak_dir_deploy_install                            (Fla
                                                                              const char                   **previous_ids,
                                                                              gboolean                       reinstall,
                                                                              gboolean                       pin_on_deploy,
+                                                                             gboolean                       update_preinstalled_on_deploy,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
 gboolean              flatpak_dir_install                                   (FlatpakDir                    *self,
@@ -688,6 +701,7 @@ gboolean              flatpak_dir_install                                   (Fla
                                                                              gboolean                       reinstall,
                                                                              gboolean                       app_hint,
                                                                              gboolean                       pin_on_deploy,
+                                                                             gboolean                       update_preinstalled_on_deploy,
                                                                              FlatpakRemoteState            *state,
                                                                              FlatpakDecomposed             *ref,
                                                                              const char                    *opt_commit,

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1929,7 +1929,7 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_PULL) != 0,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_DEPLOY) != 0,
                             (flags & FLATPAK_INSTALL_FLAGS_NO_STATIC_DELTAS) != 0,
-                            FALSE, FALSE, FALSE, state,
+                            FALSE, FALSE, FALSE, FALSE, state,
                             ref, NULL, (const char **) subpaths, NULL, NULL, NULL, NULL,
                             progress, cancellable, error))
     return NULL;

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -330,6 +330,9 @@ gboolean            flatpak_transaction_add_install_flatpakref (FlatpakTransacti
                                                                 GBytes             *flatpakref_data,
                                                                 GError            **error);
 FLATPAK_EXTERN
+gboolean            flatpak_transaction_add_sync_preinstalled (FlatpakTransaction *self,
+                                                               GError            **error);
+FLATPAK_EXTERN
 gboolean            flatpak_transaction_add_update (FlatpakTransaction *self,
                                                     const char         *ref,
                                                     const char        **subpaths,

--- a/doc/flatpak-docs.xml.in
+++ b/doc/flatpak-docs.xml.in
@@ -52,6 +52,7 @@
       <xi:include href="@srcdir@/flatpak-permission-show.xml"/>
       <xi:include href="@srcdir@/flatpak-permission-reset.xml"/>
       <xi:include href="@srcdir@/flatpak-permission-set.xml"/>
+      <xi:include href="@srcdir@/flatpak-preinstall.xml"/>
       <xi:include href="@srcdir@/flatpak-ps.xml"/>
       <xi:include href="@srcdir@/flatpak-remote-add.xml"/>
       <xi:include href="@srcdir@/flatpak-remote-delete.xml"/>

--- a/doc/flatpak-preinstall.xml
+++ b/doc/flatpak-preinstall.xml
@@ -1,0 +1,273 @@
+<?xml version='1.0'?> <!--*-nxml-*-->
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+    "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+
+<refentry id="flatpak-preinstall">
+
+    <refentryinfo>
+        <title>flatpak preinstall</title>
+        <productname>flatpak</productname>
+
+        <authorgroup>
+            <author>
+                <contrib>Developer</contrib>
+                <firstname>Kalev</firstname>
+                <surname>Lember</surname>
+                <email>klember@redhat.com</email>
+            </author>
+        </authorgroup>
+    </refentryinfo>
+
+    <refmeta>
+        <refentrytitle>flatpak preinstall</refentrytitle>
+        <manvolnum>1</manvolnum>
+    </refmeta>
+
+    <refnamediv>
+        <refname>flatpak-preinstall</refname>
+        <refpurpose>Install flatpaks that are part of the operating system</refpurpose>
+    </refnamediv>
+
+    <refsynopsisdiv>
+            <cmdsynopsis>
+                <command>flatpak preinstall</command>
+                <arg choice="opt" rep="repeat">OPTION</arg>
+            </cmdsynopsis>
+    </refsynopsisdiv>
+
+    <refsect1>
+        <title>Description</title>
+
+        <para>
+          This command manages flatpaks that are part of the operating system. If no options are given, running <command>flatpak preinstall</command> will synchronize (install and remove) flatpaks to match the set that the OS vendor has chosen.
+        </para>
+
+        <para>
+          Preinstalled flatpaks are defined by dropping .preinstall files into <filename>/etc/flatpak/preinstall.d/</filename> directory. Each .preinstall file defines one flatpak to install. The OS runs <command>flatpak preinstall -y</command> (or its GUI equivalent) on system startup, which then does the actual installation.
+        </para>
+
+        <para>
+          This system allows the OS vendor to define the list of flatpaks that are installed together with the OS, and also makes it possible for the OS vendor to make changes to the list in the future, which is then applied once <command>flatpak preinstall</command> is run next time.
+
+          Users can opt out of preinstalled flatpaks by simply removing them, at which point they won't get automatically reinstalled again.
+        </para>
+    </refsect1>
+
+    <refsect1>
+        <title>File format</title>
+
+        <para>
+            The .preinstall file is using the same .ini file format that is used for
+            systemd unit files or application .desktop files.
+        </para>
+
+        <refsect2>
+            <title>[Flatpak Preinstall]</title>
+
+            <para>
+                All the information is contained in the [Flatpak Preinstall] group.
+            </para>
+            <para>
+                The following keys can be present in this group:
+            </para>
+            <variablelist>
+                <varlistentry>
+                    <term><option>Name</option> (string)</term>
+                    <listitem><para>The fully qualified name of the runtime or application. This key is mandatory.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>Branch</option> (string)</term>
+                    <listitem><para>The name of the branch from which to install the application or runtime. If this key is not specified, the "master" branch is used.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>IsRuntime</option> (boolean)</term>
+                    <listitem><para>Whether this file refers to a runtime. If this key is not specified, the file is assumed to refer to an application.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>CollectionID</option> (string)</term>
+                    <listitem><para>
+                        The collection ID of the remote to use, if it has one.
+                    </para></listitem>
+                </varlistentry>
+            </variablelist>
+        </refsect2>
+    </refsect1>
+
+    <refsect1>
+        <title>Example</title>
+<programlisting>
+[Flatpak Preinstall]
+Name=org.gnome.Loupe
+Branch=stable
+IsRuntime=false
+</programlisting>
+    </refsect1>
+
+    <refsect1>
+        <title>Options</title>
+
+        <para>The following options are understood:</para>
+
+        <variablelist>
+            <varlistentry>
+                <term><option>-h</option></term>
+                <term><option>--help</option></term>
+
+                <listitem><para>
+                    Show help options and exit.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--reinstall</option></term>
+
+                <listitem><para>
+                  Uninstall first if already installed.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-u</option></term>
+                <term><option>--user</option></term>
+
+                <listitem><para>
+                    Install the application or runtime in a per-user installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--system</option></term>
+
+                <listitem><para>
+                    Install the application or runtime in the default system-wide installation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--installation=NAME</option></term>
+
+                <listitem><para>
+                    Install the application or runtime in a system-wide installation
+                    specified by <arg choice="plain">NAME</arg> among those defined in
+                    <filename>/etc/flatpak/installations.d/</filename>. Using
+                    <option>--installation=default</option> is equivalent to using
+                    <option>--system</option>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--no-deploy</option></term>
+
+                <listitem><para>
+                    Download the latest version, but don't deploy it.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--no-pull</option></term>
+
+                <listitem><para>
+                    Don't download the latest version, deploy whatever is locally available.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--no-related</option></term>
+
+                <listitem><para>
+                    Don't download related extensions, such as the locale data.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--no-deps</option></term>
+
+                <listitem><para>
+                    Don't verify runtime dependencies when installing.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--sideload-repo=PATH</option></term>
+
+                <listitem><para>
+                    Adds an extra local ostree repo as a source for installation. This is equivalent
+                    to using the <filename>sideload-repos</filename> directories (see
+                    <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>),
+                    but can be done on a per-command basis. Any path added here is used in addition
+                    to ones in those directories.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--include-sdk</option></term>
+
+                <listitem><para>
+                  For each app being installed, also installs the SDK that was used to build it.
+                  Implies <option>--or-update</option>; incompatible with <option>--no-deps</option>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--include-debug</option></term>
+
+                <listitem><para>
+                  For each ref being installed, as well as all dependencies, also installs its
+                  debug info. Implies <option>--or-update</option>; incompatible with
+                  <option>--no-deps</option>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-y</option></term>
+                <term><option>--assumeyes</option></term>
+                <listitem><para>
+                    Automatically answer yes to all questions (or pick the most prioritized answer). This is useful for automation.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--noninteractive</option></term>
+                <listitem><para>
+                    Produce minimal output and avoid most questions. This is suitable for use in
+                    non-interactive situations, e.g. in a build script.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-v</option></term>
+                <term><option>--verbose</option></term>
+
+                <listitem><para>
+                    Print debug information during command processing.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--ostree-verbose</option></term>
+
+                <listitem><para>
+                    Print OSTree debug information during command processing.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+
+    <refsect1>
+        <title>Examples</title>
+
+        <para>
+            <command>$ flatpak preinstall</command>
+        </para>
+    </refsect1>
+
+    <refsect1>
+        <title>See also</title>
+
+        <para>
+            <citerefentry><refentrytitle>flatpak</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+        </para>
+
+    </refsect1>
+
+</refentry>

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -26,6 +26,7 @@ man1 = [
   'flatpak-config',
   'flatpak-update',
   'flatpak-uninstall',
+  'flatpak-preinstall',
   'flatpak-mask',
   'flatpak-pin',
   'flatpak-list',

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -30,6 +30,7 @@ app/flatpak-builtins-permission-reset.c
 app/flatpak-builtins-permission-set.c
 app/flatpak-builtins-permission-show.c
 app/flatpak-builtins-pin.c
+app/flatpak-builtins-preinstall.c
 app/flatpak-builtins-ps.c
 app/flatpak-builtins-remote-add.c
 app/flatpak-builtins-remote-delete.c

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -403,6 +403,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   gboolean local_pull;
   gboolean reinstall;
   gboolean update_pinned;
+  gboolean update_preinstalled;
   g_autofree char *url = NULL;
   g_autoptr(OngoingPull) ongoing_pull = NULL;
   g_autofree gchar *src_dir = NULL;
@@ -488,6 +489,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   local_pull = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_LOCAL_PULL) != 0;
   reinstall = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL) != 0;
   update_pinned = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED) != 0;
+  update_preinstalled = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PREINSTALLED) != 0;
 
   deploy_dir = flatpak_dir_get_if_deployed (system, ref, NULL, NULL);
 
@@ -704,7 +706,8 @@ handle_deploy (FlatpakSystemHelper   *object,
           if (!flatpak_dir_deploy_install (system, ref, arg_origin,
                                            (const char **) arg_subpaths,
                                            (const char **) arg_previous_ids,
-                                           reinstall, update_pinned, NULL, &error))
+                                           reinstall, update_pinned, update_preinstalled,
+                                           NULL, &error))
             {
               flatpak_invocation_return_error (invocation, error, "Error deploying");
               return G_DBUS_METHOD_INVOCATION_HANDLED;


### PR DESCRIPTION
This adds new FlatpakTransaction API, and a new top level CLI command to preinstall flatpaks, that is to install flatpaks that are considered part of the operating system.

A new drop-in directory /etc/flatpak/preinstall.d/ allows configuring what apps should be preinstalled, and a new flatpak preinstall command installs and removes apps based on the current configuration.

A drop-in loupe.preinstall file can look something like this:

[Flatpak Preinstall]
Name=org.gnome.Loupe
Branch=stable
IsRuntime=false

The corresponding API is flatpak_transaction_add_sync_preinstalled() which can be implemented by GUI clients to drive the actual installs on system startup.

Resolves: https://github.com/flatpak/flatpak/issues/5579