### PR TITLE
doc: Correct special value for flatpak config

### DIFF
--- a/doc/flatpak-config.xml
+++ b/doc/flatpak-config.xml
@@ -61,7 +61,7 @@
                 <listitem><para>
                    The languages that are included when installing Locale extensions.
                    The value is a semicolon-separated list of two-letter language codes,
-                   or one of the special values <literal>*</literal> or <literal>all</literal>. If this key is unset, flatpak
+                   or one of the special values <literal>*</literal> or <literal>*all*</literal>. If this key is unset, flatpak
                    defaults to including the <varname>extra-languages</varname> key and the current locale.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
To include all languages, the languages key must be set to `*all*`, not `all`. That was apparently intended to provide symmetry with how the value is represented in the output of `flatpak config`.

Alternatively, it might be better to only mention `*`. I don't really see the point of including two equivalent values (that are both stored as `xa.languages=''`), especially when `*all*` is so awkward. I'm happy to do that instead if you'd like.