### PR TITLE
transaction: Handle --include-sdk if SDK is installed in other dir

### DIFF
--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -2660,7 +2660,7 @@ add_deps (FlatpakTransaction          *self,
                 return FALSE;
             }
 
-          if (sdk_op->kind != FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
+          if (sdk_op && sdk_op->kind != FLATPAK_TRANSACTION_OPERATION_UNINSTALL)
             {
               flatpak_transaction_operation_add_related_to_op (sdk_op, op);
               run_operation_before (sdk_op, op, 2);


### PR DESCRIPTION
If an SDK is already installed in a dir that is not targeted with a flatpak transaction, and the transaction has auto_install_sdk set, add_new_dep_op returns NULL in dep_op which is not correctly handled in add_deps.