### PR TITLE
Update flatpak-builtins-update.c console message

### DIFF
--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -271,7 +271,7 @@ flatpak_builtin_update (int           argc,
   if (!has_updates)
     {
       g_print ("\n");
-      g_print (_("No apps need to be updated.\n"));
+      g_print (_("Nothing needs to be updated.\n"));
     }
 
   if (n_prefs == 0)


### PR DESCRIPTION
This minor change is intended to clarify what the program is doing when no app needs to be updated, see issue #5716