### PR TITLE
dir: Make sure all parse_ref_file out params are consistently cleared

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14462,6 +14462,7 @@ parse_ref_file (GKeyFile *keyfile,
   *url_out = NULL;
   *gpg_data_out = NULL;
   *is_runtime_out = FALSE;
+  *collection_id_out = NULL;
 
   if (!g_key_file_has_group (keyfile, FLATPAK_REF_GROUP))
     return flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Invalid file format, no %s group"), FLATPAK_REF_GROUP);


### PR DESCRIPTION
parse_ref_file() cleared all its out params to NULL, with the exception of collection_id_out. Make sure to clear this one as well to avoid surprises in the future.

Fixes commit ae7d96037 that added collection ID support to flatpakref.