### PR TITLE
[flatpak-1.16.x] session-helper: Avoid a memory leak

### DIFF
--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -215,7 +215,7 @@ handle_host_command (FlatpakDevelopment    *object,
   gsize i, j, n_fds, n_envs;
   const gint *fds;
   g_autofree FdMapEntry *fd_map = NULL;
-  gchar **env;
+  g_auto(GStrv) env = NULL;
   gint32 max_fd;
 
   if (*arg_cwd_path == 0)


### PR DESCRIPTION
I noticed this one that seems worth backporting to `flatpak-1.16.x`, when reading the commits in version 1.17.0 to prepare the update for Fedora.

---

* session-helper: Avoid a memory leak
  (cherry picked from commit cd80e843435df5ce70d9a2b6710098135ceb9085)