### PR TITLE
i18n: Update two strings

### DIFF
--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -225,7 +225,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       if (collection_id != NULL)
         len = MAX (len, g_utf8_strlen (_("Collection:"), -1));
       len = MAX (len, g_utf8_strlen (_("Installation:"), -1));
-      len = MAX (len, g_utf8_strlen (_("Installed:"), -1));
+      len = MAX (len, g_utf8_strlen (_("Installed Size:"), -1));
       if (flatpak_decomposed_is_app (ref))
         {
           len = MAX (len, g_utf8_strlen (_("Runtime:"), -1));
@@ -268,7 +268,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       if (collection_id)
         print_aligned (len, _("Collection:"), collection_id);
       print_aligned (len, _("Installation:"), flatpak_dir_get_name_cached (dir));
-      print_aligned (len, _("Installed:"), formatted_size);
+      print_aligned (len, _("Installed Size:"), formatted_size);
       if (flatpak_decomposed_is_app (ref))
         {
           g_autofree char *runtime = NULL;
@@ -456,7 +456,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
       len = MAX (len, g_utf8_strlen (_("Origin:"), -1));
       len = MAX (len, g_utf8_strlen (_("Commit:"), -1));
       len = MAX (len, g_utf8_strlen (_("Installation:"), -1));
-      len = MAX (len, g_utf8_strlen (_("Installed:"), -1));
+      len = MAX (len, g_utf8_strlen (_("Installed Size:"), -1));
       len = MAX (len, g_utf8_strlen (_("Subpaths:"), -1));
 
       flatpak_get_window_size (&rows, &cols);
@@ -514,7 +514,7 @@ flatpak_builtin_info (int argc, char **argv, GCancellable *cancellable, GError *
           print_aligned (len, _("Origin:"), origin ? origin : "-");
           print_aligned (len, _("Commit:"), formatted_commit);
           print_aligned (len, _("Installation:"), ext_installation);
-          print_aligned (len, _("Installed:"), ext_formatted_size);
+          print_aligned (len, _("Installed Size:"), ext_formatted_size);
 
           if (ext_subpaths && ext_subpaths[0])
             {

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -244,9 +244,9 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       if (collection_id != NULL)
         len = MAX (len, g_utf8_strlen (_("Collection:"), -1));
       if (formatted_download_size)
-        len = MAX (len, g_utf8_strlen (_("Download:"), -1));
+        len = MAX (len, g_utf8_strlen (_("Download Size:"), -1));
       if (formatted_installed_size)
-        len = MAX (len, g_utf8_strlen (_("Installed:"), -1));
+        len = MAX (len, g_utf8_strlen (_("Installed Size:"), -1));
       if (flatpak_decomposed_is_app (ref) == 0 && metakey != NULL)
         {
           len = MAX (len, g_utf8_strlen (_("Runtime:"), -1));
@@ -279,9 +279,9 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
       if (collection_id != NULL)
         print_aligned (len, _("Collection:"), collection_id);
       if (formatted_download_size)
-        print_aligned (len, _("Download:"), formatted_download_size);
+        print_aligned (len, _("Download Size:"), formatted_download_size);
       if (formatted_installed_size)
-        print_aligned (len, _("Installed:"), formatted_installed_size);
+        print_aligned (len, _("Installed Size:"), formatted_installed_size);
       if (flatpak_decomposed_is_app (ref) && metakey != NULL)
         {
           g_autofree char *runtime = g_key_file_get_string (metakey, "Application", "runtime", error);


### PR DESCRIPTION
In the following usages, the "Install:" and "Download:" strings were used as a short form of the "Download Size" and "Installed Size", which makes translation tricky.

Therefore, using the normal forms will be good from the translation side.