### PR TITLE
portal: Improve error message for invalid a11y own name

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -963,7 +963,7 @@ handle_spawn (PortalFlatpak         *object,
         {
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                                  G_DBUS_ERROR_INVALID_ARGS,
-                                                 "Invalid sandbox a11y own name, doesn't match app id");
+                                                 "Invalid sandbox a11y own name: '%s' doesn't match app id", sandbox_a11y_own_names[i]);
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
     }


### PR DESCRIPTION
Include the non-matching name in the message for ease of debugging.

This was useful for https://github.com/flathub/engineer.atlas.Nyxt/issues/19