### PR TITLE
prune: Move locking operations to execute only outside dry run

### DIFF
--- a/common/flatpak-prune.c
+++ b/common/flatpak-prune.c
@@ -779,28 +779,28 @@ flatpak_repo_prune (OstreeRepo    *repo,
     g_clear_pointer (&timer, g_timer_destroy);
   }
 
-  {
-    /* exclusive lock in this region, see locking strategy above */
-    glnx_autofd int lock_fd = -1;
+  if (!dry_run)
+    {
+      /* exclusive lock in this region, see locking strategy above */
+      glnx_autofd int lock_fd = -1;
 
-    if (!get_repo_lock (repo, LOCK_EX, &lock_fd, cancellable, error))
-      return FALSE;
+      if (!get_repo_lock (repo, LOCK_EX, &lock_fd, cancellable, error))
+        return FALSE;
 
-    timer = g_timer_new ();
-    g_info ("Finding reachable objects, locked (depth=%d)", depth);
-    g_timer_start (timer);
+      timer = g_timer_new ();
+      g_info ("Finding reachable objects, locked (depth=%d)", depth);
+      g_timer_start (timer);
 
-    if (!traverse_reachable_refs_unlocked (repo, depth, reachable, cancellable, error))
-      return FALSE;
+      if (!traverse_reachable_refs_unlocked (repo, depth, reachable, cancellable, error))
+        return FALSE;
 
-    data.repo = repo;
-    data.reachable = reachable;
-    data.dont_prune = dry_run;
+      data.repo = repo;
+      data.reachable = reachable;
+      data.dont_prune = dry_run;
 
-    g_timer_stop (timer);
-    g_info ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
+      g_timer_stop (timer);
+      g_info ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
 
-    if (!dry_run)
       {
         g_info ("Pruning unreachable objects");
         g_timer_start (timer);
@@ -811,7 +811,7 @@ flatpak_repo_prune (OstreeRepo    *repo,
         g_timer_stop (timer);
         g_info ("Elapsed time: %.1f sec",  g_timer_elapsed (timer, NULL));
       }
-  }
+    }
 
   /* Prune static deltas outside lock to avoid conflict with its exclusive lock */
   if (!dry_run)


### PR DESCRIPTION
The original idea behind this code was that the initial lockless scan of reachable objects will make the locking one fast enough that it won't matter to software managing flatpak repos like flat-manager. Few years later I can say this is not true, and the locking variant of scan does take too long and affects Flathub's publishing process.

By keeping only the lockless variant in dry run, we can run it on a weekly schedule without affecting operations, and issue actual pruning with flat-manager which will hold a lock in external system and avoid executing any actions requiring locking to avoid errors/timeouts.