### PR TITLE
tests: Add test-preinstall.sh to the test matrix source

### DIFF
--- a/tests/update-test-matrix
+++ b/tests/update-test-matrix
@@ -35,6 +35,7 @@ TEST_MATRIX_SOURCE=(
 	'tests/test-seccomp.sh' \
 	'tests/test-repair.sh' \
 	'tests/test-extra-data.sh{user+system}' \
+	'tests/test-preinstall.sh' \
 )
 
 "${tests_srcdir}/expand-test-matrix.sh" --meson "${TEST_MATRIX_SOURCE[*]}" > "${tests_srcdir}/test-matrix/meson.build"


### PR DESCRIPTION
test-preinstall.sh was present in the generated test-matrix/meson.build but missing from TEST_MATRIX_SOURCE in update-test-matrix, meaning it would be dropped if the matrix were regenerated.

Or is it supposed to be deleted?