### PR TITLE
 portal: Don't run method invocations in a thread

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -2966,9 +2966,6 @@ on_bus_acquired (GDBusConnection *connection,
 
   g_object_set_data_full (G_OBJECT (portal), "track-alive", GINT_TO_POINTER (42), skeleton_died_cb);
 
-  g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (portal),
-                                       G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
-
   portal_flatpak_set_version (PORTAL_FLATPAK (portal), 7);
   portal_flatpak_set_supports (PORTAL_FLATPAK (portal), supports);
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -77,7 +77,7 @@ static int opt_poll_timeout;
 static gboolean opt_poll_when_metered;
 static FlatpakSpawnSupportFlags supports = 0;
 
-G_LOCK_DEFINE (update_monitors); /* This protects the three variables below */
+G_LOCK_DEFINE_STATIC (update_monitors); /* This protects the three variables below */
 static GHashTable *update_monitors;
 static guint update_monitors_timeout = 0;
 static gboolean update_monitors_timeout_running_thread = FALSE;


### PR DESCRIPTION
Most access to the `client_pid_data_hash` hash table are unsafe due to
threading.

One approach to solve this would be to protect the hash table with a
mutex, but as per a deeper analysis, nothing in these callbacks is
slow or heavy enough to justify the need for separate threads.

Make method invocations run in the main thread.

Closes: https://github.com/flatpak/flatpak/issues/5605