### PR TITLE
flatpak: emit progress escape sequence

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -378,6 +378,7 @@ progress_changed_cb (FlatpakTransactionProgress *progress,
         }
       if (!redraw (cli))
         g_print ("\r%s", str->str); /* redraw failed, just update the progress */
+      flatpak_pty_set_progress (percent);
     }
   else
     g_print ("%s\n", str->str);
@@ -1684,6 +1685,7 @@ flatpak_cli_transaction_run (FlatpakTransaction *transaction,
 
   if (flatpak_fancy_output ())
     {
+      flatpak_pty_clear_progress ();
       flatpak_disable_raw_mode ();
       flatpak_show_cursor ();
     }

--- a/app/flatpak-tty-utils-private.h
+++ b/app/flatpak-tty-utils-private.h
@@ -83,3 +83,7 @@ void flatpak_format_choices (const char **choices,
 
 void   flatpak_print_escaped_string (const char        *s,
                                      FlatpakEscapeFlags flags);
+
+void flatpak_pty_set_progress (guint percent);
+
+void flatpak_pty_clear_progress (void);

--- a/app/flatpak-tty-utils.c
+++ b/app/flatpak-tty-utils.c
@@ -521,3 +521,15 @@ flatpak_print_escaped_string (const char        *s,
   g_autofree char *escaped = flatpak_escape_string (s, flags);
   g_print ("%s", escaped);
 }
+
+void
+flatpak_pty_clear_progress (void)
+{
+  g_print ("\033]9;4;0\007");
+}
+
+void
+flatpak_pty_set_progress (guint percent)
+{
+  g_print ("\033]9;4;1;%d\007", MIN (percent, 100));
+}


### PR DESCRIPTION
Following on systemd adopting the progress OSC that ConEmu and Windows Terminal use, this exports the progress percentage to the terminal emulator.

VTE also has support for this in the upcoming 0.80 release and is used by Ptyxis to display progress in the tab widget.