### PR TITLE
Enable VA-API extension for Intel GPUs if either i915 or xe is loaded

### DIFF
--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -517,7 +517,7 @@ flatpak_get_have_intel_gpu (void)
   static int have_intel = -1;
 
   if (have_intel == -1)
-    have_intel = g_file_test ("/sys/module/i915", G_FILE_TEST_EXISTS);
+    have_intel = g_file_test ("/sys/module/i915", G_FILE_TEST_EXISTS) || g_file_test ("/sys/module/xe", G_FILE_TEST_EXISTS);
 
   return have_intel;
 }


### PR DESCRIPTION
Enable VA-API extension for Intel GPUs if either i915 or xe is loaded

The xe module supports newer Intel discrete GPUs (the Arc series) and the i915
module is for older or integrated GPUs.

Resolves: https://github.com/flatpak/flatpak/issues/5248
