### PR TITLE
session-helper: Improve file monitoring in case of broken symlinks

### DIFF
--- a/common/flatpak-utils-base-private.h
+++ b/common/flatpak-utils-base-private.h
@@ -37,6 +37,8 @@ char * flatpak_readlink (const char *path,
                          GError    **error);
 char * flatpak_resolve_link (const char *path,
                              GError    **error);
+char * flatpak_realpath (const char  *path,
+                         GError     **error);
 char * flatpak_canonicalize_filename (const char *path);
 
 #endif /* __FLATPAK_UTILS_BASE_H__ */

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -563,12 +563,15 @@ static void file_changed (GFileMonitor     *monitor,
 static void
 update_real_monitor (MonitorData *data)
 {
-  char *real = realpath (data->source, NULL);
+  char *real = NULL;
+  g_autoptr(GError) error = NULL;
+
+  real = flatpak_realpath (data->source, &error);
 
   if (real == NULL)
     {
       g_info ("unable to get real path to monitor host file %s: %s", data->source,
-              g_strerror (errno));
+              error->message);
       return;
     }
 


### PR DESCRIPTION
On some distros, /etc/resolv.conf is a symlink pointing to files managed by an external program. When the system starts up, the destination of such a symlink may not exist, leaving /etc/resolv.conf as a dangling symlink. Session-helper's file monitoring functionality was buggy and unable to track the destinations of such broken symlinks.

If the user starts a Flatpak application before an external program (e.g. NetworkManager)  creates the destination resolv.conf file, the network connection for all Flatpak applications will be broken unless the user manually copies resolv.conf to /run/user/$UID/.flatpak-helper/monitor/.

This patch fixes the race condition #4268  by always monitoring the destinations of symlinks, no matter it is broken or not.
