### PR TITLE
app, common, tests: Avoid deprecated g_qsort_with_data()

### DIFF
--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -235,7 +235,7 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
         }
 
       keys = (FlatpakDecomposed **) g_hash_table_get_keys_as_array (names, &n_keys);
-      g_qsort_with_data (keys, n_keys, sizeof (char *), (GCompareDataFunc) flatpak_decomposed_strcmp_p, NULL);
+      qsort (keys, n_keys, sizeof (char *), (GCompareFunc) flatpak_decomposed_strcmp_p);
 
       for (i = 0; i < n_keys; i++)
         {

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14746,8 +14746,7 @@ flatpak_dir_list_remotes (FlatpakDir   *self,
   if (res == NULL)
     res = g_new0 (char *, 1); /* Return empty array, not error */
 
-  g_qsort_with_data (res, g_strv_length (res), sizeof (char *),
-                     cmp_remote, self);
+  qsort_r (res, g_strv_length (res), sizeof (char *), cmp_remote, self);
 
   return res;
 }

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -444,7 +444,7 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
   eps = g_hash_table_get_values (exports->hash);
   eps = g_list_sort (eps, (GCompareFunc) compare_eps);
 
-  g_qsort_with_data (keys, n_keys, sizeof (char *), (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (keys, n_keys, sizeof (char *), flatpak_strcmp0_ptr);
 
   g_debug ("Converting FlatpakExports to bwrap arguments...");
 
@@ -666,7 +666,7 @@ flatpak_exports_path_get_mode (FlatpakExports *exports,
   g_autoptr(GString) path_builder = g_string_new ("");
   struct stat st;
 
-  g_qsort_with_data (keys, n_keys, sizeof (char *), (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (keys, n_keys, sizeof (char *), flatpak_strcmp0_ptr);
 
   /* Syntactic canonicalization only, no need to use host_fd */
   path = canonical = flatpak_canonicalize_filename (path);

--- a/common/flatpak-repo-utils.c
+++ b/common/flatpak-repo-utils.c
@@ -3617,7 +3617,8 @@ flatpak_repo_generate_appstream (OstreeRepo   *repo,
   all_refs_keys = (FlatpakDecomposed **) g_hash_table_get_keys_as_array (all_refs, &n_keys);
 
   /* Sort refs so that appdata order is stable for e.g. deltas */
-  g_qsort_with_data (all_refs_keys, n_keys, sizeof (FlatpakDecomposed *), (GCompareDataFunc) flatpak_decomposed_strcmp_p, NULL);
+  qsort (all_refs_keys, n_keys, sizeof (FlatpakDecomposed *),
+         (GCompareFunc) flatpak_decomposed_strcmp_p);
 
   transaction = flatpak_repo_transaction_start (repo, cancellable, error);
   if (transaction == NULL)

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2410,9 +2410,8 @@ find_runtime_remote (FlatpakTransaction             *self,
   /* Put @app_remote before the others at its priority level */
   rsd.dir = priv->dir;
   rsd.prioritized_remote = app_remote;
-  g_qsort_with_data (all_remotes, g_strv_length (all_remotes), sizeof (char *),
-                     cmp_remote_with_prioritized, &rsd);
-
+  qsort_r (all_remotes, g_strv_length (all_remotes), sizeof (char *),
+           cmp_remote_with_prioritized, &rsd);
 
   app_pref = flatpak_decomposed_get_pref (app_ref);
   runtime_pref = flatpak_decomposed_get_pref (runtime_ref);

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -342,8 +342,7 @@ test_full_context (void)
                                      &n, &error);
   g_assert_nonnull (strv);
   /* The order is undefined, so sort them first */
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "!/opt");
   g_assert_cmpstr (strv[i++], ==, "/home");
@@ -357,8 +356,7 @@ test_full_context (void)
                                      &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "ipc");
   g_assert_cmpstr (strv[i++], ==, "network");
@@ -371,8 +369,7 @@ test_full_context (void)
                                      &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "cups");
   g_assert_cmpstr (strv[i++], ==, "fallback-x11");
@@ -393,8 +390,7 @@ test_full_context (void)
                                      &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "all");
   g_assert_cmpstr (strv[i++], ==, "dri");
@@ -409,8 +405,7 @@ test_full_context (void)
                                      &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, ".openarena");
   g_assert_cmpstr (strv[i], ==, NULL);
@@ -422,8 +417,7 @@ test_full_context (void)
                                      &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "LD_AUDIT");
   g_assert_cmpstr (strv[i++], ==, "LD_PRELOAD");
@@ -435,8 +429,7 @@ test_full_context (void)
                               &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "org.example.SessionService");
   g_assert_cmpstr (strv[i], ==, NULL);
@@ -453,8 +446,7 @@ test_full_context (void)
                               &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "net.example.SystemService");
   g_assert_cmpstr (strv[i], ==, NULL);
@@ -471,8 +463,7 @@ test_full_context (void)
                               &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "HYPOTHETICAL_PATH");
   g_assert_cmpstr (strv[i++], ==, "LD_AUDIT");
@@ -501,8 +492,7 @@ test_full_context (void)
                               &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "Colours");
   g_assert_cmpstr (strv[i], ==, NULL);
@@ -513,8 +503,7 @@ test_full_context (void)
                                      "Colours", &n, &error);
   g_assert_no_error (error);
   g_assert_nonnull (strv);
-  g_qsort_with_data (strv, n, sizeof (char *),
-                     (GCompareDataFunc) flatpak_strcmp0_ptr, NULL);
+  qsort (strv, n, sizeof (char *), flatpak_strcmp0_ptr);
   i = 0;
   g_assert_cmpstr (strv[i++], ==, "blue");
   g_assert_cmpstr (strv[i++], ==, "green");


### PR DESCRIPTION
For historical reasons g_qsort_with_data() "only" works with up to 2**31 items, so it won't necessarily work for pathologically large arrays and therefore is deprecated.

One advantage of g_qsort_with_data() and its replacement g_sort_array() is that GLib guarantees that they are a stable sort (will not permute items that already compare equal), which is not a guarantee for glibc's qsort() and qsort_r(). However, I don't think it's actually relevant whether we are doing a stable sort in any of these places: most of the time we are sorting an array of unique items (often the keys of a hash table, which are necessarily unique), therefore the compare function will not compare equal in any case.

Another advantage of the GLib functions is that they are portable, unlike qsort_r(). However, Flatpak is Linux-only, so we can freely use useful functions like qsort_r().