### PR TITLE
selinux: add custom type flatpak_home_t for ~/.local/share/flatpak

### DIFF
--- a/selinux/flatpak.fc
+++ b/selinux/flatpak.fc
@@ -1,1 +1,3 @@
 /usr/libexec/flatpak-system-helper	--	gen_context(system_u:object_r:flatpak_helper_exec_t,s0)
+
+HOME_DIR/\.local/share/flatpak(/.*)?		gen_context(system_u:object_r:flatpak_home_t,s0)

--- a/selinux/flatpak.if
+++ b/selinux/flatpak.if
@@ -1,1 +1,21 @@
 ## <summary></summary>
+
+#########################################
+## <summary>
+##	Transition to flatpak named content in user home
+## </summary>
+## <param name="domain">
+##	<summary>
+##      Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`flatpak_named_filetrans_home_content',`
+	gen_require(`
+		type flatpak_home_t;
+	')
+
+	optional_policy(`
+		gnome_data_filetrans($1, flatpak_home_t, dir, "flatpak")
+	')
+')

--- a/selinux/flatpak.te
+++ b/selinux/flatpak.te
@@ -12,6 +12,9 @@ type flatpak_helper_t;
 type flatpak_helper_exec_t;
 init_daemon_domain(flatpak_helper_t, flatpak_helper_exec_t)
 
+type flatpak_home_t;
+userdom_user_home_content(flatpak_home_t)
+
 auth_read_passwd(flatpak_helper_t)
 files_list_var_lib(flatpak_helper_t)
 files_read_var_lib_files(flatpak_helper_t)


### PR DESCRIPTION
The fedora selinux-policy (and therefor also the openSUSE one) has a named file transition that relabels folders in ~/.local/share/ with the type `systemd_home_t` when they are called "systemd".

This is unfortunate as this means it will also relabel the directory under `.local/share/flatpak/.*/systemd`, as it matches the directory name.

As the systemd filetrans looks valid and it is a shortcoming of SELinux in general, this is the easiest fix that would make the folders below .local/share/flatpak not be labelled incorrectly i would say.

Additionally, this will need a fix in the main selinux-policy: https://github.com/fedora-selinux/selinux-policy/pull/2998

What happens if we don't fix it?
- Users will have some of the files in .local/share/flatpak pop up when running `restorecon` which might confuse them
- At least in regular targeted mode, it will likely not make an impact in the sense that some access gets denied, so it just "looks ugly"

Reproducer openSUSE Tumbleweed:
```
$ rm -rf ~/.local/share/flatpak
$ flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
$ flatpak install --user flathub org.gnome.Builder
$ restorecon -Rvn ~/.local/share/flatpak
...
Would relabel /home/<user>/.local/share/flatpak/app/org.gnome.Builder/x86_64/stable/327753f4701dbb9046bfb0c0c9c05b16edea0fbd8df7f368525c461d8d30b5a4/files/lib/systemd from unconfined_u:object_r:systemd_home_t:s0 to unconfined_u:object_r:data_home_t:s0
...
```