### PR TITLE
flatpak: Disable progress escape sequence by default

### DIFF
--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -618,6 +618,14 @@
                     </para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><envar>FLATPAK_TTY_PROGRESS</envar></term>
+
+                    <listitem><para>
+                        May be set to <literal>1</literal> to enable emitting
+                        the progress escape character.
+                    </para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><envar>FLATPAK_USER_DIR</envar></term>
 
                     <listitem><para>


### PR DESCRIPTION
And add the FLATPAK_PTY_PROGRESS env var to re-enable it.

This seems to only be supported by recent versions of terminal emulators which will cause problems with shipping Flatpak on older distros.

Closes https://github.com/flatpak/flatpak/issues/6052