### PR TITLE
subprojects: Update dbus-proxy.wrap to v0.1.6

### DIFF
--- a/subprojects/dbus-proxy.wrap
+++ b/subprojects/dbus-proxy.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/flatpak/xdg-dbus-proxy
-# 0.1.5
-revision = 7466c8137fc06f863fde8486521984e43a26cd10
+# 0.1.6
+revision = 1c1989e56f94b9eb3b7567f8a6e8a0aa16cba496
 depth = 1


### PR DESCRIPTION
We still only require a system xdg-dbus-proxy to be v0.1.0 or later, although a newer release is recommended.