### PR TITLE
portal: Stop querying all attributes when enumerating .portals files

### DIFF
--- a/portal/portal-impl.c
+++ b/portal/portal-impl.c
@@ -128,7 +128,7 @@ load_installed_portals (gboolean opt_verbose)
   g_info ("load portals from %s", portal_dir);
 
   dir = g_file_new_for_path (portal_dir);
-  enumerator = g_file_enumerate_children (dir, "*", G_FILE_QUERY_INFO_NONE, NULL, NULL);
+  enumerator = g_file_enumerate_children (dir, G_FILE_ATTRIBUTE_STANDARD_NAME, G_FILE_QUERY_INFO_NONE, NULL, NULL);
 
   if (enumerator == NULL)
     return;


### PR DESCRIPTION
Only G_FILE_ATTRIBUTE_STANDARD_NAME is necessary here for g_file_info_get_name() and g_file_enumerator_get_child() purpose. This avoids various thumbnailing house-keeping that GIO tries to do when any thumbnailing file attribute is requested (fairly visible when run with strace), in addition to just making more sense that way.