### PR TITLE
tests: Install missing test data

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -324,6 +324,7 @@ if get_option('installed_tests')
   )
 
   install_data(
+    'gphoto2-list',
     'libtest.sh',
     'org.flatpak.Authenticator.test.service.in',
     'org.freedesktop.impl.portal.desktop.test.service.in',


### PR DESCRIPTION
Without this, "as-installed" tests via `ginsttest-runner` will fail, for example in Debian's autopkgtest framework.

Fixes: 1d56bd37 "context: Implement device lists for usb"