### PR TITLE
context: Improve check for --filesystem paths moving up

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1874,21 +1874,20 @@ flatpak_context_parse_filesystem (const char             *filesystem_and_mode,
   if (filesystem == NULL)
     return FALSE;
 
+  /* Forbid /../ in paths */
+  if (g_str_has_suffix (filesystem, "/..") ||
+      strstr (filesystem, "/../") != NULL)
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                   _("Filesystem location \"%s\" contains \"..\""),
+                   filesystem);
+      return FALSE;
+    }
+
   slash = strchr (filesystem, '/');
 
-  /* Forbid /../ in paths */
   if (slash != NULL)
     {
-      if (g_str_has_prefix (slash + 1, "../") ||
-          g_str_has_suffix (slash + 1, "/..") ||
-          strstr (slash + 1, "/../") != NULL)
-        {
-          g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
-                       _("Filesystem location \"%s\" contains \"..\""),
-                       filesystem);
-          return FALSE;
-        }
-
       /* Convert "//" and "/./" to "/" */
       for (; slash != NULL; slash = strchr (slash + 1, '/'))
         {


### PR DESCRIPTION
While the arguments for --filesystem permissions either have to come from a privileged source, or from the manifest which is supposed to be checked by the remote, it was decided that paths are not allowed to move up (..) a directory.

The check for this was both too complicated, and not sufficient, because the special directories (e.g. xdg-download) might contain only a single slash (xdg-download/..) and move one directory up.