### PR TITLE
backport the security patch of CVE-2024-32462

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -574,7 +574,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return FALSE;
 
-  flatpak_bwrap_add_args (bwrap, command, NULL);
+  flatpak_bwrap_add_args (bwrap, "--", command, NULL);
+  
   flatpak_bwrap_append_argsv (bwrap,
                               &argv[rest_argv_start + 2],
                               rest_argc - 2);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6230,6 +6230,7 @@ flatpak_dir_run_triggers (FlatpakDir   *self,
                                   "--proc", "/proc",
                                   "--dev", "/dev",
                                   "--bind", basedir, basedir,
+                                  "--",
                                   NULL);
 #endif
           flatpak_bwrap_add_args (bwrap,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -924,6 +924,9 @@ add_bwrap_wrapper (FlatpakBwrap *bwrap,
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return FALSE;
 
+  /* End of options: the next argument will be the executable name */
+  flatpak_bwrap_add_arg (bwrap, "--");
+
   return TRUE;
 }
 
@@ -3995,7 +3998,7 @@ flatpak_run_app (const char     *app_ref,
   if (!flatpak_bwrap_bundle_args (bwrap, 1, -1, FALSE, error))
     return FALSE;
 
-  flatpak_bwrap_add_arg (bwrap, command);
+  flatpak_bwrap_add_args (bwrap, "--", command, NULL);
 
   if (!add_rest_args (bwrap, app_ref_parts[1],
                       exports, (flags & FLATPAK_RUN_FLAG_FILE_FORWARDING) != 0,


### PR DESCRIPTION
Here is a vulnerability which is fixed in the main branch https://github.com/flatpak/flatpak/commit/72016e3fce8fcbeab707daf4f1a02b931fcc004d, but is not fixed in the branch of flatpak-1.8.x, maybe it should be backported?