### PR TITLE
flatpak-run: Mount /dev/ntsync with --allow=multiarch

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -474,9 +474,7 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
         {
           g_info ("Allowing ntsync access");
           if (g_file_test ("/dev/ntsync", G_FILE_TEST_EXISTS))
-            {
-              flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/ntsync", "/dev/ntsync", NULL);
-            }
+            flatpak_bwrap_add_args (bwrap, "--dev-bind", "/dev/ntsync", "/dev/ntsync", NULL);
         }
 
       if (devices & FLATPAK_CONTEXT_DEVICE_SHM)


### PR DESCRIPTION
This PR bind-mounts `/dev/ntsync` into the sandbox if the host kernel supports it and the `--allow=multiarch` permission is granted.

### Why is this needed?
NTSync is available since the [Linux 6.14 kernel](https://www.phoronix.com/news/Linux-6.14), and [WINE 11.0](https://www.winehq.org/news/2026011301) provides stable support for it. Currently, the only way for users to utilize NTSync in Flatpak is by granting `--device=all`, which completely compromises the sandbox by exposing the entire host `/dev` tree. Users should not have to choose between kernel-level synchronization performance and basic sandbox security.

### Why tie it to --allow=multiarch instead of a new --device=ntsync?
I previously opened #6353 to add a dedicated `--device=ntsync` permission, but the proposal did not gain traction. Feedback on that PR and related issues suggests a lack of interest in further expanding the `--device=` enum for virtual kernel nodes.

Tying this to `--allow=multiarch` is a pragmatic alternative that avoids API bloat, following the precedent set by `modify_ldt` as discussed in [#6199](https://github.com/flatpak/flatpak/issues/6199#issuecomment-2854379143):

1. Virtually everyone requiring `/dev/ntsync` is running Wine/Proton.
2. Even with modern WOW64 architecture, Wine requires the `--allow=multiarch` permission to pass 32-bit syscalls which are otherwise blocked.
3. Since `--allow=multiarch` is already a "de facto" Wine/compatibility flag, it is the most logical place to house the NTSync device mount.

Just as `modify_ldt` was integrated into this permission to serve the same Wine-centric needs, mounting `/dev/ntsync` here solves a major performance bottleneck without requiring new CLI arguments or permission enums.

(Note: I am not a daily C programmer, but I have ensured the logic safely checks for the device existence via `g_file_test` to prevent issues on systems without the module.)