### PR TITLE
flatpak-bisect: Use raw string for regular expression

### DIFF
--- a/scripts/flatpak-bisect
+++ b/scripts/flatpak-bisect
@@ -118,7 +118,7 @@ class Bisector():
         message = ""
         _hash = ''
         for l in history.split('\n'):
-            rehash = re.search('(?<=^commit )\w+', l)
+            rehash = re.search(r'(?<=^commit )\w+', l)
             if rehash:
                 if message:
                     messages[_hash] = message


### PR DESCRIPTION
This is showing a SyntaxWarning when using flatpak-bisect with Python 3.12. Using a raw string fixes it.

See second change listed in:
https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

Closes: #6508