### PR TITLE
flatpak: Enable progress escape sequence by default

### DIFF
--- a/app/flatpak-tty-utils.c
+++ b/app/flatpak-tty-utils.c
@@ -533,11 +533,10 @@ use_progress_escape_sequence (void)
 
   if (g_once_init_enter (&tty_progress_once))
     {
-      // FIXME: make this opt-out for Flatpak 1.18
-      if (g_strcmp0 (g_getenv ("FLATPAK_TTY_PROGRESS"), "1") == 0)
-        g_once_init_leave (&tty_progress_once, TTY_PROGRESS_ENABLED);
-      else
+      if (g_strcmp0 (g_getenv ("FLATPAK_TTY_PROGRESS"), "0") == 0)
         g_once_init_leave (&tty_progress_once, TTY_PROGRESS_DISABLED);
+      else
+        g_once_init_leave (&tty_progress_once, TTY_PROGRESS_ENABLED);
     }
 
   return tty_progress_once == TTY_PROGRESS_ENABLED;

--- a/doc/flatpak.xml
+++ b/doc/flatpak.xml
@@ -803,11 +803,10 @@
                     <term><envar>FLATPAK_TTY_PROGRESS</envar></term>
 
                     <listitem><para>
-                        May be set to <literal>1</literal> to enable reporting
+                        May be set to <literal>0</literal> to disable reporting
                         machine-readable progress to the terminal.
-                        This feature is not currently enabled by default
-                        because it uses the OSC 9;4 sequence,
-                        which some terminal emulators interpret as a
+                        This feature can be disabled because it uses the OSC 9;4
+                        sequence, which some terminal emulators interpret as a
                         popup notification.
                     </para></listitem>
                 </varlistentry>


### PR DESCRIPTION
In 4febfb59 ("flatpak: Disable progress escape sequence by default") the escape sequence has been disabled by default, but we want to enable it again for 1.18.