### PR TITLE
wayland: Unset WAYLAND_DISPLAY, WAYLAND_SOCKET when socket is disabled

### DIFF
--- a/common/flatpak-run-sockets.c
+++ b/common/flatpak-run-sockets.c
@@ -176,18 +176,17 @@ flatpak_run_add_socket_args_environment (FlatpakBwrap         *bwrap,
                                          const char           *app_id,
                                          const char           *instance_id)
 {
+  gboolean allow_wayland;
+  gboolean inherit_wayland_socket;
   gboolean has_wayland = FALSE;
   gboolean allow_x11;
-  gboolean inherit_wayland_socket;
 
-  if (sockets & FLATPAK_CONTEXT_SOCKET_WAYLAND)
-    {
-      g_info ("Allowing wayland access");
-      g_assert (app_id && instance_id);
-      inherit_wayland_socket = (sockets & FLATPAK_CONTEXT_SOCKET_INHERIT_WAYLAND_SOCKET) != 0;
-      has_wayland = flatpak_run_add_wayland_args (bwrap, app_id, instance_id,
-                                                  inherit_wayland_socket);
-    }
+  allow_wayland = (sockets & FLATPAK_CONTEXT_SOCKET_WAYLAND) != 0;
+  inherit_wayland_socket = (sockets & FLATPAK_CONTEXT_SOCKET_INHERIT_WAYLAND_SOCKET) != 0;
+  has_wayland = flatpak_run_add_wayland_args (bwrap,
+                                              app_id, instance_id,
+                                              allow_wayland,
+                                              inherit_wayland_socket);
 
   if ((sockets & FLATPAK_CONTEXT_SOCKET_FALLBACK_X11) != 0)
     allow_x11 = !has_wayland;

--- a/common/flatpak-run-wayland-private.h
+++ b/common/flatpak-run-wayland-private.h
@@ -32,6 +32,7 @@ gboolean
 flatpak_run_add_wayland_args (FlatpakBwrap *bwrap,
                               const char   *app_id,
                               const char   *instance_id,
+                              gboolean      allowed,
                               gboolean      inherit_wayland_socket);
 
 G_END_DECLS

--- a/common/flatpak-run-wayland.c
+++ b/common/flatpak-run-wayland.c
@@ -244,6 +244,7 @@ gboolean
 flatpak_run_add_wayland_args (FlatpakBwrap *bwrap,
                               const char   *app_id,
                               const char   *instance_id,
+                              gboolean      allowed,
                               gboolean      inherit_wayland_socket)
 {
   const char *wayland_display;
@@ -255,6 +256,17 @@ flatpak_run_add_wayland_args (FlatpakBwrap *bwrap,
 #ifdef ENABLE_WAYLAND_SECURITY_CONTEXT
   gboolean security_context_available = FALSE;
 #endif
+
+  if (!allowed)
+    {
+      flatpak_bwrap_unset_env (bwrap, "WAYLAND_DISPLAY");
+      flatpak_bwrap_unset_env (bwrap, "WAYLAND_SOCKET");
+      return FALSE;
+    }
+
+  g_info ("Allowing wayland access");
+
+  g_assert (app_id && instance_id);
 
   wayland_display = get_wayland_display_name ();
 


### PR DESCRIPTION
To handle those details at the right place (flatpak-run-wayland.c), we pass if the wayland socket is allowed to flatpak_run_add_wayland_args and handle it there instead of in the caller.

Closes #3948