### PR TITLE
feature: add optional user namespacing to the sandbox and run flag for seccomp

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -42,6 +42,7 @@ static char *opt_branch;
 static char *opt_command;
 static char *opt_cwd;
 static gboolean opt_devel;
+static gboolean opt_userns;
 static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
 static gboolean opt_log_a11y_bus;
@@ -69,6 +70,7 @@ static GOptionEntry options[] = {
   { "cwd", 0, 0, G_OPTION_ARG_STRING, &opt_cwd, N_("Directory to run the command in"), N_("DIR") },
   { "branch", 0, 0, G_OPTION_ARG_STRING, &opt_branch, N_("Branch to use"), N_("BRANCH") },
   { "devel", 'd', 0, G_OPTION_ARG_NONE, &opt_devel, N_("Use development runtime"), NULL },
+  { "userns", 0, 0, G_OPTION_ARG_NONE, &opt_userns, N_("Allow user namespaces inside sandbox"), NULL },
   { "runtime", 0, 0, G_OPTION_ARG_STRING, &opt_runtime, N_("Runtime to use"), N_("RUNTIME") },
   { "runtime-version", 0, 0, G_OPTION_ARG_STRING, &opt_runtime_version, N_("Runtime version to use"), N_("VERSION") },
   { "log-session-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_session_bus, N_("Log session bus calls"), NULL },
@@ -312,6 +314,8 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
     flags |= FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY;
   if (!opt_clear_env)
     flags |= FLATPAK_RUN_FLAG_CLEAR_ENV;
+  if (opt_userns)
+    flags |= FLATPAK_RUN_FLAG_USERNS;
 
   if (!flatpak_run_app (app_deploy ? app_ref : runtime_ref,
                         app_deploy,

--- a/common/flatpak-common-types-private.h
+++ b/common/flatpak-common-types-private.h
@@ -50,6 +50,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_PARENT_EXPOSE_PIDS = (1 << 20),
   FLATPAK_RUN_FLAG_PARENT_SHARE_PIDS  = (1 << 21),
   FLATPAK_RUN_FLAG_CLEAR_ENV          = (1 << 22),
+  FLATPAK_RUN_FLAG_USERNS          = (1 << 23),
 } FlatpakRunFlags;
 
 typedef struct FlatpakDir             FlatpakDir;

--- a/common/flatpak-context-private.h
+++ b/common/flatpak-context-private.h
@@ -78,6 +78,7 @@ typedef enum {
   FLATPAK_CONTEXT_FEATURE_BLUETOOTH    = 1 << 2,
   FLATPAK_CONTEXT_FEATURE_CANBUS       = 1 << 3,
   FLATPAK_CONTEXT_FEATURE_PER_APP_DEV_SHM = 1 << 4,
+  FLATPAK_CONTEXT_FEATURE_USERNS = 1 << 5,
 } FlatpakContextFeatures;
 
 typedef enum {

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -85,6 +85,7 @@ const char *flatpak_context_features[] = {
   "bluetooth",
   "canbus",
   "per-app-dev-shm",
+  "userns",
   NULL
 };
 

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -291,6 +291,7 @@ test_full_context (void)
                      FLATPAK_CONTEXT_FEATURE_MULTIARCH |
                      FLATPAK_CONTEXT_FEATURE_BLUETOOTH |
                      FLATPAK_CONTEXT_FEATURE_CANBUS |
+                     FLATPAK_CONTEXT_FEATURE_USERNS |
                      FLATPAK_CONTEXT_FEATURE_PER_APP_DEV_SHM));
   g_assert_cmpuint (context->features_valid, ==, context->features);
 


### PR DESCRIPTION
This pull request allows access to subsandboxing for flatpaks that require sandboxing for security purposes such as Chromium-based and Firefox-based web browsers.

In order to actually get the sandbox holes for that the flatpak would need to explicitly enable the `userns` flag and feature, with both of them being opt-in.

This is still a draft as I still need to figure out what else would be necessary to get this merged. Please feel free to comment on how I approached things and I would love some hand-holding as I do not know this codebase or C very well. Thank you!

WIP:
- [ ] Tests
- [ ] Documentation

### Example usage:

<img width="3430" height="880" alt="image" src="https://github.com/user-attachments/assets/7ee7aa3e-ad66-4e62-8bb2-9c2ec1b506eb" />

```
[tulip@/var/home/tulip/opt/flatpak/flatpak-userns]$ ./build/app/flatpak run --share=network --allow=userns --userns org.gnome.Sdk
[📦 org.gnome.Sdk ~]$ cd /tmp/ubuntu
[📦 org.gnome.Sdk ubuntu]$ bwrap --bind . / /bin/sh
[📦 org.gnome.Sdk \W]$ cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
[📦 org.gnome.Sdk \W]$ apt --help
apt 2.7.14 (arm64)
Usage: apt [options] command

apt is a commandline package manager and provides commands for
searching and managing as well as querying information about packages.
```
