### PR TITLE
builtins-utils: Remove unused function

### DIFF
--- a/app/flatpak-builtins-utils.c
+++ b/app/flatpak-builtins-utils.c
@@ -1428,19 +1428,6 @@ ensure_remote_state_arch (FlatpakDir         *dir,
   return flatpak_remote_state_ensure_subsummary (state, dir, arch, FALSE, cancellable, error);
 }
 
-gboolean
-ensure_remote_state_arch_for_ref (FlatpakDir         *dir,
-                                  FlatpakRemoteState *state,
-                                  const char         *ref,
-                                  gboolean            cached,
-                                  gboolean            only_sideloaded,
-                                  GCancellable       *cancellable,
-                                  GError            **error)
-{
-  g_autofree char *ref_arch = flatpak_get_arch_for_ref (ref);
-  return ensure_remote_state_arch (dir, state, ref_arch, cached, only_sideloaded,cancellable, error);
-}
-
 /* Note: cached == TRUE here means prefer-cache, not only-cache */
 gboolean
 ensure_remote_state_all_arches (FlatpakDir         *dir,

--- a/app/flatpak-builtins-utils.h
+++ b/app/flatpak-builtins-utils.h
@@ -200,13 +200,6 @@ gboolean ensure_remote_state_arch (FlatpakDir         *dir,
                                    gboolean            only_sideloaded,
                                    GCancellable       *cancellable,
                                    GError            **error);
-gboolean ensure_remote_state_arch_for_ref (FlatpakDir         *dir,
-                                           FlatpakRemoteState *state,
-                                           const char         *ref,
-                                           gboolean            cached,
-                                           gboolean            only_sideloaded,
-                                           GCancellable       *cancellable,
-                                           GError            **error);
 gboolean ensure_remote_state_all_arches (FlatpakDir         *dir,
                                          FlatpakRemoteState *state,
                                          gboolean            cached,


### PR DESCRIPTION
This was pointed out during the review of https://github.com/flatpak/flatpak/pull/4932  I thought I would submit this separately while I work through rebasing https://github.com/flatpak/flatpak/pull/4932

---

Fallout from 0221f5a1fad2cf7893af0c61849a43559edc31eb