### PR TITLE
utils-http: Fix an uninitialised variable warning

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -281,7 +281,7 @@ flatpak_get_certificates_for_uri (const char  *uri,
     {
       g_autoptr(GFile) certs_dir = g_file_new_for_path (certs_path[i]);
       g_autoptr(GFile) host_dir = g_file_get_child (certs_dir, hostport);
-      g_autoptr(GFileEnumerator) enumerator;
+      g_autoptr(GFileEnumerator) enumerator = NULL;
       g_autoptr(GError) local_error = NULL;
 
       enumerator = g_file_enumerate_children (host_dir, G_FILE_ATTRIBUTE_STANDARD_NAME,


### PR DESCRIPTION
Fixes c75ba1c7e1587300be9a418116c02d0b6bf8b34e

```
In file included from /usr/lib/aarch64-linux-gnu/glib-2.0/include/glibconfig.h:9,
 from /usr/include/glib-2.0/glib/gtypes.h:34,
 from /usr/include/glib-2.0/glib/galloca.h:34,
 from /usr/include/glib-2.0/glib.h:32,
 from /usr/include/glib-2.0/gobject/gbinding.h:30,
 from /usr/include/glib-2.0/glib-object.h:24,
 from /usr/include/glib-2.0/gio/gioenums.h:30,
 from /usr/include/glib-2.0/gio/giotypes.h:30,
 from /usr/include/glib-2.0/gio/gio.h:28,
 from ../common/flatpak-utils-http.c:23:
In function ‘glib_autoptr_clear_GFileEnumerator’,
 inlined from ‘glib_autoptr_cleanup_GFileEnumerator’ at /usr/include/glib-2.0/gio/gio-autocleanups.h:69:1,
 inlined from ‘flatpak_get_certificates_for_uri’ at ../common/flatpak-utils-http.c:284:34:
/usr/include/glib-2.0/glib/gmacros.h:1361:10: warning: ‘enumerator’ may be used uninitialized [-Wmaybe-uninitialized]
 1361 | { if (_ptr) (cleanup) ((ParentName *) _ptr); } \
 | ^
/usr/include/glib-2.0/glib/gmacros.h:1379:3: note: in expansion of macro ‘_GLIB_DEFINE_AUTOPTR_CLEANUP_FUNCS’
 1379 | _GLIB_DEFINE_AUTOPTR_CLEANUP_FUNCS(TypeName, TypeName, func)
 | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/gio/gio-autocleanups.h:69:1: note: in expansion of macro ‘G_DEFINE_AUTOPTR_CLEANUP_FUNC’
 69 | G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileEnumerator, g_object_unref)
 | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../common/flatpak-utils-http.c: In function ‘flatpak_get_certificates_for_uri’:
../common/flatpak-utils-http.c:284:34: note: ‘enumerator’ was declared here
 284 | g_autoptr(GFileEnumerator) enumerator;
```