### PR TITLE
Update subtree: libglnx 2024-12-06

### DIFF
--- a/subprojects/libglnx/glnx-shutil.c
+++ b/subprojects/libglnx/glnx-shutil.c
@@ -149,11 +149,9 @@ mkdir_p_at_internal (int              dfd,
  again:
   if (mkdirat (dfd, path, mode) == -1)
     {
-      if (errno == ENOENT)
+      if (errno == ENOENT && !did_recurse)
         {
           char *lastslash;
-
-          g_assert (!did_recurse);
 
           lastslash = strrchr (path, '/');
           if (lastslash == NULL)

--- a/subprojects/libglnx/meson_options.txt
+++ b/subprojects/libglnx/meson_options.txt
@@ -5,5 +5,5 @@ option(
   'tests',
   type : 'boolean',
   description : 'build and run unit tests',
-  value : 'true',
+  value : true,
 )

--- a/subprojects/libglnx/tests/test-libglnx-shutil.c
+++ b/subprojects/libglnx/tests/test-libglnx-shutil.c
@@ -1,6 +1,7 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
  *
- * Copyright © 2017 Endless OS Foundation LLC
+ * Copyright © 2017-2019 Endless OS Foundation LLC
+ * Copyright © 2024 Collabora Ltd.
  * SPDX-License-Identifier: LGPL-2.0-or-later
  *
  * This library is free software; you can redistribute it and/or
@@ -30,8 +31,46 @@
 #include "libglnx-testlib.h"
 
 static void
+test_mkdir_p_parent_unsuitable (void)
+{
+  _GLNX_TEST_SCOPED_TEMP_DIR;
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+  glnx_autofd int dfd = -1;
+
+  if (!glnx_ensure_dir (AT_FDCWD, "test", 0755, error))
+    return;
+  if (!glnx_opendirat (AT_FDCWD, "test", FALSE, &dfd, error))
+    return;
+
+  if (!glnx_file_replace_contents_at (dfd, "file",
+                                      (const guint8 *) "", 0,
+                                      GLNX_FILE_REPLACE_NODATASYNC,
+                                      NULL, error))
+    return;
+
+  if (symlinkat ("nosuchtarget", dfd, "link") < 0)
+    {
+      glnx_throw_errno_prefix (error, "symlinkat");
+      return;
+    }
+
+  glnx_shutil_mkdir_p_at (dfd, "file/baz", 0755, NULL, error);
+  g_test_message ("mkdir %s -> %s", "file/baz",
+                  local_error ? local_error->message : "success");
+  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_NOT_DIRECTORY);
+  g_clear_error (&local_error);
+
+  glnx_shutil_mkdir_p_at (dfd, "link/baz", 0755, NULL, error);
+  g_test_message ("mkdir %s -> %s", "link/baz",
+                  local_error ? local_error->message : "success");
+  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+  g_clear_error (&local_error);
+}
+
+static void
 test_mkdir_p_enoent (void)
 {
+  _GLNX_TEST_SCOPED_TEMP_DIR;
   _GLNX_TEST_DECLARE_ERROR(local_error, error);
   glnx_autofd int dfd = -1;
 
@@ -57,6 +96,7 @@ main (int    argc,
   g_test_init (&argc, &argv, NULL);
 
   g_test_add_func ("/mkdir-p/enoent", test_mkdir_p_enoent);
+  g_test_add_func ("/mkdir-p/parent-unsuitable", test_mkdir_p_parent_unsuitable);
 
   ret = g_test_run();
 


### PR DESCRIPTION
* Fix an assertion failure attempting to create a directory that exists
      as a dangling symlink ([GNOME/libglnx#1](https://gitlab.gnome.org/GNOME/libglnx/-/issues/1))
* Fix a Meson deprecation warning ([GNOME/libglnx!60](https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/60))
