### PR TITLE
update: Show summary of end-of-life refs by default

### DIFF
--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -51,6 +51,7 @@ static gboolean opt_app;
 static gboolean opt_appstream;
 static gboolean opt_yes;
 static gboolean opt_noninteractive;
+static gboolean opt_end_of_life_details;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to update for"), N_("ARCH") },
@@ -69,6 +70,7 @@ static GOptionEntry options[] = {
   { "noninteractive", 0, 0, G_OPTION_ARG_NONE, &opt_noninteractive, N_("Produce minimal output and don't ask questions"), NULL },
   /* Translators: A sideload is when you install from a local USB drive rather than the Internet. */
   { "sideload-repo", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_sideload_repos, N_("Use this local repo for sideloads"), N_("PATH") },
+  { "end-of-life-details", 0, 0, G_OPTION_ARG_NONE, &opt_end_of_life_details, N_("Print full information about end-of-life refs"), NULL },
   { NULL }
 };
 
@@ -136,9 +138,15 @@ flatpak_builtin_update (int           argc,
         }
 
       if (opt_noninteractive)
-        transaction = flatpak_quiet_transaction_new (dir, error);
+        {
+          transaction = flatpak_quiet_transaction_new (dir, error);
+        }
       else
-        transaction = flatpak_cli_transaction_new (dir, opt_yes, FALSE, opt_arch != NULL, error);
+        {
+          transaction = flatpak_cli_transaction_new (dir, opt_yes, FALSE, opt_arch != NULL, error);
+          flatpak_cli_transaction_set_show_eol_details (FLATPAK_CLI_TRANSACTION (transaction), opt_end_of_life_details);
+        }
+
       if (transaction == NULL)
         return FALSE;
 

--- a/app/flatpak-cli-transaction.h
+++ b/app/flatpak-cli-transaction.h
@@ -33,4 +33,7 @@ FlatpakTransaction * flatpak_cli_transaction_new (FlatpakDir * dir,
                                                   gboolean non_default_arch,
                                                   GError **error);
 
+void flatpak_cli_transaction_set_show_eol_details (FlatpakCliTransaction *self,
+                                                   gboolean show_eol_details);
+
 #endif /* __FLATPAK_CLI_TRANSACTION_H__ */


### PR DESCRIPTION
Accumulate EOL apps, runtimes, and extensions and print each in a single summary block without reason messages unless `--end-of-life-details` is used. This is a compromise to remain informative without overwhelming users with potentially a large amount of output.

The existing behavior is retained for all other commands, as well as for eol-rebase actions.

Helps #3531