### PR TITLE
Add FLATPAK_DATA_DIR environment variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -343,12 +343,8 @@ cdata.set_quoted(
   get_option('prefix') / get_option('sysconfdir') / 'flatpak',
 )
 cdata.set_quoted(
-  'FLATPAK_BASEDIR',
+  'FLATPAK_DATADIR',
   get_option('prefix') / get_option('datadir') / 'flatpak',
-)
-cdata.set_quoted(
-  'FLATPAK_TRIGGERDIR',
-  get_option('prefix') / get_option('datadir') / 'flatpak' / 'triggers',
 )
 cdata.set_quoted('LIBEXECDIR', get_option('prefix') / get_option('libexecdir'))
 cdata.set_quoted('DATADIR', get_option('prefix') / get_option('datadir'))

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,6 +18,7 @@ endif
 
 tests_environment = {
   'FLATPAK_CONFIG_DIR' : '/dev/null',
+  'FLATPAK_DATA_DIR' : '/dev/null',
   'FLATPAK_PORTAL' : project_build_root / 'portal' / 'flatpak-portal',
   'FLATPAK_REVOKEFS_FUSE' : project_build_root / 'revokefs' / 'revokefs-fuse',
   'FLATPAK_TESTS_DEBUG' : '1',


### PR DESCRIPTION
Now that we read remotes from `$datadir/flatpaks/remotes.d` as well as `/etc/flatpaks/remotes.d`, we should have a mechanism to redirect this, as we do for almost all other filesystem path locations.

To avoid an explosion of new variables, we introduce `FLATPAK_OS_CONFIG_DIR` to represent configuration that ships with the operating system.

This is useful:

 * To fix sandboxing of tests
 * When installing using flatpak into a chroot, so that we read the chroot's configuration rather than the host.

It also is used when reading triggers, but the current `FLATPAK_TRIGGERSDIR` is left for compatibility.

---

Notes:

* Should this apply to trigger at all? Are the triggers really configuration?
* If it *should* apply for triggers, then do we need compat handling of `FLATPAK_TRIGGERSDIR`?