### PR TITLE
json-oci: Mark mandatory fields as such

### DIFF
--- a/common/flatpak-json-oci.c
+++ b/common/flatpak-json-oci.c
@@ -1100,31 +1100,31 @@ flatpak_oci_index_response_class_init (FlatpakOciIndexResponseClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   FlatpakJsonClass *json_class = FLATPAK_JSON_CLASS (klass);
   static FlatpakJsonProp image_props[] = {
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexImage, digest, "Digest"),
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexImage, mediatype, "MediaType"),
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexImage, os, "OS"),
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexImage, architecture, "Architecture"),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexImage, digest, "Digest"),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexImage, mediatype, "MediaType"),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexImage, os, "OS"),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexImage, architecture, "Architecture"),
     FLATPAK_JSON_STRMAP_PROP (FlatpakOciIndexImage, annotations, "Annotations"),
     FLATPAK_JSON_STRMAP_PROP (FlatpakOciIndexImage, labels, "Labels"),
     FLATPAK_JSON_STRV_PROP (FlatpakOciIndexImage, tags, "Tags"),
     FLATPAK_JSON_LAST_PROP
   };
   static FlatpakJsonProp lists_props[] = {
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexImageList, digest, "Digest"),
-    FLATPAK_JSON_STRUCTV_PROP (FlatpakOciIndexImageList, images, "Images", image_props),
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexImageList, mediatype, "MediaType"),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexImageList, digest, "Digest"),
+    FLATPAK_JSON_MANDATORY_STRUCTV_PROP (FlatpakOciIndexImageList, images, "Images", image_props),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexImageList, mediatype, "MediaType"),
     FLATPAK_JSON_STRV_PROP (FlatpakOciIndexImageList, tags, "Tags"),
     FLATPAK_JSON_LAST_PROP
   };
   static FlatpakJsonProp results_props[] = {
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexRepository, name, "Name"),
-    FLATPAK_JSON_STRUCTV_PROP (FlatpakOciIndexRepository, images, "Images", image_props),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexRepository, name, "Name"),
+    FLATPAK_JSON_MANDATORY_STRUCTV_PROP (FlatpakOciIndexRepository, images, "Images", image_props),
     FLATPAK_JSON_STRUCTV_PROP (FlatpakOciIndexRepository, lists, "Lists", lists_props),
     FLATPAK_JSON_LAST_PROP
   };
   static FlatpakJsonProp props[] = {
-    FLATPAK_JSON_STRING_PROP (FlatpakOciIndexResponse, registry, "Registry"),
-    FLATPAK_JSON_STRUCTV_PROP (FlatpakOciIndexResponse, results, "Results", results_props),
+    FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciIndexResponse, registry, "Registry"),
+    FLATPAK_JSON_MANDATORY_STRUCTV_PROP (FlatpakOciIndexResponse, results, "Results", results_props),
     FLATPAK_JSON_LAST_PROP
   };
 

--- a/common/flatpak-json-private.h
+++ b/common/flatpak-json-private.h
@@ -69,6 +69,8 @@ struct _FlatpakJsonProp
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_BOOL }
 #define FLATPAK_JSON_STRV_PROP(_struct, _field, _name) \
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRV }
+#define FLATPAK_JSON_MANDATORY_STRV_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRV, 0, 0, FLATPAK_JSON_PROP_FLAGS_MANDATORY }
 #define FLATPAK_JSON_STRMAP_PROP(_struct, _field, _name) \
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRMAP }
 #define FLATPAK_JSON_BOOLMAP_PROP(_struct, _field, _name) \
@@ -85,6 +87,8 @@ struct _FlatpakJsonProp
   { "parent", G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_PARENT, (gpointer) _props}
 #define FLATPAK_JSON_STRUCTV_PROP(_struct, _field, _name, _props) \
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRUCTV, (gpointer) _props, (gpointer) sizeof (**((_struct *) 0)->_field) }
+#define FLATPAK_JSON_MANDATORY_STRUCTV_PROP(_struct, _field, _name, _props) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRUCTV, (gpointer) _props, (gpointer) sizeof (**((_struct *) 0)->_field), FLATPAK_JSON_PROP_FLAGS_MANDATORY}
 #define FLATPAK_JSON_LAST_PROP { NULL }
 
 G_DECLARE_DERIVABLE_TYPE (FlatpakJson, flatpak_json, FLATPAK, JSON, GObject)


### PR DESCRIPTION
The flatpak OCI spec
(https://github.com/flatpak/flatpak-oci-specs/blob/main/registry-index.md) is not very specific about which fields are required; but the code certainly makes some assumptions about it.

Mark as many fields mandatory as possible. This was tested against the fedora remote.

Fixes #6359