### PR TITLE
wayland: Only have one code path to bind-mount WAYLAND_DISPLAY into sandbox

### DIFF
--- a/common/flatpak-run-wayland.c
+++ b/common/flatpak-run-wayland.c
@@ -301,11 +301,6 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap,
       flatpak_bwrap_add_runtime_dir_member (bwrap, wayland_display);
     }
 
-#ifdef ENABLE_WAYLAND_SECURITY_CONTEXT
-  if (security_context_available)
-    return TRUE;
-#endif
-
   /* If inherit-wayland-socket is not set, unset WAYLAND_SOCKET unconditionally
    * without checking the validity of the value of WAYLAND_SOCKET. */
   if (!inherit_wayland_socket)


### PR DESCRIPTION
* wayland: Avoid some duplication when getting the Wayland display name
    
    There's no need to have the logic for falling back to `wayland-0` in more
    than one place.

* wayland: Only have one code path to bind-mount WAYLAND_DISPLAY into sandbox
    
    In the older code path where we were not using Wayland security contexts,
    we would try to preserve the name of the Wayland display socket
    (`$WAYLAND_DISPLAY`), only falling back to `wayland-0` if the name was
    something unconventional (contains `/` or does not start with `wayland-`).
    This means that in practice, apps could often successfully use a value
    of `$WAYLAND_DISPLAY` from the wrong "world" - for example reading the
    value used outside the sandbox from a file in code that runs inside the
    sandbox, or conversely, passing the value used inside the sandbox via
    IPC to a service like gpg-agent outside the sandbox.
    
    However, the implementation in
    flatpak_run_add_wayland_security_context_args() did not do this, and
    instead would unconditionally use `wayland-0`. There's no real need to
    enforce use of that name.
    
    Apps should not really be passing the string value of `WAYLAND_DISPLAY`
    across a sandbox boundary, but in practice some do, and we will get
    better interoperability if we try to keep that working in at least the
    simple cases. This is similar in spirit to how we have handled X11
    since 2022 (flatpak/flatpak#5034).
    
    For now, we skip the last few lines of flatpak_run_add_wayland_args() if
    we are using Wayland security contexts, to preserve existing
    functionality. A subsequent commit will revisit that.
    
    Resolves: https://github.com/flatpak/flatpak/issues/5863

* wayland: Handle WAYLAND_SOCKET, even when using security-context-v1
    
    As described in #5614, `WAYLAND_SOCKET` provides a single-use socket
    as a file descriptor, which some Wayland compositors use to track
    special-purpose Wayland clients like input methods and panels.
    Since #5615, there are two cases for how it works:
    
    1. With `--nosocket=inherit-wayland-socket` (default): the file
       descriptor is marked close-on-exec so that the sandboxed app does
       not inherit it, and the `WAYLAND_SOCKET` environment variable
       becomes unset. Every time the sandboxed app connects to Wayland,
       because `WAYLAND_SOCKET` is unset, it will fall back to the ordinary,
       public `WAYLAND_DISPLAY`.
    
    2. With `--socket=inherit-wayland-socket`: the file descriptor is
       allowed to be inherited, and the environment variable continues
       to be set. The first time the sandboxed app connects to Wayland,
       it will connect to the `WAYLAND_SOCKET`. The second and subsequent
       connection attempts will be to the ordinary `WAYLAND_DISPLAY`.
    
    However, when #4920 added a code path for the Wayland security-context-v1
    interface, it was implemented as a completely separate code path which
    early-returned from flatpak_run_add_wayland_args() before the point
    where #5615 subsequently added the implementation for (1.). The practical
    result of this is that if the compositor sets `WAYLAND_SOCKET` for
    a Flatpak app, and it also happens to implement security-context-v1,
    then the application will always inherit the `WAYLAND_SOCKET` as though
    `--socket=inherit-wayland-socket` had been used. In this case, the app's
    first connection to Wayland will use the `WAYLAND_SOCKET` (bypassing
    the security context mechanism), the same as in compositors that do not
    implement security-context-v1 at all, and only the second and subsequent
    connections will use the special per-app `WAYLAND_DISPLAY` created by the
    security context mechanism. This seems likely to be unexpected.
    
    To give maintainers and users a choice between behaviours (1.) and (2.),
    we can put the security-context-v1 code path through the same code to
    handle `WAYLAND_SOCKET` that is used for Wayland compositors that do not
    implement that interface. This means that
    `--nosocket=inherit-wayland-socket` disables `WAYLAND_SOCKET` in all
    cases: if the compositor supports security-context-v1 and the feature
    was also available when Flatpak was compiled, then all of the sandboxed
    app's Wayland connections will be to the per-app `WAYLAND_DISPLAY`
    created by security-context-v1, and otherwise all of the sandboxed app's
    Wayland connections will be to the ordinary, public `WAYLAND_DISPLAY`.
    
    With `--socket=inherit-wayland-socket`, the sandboxed app's
    first connection to Wayland will continue to be to the inherited
    `WAYLAND_SOCKET` fd, and the second and subsequent connections will
    be to the `WAYLAND_DISPLAY`, which might either be the special per-app
    version created by security-context-v1, or the ordinary public version.

---

cc @emersion @swick @orionn333 @twelho

I cannot usefully test this myself, because my compositor (GNOME Shell) does not support the security contexts extension. But I prepared the merge request anyway, in an attempt to be nice to people affected by #5863 by getting a fix or workaround for it into 1.16.x, since nobody seems to have followed up on my request for someone who was affected to try this.