### PR TITLE
ci: Fix immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,10 @@ jobs:
           echo $preRelease
 
       - name: Create release
-        uses: ncipollo/release-action@v1.15.0
+        uses: ncipollo/release-action@v1.20.0
         with:
           tag: ${{ env.releaseVersion }}
           body: ${{ env.releaseChangelog }}
           prerelease: ${{ env.preRelease }}
           artifacts: _build/meson-dist/*
+          immutableCreate: true


### PR DESCRIPTION
Github supports immutable releases. They can't be changed once published. This is great, but the release action was broken and created an immutable release, published it, and then tried to upload the dist artifacts.

Upgrade to the latest version and explicitly create an immutable release. In this version, the release action creates a draft release, uploads the dist artifacts, and then publishes it.