### PR TITLE
gir: Fix closure annotations

### DIFF
--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1728,8 +1728,8 @@ flatpak_installation_load_app_overrides (FlatpakInstallation *self,
  * flatpak_installation_install_bundle:
  * @self: a #FlatpakInstallation
  * @file: a #GFile that is an flatpak bundle
- * @progress: (scope call) (nullable): progress callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): progress callback
+ * @progress_data: (nullable): user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -1854,8 +1854,8 @@ flatpak_installation_install_ref_file (FlatpakInstallation *self,
  * @arch: (nullable): which architecture to fetch (default: current architecture)
  * @branch: (nullable): which branch to fetch (default: 'master')
  * @subpaths: (nullable) (array zero-terminated=1): A list of subpaths to fetch, or %NULL for everything
- * @progress: (scope call) (nullable): progress callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): progress callback
+ * @progress_data: (nullable): user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -1959,8 +1959,8 @@ flatpak_installation_install_full (FlatpakInstallation    *self,
  * @name: name of the app/runtime to fetch
  * @arch: (nullable): which architecture to fetch (default: current architecture)
  * @branch: (nullable): which branch to fetch (default: 'master')
- * @progress: (scope call) (nullable): progress callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): progress callback
+ * @progress_data: (nullable): user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -2010,8 +2010,8 @@ flatpak_installation_install (FlatpakInstallation    *self,
  * @arch: (nullable): architecture of the app or runtime to update (default: current architecture)
  * @branch: (nullable): name of the branch of the app or runtime to update (default: master)
  * @subpaths: (nullable) (array zero-terminated=1): A list of subpaths to fetch, or %NULL for everything
- * @progress: (scope call) (nullable): the callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): the callback
+ * @progress_data: (nullable): user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -2125,8 +2125,8 @@ flatpak_installation_update_full (FlatpakInstallation    *self,
  * @name: name of the app or runtime to update
  * @arch: (nullable): architecture of the app or runtime to update (default: current architecture)
  * @branch: (nullable): name of the branch of the app or runtime to update (default: master)
- * @progress: (scope call) (nullable): the callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): the callback
+ * @progress_data: (nullable): user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -2173,8 +2173,8 @@ flatpak_installation_update (FlatpakInstallation    *self,
  *  %NULL, flatpak_get_default_arch() is assumed
  * @branch: (nullable): name of the branch of the app or runtime to uninstall;
  *  if %NULL, `master` is assumed
- * @progress: (scope call) (nullable): the callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): the callback
+ * @progress_data: (nullable): user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -2216,8 +2216,8 @@ flatpak_installation_uninstall (FlatpakInstallation    *self,
  *  %NULL, flatpak_get_default_arch() is assumed
  * @branch: (nullable): name of the branch of the app or runtime to uninstall;
  *  if %NULL, `master` is assumed
- * @progress: (scope call) (nullable): the callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): the callback
+ * @progress_data: (nullable): user data passed to @progress
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError
  *
@@ -2604,8 +2604,8 @@ flatpak_installation_update_appstream_sync (FlatpakInstallation *self,
  * @self: a #FlatpakInstallation
  * @remote_name: the name of the remote
  * @arch: (nullable): Architecture to update, or %NULL for the local machine arch
- * @progress: (scope call) (nullable): progress callback
- * @progress_data: (closure progress) (nullable): user data passed to @progress
+ * @progress: (scope call) (closure progress_data) (nullable): progress callback
+ * @progress_data: (nullable): user data passed to @progress
  * @out_changed: (nullable): Set to %TRUE if the contents of the appstream changed, %FALSE if nothing changed
  * @cancellable: (nullable): a #GCancellable
  * @error: return location for a #GError


### PR DESCRIPTION
This is a new warning. Reproducible on F41
Fixes:
```
../common/flatpak-installation.c:1963: Warning: Flatpak: invalid closure annotation: only valid on callback parameters 
../common/flatpak-installation.c:1858: Warning: Flatpak: invalid closure annotation: only valid on callback parameters 
../common/flatpak-installation.c:2129: Warning: Flatpak: invalid closure annotation: only valid on callback parameters 
../common/flatpak-installation.c:2014: Warning: Flatpak: invalid closure annotation: only valid on callback parameters 
../common/flatpak-installation.c:1732: Warning: Flatpak: invalid closure annotation: only valid on callback parameters 
../common/flatpak-installation.c:2177: Warning: Flatpak: invalid closure annotation: only valid on callback parameters 
../common/flatpak-installation.c:2220: Warning: Flatpak: invalid closure annotation: only valid on callback parameters 
../common/flatpak-installation.c:2608: Warning: Flatpak: invalid closure annotation: only valid on callback parameters
```

~~Note: If the annotation were misplaced I don't know where they  should have been put.~~