### PR TITLE
Log overrides and context when running an app

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -367,6 +367,8 @@ flatpak_option_context_parse (GOptionContext     *context,
 
       if (opt_verbose > 0 || opt_ostree_verbose)
         flatpak_disable_fancy_output ();
+
+      flatpak_set_debugging (opt_verbose > 1);
     }
 
   /* sudo flatpak --user ... would operate on the root user's installation,

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -100,6 +100,8 @@ gboolean       flatpak_context_parse_filesystem (const char             *filesys
 
 FlatpakContext *flatpak_context_new (void);
 void           flatpak_context_free (FlatpakContext *context);
+void           flatpak_context_dump (FlatpakContext *context,
+                                     const char     *title);
 void           flatpak_context_merge (FlatpakContext *context,
                                       FlatpakContext *other);
 GOptionEntry  *flatpak_context_get_option_entries (void);

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -3142,3 +3142,38 @@ flatpak_context_get_allowed_exports (FlatpakContext *context,
 
   return TRUE;
 }
+
+void
+flatpak_context_dump (FlatpakContext *context,
+                      const char     *title)
+{
+  if (flatpak_is_debugging ())
+    {
+      g_autoptr(GError) local_error = NULL;
+      g_autoptr(GKeyFile) metakey = NULL;
+      g_autofree char *data = NULL;
+      char *saveptr = NULL;
+      const char *line;
+
+      metakey = g_key_file_new ();
+      flatpak_context_save_metadata (context, FALSE, metakey);
+
+      data = g_key_file_to_data (metakey, NULL, &local_error);
+
+      if (data == NULL)
+        {
+          g_debug ("%s: (unable to serialize: %s)",
+                   title, local_error->message);
+          return;
+        }
+
+      g_debug ("%s:", title);
+
+      for (line = strtok_r (data, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_debug ("\t%s", line);
+
+      g_debug ("\t#");
+    }
+}

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1498,16 +1498,48 @@ flatpak_deploy_get_overrides (FlatpakDeploy *deploy)
   FlatpakContext *overrides = flatpak_context_new ();
 
   if (deploy->system_overrides)
-    flatpak_context_merge (overrides, deploy->system_overrides);
+    {
+      flatpak_context_dump (deploy->system_overrides,
+                            "System-wide overrides for all apps");
+      flatpak_context_merge (overrides, deploy->system_overrides);
+    }
+  else
+    {
+      g_debug ("No system-wide overrides for all apps");
+    }
 
   if (deploy->system_app_overrides)
-    flatpak_context_merge (overrides, deploy->system_app_overrides);
+    {
+      flatpak_context_dump (deploy->system_app_overrides,
+                            "System-wide overrides for specified app");
+      flatpak_context_merge (overrides, deploy->system_app_overrides);
+    }
+  else
+    {
+      g_debug ("No system-wide per-app overrides for specified app");
+    }
 
   if (deploy->user_overrides)
-    flatpak_context_merge (overrides, deploy->user_overrides);
+    {
+      flatpak_context_dump (deploy->user_overrides,
+                            "Per-user overrides for all apps");
+      flatpak_context_merge (overrides, deploy->user_overrides);
+    }
+  else
+    {
+      g_debug ("No per-user overrides for all apps");
+    }
 
   if (deploy->user_app_overrides)
-    flatpak_context_merge (overrides, deploy->user_app_overrides);
+    {
+      flatpak_context_dump (deploy->user_app_overrides,
+                            "Per-user overrides for specified app");
+      flatpak_context_merge (overrides, deploy->user_app_overrides);
+    }
+  else
+    {
+      g_debug ("No per-user overrides for specified app");
+    }
 
   return overrides;
 }

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1046,12 +1046,15 @@ flatpak_app_compute_permissions (GKeyFile *app_metadata,
 
       /* Don't inherit any permissions from the runtime, only things like env vars. */
       flatpak_context_reset_permissions (app_context);
+
+      flatpak_context_dump (app_context, "Metadata from runtime");
     }
 
   if (app_metadata != NULL &&
       !flatpak_context_load_metadata (app_context, app_metadata, error))
     return NULL;
 
+  flatpak_context_dump (app_context, "Metadata from app manifest");
   return g_steal_pointer (&app_context);
 }
 
@@ -3038,10 +3041,16 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
     }
 
   if (sandboxed)
-    flatpak_context_make_sandboxed (app_context);
+    {
+      flatpak_context_make_sandboxed (app_context);
+      flatpak_context_dump (app_context, "After making sandboxed");
+    }
 
   if (extra_context)
-    flatpak_context_merge (app_context, extra_context);
+    {
+      flatpak_context_dump (extra_context, "Command-line overrides");
+      flatpak_context_merge (app_context, extra_context);
+    }
 
   original_runtime_files = flatpak_deploy_get_files (runtime_deploy);
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3052,6 +3052,7 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
       flatpak_context_merge (app_context, extra_context);
     }
 
+  flatpak_context_dump (app_context, "Final context");
   original_runtime_files = flatpak_deploy_get_files (runtime_deploy);
 
   if (custom_usr_path != NULL)

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -345,6 +345,9 @@ gboolean flatpak_validate_path_characters (const char *path,
 
 gboolean running_under_sudo (void);
 
+void flatpak_set_debugging (gboolean debugging);
+gboolean flatpak_is_debugging (void);
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 #endif /* __FLATPAK_UTILS_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2452,3 +2452,22 @@ running_under_sudo (void)
 
   return FALSE;
 }
+
+static gboolean is_debugging = FALSE;
+
+void
+flatpak_set_debugging (gboolean debugging)
+{
+  is_debugging = debugging;
+}
+
+gboolean
+flatpak_is_debugging (void)
+{
+#if GLIB_CHECK_VERSION (2, 68, 0)
+  if (!g_log_writer_default_would_drop (G_LOG_LEVEL_DEBUG, G_LOG_DOMAIN))
+    return TRUE;
+#endif
+
+  return is_debugging;
+}


### PR DESCRIPTION
* utils: Add flatpak_is_debugging()
    
    This can be used to disable code paths that assemble relatively
    "expensive" debug information when debugging is not enabled.
    It's activated by `flatpak -v -v`.
    
    With a sufficiently modern GLib version, it also activates for
    `G_MESSAGES_DEBUG=all` or `G_MESSAGES_DEBUG=flatpak`.

* context: Add a function to log a FlatpakContext
    
    This writes out the context as a series of debug messages.

* dir: When we load overrides, log them as debug messages
    
    The more involved parts of this are skipped if debug logging is disabled.
    This will help to diagnose what is going on when users have added
    overrides that make their app not work as intended.

* run: Debug-log sources of parameters other than overrides
    
    Every time we load something into the context, debug-log what it was.
    Again, the more involved parts of this are skipped if debug logging is
    disabled.
    
    This will help to diagnose what is going on if the app metadata or the
    command-line options are setting sandboxing parameters that break an app.

* run: Debug-log the final context for an app
    
    This indicates what sandboxing parameters we are going to be using
    in the end.

---

Inspired by having to ask issue reporters "what overrides have you added?" on a lot of bug reports. With this, it will be enough to run `flatpak -vv run $the_app_id` and all the information will be there.