### PR TITLE
exports: add host-complete

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -94,6 +94,7 @@ const char *flatpak_context_special_filesystems[] = {
   "host-etc",
   "host-os",
   "host-reset",
+  "host-complete",
   NULL
 };
 
@@ -1033,7 +1034,7 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
     }
 
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
-               _("Unknown filesystem location %s, valid locations are: host, host-os, host-etc, home, xdg-*[/…], ~/dir, /dir"), filesystem);
+               _("Unknown filesystem location %s, valid locations are: host, host-os, host-etc, host-complete, home, xdg-*[/…], ~/dir, /dir"), filesystem);
   return FALSE;
 }
 
@@ -2839,7 +2840,7 @@ flatpak_context_export (FlatpakContext *context,
 {
   gboolean home_access = FALSE;
   g_autoptr(GString) xdg_dirs_conf = NULL;
-  FlatpakFilesystemMode fs_mode, os_mode, etc_mode, home_mode;
+  FlatpakFilesystemMode fs_mode, os_mode, etc_mode, complete_mode, home_mode;
   GHashTableIter iter;
   gpointer key, value;
   g_autoptr(GError) local_error = NULL;
@@ -2905,6 +2906,12 @@ flatpak_context_export (FlatpakContext *context,
 
   if (etc_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_host_etc_expose (exports, etc_mode);
+
+  complete_mode = MAX (GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "host-complete")),
+                        fs_mode);
+
+  if (complete_mode != FLATPAK_FILESYSTEM_MODE_NONE)
+    flatpak_exports_add_host_complete_expose (exports, complete_mode);
 
   home_mode = GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "home"));
   if (home_mode != FLATPAK_FILESYSTEM_MODE_NONE)

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -43,6 +43,8 @@ void flatpak_exports_add_host_etc_expose (FlatpakExports       *exports,
                                           FlatpakFilesystemMode mode);
 void flatpak_exports_add_host_os_expose (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode);
+void flatpak_exports_add_host_complete_expose (FlatpakExports       *exports,
+                                               FlatpakFilesystemMode mode);
 gboolean flatpak_exports_add_path_expose (FlatpakExports         *exports,
                                           FlatpakFilesystemMode   mode,
                                           const char             *path,

--- a/common/flatpak-exports.c
+++ b/common/flatpak-exports.c
@@ -157,6 +157,7 @@ struct _FlatpakExports
   FlatpakFilesystemMode host_etc;
   FlatpakFilesystemMode host_os;
   int                   host_fd;
+  FlatpakFilesystemMode host_complete;
   FlatpakExportsTestFlags test_flags;
 };
 
@@ -641,6 +642,20 @@ flatpak_exports_append_bwrap_args (FlatpakExports *exports,
           S_ISDIR (buf.st_mode))
         flatpak_bwrap_add_args (bwrap,
                                 etc_bind_mode, "/etc", "/run/host/etc", NULL);
+    }
+
+  g_assert (exports->host_complete >= FLATPAK_FILESYSTEM_MODE_NONE);
+  g_assert (exports->host_complete <= FLATPAK_FILESYSTEM_MODE_LAST);
+
+  if (exports->host_complete != FLATPAK_FILESYSTEM_MODE_NONE)
+    {
+      const char *complete_bind_mode = "--bind";
+
+      if (exports->host_complete == FLATPAK_FILESYSTEM_MODE_READ_ONLY)
+      complete_bind_mode = "--ro-bind";
+
+      flatpak_bwrap_add_args (bwrap,
+                              complete_bind_mode, "/", "/run/host/complete", NULL);
     }
 
   /* As per the os-release specification https://www.freedesktop.org/software/systemd/man/os-release.html
@@ -1133,4 +1148,14 @@ flatpak_exports_add_host_os_expose (FlatpakExports       *exports,
   g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
 
   exports->host_os = mode;
+}
+
+void
+flatpak_exports_add_host_complete_expose (FlatpakExports       *exports,
+                                          FlatpakFilesystemMode mode)
+{
+  g_return_if_fail (mode > FLATPAK_FILESYSTEM_MODE_NONE);
+  g_return_if_fail (mode <= FLATPAK_FILESYSTEM_MODE_LAST);
+
+  exports->host_complete = mode;
 }

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -234,7 +234,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This updates the [Context] group in the metadata.
-                    FS can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    FS can be one of: home, host, host-os, host-etc, host-complete, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -254,7 +254,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    FILESYSTEM can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    FILESYSTEM can be one of: home, host, host-os, host-etc, host-complete, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -223,7 +223,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-complete, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -243,7 +243,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-complete xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -344,6 +344,19 @@
                                 Available since 1.7.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>host-complete</option></term>
+                            <listitem><para>
+                                The complete host operating system /.
+                            </para>
+                            <para>
+                                To avoid conflicting with the Flatpak
+                                runtime, this is mounted in the sandbox
+                                at <filename>/run/host/complete</filename>.
+                            </para>
+                            <para>
+                                Available since TBD.
+                            </para></listitem></varlistentry>
+
                             <varlistentry><term><option>xdg-desktop</option>,
                                 <option>xdg-documents</option>,
                                 <option>xdg-download</option>,
@@ -728,7 +741,7 @@
             <para>
                 The default policy for the session bus only allows the
                 application to own its own application ID, its
-                subnames and its own application id as a subname of 
+                subnames and its own application id as a subname of
                 "org.mpris.MediaPlayer2". For instance if the app is called
                 "org.my.App", it can only own "org.my.App", "org.my.App.*"
                 and "org.mpris.MediaPlayer2.org.my.App".

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -51,7 +51,7 @@
             <command>flatpak override</command>.
         </para>
         <para>
-            The application overrides are saved in text files residing in $XDG_DATA_HOME/flatpak/overrides in user mode. 
+            The application overrides are saved in text files residing in $XDG_DATA_HOME/flatpak/overrides in user mode.
         </para>
         <para>
             If the application ID <arg choice="plain">APP</arg> is not specified
@@ -211,7 +211,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-complete, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -402,7 +402,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-complete, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     xdg-run, xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths


### PR DESCRIPTION
host-complete is the sledgehammer permission for file browser and similar apps that the user might want to give full access to.

this works same as the existing host keywords by mounting into /run/host/complete. applications will need adjustments to essentially treat that path as "root".

since this opens the door to all sorts of malicious software I'd advise putting this permission under tight review in flatpak repositories.

Resolves: #5723