### PR TITLE
Default to text auth on WSL

### DIFF
--- a/app/flatpak-main.c
+++ b/app/flatpak-main.c
@@ -605,6 +605,8 @@ install_polkit_agent (void)
   g_autoptr(GError) local_error = NULL;
   g_autoptr(GDBusConnection) bus = NULL;
   const char *on_session;
+  const char *env;
+  const char *distro_name;
 
   on_session = g_getenv ("FLATPAK_SYSTEM_HELPER_ON_SESSION");
   if (on_session != NULL)
@@ -633,7 +635,11 @@ install_polkit_agent (void)
       subject = polkit_unix_process_new_for_owner (getpid (), 0, getuid ());
 
       g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
-      if (g_strcmp0 (g_getenv ("FLATPAK_FORCE_TEXT_AUTH"), "1") != 0)
+      env = g_getenv ("WSL_INTEROP");
+      distro_name = g_getenv ("WSL_DISTRO_NAME");
+      if ((env == NULL || *env == '\0') &&
+          (distro_name == NULL || *distro_name == '\0') &&
+          g_strcmp0 (g_getenv ("FLATPAK_FORCE_TEXT_AUTH"), "1") != 0)
         g_variant_builder_add (&opt_builder, "{sv}", "fallback", g_variant_new_boolean (TRUE));
       options = g_variant_ref_sink (g_variant_builder_end (&opt_builder));
 


### PR DESCRIPTION
- Fixes #6476 .
- Default to text auth on WSL.
- Since this bug can be reproduced on Ubuntu, Debian, and Fedora, we should set `FLATPAK_FORCE_TEXT_AUTH=1` for all WSL users instead of ignoring its existence. After all, the so-called `graphical prompt` in the flatpak documentation seems to be something unique to GNOME. `WSL_DISTRO_NAME` and `WSL_INTEROP` are both located at https://github.com/microsoft/WSL/blob/master/src/linux/init/util.h .

> https://docs.flatpak.org/zh-cn/latest/flatpak-command-reference.html# :
> May be set to 1 to force use of a simple built-in [polkit(8)](https://docs.flatpak.org/zh-cn/latest/flatpak-command-reference.html#polkit) agent when authentication is required to modify the system-wide installation. By default, the desktop environment's polkit agent is used, if one is available, usually resulting in a graphical prompt.