### PR TITLE
profile: fix a shellcheck warning

### DIFF
--- a/profile/flatpak.sh
+++ b/profile/flatpak.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh
 if command -v flatpak > /dev/null; then
     # set XDG_DATA_DIRS to include Flatpak installations
 


### PR DESCRIPTION
Error: SHELLCHECK_WARNING (CWE-758): [#def1]
/etc/profile.d/flatpak.sh:1:1: error[SC2148]: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

Resolves: https://openscanhub.fedoraproject.org/task/51962/log/flatpak-1.16.0-3.fc43/scan-results.html#def1