### PR TITLE
portal: Allow passing device permissions to subsandbox

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1120,6 +1120,39 @@ handle_spawn (PortalFlatpak         *object,
                g_strv_contains ((const char * const *) devices, "all")))
             g_ptr_array_add (flatpak_argv, g_strdup ("--device=dri"));
         }
+      if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_INPUT)
+        {
+          if (devices != NULL &&
+              (g_strv_contains ((const char * const *) devices, "input") ||
+               g_strv_contains ((const char * const *) devices, "all")))
+            g_ptr_array_add (flatpak_argv, g_strdup ("--device=input"));
+        }
+      if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_USB)
+        {
+          if (devices != NULL &&
+              (g_strv_contains ((const char * const *) devices, "usb") ||
+               g_strv_contains ((const char * const *) devices, "all")))
+            g_ptr_array_add (flatpak_argv, g_strdup ("--device=usb"));
+        }
+      if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_KVM)
+        {
+          if (devices != NULL &&
+              (g_strv_contains ((const char * const *) devices, "kvm") ||
+               g_strv_contains ((const char * const *) devices, "all")))
+            g_ptr_array_add (flatpak_argv, g_strdup ("--device=kvm"));
+        }
+      if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SHM)
+        {
+          if (devices != NULL &&
+              (g_strv_contains ((const char * const *) devices, "shm")))
+            g_ptr_array_add (flatpak_argv, g_strdup ("--device=shm"));
+        }
+      if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_DEVICES)
+        {
+          if (devices != NULL &&
+              (g_strv_contains ((const char * const *) devices, "all")))
+            g_ptr_array_add (flatpak_argv, g_strdup ("--device=all"));
+        }
       if (sandbox_flags & FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS)
         g_ptr_array_add (flatpak_argv, g_strdup ("--session-bus"));
 
@@ -2969,7 +3002,7 @@ on_bus_acquired (GDBusConnection *connection,
   g_dbus_interface_skeleton_set_flags (G_DBUS_INTERFACE_SKELETON (portal),
                                        G_DBUS_INTERFACE_SKELETON_FLAGS_HANDLE_METHOD_INVOCATIONS_IN_THREAD);
 
-  portal_flatpak_set_version (PORTAL_FLATPAK (portal), 7);
+  portal_flatpak_set_version (PORTAL_FLATPAK (portal), 8);
   portal_flatpak_set_supports (PORTAL_FLATPAK (portal), supports);
 
   g_signal_connect (portal, "handle-spawn", G_CALLBACK (handle_spawn), NULL);

--- a/portal/flatpak-portal.h
+++ b/portal/flatpak-portal.h
@@ -45,6 +45,11 @@ typedef enum {
   FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_GPU = 1 << 2,
   FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS = 1 << 3,
   FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y = 1 << 4,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_INPUT = 1 << 5,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_USB = 1 << 6,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_KVM = 1 << 7,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SHM = 1 << 8,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_DEVICES = 1 << 9,
   FLATPAK_SPAWN_SANDBOX_FLAGS_NONE = 0
 } FlatpakSpawnSandboxFlags;
 
@@ -72,6 +77,11 @@ typedef enum {
                                          FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SOUND | \
                                          FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_GPU | \
                                          FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS | \
-                                         FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y)
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_INPUT | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_USB | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_KVM | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SHM | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_DEVICES)
 
 #endif /* __FLATPAK_PORTAL_H__ */


### PR DESCRIPTION
This allows to pass all device permissions to a subsandbox