### PR TITLE
flatpak-run: Mount /dev/ntsync with --device=ntsync

### DIFF
--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -70,6 +70,7 @@ typedef enum {
   FLATPAK_CONTEXT_DEVICE_SHM         = 1 << 3,
   FLATPAK_CONTEXT_DEVICE_INPUT       = 1 << 4,
   FLATPAK_CONTEXT_DEVICE_USB         = 1 << 5,
+  FLATPAK_CONTEXT_DEVICE_NTSYNC      = 1 << 6,
 } FlatpakContextDevices;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -76,6 +76,7 @@ const char *flatpak_context_devices[] = {
   "shm",
   "input",
   "usb",
+  "ntsync",
   NULL
 };
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -446,6 +446,14 @@ flatpak_run_add_environment_args (FlatpakBwrap    *bwrap,
               flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/input", "/dev/input", NULL);
         }
 
+      if (context->devices & FLATPAK_CONTEXT_DEVICE_NTSYNC)
+        {
+          g_info ("Allowing ntsync device access.");
+
+          if (g_file_test ("/dev/ntsync", G_FILE_TEST_EXISTS))
+              flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/ntsync", "/dev/ntsync", NULL);
+        }
+
       if (context->devices & FLATPAK_CONTEXT_DEVICE_KVM)
         {
           g_info ("Allowing kvm access");

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -162,7 +162,7 @@
                 <listitem><para>
                     Expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, input, usb, kvm, shm, all.
+                    DEVICE must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -173,7 +173,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This updates
                     the [Context] group in the metadata.
-                    DEVICE must be one of: dri, input, usb, kvm, shm, all.
+                    DEVICE must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -172,7 +172,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -183,7 +183,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -192,6 +192,12 @@
                                 Available since 1.15.11.
                             </para></listitem></varlistentry>
 
+                            <varlistentry><term><option>ntsync</option></term>
+                            <listitem><para>
+                                NTSync device
+                                (<filename>/dev/ntsync</filename>).
+                            </para></listitem></varlistentry>
+
                             <varlistentry><term><option>kvm</option></term>
                             <listitem><para>
                                 Virtualization

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -160,7 +160,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -171,7 +171,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -355,7 +355,7 @@
                 <listitem><para>
                     Expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, usb, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>
@@ -366,7 +366,7 @@
                 <listitem><para>
                     Don't expose a device to the application. This overrides to
                     the Context section from the application metadata.
-                    <arg choice="plain">DEVICE</arg> must be one of: dri, usb, input, kvm, shm, all.
+                    <arg choice="plain">DEVICE</arg> must be one of: dri, input, usb, ntsync, kvm, shm, all.
                     This option can be used multiple times.
                 </para></listitem>
             </varlistentry>


### PR DESCRIPTION
NTSync was already released in the [Linux 6.14](https://www.phoronix.com/news/Linux-6.14) kernel version. The [WINE 10.16](https://www.winehq.org/news/2025100301) release notes also state that NTSync support has been added. During this time, the only workaround for people was using `--device=all`. This is why I defined `--device=ntsync`.
Reference issue: https://github.com/flatpak/flatpak/issues/6199

Note: I do not know C. All I did was mimic https://github.com/flatpak/flatpak/pull/5855 and https://github.com/flatpak/flatpak/pull/5481. I wanted to try my luck since people might not have the time. I apologize if I did not do it properly.