### PR TITLE
run: Use the instance id in the cgroup name

### DIFF
--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -31,6 +31,7 @@
 #include "flatpak-exports-private.h"
 
 gboolean flatpak_run_in_transient_unit (const char *app_id,
+                                        const char *instance_id,
                                         GError    **error);
 
 void     flatpak_run_extend_ld_path       (FlatpakBwrap       *bwrap,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -511,7 +511,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
 
   /* Must run this before spawning the dbus proxy, to ensure it
      ends up in the app cgroup */
-  if (!flatpak_run_in_transient_unit (app_id, &my_error))
+  if (!flatpak_run_in_transient_unit (app_id, instance_id, &my_error))
     {
       /* We still run along even if we don't get a cgroup, as nothing
          really depends on it. Its just nice to have */
@@ -819,13 +819,14 @@ systemd_unit_name_escape (const gchar *in)
 }
 
 gboolean
-flatpak_run_in_transient_unit (const char *appid, GError **error)
+flatpak_run_in_transient_unit (const char *app_id, const char *instance_id, GError **error)
 {
   g_autoptr(GDBusConnection) conn = NULL;
   g_autofree char *path = NULL;
   g_autofree char *address = NULL;
   g_autofree char *name = NULL;
-  g_autofree char *appid_escaped = NULL;
+  g_autofree char *app_id_escaped = NULL;
+  g_autofree char *instance_id_escaped = NULL;
   g_autofree char *job = NULL;
   SystemdManager *manager = NULL;
   GVariantBuilder builder;
@@ -863,8 +864,11 @@ flatpak_run_in_transient_unit (const char *appid, GError **error)
   if (!manager)
     goto out;
 
-  appid_escaped = systemd_unit_name_escape (appid);
-  name = g_strdup_printf ("app-flatpak-%s-%d.scope", appid_escaped, getpid ());
+  app_id_escaped = systemd_unit_name_escape (app_id);
+  instance_id_escaped = systemd_unit_name_escape (instance_id);
+  name = g_strdup_printf ("app-flatpak-%s-%s.scope",
+                          app_id_escaped,
+                          instance_id_escaped);
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(sv)"));
 


### PR DESCRIPTION
The systemd Desktop Environments conventions for cgroup names is

  `app[-<launcher>]-<ApplicationID>[@<RANDOM>].service`

where RANDOM should ensure that multiple instances of the application can be launched. Currently flatpak uses the PID of itself but the instance fullfills this convention and is a bit more useful for matching the cgroup to a flatpak instance.