### PR TITLE
testlib: add expected argument to fcntl(F_DUPFD)

### DIFF
--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -257,7 +257,7 @@ tests_stdout_to_stderr_begin (void)
 {
   TestsStdoutToStderr *original = g_new0 (TestsStdoutToStderr, 1);
 
-  original->fd = fcntl (STDOUT_FILENO, F_DUPFD_CLOEXEC);
+  original->fd = fcntl (STDOUT_FILENO, F_DUPFD_CLOEXEC, 3);
 
   if (original->fd < 0)
     g_error ("fcntl F_DUPFD_CLOEXEC: %s", g_strerror (errno));


### PR DESCRIPTION
The F_DUPFD and its relative F_DUPFD_CLOEXEC both expect an int argument as extra argument, being the minimal value for the new FD. This argument must be within the accepted range (see ulimit -H -n).

This was detected in Ubuntu during testing against the latest glibc, stracing resulted in:

107244 fcntl(1, F_DUPFD_CLOEXEC, 1847846346272) = -1 EINVAL (Invalid argument)

On the system in question (ppc64el machine running Ubuntu Questing), the relevant limit is 524288.

For the fix we use 3 as a reasonable floor value, as in the first one after stderr. It also happens to be the one used in revokefs/main.c.

Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/2121039