### PR TITLE
flatpak-cli: improve i18n

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -317,7 +317,8 @@ progress_changed_cb (FlatpakTransactionProgress *progress,
           guint64 total_time = elapsed_time * 100 / (double) percent;
           remaining = format_duration (total_time - elapsed_time);
         }
-      speed = g_strdup_printf ("%s/s%s%s", formatted_bytes_sec, remaining ? "  " : "", remaining ? remaining : "");
+      /* Formatted size/remaining time in seconds */
+      speed = g_strdup_printf (_("%s/s%s%s"), formatted_bytes_sec, remaining ? "  " : "", remaining ? remaining : "");
       cli->speed_len = MAX (cli->speed_len, strlen (speed) + 2);
     }
 
@@ -353,7 +354,9 @@ progress_changed_cb (FlatpakTransactionProgress *progress,
     g_string_append (str, " ");
 
   g_string_append (str, " ");
-  g_string_append_printf (str, "%3d%%", percent);
+  /* Download progress percentage, use the appropriate
+    percent format for your language */
+  g_string_append_printf (str, _("%3d%%"), percent);
 
   if (speed)
     g_string_append_printf (str, "  %s", speed);


### PR DESCRIPTION
- Make percent values translatable

  Various languages use different ways to format the percentage values[1], making it translatable will allow a more coherent way to display the information. Padding has been increased by one to accommodate the languages that use a space between the number and the sign value.

- Make remaining time abbreviation translatable

  Making this value translatable will allow languages to display the seconds abbreviation in their language. This is particulary an issue for Turkish, in which hours and seconds start with the same letter, so it's not possible to distinguish which is which. We use a second letter (sa, sn) to figure it out.

[1] https://en.wikipedia.org/wiki/Percent_sign#Form_and_spacing