### PR TITLE
app: Check for component name when searching

### DIFF
--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -303,7 +303,8 @@ flatpak_builtin_search (int argc, char **argv, GCancellable *cancellable, GError
           if (score == 0)
             {
               g_autofree char *app_id = component_get_flatpak_id (app);
-              if (strcasestr (app_id, search_text) != NULL)
+              const char *app_name = as_component_get_name (app);
+              if (strcasestr (app_id, search_text) != NULL || strcasestr (app_name, search_text) != NULL)
                 score = 50;
               else
                 continue;


### PR DESCRIPTION
We add the component name as part of the fallback search.

Before this patch, queries as

    flatpak search Element

or

    flatpak search d-spy

return no results even though the search term coincides with the application name.