### PR TITLE
context: Fix make-sandboxed with multiarch by owning the old permission

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -3711,8 +3711,9 @@ flatpak_context_make_sandboxed (FlatpakContext *context)
   /* We drop almost everything from the app permission, except
    * multiarch which is inherited, to make sure app code keeps
    * running. */
-  FlatpakPermission *multiarch =
-    g_hash_table_lookup (context->features_permissions, "multiarch");
+  g_autoptr(FlatpakPermission) multiarch =
+    flatpak_permission_dup (g_hash_table_lookup (context->features_permissions,
+                                                 "multiarch"));
 
   g_hash_table_remove_all (context->shares_permissions);
   g_hash_table_remove_all (context->socket_permissions);
@@ -3723,7 +3724,7 @@ flatpak_context_make_sandboxed (FlatpakContext *context)
     {
       g_hash_table_insert (context->features_permissions,
                            g_strdup ("multiarch"),
-                           flatpak_permission_dup (multiarch));
+                           g_steal_pointer (&multiarch));
     }
 
   g_hash_table_remove_all (context->persistent);


### PR DESCRIPTION
We would get a reference to the old permission, then free it, and then insert the freed pointer into the new hashtable again.

Closes: #6524
Fixes: 6667e1d3 ("context: Use the new permission system for shares and features")