### PR TITLE
run: Unset PYTHONPYCACHEPREFIX from envrionment

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -567,6 +567,7 @@ static const ExportData default_exports[] = {
      if set on the host. We clear these always. If updating this list,
      also update the list in flatpak-run.xml. */
   {"PYTHONPATH", NULL},
+  {"PYTHONPYCACHEPREFIX", NULL},
   {"PERLLIB", NULL},
   {"PERL5LIB", NULL},
   {"XCURSOR_PATH", NULL},

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -101,6 +101,7 @@
             <member>container</member>
             <member>TZDIR</member>
             <member>PYTHONPATH</member>
+            <member>PYTHONPYCACHEPREFIX</member>
             <member>PERLLIB</member>
             <member>PERL5LIB</member>
             <member>XCURSOR_PATH</member>


### PR DESCRIPTION
This repeatedly lead to errors when users had it set to a directory accessible from the flatpak when importing pillow/PIL.

Briefly discussed and suggested in #4280 

Incidents which led me to create this PR:
https://github.com/pdfarranger/pdfarranger/issues/866
https://github.com/pdfarranger/pdfarranger/issues/1194 (not yet confirmed but very likely)