### PR TITLE
system-helper: Add appstream-update to privileged group polkit rules

### DIFF
--- a/system-helper/org.freedesktop.Flatpak.rules.in
+++ b/system-helper/org.freedesktop.Flatpak.rules.in
@@ -3,6 +3,7 @@ polkit.addRule(function(action, subject) {
          action.id == "org.freedesktop.Flatpak.runtime-install"||
          action.id == "org.freedesktop.Flatpak.app-uninstall" ||
          action.id == "org.freedesktop.Flatpak.runtime-uninstall" ||
+         action.id == "org.freedesktop.Flatpak.appstream-update" ||
          action.id == "org.freedesktop.Flatpak.modify-repo") &&
         subject.active == true && subject.local == true &&
         subject.isInGroup("@privileged_group@")) {


### PR DESCRIPTION
It appears appstream-update is required to do `flatpak update --apstream`. I was trying to run this (via arch-update) in a systemd service/timer and after debugging found it was failing due to this action not being allowed.

I think it makes sense to add it.