### PR TITLE
Backport `flatpak-build: Add empty /run/host/font-dirs.xml` for 1.16

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -59,6 +59,17 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
+static void
+add_empty_font_dirs_xml (FlatpakBwrap *bwrap)
+{
+  g_autoptr(GString) xml_snippet = g_string_new ("<?xml version=\"1.0\"?>\n"
+                                                 "<!DOCTYPE fontconfig SYSTEM \"urn:fontconfig:fonts.dtd\">\n"
+                                                 "<fontconfig></fontconfig>\n");
+
+  if (!flatpak_bwrap_add_args_data (bwrap, "font-dirs.xml", xml_snippet->str, xml_snippet->len, "/run/host/font-dirs.xml", NULL))
+    g_warning ("Unable to add fontconfig data snippet");
+}
+
 /* Unset FD_CLOEXEC on the array of fds passed in @user_data */
 static void
 child_setup (gpointer user_data)
@@ -558,6 +569,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                          app_context, app_id_dir, NULL, -1,
                                          instance_id, NULL, cancellable, error))
     return FALSE;
+
+  add_empty_font_dirs_xml (bwrap);
 
   for (i = 0; opt_bind_mounts != NULL && opt_bind_mounts[i] != NULL; i++)
     {


### PR DESCRIPTION
I am backporting this, because I really would like to see it included with flatpak 1.16.2, in case this will be released before 1.18.0. flathub currently uses flatpak 1.16.1, and the issue fixed by this patch currently prevents org.kicad.KiCad from running our test suite for flathub builds. Thanks for considering this. In case I should also edit the `NEWS` file, please let me know.

---

flatpak run writes /run/host/font-dirs.xml, but flatpak build so far didn't.  This resulted in fontconfig writing:

Fontconfig error: Cannot load config file "/run/host/font-dirs.xml": No such file: /run/host/font-dirs.xml

to the stderr of all processes utilizing fontconfig and run during flatpak build, as /run/host/font-dirs.xml is included via /etc/fonts/50-flatpak.conf. This could cause issues for tests run during building an application, for example.

Closes #6137

(cherry picked from commit 054f4f4a7b674067a8167fb2eed6e8d768852f94)