### PR TITLE
Fix a memory leaks

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7551,9 +7551,6 @@ export_desktop_file (const char         *app,
   g_autofree gchar *new_data = NULL;
   gsize new_data_len;
   g_autoptr(GKeyFile) keyfile = NULL;
-  g_autofree gchar *old_exec = NULL;
-  gint old_argc;
-  g_auto(GStrv) old_argv = NULL;
   g_auto(GStrv) groups = NULL;
   g_autofree char *escaped_app = maybe_quote (app);
   g_autofree char *escaped_branch = maybe_quote (branch);
@@ -7669,6 +7666,9 @@ export_desktop_file (const char         *app,
 
   for (i = 0; groups[i] != NULL; i++)
     {
+      gint old_argc;
+      g_auto(GStrv) old_argv = NULL;
+      g_autofree gchar *old_exec = NULL;
       g_autoptr(GString) new_exec = NULL;
       g_auto(GStrv) flatpak_run_opts = g_key_file_get_string_list (keyfile, groups[i], "X-Flatpak-RunOptions", NULL, NULL);
       g_autofree char *flatpak_run_args = format_flatpak_run_args_from_run_opts (flatpak_run_opts);


### PR DESCRIPTION
When iterating more than one group, the variable got clobbered. Narrowing their scope helps.
This was triggered installing an Inkscape test build


The leak was:
```
==158172==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 2 object(s) allocated from:
    #0 0x7f39fc2f7350 in calloc (/lib64/libasan.so.8+0xf7350) (BuildId: a4ad7eb954b390cf00f07fa10952988a41d9fc7a)
    #1 0x7f39fc980871 in g_malloc0 (/lib64/libglib-2.0.so.0+0x64871) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #2 0x7f39fc9a1394 in g_shell_parse_argv (/lib64/libglib-2.0.so.0+0x85394) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #3 0x5855bd in export_desktop_file ../common/flatpak-dir.c:7676
    #4 0x588369 in rewrite_export_dir ../common/flatpak-dir.c:7848
    #5 0x587965 in rewrite_export_dir ../common/flatpak-dir.c:7805
    #6 0x587965 in rewrite_export_dir ../common/flatpak-dir.c:7805
    #7 0x588f81 in flatpak_rewrite_export_dir ../common/flatpak-dir.c:7929
    #8 0x59173d in flatpak_dir_deploy ../common/flatpak-dir.c:9014
    #9 0x592d57 in flatpak_dir_deploy_install ../common/flatpak-dir.c:9183
    #10 0x59958e in flatpak_dir_install ../common/flatpak-dir.c:10070
    #11 0x6a20d2 in _run_op_kind ../common/flatpak-transaction.c:4770
    #12 0x6a5e98 in flatpak_transaction_real_run ../common/flatpak-transaction.c:5277
    #13 0x4e0a11 in flatpak_cli_transaction_run ../app/flatpak-cli-transaction.c:1683
    #14 0x6a191c in flatpak_transaction_run ../common/flatpak-transaction.c:4738
    #15 0x492495 in install_from ../app/flatpak-builtins-install.c:268
    #16 0x492cac in flatpak_builtin_install ../app/flatpak-builtins-install.c:319
    #17 0x4eafa6 in flatpak_run ../app/flatpak-main.c:859
    #18 0x4eb9ed in main ../app/flatpak-main.c:964
    #19 0x7f39fb731087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #20 0x7f39fb73114a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #21 0x41aa34 in _start (/var/home/hub/source/flatpak/_build/app/flatpak+0x41aa34) (BuildId: c0a8def42278e3090b081b437dcacbb50bb377e3)

Direct leak of 21 byte(s) in 2 object(s) allocated from:
    #0 0x7f39fc2f7997 in malloc (/lib64/libasan.so.8+0xf7997) (BuildId: a4ad7eb954b390cf00f07fa10952988a41d9fc7a)
    #1 0x7f39fc97f879 in g_malloc (/lib64/libglib-2.0.so.0+0x63879) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #2 0x7f39fc972ed0 in g_key_file_parse_value_as_string (/lib64/libglib-2.0.so.0+0x56ed0) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #3 0x7f39fc973014 in g_key_file_get_string (/lib64/libglib-2.0.so.0+0x57014) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #4 0x58555d in export_desktop_file ../common/flatpak-dir.c:7675
    #5 0x588369 in rewrite_export_dir ../common/flatpak-dir.c:7848
    #6 0x587965 in rewrite_export_dir ../common/flatpak-dir.c:7805
    #7 0x587965 in rewrite_export_dir ../common/flatpak-dir.c:7805
    #8 0x588f81 in flatpak_rewrite_export_dir ../common/flatpak-dir.c:7929
    #9 0x59173d in flatpak_dir_deploy ../common/flatpak-dir.c:9014
    #10 0x592d57 in flatpak_dir_deploy_install ../common/flatpak-dir.c:9183
    #11 0x59958e in flatpak_dir_install ../common/flatpak-dir.c:10070
    #12 0x6a20d2 in _run_op_kind ../common/flatpak-transaction.c:4770
    #13 0x6a5e98 in flatpak_transaction_real_run ../common/flatpak-transaction.c:5277
    #14 0x4e0a11 in flatpak_cli_transaction_run ../app/flatpak-cli-transaction.c:1683
    #15 0x6a191c in flatpak_transaction_run ../common/flatpak-transaction.c:4738
    #16 0x492495 in install_from ../app/flatpak-builtins-install.c:268
    #17 0x492cac in flatpak_builtin_install ../app/flatpak-builtins-install.c:319
    #18 0x4eafa6 in flatpak_run ../app/flatpak-main.c:859
    #19 0x4eb9ed in main ../app/flatpak-main.c:964
    #20 0x7f39fb731087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #21 0x7f39fb73114a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #22 0x41aa34 in _start (/var/home/hub/source/flatpak/_build/app/flatpak+0x41aa34) (BuildId: c0a8def42278e3090b081b437dcacbb50bb377e3)

Indirect leak of 384 byte(s) in 3 object(s) allocated from:
    #0 0x7f39fc2f6898 in realloc.part.0 (/lib64/libasan.so.8+0xf6898) (BuildId: a4ad7eb954b390cf00f07fa10952988a41d9fc7a)
    #1 0x7f39fc98092a in g_realloc (/lib64/libglib-2.0.so.0+0x6492a) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #2 0x7f39fc99fa39 in g_string_expand (/lib64/libglib-2.0.so.0+0x83a39) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #3 0x7f39fc99fab0 in g_string_sized_new (/lib64/libglib-2.0.so.0+0x83ab0) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #4 0x7f39fc9a0b7f in g_shell_unquote (/lib64/libglib-2.0.so.0+0x84b7f) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #5 0x7f39fc9a13aa in g_shell_parse_argv (/lib64/libglib-2.0.so.0+0x853aa) (BuildId: 36b60dbd02e796145a982d0151ce37202ec05649)
    #6 0x5855bd in export_desktop_file ../common/flatpak-dir.c:7676
    #7 0x588369 in rewrite_export_dir ../common/flatpak-dir.c:7848
    #8 0x587965 in rewrite_export_dir ../common/flatpak-dir.c:7805
    #9 0x587965 in rewrite_export_dir ../common/flatpak-dir.c:7805
    #10 0x588f81 in flatpak_rewrite_export_dir ../common/flatpak-dir.c:7929
    #11 0x59173d in flatpak_dir_deploy ../common/flatpak-dir.c:9014
    #12 0x592d57 in flatpak_dir_deploy_install ../common/flatpak-dir.c:9183
    #13 0x59958e in flatpak_dir_install ../common/flatpak-dir.c:10070
    #14 0x6a20d2 in _run_op_kind ../common/flatpak-transaction.c:4770
    #15 0x6a5e98 in flatpak_transaction_real_run ../common/flatpak-transaction.c:5277
    #16 0x4e0a11 in flatpak_cli_transaction_run ../app/flatpak-cli-transaction.c:1683
    #17 0x6a191c in flatpak_transaction_run ../common/flatpak-transaction.c:4738
    #18 0x492495 in install_from ../app/flatpak-builtins-install.c:268
    #19 0x492cac in flatpak_builtin_install ../app/flatpak-builtins-install.c:319
    #20 0x4eafa6 in flatpak_run ../app/flatpak-main.c:859
    #21 0x4eb9ed in main ../app/flatpak-main.c:964
    #22 0x7f39fb731087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #23 0x7f39fb73114a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #24 0x41aa34 in _start (/var/home/hub/source/flatpak/_build/app/flatpak+0x41aa34) (BuildId: c0a8def42278e3090b081b437dcacbb50bb377e3)

SUMMARY: AddressSanitizer: 445 byte(s) leaked in 7 allocation(s).
```