### PR TITLE
doc: Add compilation instructions for Ubuntu 24.04

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,11 @@ a development machine that's expected to break sometimes!**
 
 ### On Debian
 
+Make sure that `deb-src` apt sources are enabled in `/etc/apt/sources.list.d/*.sources` or `/etc/apt/sources.list`. 
+See distribution documentation for details.
+
+Then use commands similar to these:
+
 ```
 git clone https://github.com/flatpak/flatpak
 cd flatpak
@@ -26,6 +31,8 @@ meson compile -C _build
 meson test -C _build
 sudo meson install -C _build
 ```
+
+Note: Older versions of Ubuntu/Debian, such as `Ubuntu 24.04`, may require also installing `meson` and cannot use the system `bwrap`.
 
 ### On Fedora
 


### PR DESCRIPTION
- Fixes #6493 .
- doc: Add compilation instructions for Ubuntu 24.04 .
- Clearly, Ubuntu 24.04 does not enable the `deb-src` repo by default, and `meson` is not a build dependency of `flatpak`. `sudo sed --in-place 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources` is essentially setting the behavior of `/etc/apt/sources.list.d/ubuntu.sources` via the GUI in Ubuntu Desktop.
- <img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/97bb2aaf-224b-4cc6-a288-ab74be253696" />
