### PR TITLE
CONTRIBUTING: Remove mention of Autotools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,23 +41,6 @@ meson test -C _build
 sudo meson install -C _build
 ```
 
-## Building with Autotools
-
-Older branches of Flatpak used GNU Autotools. See
-https://github.com/flatpak/flatpak/blob/flatpak-1.14.x/CONTRIBUTING.md
-for more details of that build system.
-
-The Autotools build system is likely to be removed from a future version
-of Flatpak, leaving Meson as the only build system supported.
-
-Newer releases of Flatpak do not include Autotools-generated files in
-the source archive. If it is necessary to build these releases with
-Autotools for some reason, the build system must be set up by running:
-
-    ./autogen.sh
-
-before proceeding as if for any other Autotools project.
-
 ## How to run a specified set of tests
 
 Sometimes you don't want to run the whole test suite but just one you're


### PR DESCRIPTION
Autotools support was removed as of commit 8e63eda, remove mention of the Autotools support in the CONTRIBUTING file

Alternatively, we could still reference the support in 1.14.x, but remove the bit where it says you may set up autotools building in the newer revs.