### PR TITLE
Revert "run: Use the instance id in the cgroup name"

### DIFF
--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -31,7 +31,6 @@
 #include "flatpak-exports-private.h"
 
 gboolean flatpak_run_in_transient_unit (const char *app_id,
-                                        const char *instance_id,
                                         GError    **error);
 
 void     flatpak_run_extend_ld_path       (FlatpakBwrap       *bwrap,

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -511,7 +511,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
 
   /* Must run this before spawning the dbus proxy, to ensure it
      ends up in the app cgroup */
-  if (!flatpak_run_in_transient_unit (app_id, instance_id, &my_error))
+  if (!flatpak_run_in_transient_unit (app_id, &my_error))
     {
       /* We still run along even if we don't get a cgroup, as nothing
          really depends on it. Its just nice to have */
@@ -819,14 +819,13 @@ systemd_unit_name_escape (const gchar *in)
 }
 
 gboolean
-flatpak_run_in_transient_unit (const char *app_id, const char *instance_id, GError **error)
+flatpak_run_in_transient_unit (const char *appid, GError **error)
 {
   g_autoptr(GDBusConnection) conn = NULL;
   g_autofree char *path = NULL;
   g_autofree char *address = NULL;
   g_autofree char *name = NULL;
-  g_autofree char *app_id_escaped = NULL;
-  g_autofree char *instance_id_escaped = NULL;
+  g_autofree char *appid_escaped = NULL;
   g_autofree char *job = NULL;
   SystemdManager *manager = NULL;
   GVariantBuilder builder;
@@ -864,11 +863,8 @@ flatpak_run_in_transient_unit (const char *app_id, const char *instance_id, GErr
   if (!manager)
     goto out;
 
-  app_id_escaped = systemd_unit_name_escape (app_id);
-  instance_id_escaped = systemd_unit_name_escape (instance_id);
-  name = g_strdup_printf ("app-flatpak-%s-%s.scope",
-                          app_id_escaped,
-                          instance_id_escaped);
+  appid_escaped = systemd_unit_name_escape (appid);
+  name = g_strdup_printf ("app-flatpak-%s-%d.scope", appid_escaped, getpid ());
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(sv)"));
 


### PR DESCRIPTION
apply_extra_data() passes a null instance ID to
flatpak_run_add_environment_args(), causing a segfault in flatpak_run_in_transient_unit() which assumes the instance ID is non-null. Revert this for now: flatpak#5962 was non-essential, and we can redo it in a less crashy way later.

This reverts commit 7d6f3e8b6b51f26b380235fad8e32a4872449ff1.

Resolves: https://github.com/flatpak/flatpak/issues/6009

cc @swick 

I'm going to merge this immediately, assuming CI is successful. I'm happy to review a redo of #5962 (and I might even implement one myself if I find some time for it) but for now let's stop the bleeding, since several major distros are (IMO unwisely) already using our development releases as though they were stable releases.