### PR TITLE
context: Canonicalize xdg dir and home dir paths

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -44,6 +44,7 @@
 #include "flatpak-error.h"
 #include "flatpak-metadata-private.h"
 #include "flatpak-usb-private.h"
+#include "flatpak-utils-base-private.h"
 #include "flatpak-utils-private.h"
 
 /* Same order as enum */
@@ -4051,6 +4052,8 @@ flatpak_context_export (FlatpakContext *context,
           const char *rest = NULL;
           const char *config_key = NULL;
           g_autofree char *subpath = NULL;
+          g_autofree char *canonical_path = NULL;
+          g_autofree char *canonical_home = NULL;
 
           if (!get_xdg_user_dir_from_string (filesystem, &config_key, &rest, &path))
             {
@@ -4061,7 +4064,10 @@ flatpak_context_export (FlatpakContext *context,
           if (path == NULL)
             continue; /* Unconfigured, ignore */
 
-          if (strcmp (path, g_get_home_dir ()) == 0)
+          canonical_path = flatpak_canonicalize_filename (path);
+          canonical_home = flatpak_canonicalize_filename (g_get_home_dir ());
+
+          if (strcmp (canonical_path, canonical_home) == 0)
             {
               /* xdg-user-dirs sets disabled dirs to $HOME, and its in general not a good
                  idea to set full access to $HOME other than explicitly, so we ignore


### PR DESCRIPTION
When an xdg dir is not available, it is supposed to point at $HOME. We do not want to mount $HOME though in that case, so we just skip the xdg dir instead.

The check compares the strings of the the xdg dir path and the home dir path. So far it relied on the functions internally canonicalizing the paths in the same way, but there was a glib regression:

https://gitlab.gnome.org/GNOME/glib/-/issues/3811
("g_get_user_special_dir doesn't strip trailing slash from $HOME")

Which then was fixed in cb3e9fe74 ("gutils: Strip all trailing slashes").

We can however just canonicalize on the paths on the caller side to make this more robust, so let's just do that.

Closes: #6323