### PR TITLE
flatpak-run: Mount /dev/bus/usb with --device=usb

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -1,5 +1,6 @@
 /*
  * Copyright © 2014-2018 Red Hat, Inc
+ * Copyright © 2024 GNOME Foundation, Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,6 +17,7 @@
  *
  * Authors:
  *       Alexander Larsson <alexl@redhat.com>
+ *       Hubert Figuière <hub@figuiere.net>
  */
 
 #ifndef __FLATPAK_CONTEXT_H__
@@ -65,6 +67,7 @@ typedef enum {
   FLATPAK_CONTEXT_DEVICE_KVM         = 1 << 2,
   FLATPAK_CONTEXT_DEVICE_SHM         = 1 << 3,
   FLATPAK_CONTEXT_DEVICE_INPUT       = 1 << 4,
+  FLATPAK_CONTEXT_DEVICE_USB         = 1 << 5,
 } FlatpakContextDevices;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1,5 +1,6 @@
 /* vi:set et sw=2 sts=2 cin cino=t0,f0,(0,{s,>2s,n-s,^-s,e-s:
  * Copyright © 2014-2018 Red Hat, Inc
+ * Copyright © 2024 GNOME Foundation, Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,6 +17,7 @@
  *
  * Authors:
  *       Alexander Larsson <alexl@redhat.com>
+ *       Hubert Figuière <hub@figuiere.net>
  */
 
 #include "config.h"
@@ -71,6 +73,7 @@ const char *flatpak_context_devices[] = {
   "kvm",
   "shm",
   "input",
+  "usb",
   NULL
 };
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1,5 +1,6 @@
 /* vi:set et sw=2 sts=2 cin cino=t0,f0,(0,{s,>2s,n-s,^-s,e-s:
  * Copyright © 2014-2019 Red Hat, Inc
+ * Copyright © 2024 GNOME Foundation, Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,6 +17,7 @@
  *
  * Authors:
  *       Alexander Larsson <alexl@redhat.com>
+ *       Hubert Figuière <hub@figuiere.net>
  */
 
 #include "config.h"
@@ -381,6 +383,15 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
       flatpak_bwrap_add_args (bwrap,
                               "--dev", "/dev",
                               NULL);
+
+      if (context->devices & FLATPAK_CONTEXT_DEVICE_USB)
+        {
+          g_info ("Allowing USB device access.");
+
+          if (g_file_test ("/dev/bus/usb", G_FILE_TEST_IS_DIR))
+              flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/bus/usb", "/dev/bus/usb", NULL);
+        }
+
       if (context->devices & FLATPAK_CONTEXT_DEVICE_DRI)
         {
           g_info ("Allowing dri access");

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -162,7 +162,7 @@
                 <listitem><para>
                     Expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, input, kvm, shm, all.
+                    DEVICE must be one of: dri, input, usb, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -173,7 +173,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, input, kvm, shm, all.
+                    DEVICE must be one of: dri, input, usb, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -172,7 +172,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -183,7 +183,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -164,7 +164,9 @@
                 <varlistentry>
                     <term><option>devices</option> (list)</term>
                     <listitem><para>
-                        List of devices to make available in the sandbox.
+                        List of devices to make available in the sandbox. This
+                        just expose the devices nodes, it doesn't grant any
+                        permission that the user doesn't already have.
                         Possible values:
                         <variablelist>
 
@@ -180,6 +182,14 @@
                                 Input devices
                                 (<filename>/dev/input</filename>).
                                 Available since 1.15.6.
+                            </para></listitem></varlistentry>
+
+                            <varlistentry><term><option>usb</option></term>
+                            <listitem><para>
+                                USB device bus
+                                (all device nodes below
+                                <filename>/dev/bus/usb</filename>).
+                                Available since 1.15.11.
                             </para></listitem></varlistentry>
 
                             <varlistentry><term><option>kvm</option></term>

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -160,7 +160,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -171,7 +171,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -340,7 +340,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, usb, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -351,7 +351,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, usb, input, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
This adds a new `usb` device in the list to grant access to the whole
USB bus. This is narrower than `all` and should be enough for
anything accessing the USB directly (i.e. using libusb or equivalent).

This doesn't grant access to synthesized devices, i.e those exposed
in /dev but using USB, including but not limited to USBserial, webcams,
hidraw, hid, sound.

Close #4405 

-- END COMMIT MESSAGE
This is part of the ongoing work in #5620.

With `--device=usb` the whole USB bus is exposed without having to use `--device=all`.

This has the same problem from #5681 with PR #5708 as a proposal.

With the USB device portal from #5620, the plan is to have the disable if the use of the portal is requested. The idea is to compromise between the work required to use the USB portal (it's not zero cost) and the use of `--device=all`..