### PR TITLE
Allow owning app id names on the a11y bus

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -26,6 +26,11 @@
 #include "flatpak-exports-private.h"
 
 typedef enum {
+  FLATPAK_SESSION_BUS,
+  FLATPAK_SYSTEM_BUS,
+} FlatpakBus;
+
+typedef enum {
   FLATPAK_POLICY_NONE,
   FLATPAK_POLICY_SEE,
   FLATPAK_POLICY_TALK,
@@ -125,7 +130,7 @@ void           flatpak_context_to_args (FlatpakContext *context,
 FlatpakRunFlags flatpak_context_get_run_flags (FlatpakContext *context);
 void           flatpak_context_add_bus_filters (FlatpakContext *context,
                                                 const char     *app_id,
-                                                gboolean        session_bus,
+                                                FlatpakBus      bus,
                                                 gboolean        sandboxed,
                                                 FlatpakBwrap   *bwrap);
 

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -28,6 +28,7 @@
 typedef enum {
   FLATPAK_SESSION_BUS,
   FLATPAK_SYSTEM_BUS,
+  FLATPAK_A11Y_BUS,
 } FlatpakBus;
 
 typedef enum {
@@ -89,6 +90,7 @@ struct FlatpakContext
   GHashTable            *filesystems;
   GHashTable            *session_bus_policy;
   GHashTable            *system_bus_policy;
+  GHashTable            *a11y_bus_policy;
   GHashTable            *generic_policy;
 };
 
@@ -125,6 +127,9 @@ GStrv          flatpak_context_get_session_bus_policy_allowed_own_names (Flatpak
 void           flatpak_context_set_system_bus_policy (FlatpakContext *context,
                                                       const char     *name,
                                                       FlatpakPolicy   policy);
+void           flatpak_context_set_a11y_bus_policy (FlatpakContext *context,
+                                                    const char     *name,
+                                                    FlatpakPolicy   policy);
 void           flatpak_context_to_args (FlatpakContext *context,
                                         GPtrArray      *args);
 FlatpakRunFlags flatpak_context_get_run_flags (FlatpakContext *context);

--- a/common/flatpak-run-dbus-private.h
+++ b/common/flatpak-run-dbus-private.h
@@ -39,10 +39,11 @@ gboolean flatpak_run_add_system_dbus_args (FlatpakBwrap   *app_bwrap,
                                            FlatpakContext *context,
                                            FlatpakRunFlags flags);
 
-gboolean flatpak_run_add_a11y_dbus_args (FlatpakBwrap   *app_bwrap,
-                                         FlatpakBwrap   *proxy_arg_bwrap,
-                                         FlatpakContext *context,
-                                         FlatpakRunFlags flags);
+gboolean flatpak_run_add_a11y_dbus_args (FlatpakBwrap    *app_bwrap,
+                                         FlatpakBwrap    *proxy_arg_bwrap,
+                                         FlatpakContext  *context,
+                                         FlatpakRunFlags  flags,
+                                         const char      *app_id);
 
 gboolean flatpak_run_maybe_start_dbus_proxy (FlatpakBwrap *app_bwrap,
                                              FlatpakBwrap *proxy_arg_bwrap,

--- a/common/flatpak-run-dbus.c
+++ b/common/flatpak-run-dbus.c
@@ -375,10 +375,11 @@ flatpak_run_add_system_dbus_args (FlatpakBwrap   *app_bwrap,
 }
 
 gboolean
-flatpak_run_add_a11y_dbus_args (FlatpakBwrap   *app_bwrap,
-                                FlatpakBwrap   *proxy_arg_bwrap,
-                                FlatpakContext *context,
-                                FlatpakRunFlags flags)
+flatpak_run_add_a11y_dbus_args (FlatpakBwrap    *app_bwrap,
+                                FlatpakBwrap    *proxy_arg_bwrap,
+                                FlatpakContext  *context,
+                                FlatpakRunFlags  flags,
+                                const char      *app_id)
 {
   static const char sandbox_socket_path[] = "/run/flatpak/at-spi-bus";
   static const char sandbox_dbus_address[] = "unix:path=/run/flatpak/at-spi-bus";
@@ -439,6 +440,8 @@ flatpak_run_add_a11y_dbus_args (FlatpakBwrap   *app_bwrap,
                           "--call=org.a11y.atspi.Registry=org.a11y.atspi.DeviceEventController.NotifyListenersSync@/org/a11y/atspi/registry/deviceeventcontroller",
                           "--call=org.a11y.atspi.Registry=org.a11y.atspi.DeviceEventController.NotifyListenersAsync@/org/a11y/atspi/registry/deviceeventcontroller",
                           NULL);
+
+  flatpak_context_add_bus_filters (context, app_id, FLATPAK_A11Y_BUS, flags & FLATPAK_RUN_FLAG_SANDBOX, proxy_arg_bwrap);
 
   if ((flags & FLATPAK_RUN_FLAG_LOG_A11Y_BUS) != 0)
     flatpak_bwrap_add_args (proxy_arg_bwrap, "--log", NULL);

--- a/common/flatpak-run-dbus.c
+++ b/common/flatpak-run-dbus.c
@@ -289,7 +289,7 @@ flatpak_run_add_session_dbus_args (FlatpakBwrap   *app_bwrap,
 
       if (!unrestricted)
         {
-          flatpak_context_add_bus_filters (context, app_id, TRUE, flags & FLATPAK_RUN_FLAG_SANDBOX, proxy_arg_bwrap);
+          flatpak_context_add_bus_filters (context, app_id, FLATPAK_SESSION_BUS, flags & FLATPAK_RUN_FLAG_SANDBOX, proxy_arg_bwrap);
 
           /* Allow calling any interface+method on all portals, but only receive broadcasts under /org/desktop/portal */
           flatpak_bwrap_add_arg (proxy_arg_bwrap,
@@ -359,7 +359,7 @@ flatpak_run_add_system_dbus_args (FlatpakBwrap   *app_bwrap,
       flatpak_bwrap_add_args (proxy_arg_bwrap, real_dbus_address, proxy_socket, NULL);
 
       if (!unrestricted)
-        flatpak_context_add_bus_filters (context, NULL, FALSE, flags & FLATPAK_RUN_FLAG_SANDBOX, proxy_arg_bwrap);
+        flatpak_context_add_bus_filters (context, NULL, FLATPAK_SYSTEM_BUS, flags & FLATPAK_RUN_FLAG_SANDBOX, proxy_arg_bwrap);
 
       if ((flags & FLATPAK_RUN_FLAG_LOG_SYSTEM_BUS) != 0)
         flatpak_bwrap_add_args (proxy_arg_bwrap, "--log", NULL);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -496,7 +496,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
   flatpak_run_add_socket_args_environment (bwrap, context->shares, context->sockets, app_id, instance_id);
   flatpak_run_add_session_dbus_args (bwrap, proxy_arg_bwrap, context, flags, app_id);
   flatpak_run_add_system_dbus_args (bwrap, proxy_arg_bwrap, context, flags);
-  flatpak_run_add_a11y_dbus_args (bwrap, proxy_arg_bwrap, context, flags);
+  flatpak_run_add_a11y_dbus_args (bwrap, proxy_arg_bwrap, context, flags, app_id);
 
   /* Must run this before spawning the dbus proxy, to ensure it
      ends up in the app cgroup */

--- a/data/org.freedesktop.portal.Flatpak.xml
+++ b/data/org.freedesktop.portal.Flatpak.xml
@@ -36,7 +36,7 @@
       bus name org.freedesktop.portal.Flatpak and the object path
       /org/freedesktop/portal/Flatpak.
 
-      This documentation describes version 6 of this interface.
+      This documentation describes version 7 of this interface.
   -->
   <interface name='org.freedesktop.portal.Flatpak'>
     <property name="version" type="u" access="read"/>
@@ -238,6 +238,19 @@
 
              </para><para>
              This was added in version 3 of this interface (available from flatpak 1.6.0 and later).
+             </para></listitem>
+           </varlistentry>
+           <varlistentry>
+             <term>sandbox-a11y-own-names as</term>
+             <listitem><para>
+               An array of D-Bus names to be owned on the accessibility bus. The
+               names must have the app id as prefix.
+             </para><para>
+               Only applies when `sandbox-flags` contains access to the accessibility
+               bus as well.
+             </para><para>
+               This was added in version 7 of this interface (available from
+               flatpak 1.16.0 and later).
              </para></listitem>
            </varlistentry>
            <varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -567,6 +567,17 @@ key=v1;v2;
             </varlistentry>
 
             <varlistentry>
+                <term><option>--a11y-own-name=NAME</option></term>
+
+                <listitem><para>
+                    Allow the application to own the well known name <arg choice="plain">NAME</arg> on the a11y bus.
+                    If <arg choice="plain">NAME</arg> ends with .*, it allows the application to own all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--persist=FILENAME</option></term>
 
                 <listitem><para>

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -783,6 +783,7 @@ handle_spawn (PortalFlatpak         *object,
   g_auto(GStrv) unset_env = NULL;
   g_auto(GStrv) sandbox_expose = NULL;
   g_auto(GStrv) sandbox_expose_ro = NULL;
+  g_auto(GStrv) sandboxed_a11y_own_names = NULL;
   g_autoptr(FlatpakInstance) instance = NULL;
   g_autoptr(GVariant) sandbox_expose_fd = NULL;
   g_autoptr(GVariant) sandbox_expose_fd_ro = NULL;
@@ -800,6 +801,7 @@ handle_spawn (PortalFlatpak         *object,
   glnx_autofd int env_fd = -1;
   const char *flatpak;
   gboolean testing = FALSE;
+  g_autofree char *app_id_prefix = NULL;
 
   child_setup_data.instance_id_fd = -1;
   child_setup_data.env_fd = -1;
@@ -899,6 +901,7 @@ handle_spawn (PortalFlatpak         *object,
   g_variant_lookup (arg_options, "sandbox-expose", "^as", &sandbox_expose);
   g_variant_lookup (arg_options, "sandbox-expose-ro", "^as", &sandbox_expose_ro);
   g_variant_lookup (arg_options, "sandbox-flags", "u", &sandbox_flags);
+  g_variant_lookup (arg_options, "sandboxed-a11y-own-names", "^as", &sandboxed_a11y_own_names);
   sandbox_expose_fd = g_variant_lookup_value (arg_options, "sandbox-expose-fd", G_VARIANT_TYPE ("ah"));
   sandbox_expose_fd_ro = g_variant_lookup_value (arg_options, "sandbox-expose-fd-ro", G_VARIANT_TYPE ("ah"));
   g_variant_lookup (arg_options, "unset-env", "^as", &unset_env);
@@ -941,6 +944,26 @@ handle_spawn (PortalFlatpak         *object,
       if (!is_valid_expose (expose, &error))
         {
           g_dbus_method_invocation_return_gerror (invocation, error);
+          return G_DBUS_METHOD_INVOCATION_HANDLED;
+        }
+    }
+
+  app_id_prefix = g_strdup_printf ("%s.", app_id);
+  for (i = 0; sandboxed_a11y_own_names != NULL && sandboxed_a11y_own_names[i] != NULL; i++)
+    {
+      if (!(sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y))
+        {
+          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+                                                 G_DBUS_ERROR_INVALID_ARGS,
+                                                 "Invalid sandbox a11y own name, accessibility disabled in the sandbox");
+          return G_DBUS_METHOD_INVOCATION_HANDLED;
+        }
+
+      if (!g_str_has_prefix (sandboxed_a11y_own_names[i], app_id_prefix))
+        {
+          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+                                                 G_DBUS_ERROR_INVALID_ARGS,
+                                                 "Invalid sandbox a11y own name, doesn't match app id");
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
     }
@@ -1099,8 +1122,14 @@ handle_spawn (PortalFlatpak         *object,
         }
       if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS)
         g_ptr_array_add (flatpak_argv, g_strdup ("--session-bus"));
+
       if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y)
-        g_ptr_array_add (flatpak_argv, g_strdup ("--a11y-bus"));
+        {
+          g_ptr_array_add (flatpak_argv, g_strdup ("--a11y-bus"));
+
+          for (i = 0; sandboxed_a11y_own_names != NULL && sandboxed_a11y_own_names[i] != NULL; i++)
+            g_ptr_array_add (flatpak_argv, g_strdup_printf ("--a11y-own-name=%s", sandboxed_a11y_own_names[i]));
+        }
     }
   else
     {
@@ -2940,7 +2969,7 @@ on_bus_acquired (GDBusConnection *connection,
   g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (portal),
                                        G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
 
-  portal_flatpak_set_version (PORTAL_FLATPAK (portal), 6);
+  portal_flatpak_set_version (PORTAL_FLATPAK (portal), 7);
   portal_flatpak_set_supports (PORTAL_FLATPAK (portal), supports);
 
   g_signal_connect (portal, "handle-spawn", G_CALLBACK (handle_spawn), NULL);

--- a/tests/test-portal.c
+++ b/tests/test-portal.c
@@ -249,7 +249,7 @@ test_basic (Fixture *f,
   /* We can't easily tell whether EXPOSE_PIDS ought to be set or not */
   g_assert_cmpuint ((portal_flatpak_get_supports (f->proxy) &
                      (~FLATPAK_SPAWN_SUPPORT_FLAGS_EXPOSE_PIDS)), ==, 0);
-  g_assert_cmpuint (portal_flatpak_get_version (f->proxy), ==, 6);
+  g_assert_cmpuint (portal_flatpak_get_version (f->proxy), ==, 7);
 
   handler_id = g_signal_connect (f->proxy, "spawn-exited",
                                  G_CALLBACK (count_successful_exit_cb),


### PR DESCRIPTION
This is necessary for WebKit, and potentially LibreOffice, that may spawn a Flatpak subsandbox proceess with an a11y tree, and may need to connect both trees.

Add `--a11y-own-name` to flatpak-run, and a corresponding way to pass this value through the Flatpak portal.