### PR TITLE
exports: add host-root

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -94,6 +94,7 @@ const char *flatpak_context_special_filesystems[] = {
   "host-etc",
   "host-os",
   "host-reset",
+  "host-root",
   NULL
 };
 
@@ -1033,7 +1034,7 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
     }
 
   g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
-               _("Unknown filesystem location %s, valid locations are: host, host-os, host-etc, home, xdg-*[/…], ~/dir, /dir"), filesystem);
+               _("Unknown filesystem location %s, valid locations are: host, host-os, host-etc, host-root, home, xdg-*[/…], ~/dir, /dir"), filesystem);
   return FALSE;
 }
 
@@ -2839,7 +2840,7 @@ flatpak_context_export (FlatpakContext *context,
 {
   gboolean home_access = FALSE;
   g_autoptr(GString) xdg_dirs_conf = NULL;
-  FlatpakFilesystemMode fs_mode, os_mode, etc_mode, home_mode;
+  FlatpakFilesystemMode fs_mode, os_mode, etc_mode, root_mode, home_mode;
   GHashTableIter iter;
   gpointer key, value;
   g_autoptr(GError) local_error = NULL;
@@ -2905,6 +2906,12 @@ flatpak_context_export (FlatpakContext *context,
 
   if (etc_mode != FLATPAK_FILESYSTEM_MODE_NONE)
     flatpak_exports_add_host_etc_expose (exports, etc_mode);
+
+  root_mode = MAX (GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "host-root")),
+                   fs_mode);
+
+  if (root_mode != FLATPAK_FILESYSTEM_MODE_NONE)
+    flatpak_exports_add_host_root_expose (exports, root_mode);
 
   home_mode = GPOINTER_TO_INT (g_hash_table_lookup (context->filesystems, "home"));
   if (home_mode != FLATPAK_FILESYSTEM_MODE_NONE)

--- a/common/flatpak-exports-private.h
+++ b/common/flatpak-exports-private.h
@@ -43,6 +43,8 @@ void flatpak_exports_add_host_etc_expose (FlatpakExports       *exports,
                                           FlatpakFilesystemMode mode);
 void flatpak_exports_add_host_os_expose (FlatpakExports       *exports,
                                          FlatpakFilesystemMode mode);
+void flatpak_exports_add_host_root_expose (FlatpakExports       *exports,
+                                           FlatpakFilesystemMode mode);
 gboolean flatpak_exports_add_path_expose (FlatpakExports         *exports,
                                           FlatpakFilesystemMode   mode,
                                           const char             *path,

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -234,7 +234,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This updates the [Context] group in the metadata.
-                    FS can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    FS can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -254,7 +254,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    FILESYSTEM can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    FILESYSTEM can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -223,7 +223,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
@@ -243,7 +243,7 @@
                     Remove access to the specified subset of the filesystem from
                     the application. This overrides to the Context section from the
                     application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -344,6 +344,26 @@
                                 Available since 1.7.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>host-root</option></term>
+                            <listitem><para>
+                                The complete host operating system.
+                            </para>
+                            <para>
+                                To avoid conflicting with the Flatpak
+                                runtime, this is mounted in the sandbox
+                                at <filename>/run/host/root</filename>.
+                            </para>
+                            <para>
+                                This permission is only intended to be used
+                                as a last resort when there is no possible
+                                alternative with other filesystem
+                                permissions for applications that need the
+                                entire root filesystem of the host.
+                            </para>
+                            <para>
+                                Available since 1.17.
+                            </para></listitem></varlistentry>
+
                             <varlistentry><term><option>xdg-desktop</option>,
                                 <option>xdg-documents</option>,
                                 <option>xdg-download</option>,

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -361,6 +361,25 @@
                                 entire root filesystem of the host.
                             </para>
                             <para>
+                                Please note that following symlinks under
+                                <filename>/run/host/root</filename> naively
+                                will result in a wrong path. For example,
+                                using <literal>realpath()</literal> is wrong.
+                                Instead, applications will have to implement
+                                some way of following symlinks in a way that
+                                behaves as if it were chroot'd into
+                                <filename>/run/host/root</filename>.
+                            </para>
+                            <para>
+                                There are a few ways to do this. Modern
+                                kernels support the <ulink url="https://man7.org/linux/man-pages/man2/openat2.2.html">openat2()</ulink>
+                                call with <literal>RESOLVE_IN_ROOT</literal>.
+                                For a more portable solution with support for
+                                older kernels, see the implementation from
+                                the <ulink url="https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/65adfdd5fc812aeb5f33986755f6ff72c9612afa/steam-runtime-tools/resolve-in-sysroot.c">steam-runtime-tools</ulink>
+                                as an example.
+                            </para>
+                            <para>
                                 Available since 1.17.
                             </para></listitem></varlistentry>
 

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -211,7 +211,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -402,7 +402,7 @@
                 <listitem><para>
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
-                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download,
+                    <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
                     xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
                     xdg-run, xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths


### PR DESCRIPTION
Adapted from: https://github.com/flatpak/flatpak/pull/6125

In systemd v259, /run/host/root will be a documented location for bind mounting the host's root filesystem into a container. Ref: https://github.com/systemd/systemd/pull/38384

host-root is the sledgehammer permission for file browsers and similar apps that the user might want to give full access to.

This works same as the existing host keywords by mounting into /run/host/root. applications will need adjustments to essentially treat that path as "root".

Since this opens the door to all sorts of malicious software, the permission should be put under tight review in flatpak repositories.

Resolves: #5723