### PR TITLE
run: Add udmabuf to --device=dri

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -398,6 +398,7 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
           int i;
           static const char * const dri_devices[] = {
             "/dev/dri",
+            "/dev/udmabuf",
             /* mali */
             "/dev/mali",
             "/dev/mali0",


### PR DESCRIPTION
udmabuf allows clients to allocate virtual memory as dmabufs, which then potentially can be imported by other dma subsystems - most importantly GPU drivers and KMS. This can avoid copies and thus increase performance.

Unlike other dmabuf allocators like e.g. dma heaps this doesn't have known issues relevant for sandboxing. Notably memory accounting works as expected, so apps can't use udmabuf to escape resource limitations. For this reason systemd, since version 257[1], grants "uaccess" access to udmabuf by default, considering it as "safe".

With udmabuf increasingly being availably by default, various apps and libraries start making use of it - examples include libcamera, mesa llvmpipe and Gstreamer. Thus let's grant access to it in Flatpak as well.

For now limit it to "dri" access as sharing buffers with GPUs is the most common use-case. There is no strong reason to not lift restrictions further if the need arises, though.

1: https://github.com/systemd/systemd/pull/33738

---

Todo: add links to related projects once the FDO gitlab is bad.