### PR TITLE
subprojects: Update bubblewrap to v0.11.0

### DIFF
--- a/subprojects/bubblewrap.wrap
+++ b/subprojects/bubblewrap.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/containers/bubblewrap.git
-# v0.10.0
-revision = dc63ec667e6546f34e0b6c088cdf8ae7c7dea0f3
+# v0.11.0
+revision = 9ca3b05ec787acfb4b17bed37db5719fa777834f
 depth = 1


### PR DESCRIPTION
<https://github.com/containers/bubblewrap/releases/tag/v0.11.0>

We don't use any of the new features yet, so the minimum required version in the build system is still 0.10.0.