### PR TITLE
repo-utils: Drop stripping .desktop suffixes from appstream cids

### DIFF
--- a/common/flatpak-repo-utils.c
+++ b/common/flatpak-repo-utils.c
@@ -3232,9 +3232,6 @@ extract_appstream (OstreeRepo        *repo,
               continue;
             }
 
-          if (g_str_has_suffix (component_id_suffix, ".desktop"))
-            component_id_suffix[strlen (component_id_suffix) - strlen (".desktop")] = 0;
-
           if (!copy_icon (component_id_text, icons_dir, repo, size1_mtree, "64x64", &my_error))
             {
               g_print (_("Error copying 64x64 icon for component %s: %s\n"), component_id_text, my_error->message);


### PR DESCRIPTION
This is attempt 2 at landing https://github.com/flatpak/flatpak/pull/5752. The previous one bitrotted, and I deleted the fork some time ago, so can't reopen that PR. 

The bug however, is still there even though the number of cids ending at `.desktop` dropped significantly in one year since that PR.

We should attempt to backport this to 1.16.x if merged to main, both flatpak and flatpak-builder are now fully switched to libappstream and no longer supports appstream-glib