### PR TITLE
Add support for address sanitizer and fix a bunch of memory leaks

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1538,20 +1538,24 @@ flatpak_deploy_new (GFile             *dir,
 GFile *
 flatpak_get_system_default_base_dir_location (void)
 {
-  static gsize path = 0;
+  static gsize file = 0;
 
-  if (g_once_init_enter (&path))
+  if (g_once_init_enter (&file))
     {
       gsize setup_value = 0;
+      const char *path;
       const char *system_dir = g_getenv ("FLATPAK_SYSTEM_DIR");
-      if (system_dir != NULL)
-        setup_value = (gsize) system_dir;
+      if (system_dir != NULL && *system_dir != 0)
+        path = system_dir;
       else
-        setup_value = (gsize) FLATPAK_SYSTEMDIR;
-      g_once_init_leave (&path, setup_value);
+        path = FLATPAK_SYSTEMDIR;
+
+      setup_value = (gsize) g_file_new_for_path (path);
+
+      g_once_init_leave (&file, setup_value);
     }
 
-  return g_file_new_for_path ((char *) path);
+  return g_object_ref ((GFile *) file);
 }
 
 static FlatpakDirStorageType

--- a/common/flatpak-repo-utils.c
+++ b/common/flatpak-repo-utils.c
@@ -374,7 +374,7 @@ flatpak_repo_parse_extra_data_sources (GVariant      *extra_data_sources,
                                        const char   **uri)
 {
   g_autoptr(GVariant) sha256_v = NULL;
-  g_variant_get_child (extra_data_sources, index, "(^aytt@ay&s)",
+  g_variant_get_child (extra_data_sources, index, "(^&aytt@ay&s)",
                        name,
                        download_size,
                        installed_size,

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -726,7 +726,7 @@ main (int    argc,
 {
   gboolean replace;
   gboolean opt_verbose;
-  GOptionContext *context;
+  g_autoptr(GOptionContext) context = NULL;
   GDBusConnection *session_bus;
   GBusNameOwnerFlags flags;
   g_autoptr(GError) error = NULL;

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -2485,7 +2485,8 @@ static gboolean
 transaction_ready (FlatpakTransaction *transaction,
                    TransactionData *d)
 {
-  GList *ops = flatpak_transaction_get_operations (transaction);
+  g_autolist(FlatpakTransactionOperation) ops =
+    flatpak_transaction_get_operations (transaction);
   int status;
   GList *l;
 

--- a/tests/flatpak-asan.supp
+++ b/tests/flatpak-asan.supp
@@ -1,0 +1,10 @@
+# GOnce, deliberately leaking once per process
+leak:flatpak_get_user_base_dir_location
+leak:flatpak_get_system_default_base_dir_location
+# external (libostree)
+leak:static_delta_part_execute_thread
+leak:_ostree_static_delta_part_open
+# Bugs in our code
+# Take a look at them and try to figure out  what's going on!
+leak:flatpak_authenticator_request_proxy_new_for_bus_sync
+leak:flatpak_authenticator_proxy_new_for_bus_sync

--- a/tests/flatpak.supp
+++ b/tests/flatpak.supp
@@ -254,6 +254,14 @@
    fun:g_file_new_for_path
    fun:flatpak_get_user_base_dir_location
 }
+# Deliberately leaking once per process
+{
+   flatpak_get_system_default_base_dir_location
+   Memcheck:Leak
+   ...
+   fun:g_file_new_for_path
+   fun:flatpak_get_system_default_base_dir_location
+}
 
 # https://github.com/ostreedev/ostree/issues/2592
 {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -37,7 +37,7 @@ tests_environment_prepend = {
   'PATH' : project_build_root / 'app',
 }
 
-lsan_options = 'log_threads=1'
+lsan_options = 'log_threads=1:suppressions=' + meson.current_source_dir() / 'flatpak-asan.supp'
 
 if get_option('installed_tests')
   configure_file(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -37,6 +37,8 @@ tests_environment_prepend = {
   'PATH' : project_build_root / 'app',
 }
 
+lsan_options = 'log_threads=1'
+
 if get_option('installed_tests')
   configure_file(
     input : 'installed-tests.sh.in',
@@ -165,6 +167,10 @@ foreach testcase : c_tests
   foreach k, v: tests_environment_prepend
     test_env.prepend(k, v)
   endforeach
+
+  lsan_log_path = ':log_path=' + meson.current_build_dir() / \
+                  'asan_' + name.underscorify() + '.log'
+  test_env.set('LSAN_OPTIONS', lsan_options + lsan_log_path)
 
   if can_run_host_binaries
     test(
@@ -388,6 +394,10 @@ foreach testcase : wrapped_tests
   foreach k, v: tests_environment_prepend
     test_env.prepend(k, v)
   endforeach
+
+  lsan_log_path = ':log_path=' + meson.current_build_dir() / \
+                  'asan_' + name.underscorify() + '.log'
+  test_env.set('LSAN_OPTIONS', lsan_options + lsan_log_path)
 
   if can_run_host_binaries
     test(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,41 +4,38 @@
 installed_testdir = get_option('prefix') / get_option('libexecdir') / 'installed-tests' / 'Flatpak'
 installed_tests_metadir = get_option('prefix') / get_option('datadir') / 'installed-tests' / 'Flatpak'
 
-tests_environment = environment()
-tests_environment.set('FLATPAK_CONFIG_DIR', '/dev/null')
-tests_environment.set(
-  'FLATPAK_PORTAL',
-  project_build_root / 'portal' / 'flatpak-portal',
-)
-tests_environment.set(
-  'FLATPAK_REVOKEFS_FUSE',
-  project_build_root / 'revokefs' / 'revokefs-fuse',
-)
-tests_environment.set('FLATPAK_TESTS_DEBUG', '1')
-tests_environment.set('FLATPAK_TESTS_STRICT_TAP', '1')
-tests_environment.set('FLATPAK_TRIGGERSDIR', project_source_root / 'triggers')
-tests_environment.set(
-  'FLATPAK_VALIDATE_ICON',
-  project_build_root / 'icon-validator' / 'flatpak-validate-icon',
-)
-tests_environment.set('FUSERMOUNT', fusermount)
-tests_environment.set('G_TEST_BUILDDIR', meson.current_build_dir())
-tests_environment.set('G_TEST_SRCDIR', meson.current_source_dir())
-tests_environment.prepend('GI_TYPELIB_PATH', project_build_root / 'common')
-tests_environment.prepend('LD_LIBRARY_PATH', project_build_root / 'common')
-tests_environment.prepend('PATH', project_build_root / 'app')
-
 if get_option('system_bubblewrap') == ''
-  tests_environment.set('FLATPAK_BWRAP', project_build_root / 'subprojects' / 'bubblewrap' / 'flatpak-bwrap')
+  env_flatpak_bwrap = project_build_root / 'subprojects' / 'bubblewrap' / 'flatpak-bwrap'
 else
-  tests_environment.set('FLATPAK_BWRAP', get_option('system_bubblewrap'))
+  env_flatpak_bwrap = get_option('system_bubblewrap')
 endif
 
 if get_option('system_dbus_proxy') == ''
-  tests_environment.set('FLATPAK_DBUSPROXY', project_build_root / 'subprojects' / 'dbus-proxy' / 'flatpak-dbus-proxy')
+  env_flatpak_dbusproxy = project_build_root / 'subprojects' / 'dbus-proxy' / 'flatpak-dbus-proxy'
 else
-  tests_environment.set('FLATPAK_DBUSPROXY', get_option('system_dbus_proxy'))
+  env_flatpak_dbusproxy = get_option('system_dbus_proxy')
 endif
+
+tests_environment = {
+  'FLATPAK_CONFIG_DIR' : '/dev/null',
+  'FLATPAK_PORTAL' : project_build_root / 'portal' / 'flatpak-portal',
+  'FLATPAK_REVOKEFS_FUSE' : project_build_root / 'revokefs' / 'revokefs-fuse',
+  'FLATPAK_TESTS_DEBUG' : '1',
+  'FLATPAK_TESTS_STRICT_TAP' : '1',
+  'FLATPAK_TRIGGERSDIR' : project_source_root / 'triggers',
+  'FLATPAK_VALIDATE_ICON' : project_build_root / 'icon-validator' / 'flatpak-validate-icon',
+  'FUSERMOUNT' : fusermount,
+  'G_TEST_BUILDDIR' : meson.current_build_dir(),
+  'G_TEST_SRCDIR' : meson.current_source_dir(),
+  'FLATPAK_BWRAP' : env_flatpak_bwrap,
+  'FLATPAK_DBUSPROXY' : env_flatpak_dbusproxy,
+}
+
+tests_environment_prepend = {
+  'GI_TYPELIB_PATH' : project_build_root / 'common',
+  'LD_LIBRARY_PATH' : project_build_root / 'common',
+  'PATH' : project_build_root / 'app',
+}
 
 if get_option('installed_tests')
   configure_file(
@@ -164,13 +161,18 @@ foreach testcase : c_tests
     )
   endif
 
+  test_env = environment(tests_environment)
+  foreach k, v: tests_environment_prepend
+    test_env.prepend(k, v)
+  endforeach
+
   if can_run_host_binaries
     test(
       name,
       tap_test,
       args : [exe],
       depends : runtime_repo,
-      env : tests_environment,
+      env : test_env,
       protocol : 'tap',
       timeout : options.get('timeout', 30),
     )
@@ -382,13 +384,18 @@ foreach testcase : wrapped_tests
     )
   endif
 
+  test_env = environment(tests_environment)
+  foreach k, v: tests_environment_prepend
+    test_env.prepend(k, v)
+  endforeach
+
   if can_run_host_binaries
     test(
       name,
       tap_test,
       args : [meson.current_source_dir() / name],
       depends : runtime_repo,
-      env : tests_environment,
+      env : test_env,
       is_parallel : is_parallel,
       protocol : 'tap',
       timeout : timeout,


### PR DESCRIPTION
Tried to reproduce an issue with address sanitizer but couldn't. Then tried to see if the tests would reproduce the issue but they would fail rather randomly. Figured out that we rely on structured output in a bunch of places so redirecting all the asan output works.

Fixed most of the issues that asan then found but couldn't figure out the ones coming from:
```
leak:flatpak_authenticator_request_proxy_new_for_bus_sync
leak:flatpak_authenticator_proxy_new_for_bus_sync
```