### PR TITLE
dir: Also reload repo configuration after setting via system helper

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4460,6 +4460,9 @@ flatpak_dir_set_config (FlatpakDir *self,
                                                      NULL, error))
         return FALSE;
 
+      if (!_flatpak_dir_reload_config (self, NULL, error))
+        return FALSE;
+
       return TRUE;
     }
 


### PR DESCRIPTION
Without doing so, flatpak_dir_get_config() won't reflect changes made with flatpak_dir_set_config().

This fixes passing multiple patterns to `flatpak mask` for the system installation.

I found this while investigating https://github.com/flatpak/flatpak/issues/4907