### PR TITLE
profile: Include flatpak bin dirs in $PATH

### DIFF
--- a/profile/flatpak.fish
+++ b/profile/flatpak.fish
@@ -1,10 +1,12 @@
 if type -q flatpak
-    # Set XDG_DATA_DIRS to include Flatpak installations
+    # Set XDG_DATA_DIRS and PATH to include Flatpak installations
 
     set -x --path XDG_DATA_DIRS $XDG_DATA_DIRS
+    set -x --path PATH $PATH
 
     set -q XDG_DATA_DIRS[1]; or set XDG_DATA_DIRS /usr/local/share /usr/share
     set -q XDG_DATA_HOME; or set -l XDG_DATA_HOME $HOME/.local/share
+    set -q PATH[1]; or set PATH /usr/local/bin /usr/bin
 
     set -l installations $XDG_DATA_HOME/flatpak
     begin
@@ -16,6 +18,12 @@ if type -q flatpak
     for dir in {$installations[-1..1]}/exports/share
         if not contains $dir $XDG_DATA_DIRS
             set -p XDG_DATA_DIRS $dir
+        end
+    end
+
+    for dir in {$installations[-1..1]}/exports/bin
+        if not contains $dir $PATH
+            set -p PATH $dir
         end
     end
 end

--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -1,28 +1,51 @@
 if command -v flatpak > /dev/null; then
-    # set XDG_DATA_DIRS to include Flatpak installations
+    # set XDG_DATA_DIRS and PATH to include Flatpak installations
 
-    new_dirs=$(
-        (
-            unset G_MESSAGES_DEBUG
-            echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
-            GIO_USE_VFS=local flatpak --installations
-        ) | (
-            new_dirs=
+    installation_dirs=$(
+         unset G_MESSAGES_DEBUG
+         echo "${XDG_DATA_HOME:-"$HOME/.local/share"}/flatpak"
+         GIO_USE_VFS=local flatpak --installations
+    )
+
+    new_share_dirs=$(echo "$installation_dirs" |
+	(
+            new_share_dirs=
             while read -r install_path
             do
                 share_path=$install_path/exports/share
                 case ":$XDG_DATA_DIRS:" in
                     (*":$share_path:"*) :;;
                     (*":$share_path/:"*) :;;
-                    (*) new_dirs=${new_dirs:+${new_dirs}:}$share_path;;
+                    (*) new_share_dirs=${new_share_dirs:+${new_share_dirs}:}$share_path;;
                 esac
             done
-            echo "$new_dirs"
+            echo "$new_share_dirs"
         )
     )
 
     export XDG_DATA_DIRS
-    XDG_DATA_DIRS="${new_dirs:+${new_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+    XDG_DATA_DIRS="${new_share_dirs:+${new_share_dirs}:}${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 
-    unset new_dirs
+    unset new_share_dirs
+
+    new_bin_dirs=$(echo "$installation_dirs" |
+	(
+            new_bin_dirs=
+            while read -r install_path
+            do
+                bin_path=$install_path/exports/bin
+                case ":$PATH:" in
+                    (*":$bin_path:"*) :;;
+                    (*":$bin_path/:"*) :;;
+                    (*) new_bin_dirs=${new_bin_dirs:+${new_bin_dirs}:}$bin_path;;
+                esac
+            done
+            echo "$new_bin_dirs"
+        )
+    )
+
+    export PATH
+    PATH="${new_bin_dirs:+${new_bin_dirs}:}${PATH:-/usr/local/bin:/usr/bin}"
+
+    unset new_bin_dirs
 fi


### PR DESCRIPTION
Users downstream expect flatpak binaries also to be in PATH, even though binaries use rDNS it can be very helpful for terminal-targeted desktops like sway.

Arch Linux already includes a downstream profile script to include the bin dirs[1].

Based on the recent conversation in the Matrix room.

[1] https://gitlab.archlinux.org/archlinux/packaging/packages/flatpak/-/blob/1-1.15.10-1/flatpak-bindir.sh