### PR TITLE
 Update subtree: libglnx 2024-08-23

### DIFF
--- a/subprojects/libglnx/glnx-backports.h
+++ b/subprojects/libglnx/glnx-backports.h
@@ -28,6 +28,7 @@
 
 #include <string.h>
 
+#include <glib-unix.h>
 #include <gio/gio.h>
 
 G_BEGIN_DECLS
@@ -80,6 +81,10 @@ gboolean              glnx_set_object  (GObject **object_ptr,
 #define G_OPTION_FLAG_NONE ((GOptionFlags) 0)
 #endif
 
+#ifndef G_PID_FORMAT  /* added in 2.50 */
+#define G_PID_FORMAT "i"
+#endif
+
 #if !GLIB_CHECK_VERSION(2, 60, 0)
 #define g_strv_equal _glnx_strv_equal
 gboolean _glnx_strv_equal (const gchar * const *strv1,
@@ -125,16 +130,22 @@ _glnx_memdup2 (gconstpointer mem,
   (((a) > (b) ? (a) - (b) : (b) - (a)) < (epsilon))
 #endif
 
-#if !GLIB_CHECK_VERSION(2, 70, 0)
-#define g_steal_fd _glnx_steal_fd
 static inline int
 _glnx_steal_fd (int *fdp)
 {
+#if GLIB_CHECK_VERSION(2, 70, 0)
+  /* Allow it to be used without deprecation warnings, even if the target
+   * GLib version is older */
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  return g_steal_fd (fdp);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#else
   int fd = *fdp;
   *fdp = -1;
   return fd;
-}
 #endif
+}
+#define g_steal_fd _glnx_steal_fd
 
 #if !GLIB_CHECK_VERSION(2, 74, 0)
 #define G_APPLICATION_DEFAULT_FLAGS ((GApplicationFlags) 0)

--- a/subprojects/libglnx/meson.build
+++ b/subprojects/libglnx/meson.build
@@ -40,7 +40,7 @@ foreach check_function : check_functions
     #include <linux/random.h>
     #include <sys/mman.h>
 
-    int func (void) {
+    void func (void) {
       (void) ''' + check_function + ''';
     }
     ''',


### PR DESCRIPTION
* Fix function detection when using -Werror=return-type (Resolves: flatpak/flatpak#5778)
* Add a fallback definition for G_PID_FORMAT
* Avoid warnings for g_steal_fd() when targeting older GLib
* Include \<glib-unix.h> from glnx-backports.h

---

Changes: https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/55, https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/56, https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/57, https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/59