### PR TITLE
dir: Add basic OS info to Flatpak-Os-Info header when pulling objects

### DIFF
--- a/app/flatpak-builtins-config.c
+++ b/app/flatpak-builtins-config.c
@@ -178,6 +178,21 @@ parse_lang (const char *value, GError **error)
 }
 
 static char *
+parse_boolean (const char  *value,
+               GError     **error)
+{
+  if (g_strcmp0 (value, "true") == 0)
+    return g_strdup ("true");
+  else if (g_strcmp0 (value, "false") == 0)
+    return g_strdup ("false");
+  else
+    {
+      flatpak_fail (error, _("'%s' is not a valid value (use 'true' or 'false')"), value);
+      return NULL;
+    }
+}
+
+static char *
 print_locale (const char *value)
 {
   return g_strdup (value);
@@ -192,11 +207,31 @@ print_lang (const char *value)
 }
 
 static char *
+print_boolean (const char *value)
+{
+  if (!value)
+    return g_strdup ("*unset*");
+  
+  if (g_strcmp0 (value, "true") == 0)
+    return g_strdup ("true");
+  else if (g_strcmp0 (value, "false") == 0)
+    return g_strdup ("false");
+  else
+    return g_strdup ("*invalid*");
+}
+
+static char *
 get_lang_default (FlatpakDir *dir)
 {
   g_auto(GStrv) langs = flatpak_dir_get_default_locale_languages (dir);
 
   return g_strjoinv (";", langs);
+}
+
+static char *
+get_report_os_info_default (FlatpakDir *dir)
+{
+  return g_strdup ("true");
 }
 
 typedef struct
@@ -210,6 +245,7 @@ typedef struct
 ConfigKey keys[] = {
   { "languages", parse_lang, print_lang, get_lang_default },
   { "extra-languages", parse_locale, print_locale, NULL },
+  { "report-os-info", parse_boolean, print_boolean, get_report_os_info_default },
 };
 
 static ConfigKey *

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -72,6 +72,8 @@ gint flatpak_strcmp0_ptr (gconstpointer a,
 /* Sometimes this is /var/run which is a symlink, causing weird issues when we pass
  * it as a path into the sandbox */
 char * flatpak_get_real_xdg_runtime_dir (void);
+char * flatpak_get_os_release_id (void);
+char * flatpak_get_os_release_version_id (void);
 
 gboolean  flatpak_has_path_prefix (const char *str,
                                    const char *prefix);

--- a/doc/flatpak-config.xml
+++ b/doc/flatpak-config.xml
@@ -76,6 +76,16 @@
                    (for example, <literal>en;en_DK;zh_HK.big5hkscs;uz_UZ.utf8@cyrillic</literal>).
                 </para></listitem>
             </varlistentry>
+            <varlistentry>
+                <term><varname>report-os-info</varname></term>
+                <listitem><para>
+                   If this key is set to <literal>false</literal> or the <filename>no-report-os-info</filename>
+                   file exists at <envar>FLATPAK_CONFIG_DIR</envar> Flatpak will not report the OS name,
+                   version, and architecture from <filename>/etc/os-release</filename> to the Flatpak
+                   remote via the <literal>Flatpak-Os-Info</literal> HTTP header when pulling objects.
+                   The default value of the key if unset is <literal>true</literal>.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
 
         <para>


### PR DESCRIPTION
Fixes https://github.com/flatpak/flatpak/issues/5549