### PR TITLE
tests: Tell "as-installed" tests where they can find triggers

### DIFF
--- a/tests/installed-tests.sh.in
+++ b/tests/installed-tests.sh.in
@@ -1,4 +1,7 @@
 # Copyright 2024 Collabora Ltd.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+FLATPAK_TRIGGERSDIR='@FLATPAK_TRIGGERSDIR@'
 FUSERMOUNT='@FUSERMOUNT@'
+
+export FLATPAK_TRIGGERSDIR

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,6 +46,7 @@ if get_option('installed_tests')
     output : 'installed-tests.sh',
     configuration : {
       'FUSERMOUNT' : fusermount,
+      'FLATPAK_TRIGGERSDIR' : get_option('prefix') / get_option('datadir') / 'flatpak' / 'triggers',
     },
     install_dir : installed_testdir,
   )


### PR DESCRIPTION
Since commit d10e1148 "Add initial support for preinstalling flatpaks", the test suite sets FLATPAK_DATA_DIR to a temporary directory, both while running uninstalled and as-installed.

While running uninstalled we already set FLATPAK_TRIGGERSDIR to the trigger scripts in the source tree, but when running "as-installed", we need to run the triggers that the OS installs as part of the flatpak package (or equivalent).

Not having this caused autopkgtests (automated as-installed tests) in Debian to regress with 1.17.x.

Fixes: d10e1148 "Add initial support for preinstalling flatpaks"