### PR TITLE
Use const strings where it's straightforward to do so

### DIFF
--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -73,7 +73,8 @@ flatpak_complete_dir (FlatpakCompletion *completion)
 
 void
 flatpak_complete_word (FlatpakCompletion *completion,
-                       char *format, ...)
+                       const char *format,
+                       ...)
 {
   va_list args;
   const char *rest;

--- a/app/flatpak-complete.h
+++ b/app/flatpak-complete.h
@@ -47,7 +47,7 @@ FlatpakCompletion *flatpak_completion_new (const char *arg_line,
                                            const char *arg_point,
                                            const char *arg_cur);
 void               flatpak_complete_word (FlatpakCompletion *completion,
-                                          char              *format,
+                                          const char        *format,
                                           ...) G_GNUC_PRINTF (2, 3);
 void               flatpak_complete_ref (FlatpakCompletion *completion,
                                          OstreeRepo        *repo);

--- a/app/flatpak-table-printer.c
+++ b/app/flatpak-table-printer.c
@@ -614,7 +614,7 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
       for (i = 0; i < printer->columns->len && i < printer->n_columns; i++)
         {
           TableColumn *col = g_ptr_array_index (printer->columns, i);
-          char *title = col && col->title ? col->title : "";
+          const char *title = col && col->title ? col->title : "";
           gboolean expand = col ? col->expand : FALSE;
           gboolean ellipsize = col ? col->ellipsize : FALSE;
           int len = widths[i];
@@ -636,7 +636,7 @@ flatpak_table_printer_print_full (FlatpakTablePrinter *printer,
           if (shrinks[i] > 0 && ellipsize)
             {
               len -= shrinks[i];
-              freeme = title = ellipsize_string (title, len);
+              title = freeme = ellipsize_string (title, len);
             }
 
           if (i > 0)

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8925,7 +8925,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
       files_etc = g_file_resolve_relative_path (checkoutdir, "files/etc");
       if (g_file_query_exists (files_etc, cancellable))
         {
-          char *etcfiles[] = {"passwd", "group", "machine-id" };
+          static const char * const etcfiles[] = {"passwd", "group", "machine-id" };
           g_autoptr(GFile) etc_resolve_conf = g_file_get_child (files_etc, "resolv.conf");
           int i;
           for (i = 0; i < G_N_ELEMENTS (etcfiles); i++)

--- a/common/flatpak-run-dbus.c
+++ b/common/flatpak-run-dbus.c
@@ -212,7 +212,7 @@ extract_unix_path_from_dbus_address (const char *address)
 }
 
 static char *
-create_proxy_socket (char *template)
+create_proxy_socket (const char *template)
 {
   g_autofree char *user_runtime_dir = flatpak_get_real_xdg_runtime_dir ();
   g_autofree char *proxy_socket_dir = g_build_filename (user_runtime_dir, ".dbus-proxy", NULL);

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -385,7 +385,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
         {
           g_info ("Allowing dri access");
           int i;
-          char *dri_devices[] = {
+          static const char * const dri_devices[] = {
             "/dev/dri",
             /* mali */
             "/dev/mali",

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -153,12 +153,12 @@ flatpak_run_add_extension_args (FlatpakBwrap      *bwrap,
         {
           g_autofree char *parent = g_path_get_dirname (directory);
 
-          if (g_hash_table_lookup (mounted_tmpfs, parent) == NULL)
+          if (!g_hash_table_contains (mounted_tmpfs, parent))
             {
               flatpak_bwrap_add_args (bwrap,
                                       "--tmpfs", parent,
                                       NULL);
-              g_hash_table_insert (mounted_tmpfs, g_steal_pointer (&parent), "mounted");
+              g_hash_table_add (mounted_tmpfs, g_steal_pointer (&parent));
             }
         }
 
@@ -229,13 +229,13 @@ flatpak_run_add_extension_args (FlatpakBwrap      *bwrap,
                 {
                   g_autofree char *symlink_path = g_build_filename (merge_dir, dent->d_name, NULL);
                   /* Only create the first, because extensions are listed in prio order */
-                  if (g_hash_table_lookup (created_symlink, symlink_path) == NULL)
+                  if (!g_hash_table_contains (created_symlink, symlink_path))
                     {
                       g_autofree char *symlink = g_build_filename (directory, ext->merge_dirs[i], dent->d_name, NULL);
                       flatpak_bwrap_add_args (bwrap,
                                               "--symlink", symlink, symlink_path,
                                               NULL);
-                      g_hash_table_insert (created_symlink, g_steal_pointer (&symlink_path), "created");
+                      g_hash_table_add (created_symlink, g_steal_pointer (&symlink_path));
                     }
                 }
             }

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -304,7 +304,7 @@ static const char *
 flatpak_get_kernel_arch (void)
 {
   static struct utsname buf;
-  static char *arch = NULL;
+  static const char *arch = NULL;
   char *m;
 
   if (arch != NULL)

--- a/revokefs/demo.c
+++ b/revokefs/demo.c
@@ -30,7 +30,7 @@ main (int argc, char *argv[])
   socket_0 = g_strdup_printf ("--socket=%d", sockets[0]);
   socket_1 = g_strdup_printf ("--socket=%d", sockets[1]);
 
-  char *backend_argv[] =
+  const char * const backend_argv[] =
     {
      "./revokefs-fuse",
      "--backend",
@@ -42,7 +42,7 @@ main (int argc, char *argv[])
   /* Don't inherit fuse socket in backend */
   fcntl (sockets[1], F_SETFD, FD_CLOEXEC);
   if (!g_spawn_async (NULL,
-                      backend_argv,
+                      (char **) backend_argv,
                       NULL,
                       G_SPAWN_LEAVE_DESCRIPTORS_OPEN,
                       NULL, NULL,
@@ -53,7 +53,7 @@ main (int argc, char *argv[])
     }
   close (sockets[0]); /* Close backend side now so it doesn't get into the fuse child */
 
-  char *fuse_argv[] =
+  const char * const fuse_argv[] =
     {
      "./revokefs-fuse",
      socket_1,
@@ -63,7 +63,7 @@ main (int argc, char *argv[])
     };
 
   if (!g_spawn_async (NULL,
-                      fuse_argv,
+                      (char **) fuse_argv,
                       NULL,
                       G_SPAWN_LEAVE_DESCRIPTORS_OPEN,
                       NULL, NULL,

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -697,7 +697,7 @@ start_p11_kit_server (const char *flatpak_dir)
   g_autoptr(GError) local_error = NULL;
   g_auto(GStrv) stdout_lines = NULL;
   int i;
-  char *p11_argv[] = {
+  const char * const p11_argv[] = {
     "p11-kit", "server",
     /* We explicitly request --sh here, because we then fail on earlier versions that doesn't support
      * this flag. This is good, because those earlier versions did not properly daemonize and caused
@@ -713,7 +713,8 @@ start_p11_kit_server (const char *flatpak_dir)
   g_info ("starting p11-kit server");
 
   if (!g_spawn_sync (NULL,
-                     p11_argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_STDERR_TO_DEV_NULL,
+                     (char **) p11_argv, NULL,
+                     G_SPAWN_SEARCH_PATH | G_SPAWN_STDERR_TO_DEV_NULL,
                      NULL, NULL,
                      &p11_kit_stdout, NULL,
                      &exit_status, &local_error))

--- a/tests/can-use-fuse.c
+++ b/tests/can-use-fuse.c
@@ -33,8 +33,8 @@ check_fuse (void)
 {
   g_autofree gchar *fusermount = NULL;
   g_autofree gchar *path = NULL;
-  char *argv[] = { "flatpak-fuse-test", NULL };
-  struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (argv) - 1, argv);
+  static const char * const argv[] = { "flatpak-fuse-test", NULL };
+  struct fuse_args args = FUSE_ARGS_INIT (G_N_ELEMENTS (argv) - 1, (char **) argv);
   g_autoptr(GError) error = NULL;
 #if FUSE_USE_VERSION >= 31
   struct fuse *fuse = NULL;

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -805,7 +805,7 @@ static void
 test_filter_parser (void)
 {
   struct {
-    char *filter;
+    const char *filter;
     guint expected_error;
   } filters[] = {
     {
@@ -860,7 +860,7 @@ test_filter (void)
   g_autoptr(GRegex) deny_refs = NULL;
   gboolean ret;
   int i;
-  char *filter =
+  const char *filter =
     " # This is a comment\n"
     "\tallow\t org.foo.*#comment\n"
     "  deny   org.*   # Comment\n"
@@ -872,7 +872,7 @@ test_filter (void)
     "allow runtime/com.gazonk\n"
     "allow runtime/com.gazonk.*\t#comment*a*"; /* Note: lack of last newline to test */
   struct {
-    char *ref;
+    const char *ref;
     gboolean expected_result;
   } filter_refs[] = {
      /* General denies (org/com)*/


### PR DESCRIPTION
Prompted by updating the copy of some Flatpak-derived code in a project that compiles with `-Wwrite-strings` ([steam-runtime-tools](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools)).

This is not enough to get Flatpak fully const-correct for strings: there are still a lot of missing casts around `flatpak_strv_merge()` and `flatpak_subpaths_merge()` (which should ideally take `const char * const *` arguments, but that would be inconvenient for many callers).

* utils: Be more const-correct
    
    For historical reasons C string literals are officially of type `char *`,
    but if we build with -Wwrite-strings, they are `const char *` as they
    should be.
    
* complete: Slightly increase const-correctness

* table-printer: Slightly increase const-correctness

* Constify tables of immutable strings

* Constify arrays of program arguments
    
    These are passed to non-const-correct APIs which still need a cast, but
    at least we can declare the array in a way that reduces mistakes.

* run-dbus: Slightly increase const-correctness

* run: Use hash tables as sets in the conventional way
    
    GLib has optimizations for hash tables that are sets (conventionally
    represented as key == value), and the APIs to work with such hash tables
    are also slightly nicer, so use them instead of putting an arbitrary
    constant string in the value.

* tests: Constify test data where it's easy to do so