### PR TITLE
uninstall: Skip in-use runtime check with --unused

### DIFF
--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -520,7 +520,7 @@ flatpak_builtin_uninstall (int argc, char **argv, GCancellable *cancellable, GEr
           * is limited to checking within the same installation; it won't
           * prompt for a user app depending on a system runtime.
          */
-        if (!opt_force_remove &&
+        if (!opt_force_remove && !opt_unused &&
             !confirm_runtime_removal (opt_yes, udir, ref))
           {
             uninstall_dir_remove_ref (udir, ref);


### PR DESCRIPTION
`confirm_runtime_removal()` doesn't know about autoprune-unless extensions, so it prompts unnecessarily when they're removed by `flatpak uninstall --unused`. To avoid this, we can simply skip it and trust `flatpak_dir_list_unused_refs()`.

Closes #5712
Helps #2718