### PR TITLE
run: Allow /dev/ntsync unconditionally

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -411,6 +411,8 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
                               "--dev", "/dev",
                               NULL);
 
+      flatpak_bwrap_add_args (bwrap, "--dev-bind-try", "/dev/ntsync", "/dev/ntsync", NULL);
+
       if (devices & FLATPAK_CONTEXT_DEVICE_USB)
         {
           g_info ("Allowing USB device access.");


### PR DESCRIPTION
It seems to not expose any new capabilities and neither seems to greatly affect the kernel attack surface, so let's just enable it unconditionally.

If this turns out to be a bad decision, we can remove it again and maybe guard it behind a new --device permission.

Closes: #6199