### PR TITLE
meson: switch default dbus_config_dir to /usr/share/dbus-1/

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -126,7 +126,7 @@ endif
 
 dbus_config_dir = get_option('dbus_config_dir')
 if dbus_config_dir == ''
-  dbus_config_dir = get_option('sysconfdir') / 'dbus-1' / 'system.d'
+  dbus_config_dir = get_option('datadir') / 'dbus-1' / 'system.d'
 endif
 
 dbus_service_dir = get_option('dbus_service_dir')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,7 +16,7 @@ option(
 option(
   'dbus_config_dir',
   type : 'string',
-  description : 'directory for D-Bus system configuration [$sysconfdir/dbus-1/system.d]',
+  description : 'directory for D-Bus system configuration [$datadir/dbus-1/system.d]',
   value : '',
 )
 option(


### PR DESCRIPTION
Upstream/vendor configuration files should be installed under /usr/, so that local users/admins can install overrides in /etc/. Distributions like Ubuntu are already manually configuring this, so just make it the default.

On request of the Fedora maintainer: https://src.fedoraproject.org/rpms/flatpak/pull-request/21