### PR TITLE
builtins/install: Allow flatpak+https URIs in flatpak install --from

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -236,6 +236,9 @@ install_from (FlatpakDir *dir,
 
   filename = argv[1];
 
+  if (g_str_has_prefix (filename, "flatpak+https:"))
+    filename += strlen ("flatpak+");
+
   if (g_str_has_prefix (filename, "http:") ||
       g_str_has_prefix (filename, "https:"))
     {


### PR DESCRIPTION
Those schemes are in use by flathub, usually to be handled by an app store, but we can also handle it directly with `flatpak install`.

Base on an idea from user bbb651 in
https://github.com/flatpak/flatpak/pull/6259.