### PR TITLE
dir: Allow app updates without consulting parental controls

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -663,6 +663,7 @@ gboolean              flatpak_dir_deploy                                    (Fla
                                                                              const char                    *checksum_or_latest,
                                                                              const char * const            *subpaths,
                                                                              const char * const            *previous_ids,
+                                                                             const char                    *parental_controls_action_id,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
 gboolean              flatpak_dir_deploy_update                             (FlatpakDir                    *self,

--- a/system-helper/org.freedesktop.Flatpak.policy.in
+++ b/system-helper/org.freedesktop.Flatpak.policy.in
@@ -284,13 +284,39 @@
              * Set the malcontent `is-system-installation-allowed` property of
                all users’ parental controls policies to true.
      -->
-    <description>Override parental controls</description>
+    <description>Override parental controls for installs</description>
     <message>Authentication is required to install software which is restricted by your parental controls policy</message>
     <icon_name>package-x-generic</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
       <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.Flatpak.override-parental-controls-update</annotate>
+  </action>
+
+  <action id="org.freedesktop.Flatpak.override-parental-controls-update">
+    <!-- SECURITY:
+          - This is like org.freedesktop.Flatpak.override-parental-controls, but
+            it’s queried for app updates, whereas the former is queried for app
+            installs.
+          - As with the above action, this one is only queried if
+            org.freedesktop.Flatpak.app-update has allowed the app update, and
+            only if the app being updated has too extreme content for the user
+            who is trying to update it.
+          - The default policy for this is to *allow* updates to ‘too extreme’
+            apps by default, on the basis that having an out-of-date (i.e.
+            insecure or unsupported) app is a worse outcome than automatically
+            installing an update which has radically different content from the
+            version of the app which the parent originally vetted and installed.
+     -->
+    <description>Override parental controls for updates</description>
+    <message>Authentication is required to update software which is restricted by your parental controls policy</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
     </defaults>
   </action>
 


### PR DESCRIPTION
Currently, app installs and updates are treated the same from the point of view of the parental controls permissions checks. This was intended so that parents have to re-check each app update to make sure it’s still appropriate for their children.

In practice, though, parents are not that hands-on, and there are a lot of regular app updates. The tradeoff between app updates (which bring security fixes and features) and not changing so much in apps that a parent’s initial assessment of their suitability for their child is probably skewed the wrong way. We should be preferring updates (in particular, so we get security updates), and assuming that if an app is OK to begin with, it’s probably not going to change so radically as to become unsuitable for a child with an update.

As a data point, Google Play’s parental controls will allow apps to be automatically updated even if a child account can’t install new apps.

So, implement this by splitting the existing
`org.freedesktop.Flatpak.override-parental-controls` polkit action in two: the existing action for _installs_, and a new `org.freedesktop.Flatpak.override-parental-controls-update` action for _updates_. `FlatpakDir` is changed to use the appropriate action depending on whether an app is being installed from scratch or updated. The default policies for the two actions differ.

Users/Distros who disagree with the new default policy can provide their own polkit rules to change the behaviour of
`override-parental-controls-update` so that it matches `override-parental-controls`, to bring back the old behaviour.

Signed-off-by: Philip Withnall <pwithnall@gnome.org>

Fixes: https://github.com/flatpak/flatpak/issues/5552