### PR TITLE
app/common: fix sudo check by checking euid

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -376,7 +376,7 @@ flatpak_option_context_parse (GOptionContext     *context,
    * which is almost certainly not what the user intended so just consider it
    * an error.
    */
-  if (opt_user && running_under_sudo ())
+  if (opt_user && running_under_sudo_root ())
     return flatpak_fail_error (error, FLATPAK_ERROR,
                                _("Refusing to operate under sudo with --user. "
                                  "Omit sudo to operate on the user installation, "

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3054,7 +3054,7 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
   /* This check exists to stop accidental usage of `sudo flatpak run`
      and is not to prevent running as root.
    */
-  if (running_under_sudo ())
+  if (running_under_sudo_root ())
     return flatpak_fail_error (error, FLATPAK_ERROR,
                                _("\"flatpak run\" is not intended to be run as `sudo flatpak run`. "
                                  "Use `sudo -i` or `su -l` instead and invoke \"flatpak run\" from "

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -350,7 +350,7 @@ char * flatpak_escape_string (const char        *s,
 gboolean flatpak_validate_path_characters (const char *path,
                                            GError    **error);
 
-gboolean running_under_sudo (void);
+gboolean running_under_sudo_root (void);
 
 void flatpak_set_debugging (gboolean debugging);
 gboolean flatpak_is_debugging (void);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2481,7 +2481,7 @@ flatpak_validate_path_characters (const char *path,
 }
 
 gboolean
-running_under_sudo (void)
+running_under_sudo_root (void)
 {
   const char *sudo_command_env = g_getenv ("SUDO_COMMAND");
   g_auto(GStrv) split_command = NULL;
@@ -2491,7 +2491,9 @@ running_under_sudo (void)
 
   /* SUDO_COMMAND could be a value like `/usr/bin/flatpak run foo` */
   split_command = g_strsplit (sudo_command_env, " ", 2);
-  if (g_str_has_suffix (split_command[0], "flatpak"))
+  /* Check if sudo was used to run as root instead of non-root users
+   * using -u or -g for example. */
+  if (g_str_has_suffix (split_command[0], "flatpak") && geteuid () == 0)
     return TRUE;
 
   return FALSE;


### PR DESCRIPTION
Sudo can be used in several ways other than calling a command with the root user. For example, one can use -u to run the command as the specified user, or -g to specify a primary group to run the command as.

Flatpak adds a check when --user is used to prevent an installation in the root's directory, for example, but it does it by only checking if sudo was used. As stated previously, it does not necessarily imply root, so this patch explicitly checks if the command is being run with the root user. The same happens with the flatpak run command.

Fixes: https://github.com/flatpak/flatpak/issues/5979