### PR TITLE
ci: Add flatpak-1.16.x to branch allowlist

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ on:
     - flatpak-1.10.x
     - flatpak-1.12.x
     - flatpak-1.14.x
+    - flatpak-1.16.x
   pull_request:
     paths-ignore:
     - README.md
@@ -31,6 +32,7 @@ on:
     - flatpak-1.10.x
     - flatpak-1.12.x
     - flatpak-1.14.x
+    - flatpak-1.16.x
   merge_group:
     types:
     - checks_requested


### PR DESCRIPTION
This lets CI run for the flatpak-1.16.x branch. Needs backporting to fully work.