### PR TITLE
fix: cross typos, detail below

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = node_modules,po,subprojects
+ignore-regex = .*(ratatui|Affinitized|affinitized).*
+ignore-words-list = nd,ot,THUR,IST,fo,hel,bu

--- a/NEWS
+++ b/NEWS
@@ -1372,7 +1372,7 @@ Changes in 1.10.2
 Released: 2021-03-10
 
 This is a security update which fixes a potential attack where
-a flatpak application could use custom formated .desktop files to
+a flatpak application could use custom formatted .desktop files to
 gain access to files on the host system.
 
 Other changes:
@@ -1380,7 +1380,7 @@ Other changes:
 * Fix memory leaks
 * Some test fixes
 * Documentation updates
-* G_BEGIN/END_DECLS added to library headders for c++ use
+* G_BEGIN/END_DECLS added to library headers for c++ use
 * Fix for X11 cookies on OpenSUSE
 * Spawn portal better handles non-utf8 filenames
 
@@ -1429,7 +1429,7 @@ Changes in 1.9.3
 Released: 2020-12-22
 
 I expect this to be the final 1.9.x release, and we can expect 1.10.0
-early next year, containing basically whats in this release in terms
+early next year, containing basically what's in this release in terms
 of features.
 
 A minor change in the new indexed summary format in this release. The
@@ -1450,7 +1450,7 @@ Other changes:
  * flatpak_installation_list_installed_refs_for_update() now handles
    some case better when apps in the user installation depends on
    runtimes in the system installation.
- * New version of the deploy files which guarantees the existance of
+ * New version of the deploy files which guarantees the existence of
    a bit more data. This is useful for eol detection of apps that were
    installed with previous flatpak versions.
  * Some corner cases when installing an app with extra-data into a nonstandard
@@ -1513,7 +1513,7 @@ Other major changes
    that are unused.
  * The end-of-life warnings in the flatpak CLI are now better, showing
    more useful details (like version and what apps are using the runtime)
-   and less unuseful details.
+   and less useless details.
  * Some changes was made in which dconf paths were considered "similar"
    to the app id, allowing for example `org.gnome.SoundJuicer` to
    migrate from `/org/gnome/sound-juicer`.
@@ -1570,12 +1570,12 @@ Released: 2020-11-17
 Changes in 1.8.2
 ================
 
- * Added validation of collection id settins for remotes
+ * Added validation of collection id settings for remotes
  * Fix seccomp filters on s390
  * Robustness fixes to the spawn portal
  * Fix support for masking update in the system installation
  * Better support for distros with uncommon models of merged /usr
- * Cache responses from localed/AccoutService
+ * Cache responses from located/AccoutService
  * Fix hangs in cases where xdg-dbus-proxy fails to start
  * Fix double-free in cups socket detection
  * OCI authenticator now doesn't ask for auth in case of http errors
@@ -1703,7 +1703,7 @@ Changes in 1.6.1
 
 This is a (mild) security update. Flatpak 1.6.0 added the ability for an application to request it to be
 updated, as long as the new version doesn't require new permissions. Unfortunately in some special cases,
-if an app had acces to the home directory, but not the rest of the filesystem it would still allow a
+if an app had access to the home directory, but not the rest of the filesystem it would still allow a
 self-update where the new version could access some files outside the home directory..
 
 This is fixed in this version, and all users of 1.6.0 are recommended to update.
@@ -1762,7 +1762,7 @@ Other changes:
  * Improved docs and help output
  * Fix support for fd forwarding and the allow_a11y flag in the sandboxing portal
  * Some improvements to the new permission-set command
- * New remote option that allows settting the default token type (mostly for debugging)
+ * New remote option that allows setting the default token type (mostly for debugging)
 
 
 
@@ -1770,7 +1770,7 @@ Changes in 1.5.1
 ================
 
 The major new feature of this is the support for protected applications and the system
-around authenticting downloads to it. This is not considered stable yet, but this release
+around authenticating downloads to it. This is not considered stable yet, but this release
 has the initial work to make it possible for developers to play around with this. I
 will send out a separate mail about this later.
 
@@ -1799,11 +1799,11 @@ Changes in 1.5.0
  * New command flatpak mask allows pinning version and avoiding auto-downloads.
  * Support self-updates and update monitoring in the flatpak portal.
  * Fix updates of exported services with dbus-broken.
- * Don't show arch columns in terminal outout if all are the same.
+ * Don't show arch columns in terminal output if all are the same.
  * Fix some cases where origin remotes were not properly removed.
  * flatpak-session-helper now links to more libraries.
  * OCI: Support images tagged with labels as well as annotations.
- * OCI: Alway generate a history for images.
+ * OCI: Always generate a history for images.
  * OCI: Support docker mimetypes in addition to OCI mimetypes.
  * Uninstall now always work, even if the remote it came from was force removed.
  * New config key default-languages that allows additions to the system list
@@ -1903,7 +1903,7 @@ Changes in 1.3.3
    the helper sometimes not work.
  * Fix build with older versions of glib
  * The list and remote-ls output is now less wide, not showing the
-   appdata summary by default and only showing the archtecture and
+   appdata summary by default and only showing the architecture and
    origin if necessary (i.e. not if its the same for all rows).
  * flatpak remote-ls now filters end-of-lifed apps by default.
  * flatpak permission-reset now supports --all
@@ -1954,7 +1954,7 @@ Other changes:
    for installers to take advantage of the automatic rebasing.
  * New permission --socket=pcsc for access to smart cards.
  * We now store the description, comment, icon and homepage fields from
-   the flatpakrepo files in the remote confiuration and have new library
+   the flatpakrepo files in the remote configuration and have new library
    APIs to read these back.
  * The fields above are now also settable in a repo and changes to these
    can propagate to clients.
@@ -2282,7 +2282,7 @@ Changes in 1.0.2
  * flatpak uninstall --unused now does not remove SDKs if some installed app
    refers to them.
  * Fixed bug where flatpak uninstall --unused prompted for uninstall twice.
- * Set IO class on the system helper to "idle", which should cause backgroun
+ * Set IO class on the system helper to "idle", which should cause background
    updates to affect the system less.
  * Fixed regression in flatpak uninstall --no-related.
  * Better handling of empty collection ids in flatpak bundles.
@@ -2671,7 +2671,7 @@ Major changes in 0.10.1
    back to a previous version.
  * New command "flatpak search" which allows you to search the appstream
    data from the commandline.
- * flatpak update now updates appstream data for all confured remotes, which
+ * flatpak update now updates appstream data for all configured remotes, which
    is important for search to work.
  * Allow automatic installation of gtk themes matching the active theme.
  * Handle the case when /etc/resolv.conf is a symlink
@@ -2711,7 +2711,7 @@ Major changes in 0.9.99
  * build: FLATPAK_ID and FLATPAK_ARCH are now set in the environment when building
  * update: Don't fail the entire update if some remote fails to update its metadata
  * run: /.flatpak-info now lists exact commits and extensions in use
- * run: We now use a per-app ld.so.cache file whenn running. This should speed things up,
+ * run: We now use a per-app ld.so.cache file when running. This should speed things up,
    and allows ldconfig to report the correct results.
  * The verbose mode was changed into two levels, use -vv to show the more detailed info, which
    currently only contains the full bubblewrap argument lists.
@@ -2950,7 +2950,7 @@ Major changes in 0.9.4
  * Titles and default branches are now automatically updated from
    the remote unless they are explicitly set. You no longer have
    to run flatpak remote-modify --update.
- * Some performance inprovements when installing apps.
+ * Some performance improvements when installing apps.
  * When exporting a build, the commit objects now always include
    the branchname, the metadata and install/download size.
    The sizes are reused for faster summary building, and the
@@ -3205,7 +3205,7 @@ This is a bugfix and security update.
 
 Some of the bind-mounts that flatpak sets up were not read-only as
 they should have. This includes: extensions, system fonts,
-resolv.conf, localtime and machine-id. Many of thse are typically only
+resolv.conf, localtime and machine-id. Many of these are typically only
 writable by root, but some, like the user-specific fonts and
 user-installed extensions could be modified from the sandbox.
 
@@ -3305,7 +3305,7 @@ Major changes in 0.6.14
    workarounds.
  * When installing an application system-wide, don't consider
    dependencies that are installed for the user only.
- * Flatpak install --from now tries to re-use existing remotes to
+ * Flatpak install --from now tries to reuse existing remotes to
    avoid creating unnecessary origin remotes.
  * Using --filesystem=$dir when $dir is a symlink-to-directory now works.
  * Using --filesystem=$file to expose unix sockets to the app is now

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -1564,7 +1564,7 @@ transaction_ready (FlatpakTransaction *transaction)
 
   if (self->did_interaction)
     {
-      /* We did some interaction since ready_pre_auth which messes up the formating, so re-print table */
+      /* We did some interaction since ready_pre_auth which messes up the formatting, so re-print table */
       flatpak_table_printer_print_full (printer, 0, self->cols,
                                         &self->table_height, &self->table_width);
       g_print ("\n\n");

--- a/app/flatpak-polkit-agent-text-listener.c
+++ b/app/flatpak-polkit-agent-text-listener.c
@@ -422,7 +422,7 @@ flatpak_polkit_agent_text_listener_initiate_authentication (PolkitAgentListener 
 
   fprintf (listener->tty, "%s\n", message);
 
-  /* handle multiple identies by asking which one to use */
+  /* handle multiple identities by asking which one to use */
   if (g_list_length (identities) > 1)
     {
       identity = choose_identity (listener, identities);

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -223,8 +223,8 @@ flatpak_permission_remove_conditional (FlatpakPermission *permission,
   if (permission->allowed)
     return;
 
-  /* The only way to correcly layer removal of conditional is to completely
-     remove eveything from the lower layer */
+  /* The only way to correctly layer removal of conditional is to completely
+     remove everything from the lower layer */
   permission->reset = TRUE;
 
   if (!g_ptr_array_find_with_equal_func (permission->conditionals,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -2535,7 +2535,7 @@ validate_commit_metadata (GVariant   *commit_data,
  * the system repo (thus increasing chances for e.g. reflink copying),
  * and avoids filling the users homedirectory with temporary data.
  *
- * In order to re-use this between instances we create a symlink
+ * In order to reuse this between instances we create a symlink
  * in /run to it and verify it before use.
  */
 static GFile *
@@ -14520,7 +14520,7 @@ find_ref_for_refs_set (GHashTable   *refs,
   return NULL;
 }
 
-/* This tries to find a single ref based on the specfied name/branch/arch
+/* This tries to find a single ref based on the specified name/branch/arch
  * triplet from  a remote. If arch is not specified, matches only on compatible arches.
 */
 FlatpakDecomposed *
@@ -14704,7 +14704,7 @@ flatpak_dir_get_all_installed_refs (FlatpakDir  *self,
   return g_steal_pointer (&local_refs);
 }
 
-/* This tries to find a all installed refs based on the specfied name/branch/arch
+/* This tries to find a all installed refs based on the specified name/branch/arch
  * triplet. Matches on all arches.
 */
 GPtrArray *
@@ -14743,7 +14743,7 @@ flatpak_dir_find_installed_refs (FlatpakDir           *self,
   return g_steal_pointer (&matched_refs);
 }
 
-/* This tries to find a single ref based on the specfied name/branch/arch
+/* This tries to find a single ref based on the specified name/branch/arch
  * triplet. This matches on all (installed) arches, but defaults to the primary
  * arch if that is installed. Otherwise, ambiguity is an error.
 */
@@ -17660,7 +17660,7 @@ find_used_refs (FlatpakDir         *self,
 
   /* Any injected refs are considered used, because this is used by transaction
    * to emulate installing a new ref, and we never want the new ref:s dependencies
-   * seem ununsed. */
+   * seem unused. */
   if (metadata_injection)
     {
       GLNX_HASH_TABLE_FOREACH (metadata_injection, const char *, injected_ref)

--- a/common/flatpak-error.h
+++ b/common/flatpak-error.h
@@ -64,7 +64,7 @@ G_BEGIN_DECLS
  * @FLATPAK_ERROR_AUTHENTICATION_FAILED: An authentication operation failed, for example, no
  *                                       correct password was supplied. (Since: 1.7.3)
  * @FLATPAK_ERROR_NOT_AUTHORIZED: An operation tried to access a ref, or information about it that it
- *                                was not authorized. For example, when succesfully authenticating with a
+ *                                was not authorized. For example, when successfully authenticating with a
  *                                server but the user doesn't have permissions for a private ref. (Since: 1.7.3)
  *
  * Error codes for library functions.

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1232,7 +1232,7 @@ flatpak_installation_list_installed_refs_for_update (FlatpakInstallation *self,
  * Lists only the remotes whose type is included in the @types argument.
  *
  * Since flatpak 1.7 this will never return any types except FLATPAK_REMOTE_TYPE_STATIC.
- * Equivalent functionallity to FLATPAK_REMOTE_TYPE_USB can be had by listing remote refs
+ * Equivalent functionality to FLATPAK_REMOTE_TYPE_USB can be had by listing remote refs
  * with FLATPAK_QUERY_FLAGS_ONLY_SIDELOADED.
  *
  * Returns: (transfer container) (element-type FlatpakRemote): a GPtrArray of

--- a/common/flatpak-json.c
+++ b/common/flatpak-json.c
@@ -207,7 +207,7 @@ demarshal (JsonNode            *parent_node,
             if (!JSON_NODE_HOLDS_OBJECT (val))
               {
                 g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                             "Expecting object elemen for property %s", name);
+                             "Expecting object element for property %s", name);
                 res = FALSE;
                 break;
               }

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -3383,7 +3383,7 @@ flatpak_pull_from_oci (OstreeRepo            *repo,
       return NULL;
     }
 
-  /* Assuming everyting looks good, we record the uncompressed checksum (the diff-id) of the last layer,
+  /* Assuming everything looks good, we record the uncompressed checksum (the diff-id) of the last layer,
      because that is what we can read back easily from the deploy dir, and thus is easy to use for applying deltas */
   diffid = image_config->rootfs.diff_ids[n_layers-1];
   if (diffid != NULL && g_str_has_prefix (diffid, "sha256:"))
@@ -3482,7 +3482,7 @@ flatpak_pull_from_oci (OstreeRepo            *repo,
           blob_fd = flatpak_oci_registry_download_blob (registry, oci_repository, FALSE,
                                                         image_config->rootfs.diff_ids[i], NULL,
                                                         oci_layer_progress, &progress_data,
-                                                        cancellable, NULL); /* No error here, we report the first error if this failes */
+                                                        cancellable, NULL); /* No error here, we report the first error if this fails */
         }
 
       if (blob_fd == -1)

--- a/common/flatpak-repo-utils.c
+++ b/common/flatpak-repo-utils.c
@@ -917,7 +917,7 @@ populate_commit_data_cache (OstreeRepo *repo,
           return NULL;
         }
 
-      /* Note that all summaries refered to by the index is in new format */
+      /* Note that all summaries referred to by the index is in new format */
       summary = var_summary_from_gvariant (summary_v);
       ref_map = var_summary_get_ref_map (summary);
       n_refs = var_ref_map_get_length (ref_map);

--- a/common/flatpak-run-cups.c
+++ b/common/flatpak-run-cups.c
@@ -32,7 +32,7 @@ flatpak_run_cups_check_server_is_socket (const char *server)
   return FALSE;
 }
 
-/* Try to find a default server from a cups confguration file */
+/* Try to find a default server from a cups configuration file */
 static char *
 flatpak_run_get_cups_server_name_config (const char *path)
 {

--- a/common/flatpak-run-pulseaudio.c
+++ b/common/flatpak-run-pulseaudio.c
@@ -23,7 +23,7 @@
 
 #include "flatpak-utils-private.h"
 
-/* Try to find a default server from a pulseaudio confguration file */
+/* Try to find a default server from a pulseaudio configuration file */
 static char *
 flatpak_run_get_pulseaudio_server_user_config (const char *path)
 {

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -1652,7 +1652,7 @@ flatpak_transaction_get_no_pull (FlatpakTransaction *self)
  * same as used by xdg-desktop-portal.
  *
  * On X11 it should be of the form x11:$xid where $xid is the hex
- * version of the xwindows id.
+ * version of the X11 window ID.
  *
  * On wayland is should be wayland:$handle where handle is gotten by
  * using the export call of the xdg-foreign-unstable wayland extension.
@@ -1917,7 +1917,7 @@ flatpak_transaction_set_default_arch (FlatpakTransaction *self,
  * transaction for each runtime it considers unused. This is used by the
  * "update" CLI command to garbage collect runtimes and free disk space.
  *
- * No guarantees are made about the exact hueristic used; e.g. only end-of-life
+ * No guarantees are made about the exact heuristic used; e.g. only end-of-life
  * unused runtimes may be uninstalled with this set. To see the full list of
  * unused runtimes in an installation, use
  * flatpak_installation_list_unused_refs().
@@ -3588,7 +3588,7 @@ mark_op_resolved (FlatpakTransactionOperation *op,
         }
       else
         {
-          /* This shouldn't happen, but a NULL old metadata is safe (all permisssions are considered new) */
+          /* This shouldn't happen, but a NULL old metadata is safe (all permissions are considered new) */
           g_message ("Warning: Failed to parse old metadata for %s\n", flatpak_decomposed_get_ref (op->ref));
         }
     }
@@ -4080,7 +4080,7 @@ request_tokens_basic_auth (FlatpakAuthenticatorRequest *object,
  * %TRUE, and #FlatpakTransaction::webflow-done is emitted. It will
  * cancel the ongoing authentication operation.
  *
- * This is useful for example if you're showing an authenticaion
+ * This is useful for example if you're showing an authentication
  * window with a browser, but the user closed it before it was finished.
  *
  * Since: 1.5.1

--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -318,7 +318,7 @@ flatpak_get_certificates_for_uri (const char  *uri,
                 }
 
               /* In libpod, all client certificates are added, and then the go TLS
-               * code selects the best based on TLS negotation. We just pick the first
+               * code selects the best based on TLS negotiation. We just pick the first
                * in readdir order
                * */
               if (certificates->client_cert_file == NULL)

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -45,7 +45,7 @@
  * version 1 is compact format with inline cache and no deltas
  */
 
-/* Thse are key names in the per-ref metadata in the summary */
+/* These are key names in the per-ref metadata in the summary */
 #define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
 #define OSTREE_COMMIT_TIMESTAMP2 "ot.ts" /* Shorter version of the above */
 

--- a/common/valgrind-private.h
+++ b/common/valgrind-private.h
@@ -1075,7 +1075,7 @@ typedef
 
 /* Use these to write the name of your wrapper.  NOTE: duplicates
    VG_WRAP_FUNCTION_Z{U,Z} in pub_tool_redir.h.  NOTE also: inserts
-   the default behaviour equivalance class tag "0000" into the name.
+   the default behaviour equivalence class tag "0000" into the name.
    See pub_tool_redir.h for details -- normally you don't need to
    think about this, though. */
 

--- a/data/org.freedesktop.Flatpak.Authenticator.xml
+++ b/data/org.freedesktop.Flatpak.Authenticator.xml
@@ -50,7 +50,7 @@
 
       The authenticator dbus calls are not regular dbus calls, but
       instead long running (cancellable) object implementing the
-      AuthenticatorRequest interface. This is very similiar to how
+      AuthenticatorRequest interface. This is very similar to how
       org.freedesktop.portal.Request work when its used in
       xdg-desktop-portal.
 
@@ -85,7 +85,7 @@
 
         This is not a regular dbus call that blocks until the result is done, instead it creates
         a org.freedesktop.Flatpak.AuthenticatorRequest object representing the ongoing operation and
-        returns an object path @handle to it. When the operation succeds the Response signal is emitted
+        returns an object path @handle to it. When the operation succeeds the Response signal is emitted
         on the request with a response status and a dict with details.
 
         The @refs array elements are of type (ssia{sv}) where the items are:
@@ -93,7 +93,7 @@
           <member>s: The ref being pulled</member>
           <member>s: The exact commit being pulled</member>
           <member>i: The token-type of the commit</member>
-          <member>a{sv}: Extra per-ref metadata, currenlty only has summary.* fields which are copied from the summary per-commit metadata.</member>
+          <member>a{sv}: Extra per-ref metadata, currently only has summary.* fields which are copied from the summary per-commit metadata.</member>
         </simplelist>
 
         On success (response 0) the returned details should have:
@@ -186,7 +186,7 @@
         related user interaction (dialogs, webflows etc).
 
         A Response signal with the cancelled response will be emitted if the operation
-        was cancelled. There is still a posibility of a race, so the operation might succeed
+        was cancelled. There is still a possibility of a race, so the operation might succeed
         or fail before processing the close request, so there is no guarantee that the
         operation will be cancelled.
     -->

--- a/data/org.freedesktop.portal.Documents.xml
+++ b/data/org.freedesktop.portal.Documents.xml
@@ -262,7 +262,7 @@
     <!--
         List:
         @app_id: an application ID, or '' to list all documents
-        @docs: a dictonary mapping document IDs to their filesystem path
+        @docs: a dictionary mapping document IDs to their filesystem path
 
         Lists documents in the document store for an application (or for
         all applications).

--- a/doc/flatpak-build-commit-from.xml
+++ b/doc/flatpak-build-commit-from.xml
@@ -126,7 +126,7 @@
                 <term><option>--untrusted</option></term>
 
                 <listitem><para>
-                    The source repostory is not trusted, all objects are copied (not hardlinked) and
+                    The source repository is not trusted, all objects are copied (not hardlinked) and
                     all checksums are verified.
                 </para></listitem>
             </varlistentry>

--- a/doc/flatpak-install.xml
+++ b/doc/flatpak-install.xml
@@ -49,7 +49,7 @@
         <para>
           Installs an application or runtime. The primary way to
           install is to specify a <arg choice="plain">REMOTE</arg>
-          name as the source and one ore more <arg choice="plain">REF</arg>s to specify the
+          name as the source and one or more <arg choice="plain">REF</arg>s to specify the
           application or runtime to install. If <arg choice="plain">REMOTE</arg> is omitted,
           the configured remotes are searched for the first <arg choice="plain">REF</arg>
           and the user is asked to confirm the resulting choice.

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -1283,7 +1283,7 @@ sockets=!x11;x11;if:x11:!has-wayland;
                 <varlistentry>
                     <term><option>hidden-devices</option> (string list)</term>
                     <listitem><para>
-                        List of hidden USB devices, i.e. to remove the enumarable
+                        List of hidden USB devices, i.e. to remove the enumerable
                         devices list. Each element is the same syntax the arguments
                         to `--nousb`. Hidden devices take precedence over enumerable
                         devices. Available since 1.15.11.

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -814,7 +814,7 @@ key=v1;v2;
 
                 <listitem><para>
                   Run the application in sandboxed mode, which means dropping all the extra permissions it would otherwise have, as
-                  well as access to the session/system/a11y busses and document portal.
+                  well as access to the session/system/a11y buses and document portal.
                 </para></listitem>
             </varlistentry>
 

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -130,7 +130,7 @@ handle_request_ref_tokens_close (FlatpakAuthenticatorRequest *object,
 {
   BasicAuthData *auth = user_data;
 
-  g_info ("handlling Request.Close");
+  g_info ("handling Request.Close");
 
   flatpak_authenticator_request_complete_close (object, invocation);
 
@@ -202,7 +202,7 @@ handle_request_ref_tokens_basic_auth_reply (FlatpakAuthenticatorRequest *object,
 {
   BasicAuthData *auth = user_data;
 
-  g_info ("handlling Request.BasicAuthReply %s %s", arg_user, arg_password);
+  g_info ("handling Request.BasicAuthReply %s %s", arg_user, arg_password);
 
   flatpak_authenticator_request_complete_basic_auth_reply (object, invocation);
 

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -656,7 +656,7 @@ verify_proc_self_fd (const char *proc_path,
   /* File descriptors to actually deleted files have " (deleted)"
      appended to them. This also happens to some fake fd types
      like shmem which are "/<name> (deleted)". All such
-     files are considered invalid. Unfortunatelly this also
+     files are considered invalid. Unfortunately this also
      matches files with filenames that actually end in " (deleted)",
      but there is not much to do about this. */
   if (g_str_has_suffix (path_buffer, " (deleted)"))
@@ -1052,7 +1052,7 @@ handle_spawn (PortalFlatpak         *object,
   g_ptr_array_add (flatpak_argv, g_strdup ("run"));
 
   /* If we don't clear the env, the flatpak portal service environment would
-   * leak into the flatpak instance. By default we re-use the environment of
+   * leak into the flatpak instance. By default we reuse the environment of
    * the calling instance by passing it as arguments after the --clear-env.
    */
   g_ptr_array_add (flatpak_argv, g_strdup ("--clear-env"));
@@ -2565,7 +2565,7 @@ transaction_ready (FlatpakTransaction *transaction,
       const char *ref = flatpak_transaction_operation_get_ref (op);
       FlatpakTransactionOperationType type = flatpak_transaction_operation_get_operation_type (op);
 
-      /* Actual app updates need to not increase premission requirements */
+      /* Actual app updates need to not increase permission requirements */
       if (type == FLATPAK_TRANSACTION_OPERATION_UPDATE && g_str_has_prefix (ref, "app/"))
         {
           GKeyFile *new_metadata = flatpak_transaction_operation_get_metadata (op);
@@ -2826,7 +2826,7 @@ handle_update_responses (PortalFlatpakUpdateMonitor *monitor,
     }
   while (status == PROGRESS_STATUS_RUNNING);
 
-  /* Don't return an received error as we emited it already, that would cause it to be emitted twice */
+  /* Don't return an received error as we emitted it already, that would cause it to be emitted twice */
   return TRUE;
 }
 

--- a/session-helper/flatpak-session-helper.c
+++ b/session-helper/flatpak-session-helper.c
@@ -789,7 +789,7 @@ main (int    argc,
                          m_localtime = NULL;
   struct sigaction action;
 
-  /* Save the enviroment before changing anything, so that subprocesses
+  /* Save the environment before changing anything, so that subprocesses
    * can get the unchanged version */
   original_environ = g_get_environ ();
 

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -429,7 +429,7 @@ handle_deploy (FlatpakSystemHelper   *object,
             }
 
           /* At this point, the cache-dir's repo is owned by root. Hence, any failure
-           * from here on, should always cleanup the cache-dir and not preserve it to be re-used. */
+           * from here on, should always cleanup the cache-dir and not preserve it to be reused. */
           ongoing_pull->preserve_pull = FALSE;
         }
     }

--- a/tests/expand-test-matrix.sh
+++ b/tests/expand-test-matrix.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script expands test-matrix expressions into indiviual featuressets
+# This script expands test-matrix expressions into individual featuressets
 #
 # The basic element is a feature, which is just a name:
 #  "a" == enable feature a

--- a/tests/flatpak.supp
+++ b/tests/flatpak.supp
@@ -1,4 +1,4 @@
-# Use this to suppress "possibly lost" for global statics
+# Use this to suppress "possibly lost" for global statistics
 {
    handle_reflink
    Memcheck:Param

--- a/tests/glib.supp
+++ b/tests/glib.supp
@@ -1,4 +1,4 @@
-# Based on the libhif supressions
+# Based on the libhif suppressions
 {
    gobject_init_1
    Memcheck:Leak

--- a/tests/test-auth.sh
+++ b/tests/test-auth.sh
@@ -59,7 +59,7 @@ fi
 assert_failed_with_401
 assert_not_has_dir $FL_DIR/app/org.flatpak.Authenticator.test/$ARCH/autoinstall/active/files
 
-# Propertly mark it with token-type
+# Properly mark it with token-type
 EXPORT_ARGS="--token-type=2" make_updated_app
 mark_need_token app/org.test.Hello/$ARCH/master the-secret
 

--- a/tests/test-locale-utils.c
+++ b/tests/test-locale-utils.c
@@ -172,13 +172,13 @@ test_langs_from_localed (void)
 
   if (proxy == NULL)
     {
-      g_test_skip ("Unable to communicate with localed");
+      g_test_skip ("Unable to communicate with located");
       return;
     }
 
   flatpak_get_locale_langs_from_localed_dbus (proxy, langs);
 
-  g_test_message ("Languages from localed:");
+  g_test_message ("Languages from located:");
 
   for (i = 0; i < langs->len; i++)
     {

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -53,7 +53,7 @@ create_commit() {
         mkdir $F/shared-dir
         echo "$APP.shared2" > $F/shared-dir/shared2
 
-        echo commiting $APP depth $DEPTH >&2
+        echo committing $APP depth $DEPTH >&2
         ostree --repo=$REPO --branch=$APP --fsync=false --canonical-permissions --no-xattrs commit $F >&2
         rm -rf $F
 

--- a/tests/testlibrary.c
+++ b/tests/testlibrary.c
@@ -1019,7 +1019,7 @@ test_list_refs_in_remotes (void)
       const char *ref_spec = flatpak_ref_format_ref_cached (ref);
       const char *collection_id = flatpak_ref_get_collection_id (ref);
 
-      /* Directly listing a file:/ uri remore returns collection ids for all refs */
+      /* Directly listing a file:/ uri remote returns collection ids for all refs */
       g_assert_nonnull (collection_id);
 
       /* All the main 1 collection ids should have been recorded above */


### PR DESCRIPTION
What I did
Repository rules / “don’t edit” areas
From CONTRIBUTING.md and subprojects/README.md, subprojects/ contains vendored/submodule/copylib code (bubblewrap, libglnx, dbus-proxy, variant-schema-compiler). I treated subprojects/ as third-party and excluded it from typo fixing.

You already skip po/ (translations) and node_modules/, and I kept those exclusions.

Typos fixed (project-owned files only)
I ran codespell with write mode and exclusions, and fixed the reported typos across:

NEWS
app/…
common/…
doc/…
tests/…
session-helper/…
portal/…
data/…
Then I handled the remaining items individually:

NEWS: thse -> these
common/flatpak-utils-private.h: Thse -> These
app/flatpak-polkit-agent-text-listener.c: identies -> identities tests/test-auth.sh: Propertly -> Properly
tests/testlibrary.c: remore -> remote
common/flatpak-transaction.c: improved wording to avoid the xwindows typo (X11 window ID) Added .codespellrc
Created .codespellrc:

skip: node_modules,po,subprojects
ignore-regex: .*(ratatui|Affinitized|affinitized).* ignore-words-list: nd,ot,THUR,IST,fo,hel,bu
(these were confirmed as legitimate tokens/abbreviations/namespace prefix/test strings in this repo, so they should not be “fixed”) Verification:

codespell --config .codespellrc . now exits clean.