### PR TITLE
tty-utils: Flush stdin before and after issuing Cursor Position command

### DIFF
--- a/app/flatpak-tty-utils.c
+++ b/app/flatpak-tty-utils.c
@@ -448,7 +448,7 @@ flatpak_get_cursor_pos (int * row, int *col)
   term = initial_term;
   term.c_lflag &= ~ICANON;
   term.c_lflag &= ~ECHO;
-  tcsetattr (STDIN_FILENO, TCSANOW, &term);
+  tcsetattr (STDIN_FILENO, TCSAFLUSH, &term);
 
   printf ("\033[6n");
   fflush (stdout);
@@ -461,7 +461,7 @@ flatpak_get_cursor_pos (int * row, int *col)
   if (select (STDIN_FILENO + 1, &readset, NULL, NULL, &time) == 1)
     res = scanf ("\033[%d;%dR", row, col);
 
-  tcsetattr (STDIN_FILENO, TCSADRAIN, &initial_term);
+  tcsetattr (STDIN_FILENO, TCSAFLUSH, &initial_term);
 
   return res == 2;
 }


### PR DESCRIPTION
If the user presses any key while we the CLI transaction UI is being shown, it ends up in stdin. When we issue the Cursor Position command, the result is appended to stdin and we fail to match on it because of the proceeding bytes.

Similarily, if we fail to match the command output (bad data, too slow, ..), we leave behind data in stdin which will be echoed back to the terminal when we restore the initial termios which icnludes ECHO in c_lflag.

Let's use TCSAFLUSH to flush out stdin data before we issue the command, which should help with matching the expected response.

Let's also use TCSAFLUSH when we restore the previous termios to make sure the stdin is clean and we don't echo whatever remains in stdin.

Closes: #2712