### PR TITLE
search: Enable completion of command-specific options

### DIFF
--- a/app/flatpak-builtins-search.c
+++ b/app/flatpak-builtins-search.c
@@ -350,6 +350,8 @@ flatpak_complete_search (FlatpakCompletion *completion)
     return FALSE;
 
   flatpak_complete_options (completion, global_entries);
+  flatpak_complete_options (completion, options);
   flatpak_complete_options (completion, user_entries);
+  flatpak_complete_columns (completion, all_columns);
   return TRUE;
 }


### PR DESCRIPTION
A cursory search of the other commands didn't reveal any other missing completions.