### PR TITLE
flatpak-build: Drop host permissions by default

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -436,7 +436,6 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
   if (app_context == NULL)
     return FALSE;
 
-  flatpak_context_allow_host_fs (app_context);
   flatpak_context_merge (app_context, arg_context);
 
   minimal_envp = flatpak_run_get_minimal_env (TRUE, FALSE);

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -126,7 +126,6 @@ gboolean       flatpak_context_load_metadata (FlatpakContext *context,
 void           flatpak_context_save_metadata (FlatpakContext *context,
                                               gboolean        flatten,
                                               GKeyFile       *metakey);
-void           flatpak_context_allow_host_fs (FlatpakContext *context);
 void           flatpak_context_set_session_bus_policy (FlatpakContext *context,
                                                        const char     *name,
                                                        FlatpakPolicy   policy);

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2374,13 +2374,6 @@ flatpak_context_save_metadata (FlatpakContext *context,
                                     FLATPAK_METADATA_KEY_USB_HIDDEN_DEVICES);
 }
 
-void
-flatpak_context_allow_host_fs (FlatpakContext *context)
-{
-  flatpak_context_take_filesystem (context, g_strdup ("host"),
-                                   FLATPAK_FILESYSTEM_MODE_READ_WRITE);
-}
-
 gboolean
 flatpak_context_get_needs_session_bus_proxy (FlatpakContext *context)
 {


### PR DESCRIPTION
For some reason, flatpak build always had host permissions set by default. There really isn't a good reason for this. The build should be isolated from the host as much as possible by default.

The elephant in the room: removing a permission has the potential to break the tooling that's build on top of this.

/cc @bbhtt @barthalion 