### PR TITLE
flatpak-dir: Fix a memory leak installing extra-data

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8280,7 +8280,7 @@ extract_extra_data (FlatpakDir   *self,
           const guchar *data;
           gsize len;
 
-          g_variant_get_child (extra_data, j, "(^ay@ay)",
+          g_variant_get_child (extra_data, j, "(^&ay@ay)",
                                &extra_data_name,
                                &content);
 


### PR DESCRIPTION
Return a borrowed extra_data_name from g_variant_get_child