### PR TITLE
run: Unset $TZDIR environment variable

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -559,6 +559,9 @@ static const ExportData default_exports[] = {
   /* Ensure our container environment variable takes precedence over the one
    * set by a container manager. */
   {"container", NULL},
+  /* We always make the zoneinfo available at /usr/share/zoneinfo even if it
+   * is somewhere else outside of the sandbox. */
+  {"TZDIR", NULL},
 
   /* Some env vars are common enough and will affect the sandbox badly
      if set on the host. We clear these always. If updating this list,

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -99,6 +99,7 @@
             <member>TMPDIR</member>
             <member>XDG_RUNTIME_DIR</member>
             <member>container</member>
+            <member>TZDIR</member>
             <member>PYTHONPATH</member>
             <member>PERLLIB</member>
             <member>PERL5LIB</member>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -92,16 +92,29 @@
             <member>LD_AUDIT</member>
             <member>XDG_CONFIG_DIRS</member>
             <member>XDG_DATA_DIRS</member>
-            <member>XDG_RUNTIME_DIR</member>
             <member>SHELL</member>
             <member>TEMP</member>
             <member>TEMPDIR</member>
             <member>TMP</member>
             <member>TMPDIR</member>
+            <member>XDG_RUNTIME_DIR</member>
+            <member>container</member>
             <member>PYTHONPATH</member>
             <member>PERLLIB</member>
             <member>PERL5LIB</member>
             <member>XCURSOR_PATH</member>
+            <member>GST_PLUGIN_PATH_1_0</member>
+            <member>GST_REGISTRY</member>
+            <member>GST_REGISTRY_1_0</member>
+            <member>GST_PLUGIN_PATH</member>
+            <member>GST_PLUGIN_SYSTEM_PATH</member>
+            <member>GST_PLUGIN_SCANNER</member>
+            <member>GST_PLUGIN_SCANNER_1_0</member>
+            <member>GST_PLUGIN_SYSTEM_PATH_1_0</member>
+            <member>GST_PRESET_PATH</member>
+            <member>GST_PTP_HELPER</member>
+            <member>GST_PTP_HELPER_1_0</member>
+            <member>GST_INSTALL_PLUGINS_HELPER</member>
             <member>KRB5CCNAME</member>
             <member>XKB_CONFIG_ROOT</member>
             <member>GIO_EXTRA_MODULES</member>


### PR DESCRIPTION
    We now resolve the zoneinfo and always make it available at
    /usr/share/zoneinfo in the sandbox so we unset TZDIR to get flatpak apps
    looking at the right directory.

Completely untested.