### PR TITLE
[flatpak-1.16.x] testlib: add expected argument to fcntl(F_DUPFD)

### DIFF
--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -257,7 +257,7 @@ tests_stdout_to_stderr_begin (void)
 {
   TestsStdoutToStderr *original = g_new0 (TestsStdoutToStderr, 1);
 
-  original->fd = fcntl (STDOUT_FILENO, F_DUPFD_CLOEXEC);
+  original->fd = fcntl (STDOUT_FILENO, F_DUPFD_CLOEXEC, 3);
 
   if (original->fd < 0)
     g_error ("fcntl F_DUPFD_CLOEXEC: %s", g_strerror (errno));


### PR DESCRIPTION
Here's another one that I noticed that seems worth backporting to `flatpak-1.16.x`, when reading the commits in version 1.17.0 to prepare the update for Fedora.

---

* testlib: add expected argument to fcntl(F_DUPFD)
  (cherry picked from commit 7399dea9603c30f142a45c3952626425dd91aca0)