### PR TITLE
Add Kazakh translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -12,6 +12,7 @@ hr
 hu
 id
 ka
+kk
 nl
 oc
 pl

--- a/po/kk.po
+++ b/po/kk.po
@@ -1,0 +1,6246 @@
+# Kazakh translation for flatpak.
+# Copyright (C) 2026 flatpak's COPYRIGHT HOLDER
+# This file is distributed under the same license as the flatpak package.
+# Baurzhan Muftakhidinov <baurthefirst@gmail.com>,  2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: flatpak main\n"
+"Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
+"POT-Creation-Date: 2026-03-19 23:40+0000\n"
+"PO-Revision-Date: 2026-03-29 22:26+0500\n"
+"Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>\n"
+"Language-Team: Kazakh\n"
+"Language: kk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.9\n"
+
+#: app/flatpak-builtins-build-bundle.c:59
+msgid "Export runtime instead of app"
+msgstr "Қолданба орнына орындалу ортасын экспорттау"
+
+#: app/flatpak-builtins-build-bundle.c:60
+msgid "Arch to bundle for"
+msgstr "Дестелеуге арналған архитектура"
+
+#: app/flatpak-builtins-build-bundle.c:60
+#: app/flatpak-builtins-build-export.c:62 app/flatpak-builtins-build-init.c:53
+#: app/flatpak-builtins-build-sign.c:42 app/flatpak-builtins-create-usb.c:46
+#: app/flatpak-builtins-info.c:55 app/flatpak-builtins-install.c:67
+#: app/flatpak-builtins-list.c:50 app/flatpak-builtins-make-current.c:38
+#: app/flatpak-builtins-remote-info.c:54 app/flatpak-builtins-remote-ls.c:56
+#: app/flatpak-builtins-run.c:67 app/flatpak-builtins-search.c:37
+#: app/flatpak-builtins-uninstall.c:54 app/flatpak-builtins-update.c:56
+msgid "ARCH"
+msgstr "АРХ"
+
+#: app/flatpak-builtins-build-bundle.c:61
+msgid "URL for repo"
+msgstr "Репозиторий үшін URL"
+
+#: app/flatpak-builtins-build-bundle.c:61
+#: app/flatpak-builtins-build-bundle.c:62
+#: app/flatpak-builtins-build-update-repo.c:68
+#: app/flatpak-builtins-build-update-repo.c:72
+#: app/flatpak-builtins-build-update-repo.c:73
+#: app/flatpak-builtins-history.c:69 app/flatpak-builtins-remote-add.c:80
+#: app/flatpak-builtins-remote-add.c:81 app/flatpak-builtins-remote-add.c:85
+#: app/flatpak-builtins-remote-list.c:53
+#: app/flatpak-builtins-remote-modify.c:70
+#: app/flatpak-builtins-remote-modify.c:85
+#: app/flatpak-builtins-remote-modify.c:86
+#: app/flatpak-builtins-remote-modify.c:90
+msgid "URL"
+msgstr "URL"
+
+#: app/flatpak-builtins-build-bundle.c:62
+msgid "URL for runtime flatpakrepo file"
+msgstr "Орындалу ортасының flatpakrepo файлы үшін URL"
+
+#: app/flatpak-builtins-build-bundle.c:63
+msgid "Add GPG key from FILE (- for stdin)"
+msgstr "ФАЙЛ-дан GPG кілтін қосу (stdin үшін -)"
+
+#: app/flatpak-builtins-build-bundle.c:63 app/flatpak-builtins-build.c:54
+#: app/flatpak-builtins-build-export.c:67
+#: app/flatpak-builtins-build-update-repo.c:83
+#: app/flatpak-builtins-install.c:81 app/flatpak-builtins-remote-add.c:84
+#: app/flatpak-builtins-remote-add.c:86 app/flatpak-builtins-remote-modify.c:89
+#: app/flatpak-builtins-remote-modify.c:92
+msgid "FILE"
+msgstr "ФАЙЛ"
+
+#: app/flatpak-builtins-build-bundle.c:64
+msgid "GPG Key ID to sign the OCI image with"
+msgstr "OCI бейнесіне қол қою үшін GPG кілт ID-і"
+
+#: app/flatpak-builtins-build-bundle.c:64
+#: app/flatpak-builtins-build-commit-from.c:68
+#: app/flatpak-builtins-build-export.c:68
+#: app/flatpak-builtins-build-import-bundle.c:49
+#: app/flatpak-builtins-build-sign.c:44
+#: app/flatpak-builtins-build-update-repo.c:84
+msgid "KEY-ID"
+msgstr "КІЛТ-ID"
+
+#: app/flatpak-builtins-build-bundle.c:65
+#: app/flatpak-builtins-build-commit-from.c:69
+#: app/flatpak-builtins-build-export.c:71
+#: app/flatpak-builtins-build-import-bundle.c:50
+#: app/flatpak-builtins-build-sign.c:45
+#: app/flatpak-builtins-build-update-repo.c:85
+msgid "GPG Homedir to use when looking for keyrings"
+msgstr "Кілттерді іздеу үшін қолданылатын GPG үй бумасы"
+
+#: app/flatpak-builtins-build-bundle.c:65
+#: app/flatpak-builtins-build-commit-from.c:69
+#: app/flatpak-builtins-build-export.c:71
+#: app/flatpak-builtins-build-import-bundle.c:50
+#: app/flatpak-builtins-build-sign.c:45
+#: app/flatpak-builtins-build-update-repo.c:85
+msgid "HOMEDIR"
+msgstr "ҮЙ-БУМАСЫ"
+
+#: app/flatpak-builtins-build-bundle.c:66
+msgid "OSTree commit to create a delta bundle from"
+msgstr "Дельта дестесін жасауға арналған OSTree коммиті"
+
+#: app/flatpak-builtins-build-bundle.c:66 app/flatpak-builtins-remote-info.c:55
+#: app/flatpak-builtins-update.c:57
+msgid "COMMIT"
+msgstr "КОММИТ"
+
+#: app/flatpak-builtins-build-bundle.c:67
+msgid "Export oci image instead of flatpak bundle"
+msgstr "Flatpak дестесінің орнына oci бейнесін экспорттау"
+
+#: app/flatpak-builtins-build-bundle.c:70
+msgid "How to compress OCI image layers (default: gzip)"
+msgstr "OCI бейне қабаттарын қалай сығу керек (бастапқы: gzip)"
+
+#: app/flatpak-builtins-build-bundle.c:634
+msgid ""
+"LOCATION FILENAME NAME [BRANCH] - Create a single file bundle from a local "
+"repository"
+msgstr ""
+"ОРНЫ ФАЙЛ-АТЫ АТЫ [ТАРМАҚ] - Жергілікті репозиторийден бір файлдық десте "
+"жасау"
+
+#: app/flatpak-builtins-build-bundle.c:641
+msgid "LOCATION, FILENAME and NAME must be specified"
+msgstr "ОРНЫ, ФАЙЛ-АТЫ және АТЫ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-bundle.c:644
+#: app/flatpak-builtins-build-export.c:844
+#: app/flatpak-builtins-build-import-bundle.c:136
+#: app/flatpak-builtins-build-init.c:217 app/flatpak-builtins-build-sign.c:76
+#: app/flatpak-builtins-document-export.c:112
+#: app/flatpak-builtins-document-info.c:75
+#: app/flatpak-builtins-document-list.c:191
+#: app/flatpak-builtins-document-unexport.c:70
+#: app/flatpak-builtins-history.c:482 app/flatpak-builtins-info.c:130
+#: app/flatpak-builtins-install.c:181 app/flatpak-builtins-install.c:234
+#: app/flatpak-builtins-install.c:298 app/flatpak-builtins-list.c:419
+#: app/flatpak-builtins-make-current.c:72 app/flatpak-builtins-override.c:73
+#: app/flatpak-builtins-permission-list.c:162
+#: app/flatpak-builtins-permission-remove.c:132
+#: app/flatpak-builtins-remote-add.c:323
+#: app/flatpak-builtins-remote-delete.c:68
+#: app/flatpak-builtins-remote-list.c:241 app/flatpak-builtins-remote-ls.c:407
+msgid "Too many arguments"
+msgstr "Аргументтер саны тым көп"
+
+#: app/flatpak-builtins-build-bundle.c:659
+#: app/flatpak-builtins-build-commit-from.c:338
+#: app/flatpak-builtins-build-commit-from.c:351
+#: app/flatpak-builtins-build-import-bundle.c:145
+#, c-format
+msgid "'%s' is not a valid repository"
+msgstr "'%s' жарамды репозиторий емес"
+
+#: app/flatpak-builtins-build-bundle.c:663
+#, c-format
+msgid "'%s' is not a valid repository: "
+msgstr "'%s' жарамды репозиторий емес: "
+
+#: app/flatpak-builtins-build-bundle.c:674 app/flatpak-builtins-build-sign.c:88
+#: common/flatpak-dir.c:14253
+#, c-format
+msgid "'%s' is not a valid name: %s"
+msgstr "'%s' жарамды атау емес: %s"
+
+#: app/flatpak-builtins-build-bundle.c:677
+#: app/flatpak-builtins-build-export.c:865 app/flatpak-builtins-build-sign.c:91
+#: common/flatpak-dir.c:14259
+#, c-format
+msgid "'%s' is not a valid branch name: %s"
+msgstr "'%s' жарамды тармақ атауы емес: %s"
+
+#: app/flatpak-builtins-build-bundle.c:691
+#: app/flatpak-builtins-build-import-bundle.c:149
+#: app/flatpak-builtins-build-init.c:281
+#, c-format
+msgid "'%s' is not a valid filename"
+msgstr "'%s' жарамды файл атауы емес"
+
+#: app/flatpak-builtins-build-bundle.c:706
+msgid "--oci-layer-compress value must be gzip or zstd"
+msgstr "--oci-layer-compress мәні gzip немесе zstd болуы тиіс"
+
+#: app/flatpak-builtins-build.c:49
+msgid "Use Platform runtime rather than Sdk"
+msgstr "Sdk орнына Platform орындалу ортасын қолдану"
+
+#: app/flatpak-builtins-build.c:50
+msgid "Make destination readonly"
+msgstr "Мақсатты тек оқу үшін ету"
+
+#: app/flatpak-builtins-build.c:51
+msgid "Add bind mount"
+msgstr "Байланыстырылған тіркеуді қосу"
+
+#: app/flatpak-builtins-build.c:51
+msgid "DEST=SRC"
+msgstr "МАҚСАТ=ҚАЙНАР КӨЗ"
+
+#: app/flatpak-builtins-build.c:52
+msgid "Start build in this directory"
+msgstr "Құрастыруды осы бумада бастау"
+
+#: app/flatpak-builtins-build.c:52 app/flatpak-builtins-build.c:53
+#: app/flatpak-builtins-build-init.c:64 app/flatpak-builtins-run.c:69
+msgid "DIR"
+msgstr "БУМА"
+
+#: app/flatpak-builtins-build.c:53
+msgid "Where to look for custom sdk dir (defaults to 'usr')"
+msgstr "Арнайы sdk бумасын іздейтін орын (бастапқысы 'usr')"
+
+#: app/flatpak-builtins-build.c:54 app/flatpak-builtins-build-export.c:67
+msgid "Use alternative file for the metadata"
+msgstr "Метадеректер үшін балама файлды қолдану"
+
+#: app/flatpak-builtins-build.c:55 app/flatpak-builtins-run.c:86
+msgid "Kill processes when the parent process dies"
+msgstr "Аталық процесс тоқтағанда процестерді жою"
+
+#: app/flatpak-builtins-build.c:56
+msgid "Export application homedir directory to build"
+msgstr "Құрастыру үшін қолданбаның үй бумасын экспорттау"
+
+#: app/flatpak-builtins-build.c:57 app/flatpak-builtins-run.c:74
+msgid "Log session bus calls"
+msgstr "Сессия шинасының шақыруларын журналдау"
+
+#: app/flatpak-builtins-build.c:58 app/flatpak-builtins-run.c:75
+msgid "Log system bus calls"
+msgstr "Жүйелік шина шақыруларын журналдау"
+
+#: app/flatpak-builtins-build.c:262
+msgid "DIRECTORY [COMMAND [ARGUMENT…]] - Build in directory"
+msgstr "БУМА [КОМАНДА [АРГУМЕНТ…]] - Бумада құрастыру"
+
+#: app/flatpak-builtins-build.c:285 app/flatpak-builtins-build-finish.c:656
+msgid "DIRECTORY must be specified"
+msgstr "БУМА көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build.c:296 app/flatpak-builtins-build-export.c:887
+#, c-format
+msgid "Build directory %s not initialized, use flatpak build-init"
+msgstr ""
+"%s құрастыру бумасы инициализацияланбаған, flatpak build-init қолданыңыз"
+
+#: app/flatpak-builtins-build.c:315
+msgid "metadata invalid, not application or runtime"
+msgstr "метадеректер жарамсыз, қолданба немесе орындалу ортасы емес"
+
+#: app/flatpak-builtins-build.c:446
+#, c-format
+msgid "No extension point matching %s in %s"
+msgstr "%2$s ішінде %1$s сәйкес келетін кеңейту нүктесі жоқ"
+
+#: app/flatpak-builtins-build.c:629
+#, c-format
+msgid "Missing '=' in bind mount option '%s'"
+msgstr "'%s' байланыстырылған тіркеу опциясында '=' жоқ"
+
+#: app/flatpak-builtins-build.c:673 common/flatpak-run.c:3710
+msgid "Unable to start app"
+msgstr "Қолданбаны іске қосу мүмкін емес"
+
+#: app/flatpak-builtins-build-commit-from.c:58
+msgid "Source repo dir"
+msgstr "Қайнар көз репозиторий бумасы"
+
+#: app/flatpak-builtins-build-commit-from.c:58
+msgid "SRC-REPO"
+msgstr "ҚАЙНАР-КӨЗ-РЕПОЗИТОРИЙІ"
+
+#: app/flatpak-builtins-build-commit-from.c:59
+msgid "Source repo ref"
+msgstr "Қайнар көз репозиторий сілтемесі"
+
+#: app/flatpak-builtins-build-commit-from.c:59
+msgid "SRC-REF"
+msgstr "ҚАЙНАР-КӨЗ-СІЛТЕМЕСІ"
+
+#: app/flatpak-builtins-build-commit-from.c:64
+#: app/flatpak-builtins-build-export.c:60
+msgid "One line subject"
+msgstr "Бір жолдық тақырып"
+
+#: app/flatpak-builtins-build-commit-from.c:64
+#: app/flatpak-builtins-build-export.c:60
+msgid "SUBJECT"
+msgstr "ТАҚЫРЫП"
+
+#: app/flatpak-builtins-build-commit-from.c:65
+#: app/flatpak-builtins-build-export.c:61
+msgid "Full description"
+msgstr "Толық сипаттама"
+
+#: app/flatpak-builtins-build-commit-from.c:65
+#: app/flatpak-builtins-build-export.c:61
+msgid "BODY"
+msgstr "ДЕНЕСІ"
+
+#: app/flatpak-builtins-build-commit-from.c:66
+#: app/flatpak-builtins-build-export.c:64
+#: app/flatpak-builtins-build-import-bundle.c:51
+msgid "Update the appstream branch"
+msgstr "appstream тармағын жаңарту"
+
+#: app/flatpak-builtins-build-commit-from.c:67
+#: app/flatpak-builtins-build-export.c:65
+#: app/flatpak-builtins-build-import-bundle.c:52
+#: app/flatpak-builtins-build-update-repo.c:87
+msgid "Don't update the summary"
+msgstr "Жиынтықты жаңартпау"
+
+#: app/flatpak-builtins-build-commit-from.c:68
+#: app/flatpak-builtins-build-export.c:68
+#: app/flatpak-builtins-build-import-bundle.c:49
+#: app/flatpak-builtins-build-sign.c:44
+msgid "GPG Key ID to sign the commit with"
+msgstr "Коммитке қол қою үшін GPG кілт ID-і"
+
+#: app/flatpak-builtins-build-commit-from.c:70
+#: app/flatpak-builtins-build-export.c:73
+msgid "Mark build as end-of-life"
+msgstr "Құрастыруды қолдау мерзімі аяқталған деп белгілеу"
+
+#: app/flatpak-builtins-build-commit-from.c:70
+#: app/flatpak-builtins-build-export.c:73
+msgid "REASON"
+msgstr "СЕБЕП"
+
+#: app/flatpak-builtins-build-commit-from.c:71
+msgid ""
+"Mark refs matching the OLDID prefix as end-of-life, to be replaced with the "
+"given NEWID"
+msgstr ""
+"OLDID префиксіне сәйкес келетін сілтемелерді қолдау мерзімі аяқталған деп "
+"белгілеп, берілген NEWID-пен алмастыру"
+
+#: app/flatpak-builtins-build-commit-from.c:71
+msgid "OLDID=NEWID"
+msgstr "ЕСКІ-ID=ЖАҢА-ID"
+
+#: app/flatpak-builtins-build-commit-from.c:72
+#: app/flatpak-builtins-build-export.c:75
+msgid "Set type of token needed to install this commit"
+msgstr "Осы коммитті орнату үшін қажетті токен түрін орнату"
+
+#: app/flatpak-builtins-build-commit-from.c:72
+#: app/flatpak-builtins-build-export.c:75
+msgid "VAL"
+msgstr "МӘН"
+
+#: app/flatpak-builtins-build-commit-from.c:73
+msgid "Override the timestamp of the commit (NOW for current time)"
+msgstr "Коммиттің уақыт белгісін қайта анықтау (ағымдағы уақыт үшін NOW)"
+
+#: app/flatpak-builtins-build-commit-from.c:73
+#: app/flatpak-builtins-build-export.c:76
+msgid "TIMESTAMP"
+msgstr "УАҚЫТ_МӘНІ"
+
+#: app/flatpak-builtins-build-commit-from.c:75
+#: app/flatpak-builtins-build-export.c:80
+#: app/flatpak-builtins-build-import-bundle.c:53
+#: app/flatpak-builtins-build-update-repo.c:97
+msgid "Don't generate a summary index"
+msgstr "Жиынтық индексін жасамау"
+
+#: app/flatpak-builtins-build-commit-from.c:278
+msgid "DST-REPO [DST-REF…] - Make a new commit from existing commits"
+msgstr "МАҚСАТ-РЕПО [МАҚСАТ-СІЛТЕМЕ…] - Бар коммиттерден жаңа коммит жасау"
+
+#: app/flatpak-builtins-build-commit-from.c:285
+msgid "DST-REPO must be specified"
+msgstr "МАҚСАТ-РЕПО көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-commit-from.c:293
+msgid ""
+"If --src-repo is not specified, exactly one destination ref must be specified"
+msgstr "Егер --src-repo көрсетілмесе, дәл бір мақсатты сілтеме көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-commit-from.c:296
+msgid ""
+"If --src-ref is specified, exactly one destination ref must be specified"
+msgstr "Егер --src-ref көрсетілсе, дәл бір мақсатты сілтеме көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-commit-from.c:299
+msgid "Either --src-repo or --src-ref must be specified"
+msgstr "Не --src-repo, не --src-ref көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-commit-from.c:315
+msgid "Invalid argument format of use  --end-of-life-rebase=OLDID=NEWID"
+msgstr ""
+"--end-of-life-rebase=OLDID=NEWID қолданылуының аргумент пішімі жарамсыз"
+
+#: app/flatpak-builtins-build-commit-from.c:321
+#: app/flatpak-builtins-build-commit-from.c:324
+#, c-format
+msgid "Invalid name %s in --end-of-life-rebase"
+msgstr "--end-of-life-rebase ішіндегі %s атауы жарамсыз"
+
+#: app/flatpak-builtins-build-commit-from.c:333
+#: app/flatpak-builtins-build-export.c:1092
+#, c-format
+msgid "Could not parse '%s'"
+msgstr "'%s' талдау мүмкін емес"
+
+#: app/flatpak-builtins-build-commit-from.c:498
+msgid "Can't commit from partial source commit"
+msgstr "Жартылай қайнар көз коммитінен коммит жасау мүмкін емес"
+
+#: app/flatpak-builtins-build-commit-from.c:503
+#, c-format
+msgid "%s: no change\n"
+msgstr "%s: өзгеріс жоқ\n"
+
+#: app/flatpak-builtins-build-export.c:62
+msgid "Architecture to export for (must be host compatible)"
+msgstr "Экспортталатын архитектура (хостпен үйлесімді болуы тиіс)"
+
+#: app/flatpak-builtins-build-export.c:63
+msgid "Commit runtime (/usr), not /app"
+msgstr "/app емес, орындалу ортасын (/usr) коммиттеу"
+
+#: app/flatpak-builtins-build-export.c:66
+msgid "Use alternative directory for the files"
+msgstr "Файлдар үшін балама буманы қолдану"
+
+#: app/flatpak-builtins-build-export.c:66
+msgid "SUBDIR"
+msgstr "ІШКІ-БУМА"
+
+#: app/flatpak-builtins-build-export.c:69
+msgid "Files to exclude"
+msgstr "Шығарылатын файлдар"
+
+#: app/flatpak-builtins-build-export.c:69
+#: app/flatpak-builtins-build-export.c:70
+#: app/flatpak-builtins-build-update-repo.c:90
+msgid "PATTERN"
+msgstr "ШАБЛОН"
+
+#: app/flatpak-builtins-build-export.c:70
+msgid "Excluded files to include"
+msgstr "Шығарылған файлдар ішінен қосылатындары"
+
+#: app/flatpak-builtins-build-export.c:74
+msgid "Mark build as end-of-life, to be replaced with the given ID"
+msgstr ""
+"Құрастыруды қолдау мерзімі аяқталған деп белгілеп, берілген ID-пен алмастыру"
+
+#: app/flatpak-builtins-build-export.c:74
+#: app/flatpak-builtins-document-list.c:49 app/flatpak-cli-transaction.c:1427
+msgid "ID"
+msgstr "ID"
+
+#: app/flatpak-builtins-build-export.c:76
+msgid "Override the timestamp of the commit"
+msgstr "Коммиттің уақыт белгісін қайта анықтау"
+
+#: app/flatpak-builtins-build-export.c:77
+#: app/flatpak-builtins-build-update-repo.c:75
+#: app/flatpak-builtins-remote-add.c:83 app/flatpak-builtins-remote-list.c:54
+#: app/flatpak-builtins-remote-modify.c:88
+msgid "Collection ID"
+msgstr "Коллекция ID-і"
+
+#: app/flatpak-builtins-build-export.c:472
+#, c-format
+msgid "WARNING: Error running desktop-file-validate: %s\n"
+msgstr "ЕСКЕРТУ: desktop-file-validate орындау қатесі: %s\n"
+
+#: app/flatpak-builtins-build-export.c:480
+#, c-format
+msgid "WARNING: Error reading from desktop-file-validate: %s\n"
+msgstr "ЕСКЕРТУ: desktop-file-validate-тен оқу қатесі: %s\n"
+
+#: app/flatpak-builtins-build-export.c:486
+#, c-format
+msgid "WARNING: Failed to validate desktop file %s: %s\n"
+msgstr "ЕСКЕРТУ: %s жұмыс үстелі файлын тексеру сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-builtins-build-export.c:513
+#, c-format
+msgid "WARNING: Can't find Exec key in %s: %s\n"
+msgstr "ЕСКЕРТУ: %s ішінен Exec кілті табылмады: %s\n"
+
+#: app/flatpak-builtins-build-export.c:521
+#: app/flatpak-builtins-build-export.c:614
+#, c-format
+msgid "WARNING: Binary not found for Exec line in %s: %s\n"
+msgstr "ЕСКЕРТУ: %s ішіндегі Exec жолы үшін бинарлы файл табылмады: %s\n"
+
+#: app/flatpak-builtins-build-export.c:529
+#, c-format
+msgid "WARNING: Icon not matching app id in %s: %s\n"
+msgstr "ЕСКЕРТУ: %s ішіндегі таңбаша қолданба ID-іне сәйкес келмейді: %s\n"
+
+#: app/flatpak-builtins-build-export.c:552
+#, c-format
+msgid "WARNING: Icon referenced in desktop file but not exported: %s\n"
+msgstr ""
+"ЕСКЕРТУ: Таңбаша жұмыс үстелі файлында сілтенген, бірақ экспортталмаған: %s\n"
+
+#: app/flatpak-builtins-build-export.c:719
+#, c-format
+msgid "Invalid uri type %s, only http/https supported"
+msgstr "Жарамсыз uri түрі %s, тек http/https қолдау көрсетіледі"
+
+#: app/flatpak-builtins-build-export.c:737
+#, c-format
+msgid "Unable to find basename in %s, specify a name explicitly"
+msgstr "%s ішінен базалық атау табылмады, атауды анық көрсетіңіз"
+
+#: app/flatpak-builtins-build-export.c:746
+msgid "No slashes allowed in extra data name"
+msgstr "Қосымша деректер атауында қиғаш сызықтарға рұқсат жоқ"
+
+#: app/flatpak-builtins-build-export.c:758
+#, c-format
+msgid "Invalid format for sha256 checksum: '%s'"
+msgstr "sha256 бақылау сомасы үшін жарамсыз пішім: '%s'"
+
+#: app/flatpak-builtins-build-export.c:768
+msgid "Extra data sizes of zero not supported"
+msgstr "Нөлдік қосымша деректер өлшемдеріне қолдау көрсетілмейді"
+
+#: app/flatpak-builtins-build-export.c:830
+msgid ""
+"LOCATION DIRECTORY [BRANCH] - Create a repository from a build directory"
+msgstr "ОРНЫ БУМА [ТАРМАҚ] - Құрастыру бумасынан репозиторий жасау"
+
+#: app/flatpak-builtins-build-export.c:838
+msgid "LOCATION and DIRECTORY must be specified"
+msgstr "ОРНЫ және БУМА көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-export.c:859
+#: app/flatpak-builtins-remote-add.c:327
+#, c-format
+msgid "‘%s’ is not a valid collection ID: %s"
+msgstr "‘%s’ жарамды коллекция ID-і емес: %s"
+
+#: app/flatpak-builtins-build-export.c:904
+#: app/flatpak-builtins-build-finish.c:684
+msgid "No name specified in the metadata"
+msgstr "Метадеректерде ешқандай атау көрсетілмеген"
+
+#: app/flatpak-builtins-build-export.c:1166
+#, c-format
+msgid "Commit: %s\n"
+msgstr "Коммит: %s\n"
+
+#: app/flatpak-builtins-build-export.c:1167
+#, c-format
+msgid "Metadata Total: %u\n"
+msgstr "Метадеректер жиынтығы: %u\n"
+
+#: app/flatpak-builtins-build-export.c:1168
+#, c-format
+msgid "Metadata Written: %u\n"
+msgstr "Жазылған метадеректер: %u\n"
+
+#: app/flatpak-builtins-build-export.c:1169
+#, c-format
+msgid "Content Total: %u\n"
+msgstr "Мазмұн жиынтығы: %u\n"
+
+#: app/flatpak-builtins-build-export.c:1170
+#, c-format
+msgid "Content Written: %u\n"
+msgstr "Жазылған мазмұн: %u\n"
+
+#: app/flatpak-builtins-build-export.c:1171
+msgid "Content Bytes Written:"
+msgstr "Жазылған мазмұн байттары:"
+
+#: app/flatpak-builtins-build-finish.c:52
+msgid "Command to set"
+msgstr "Орнатылатын команда"
+
+#: app/flatpak-builtins-build-finish.c:52 app/flatpak-builtins-run.c:68
+#: app/flatpak-main.c:209
+msgid "COMMAND"
+msgstr "КОМАНДА"
+
+#: app/flatpak-builtins-build-finish.c:53
+msgid "Flatpak version to require"
+msgstr "Талап етілетін Flatpak нұсқасы"
+
+#: app/flatpak-builtins-build-finish.c:53
+msgid "MAJOR.MINOR.MICRO"
+msgstr "MAJOR.MINOR.MICRO"
+
+#: app/flatpak-builtins-build-finish.c:54
+msgid "Don't process exports"
+msgstr "Экспорттарды өңдемеу"
+
+#: app/flatpak-builtins-build-finish.c:55
+msgid "Extra data info"
+msgstr "Қосымша деректер ақпараты"
+
+#: app/flatpak-builtins-build-finish.c:56 app/flatpak-builtins-build-init.c:63
+msgid "Add extension point info"
+msgstr "Кеңейту нүктесі ақпаратын қосу"
+
+#: app/flatpak-builtins-build-finish.c:56 app/flatpak-builtins-build-init.c:63
+msgid "NAME=VARIABLE[=VALUE]"
+msgstr "АТЫ=АЙНЫМАЛЫ[=МӘН]"
+
+#: app/flatpak-builtins-build-finish.c:57
+msgid "Remove extension point info"
+msgstr "Кеңейту нүктесі ақпаратын өшіру"
+
+#: app/flatpak-builtins-build-finish.c:57
+#: app/flatpak-builtins-build-update-repo.c:79 app/flatpak-builtins-info.c:58
+#: app/flatpak-builtins-remote-add.c:88 app/flatpak-builtins-remote-modify.c:94
+#: app/flatpak-main.c:182
+msgid "NAME"
+msgstr "АТЫ"
+
+#: app/flatpak-builtins-build-finish.c:58
+msgid "Set extension priority (only for extensions)"
+msgstr "Кеңейту басымдылығын орнату (тек кеңейтулер үшін)"
+
+#: app/flatpak-builtins-build-finish.c:58
+msgid "VALUE"
+msgstr "МӘН"
+
+#: app/flatpak-builtins-build-finish.c:59
+msgid "Change the sdk used for the app"
+msgstr "Қолданба үшін қолданылатын sdk-ны өзгерту"
+
+#: app/flatpak-builtins-build-finish.c:59
+msgid "SDK"
+msgstr "SDK"
+
+#: app/flatpak-builtins-build-finish.c:60
+msgid "Change the runtime used for the app"
+msgstr "Қолданба үшін қолданылатын орындалу ортасын өзгерту"
+
+#: app/flatpak-builtins-build-finish.c:60 app/flatpak-builtins-build-init.c:54
+#: app/flatpak-builtins-list.c:53 app/flatpak-builtins-remote-ls.c:58
+#: app/flatpak-builtins-run.c:72
+msgid "RUNTIME"
+msgstr "ОРЫНДАЛУ_ОРТАСЫ"
+
+#: app/flatpak-builtins-build-finish.c:61
+msgid "Set generic metadata option"
+msgstr "Жалпы метадеректер опциясын орнату"
+
+#: app/flatpak-builtins-build-finish.c:61
+msgid "GROUP=KEY[=VALUE]"
+msgstr "ТОП=КІЛТ[=МӘН]"
+
+#: app/flatpak-builtins-build-finish.c:62
+msgid "Don't inherit permissions from runtime"
+msgstr "Рұқсаттарды орындалу ортасынан мұраға алмау"
+
+#: app/flatpak-builtins-build-finish.c:155
+#, c-format
+msgid "Not exporting %s, wrong extension\n"
+msgstr "%s экспортталмайды, кеңейту қате\n"
+
+#: app/flatpak-builtins-build-finish.c:163
+#, c-format
+msgid "Not exporting %s, non-allowed export filename\n"
+msgstr "%s экспортталмайды, экспорттық файл атауына рұқсат жоқ\n"
+
+#: app/flatpak-builtins-build-finish.c:167
+#, c-format
+msgid "Exporting %s\n"
+msgstr "%s экспортталуда\n"
+
+#: app/flatpak-builtins-build-finish.c:440
+msgid "More than one executable found\n"
+msgstr "Бірден көп орындалатын файл табылды\n"
+
+#: app/flatpak-builtins-build-finish.c:451
+#, c-format
+msgid "Using %s as command\n"
+msgstr "Команда ретінде %s қолданылуда\n"
+
+#: app/flatpak-builtins-build-finish.c:456
+msgid "No executable found\n"
+msgstr "Орындалатын файл табылмады\n"
+
+#: app/flatpak-builtins-build-finish.c:511
+#, c-format
+msgid "Invalid --require-version argument: %s"
+msgstr "--require-version аргументі жарамсыз: %s"
+
+#: app/flatpak-builtins-build-finish.c:543
+#, c-format
+msgid "Too few elements in --extra-data argument %s"
+msgstr "--extra-data аргументіндегі элементтер тым аз: %s"
+
+#: app/flatpak-builtins-build-finish.c:575
+#, c-format
+msgid ""
+"Too few elements in --metadata argument %s, format should be "
+"GROUP=KEY[=VALUE]]"
+msgstr ""
+"--metadata %s аргументіндегі элементтер тым аз, пішімі ТОП=КІЛТ[=МӘН] болуы "
+"тиіс"
+
+#: app/flatpak-builtins-build-finish.c:597
+#: app/flatpak-builtins-build-init.c:458
+#, c-format
+msgid ""
+"Too few elements in --extension argument %s, format should be "
+"NAME=VAR[=VALUE]"
+msgstr ""
+"--extension %s аргументіндегі элементтер тым аз, пішімі АТЫ=АЙНЫМАЛЫ[=МӘН] "
+"болуы тиіс"
+
+#: app/flatpak-builtins-build-finish.c:603
+#: app/flatpak-builtins-build-init.c:461
+#, c-format
+msgid "Invalid extension name %s"
+msgstr "Кеңейту атауы жарамсыз: %s"
+
+#: app/flatpak-builtins-build-finish.c:646
+msgid "DIRECTORY - Finalize a build directory"
+msgstr "БУМА - Құрастыру бумасын аяқтау"
+
+#: app/flatpak-builtins-build-finish.c:668
+#, c-format
+msgid "Build directory %s not initialized"
+msgstr "%s құрастыру бумасы инициализацияланбаған"
+
+#: app/flatpak-builtins-build-finish.c:689
+#, c-format
+msgid "Build directory %s already finalized"
+msgstr "%s құрастыру бумасы қазірдің өзінде аяқталған"
+
+#: app/flatpak-builtins-build-finish.c:702
+msgid "Please review the exported files and the metadata\n"
+msgstr "Экспортталған файлдар мен метадеректерді қарап шығыңыз\n"
+
+#: app/flatpak-builtins-build-import-bundle.c:47
+msgid "Override the ref used for the imported bundle"
+msgstr "Импортталған десте үшін қолданылатын сілтемені қайта анықтау"
+
+#: app/flatpak-builtins-build-import-bundle.c:47
+msgid "REF"
+msgstr "СІЛТЕМЕ"
+
+#: app/flatpak-builtins-build-import-bundle.c:48
+msgid "Import oci image instead of flatpak bundle"
+msgstr "Flatpak дестесінің орнына oci бейнесін импорттау"
+
+#: app/flatpak-builtins-build-import-bundle.c:77
+#: app/flatpak-builtins-build-import-bundle.c:105
+#, c-format
+msgid "Importing %s (%s)\n"
+msgstr "%s (%s) импортталуда\n"
+
+#: app/flatpak-builtins-build-import-bundle.c:126
+msgid "LOCATION FILENAME - Import a file bundle into a local repository"
+msgstr "ОРНЫ ФАЙЛ-АТЫ - Жергілікті репозиторийге файлдық дестені импорттау"
+
+#: app/flatpak-builtins-build-import-bundle.c:133
+msgid "LOCATION and FILENAME must be specified"
+msgstr "ОРНЫ және ФАЙЛ-АТЫ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-init.c:53 app/flatpak-builtins-info.c:55
+#: app/flatpak-builtins-run.c:67
+msgid "Arch to use"
+msgstr "Қолданылатын архитектура"
+
+#: app/flatpak-builtins-build-init.c:54
+msgid "Initialize var from named runtime"
+msgstr "var-ды аталған орындалу ортасынан инициализациялау"
+
+#: app/flatpak-builtins-build-init.c:55
+msgid "Initialize apps from named app"
+msgstr "Қолданбаларды аталған қолданбадан инициализациялау"
+
+#: app/flatpak-builtins-build-init.c:55
+msgid "APP"
+msgstr "ҚОЛДАНБА"
+
+#: app/flatpak-builtins-build-init.c:56
+msgid "Specify version for --base"
+msgstr "--base үшін нұсқаны көрсету"
+
+#: app/flatpak-builtins-build-init.c:56 app/flatpak-builtins-run.c:73
+msgid "VERSION"
+msgstr "НҰСҚА"
+
+#: app/flatpak-builtins-build-init.c:57
+msgid "Include this base extension"
+msgstr "Осы базалық кеңейтуді қосу"
+
+#: app/flatpak-builtins-build-init.c:57 app/flatpak-builtins-build-init.c:62
+msgid "EXTENSION"
+msgstr "КЕҢЕЙТУ"
+
+#: app/flatpak-builtins-build-init.c:58
+msgid "Extension tag to use if building extension"
+msgstr "Егер кеңейту құрастырылса, қолданылатын кеңейту тегі"
+
+#: app/flatpak-builtins-build-init.c:58
+msgid "EXTENSION_TAG"
+msgstr "КЕҢЕЙТУ_ТЕГІ"
+
+#: app/flatpak-builtins-build-init.c:59
+msgid "Initialize /usr with a writable copy of the sdk"
+msgstr "/usr-ды sdk-ның жазуға болатын көшірмесімен инициализациялау"
+
+#: app/flatpak-builtins-build-init.c:60
+msgid "Specify the build type (app, runtime, extension)"
+msgstr "Құрастыру түрін көрсету (app, runtime, extension)"
+
+#: app/flatpak-builtins-build-init.c:60
+msgid "TYPE"
+msgstr "ТҮР"
+
+#: app/flatpak-builtins-build-init.c:61
+msgid "Add a tag"
+msgstr "Тег қосу"
+
+#: app/flatpak-builtins-build-init.c:61
+msgid "TAG"
+msgstr "ТЕГ"
+
+#: app/flatpak-builtins-build-init.c:62
+msgid "Include this sdk extension in /usr"
+msgstr "/usr ішіне осы sdk кеңейтуін қосу"
+
+#: app/flatpak-builtins-build-init.c:64
+msgid "Where to store sdk (defaults to 'usr')"
+msgstr "sdk сақталатын орын (бастапқысы 'usr')"
+
+#: app/flatpak-builtins-build-init.c:65
+msgid "Re-initialize the sdk/var"
+msgstr "sdk/var-ды қайта инициализациялау"
+
+#: app/flatpak-builtins-build-init.c:118
+#, c-format
+msgid "Requested extension %s/%s/%s is only partially installed"
+msgstr "Сұралған %s/%s/%s кеңейтуі тек жартылай орнатылған"
+
+#: app/flatpak-builtins-build-init.c:147
+#, c-format
+msgid "Requested extension %s/%s/%s not installed"
+msgstr "Сұралған %s/%s/%s кеңейтуі орнатылмаған"
+
+#: app/flatpak-builtins-build-init.c:207
+msgid ""
+"DIRECTORY APPNAME SDK RUNTIME [BRANCH] - Initialize a directory for building"
+msgstr ""
+"БУМА ҚОЛДАНБА_АТАУЫ SDK ОРЫНДАЛУ_ОРТАСЫ [ТАРМАҚ] - Құрастыру үшін буманы "
+"инициализациялау"
+
+#: app/flatpak-builtins-build-init.c:214
+msgid "RUNTIME must be specified"
+msgstr "ОРЫНДАЛУ_ОРТАСЫ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-init.c:235
+#, c-format
+msgid "'%s' is not a valid build type name, use app, runtime or extension"
+msgstr ""
+"'%s' жарамды құрастыру түрі емес, app, runtime немесе extension қолданыңыз"
+
+#: app/flatpak-builtins-build-init.c:241 app/flatpak-builtins-override.c:79
+#, c-format
+msgid "'%s' is not a valid application name: %s"
+msgstr "'%s' жарамды қолданба атауы емес: %s"
+
+#: app/flatpak-builtins-build-init.c:295
+#, c-format
+msgid "Build directory %s already initialized"
+msgstr "%s құрастыру бумасы қазірдің өзінде инициализацияланған"
+
+#: app/flatpak-builtins-build-sign.c:42 app/flatpak-builtins-install.c:67
+#: app/flatpak-builtins-remote-info.c:54
+msgid "Arch to install for"
+msgstr "Орнату архитектурасы"
+
+#: app/flatpak-builtins-build-sign.c:43 app/flatpak-builtins-create-usb.c:48
+#: app/flatpak-builtins-install.c:74 app/flatpak-builtins-remote-info.c:56
+#: app/flatpak-builtins-uninstall.c:58 app/flatpak-builtins-update.c:64
+msgid "Look for runtime with the specified name"
+msgstr "Көрсетілген атауы бар орындалу ортасын іздеу"
+
+#: app/flatpak-builtins-build-sign.c:66
+msgid "LOCATION [ID [BRANCH]] - Sign an application or runtime"
+msgstr "ОРНЫ [ID [ТАРМАҚ]] - Қолданбаға немесе орындалу ортасына қол қою"
+
+#: app/flatpak-builtins-build-sign.c:73
+#: app/flatpak-builtins-build-update-repo.c:499
+#: app/flatpak-builtins-remote-add.c:320 app/flatpak-builtins-repo.c:739
+msgid "LOCATION must be specified"
+msgstr "ОРНЫ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-build-sign.c:94
+msgid "No gpg key ids specified"
+msgstr "GPG кілт ID-лері көрсетілмеген"
+
+#: app/flatpak-builtins-build-update-repo.c:68
+msgid "Redirect this repo to a new URL"
+msgstr "Бұл репозиторийді жаңа URL-ге бағыттау"
+
+#: app/flatpak-builtins-build-update-repo.c:69
+msgid "A nice name to use for this repository"
+msgstr "Бұл репозиторий үшін қолданылатын жақсы атау"
+
+#: app/flatpak-builtins-build-update-repo.c:69
+#: app/flatpak-builtins-remote-add.c:77 app/flatpak-builtins-remote-modify.c:82
+msgid "TITLE"
+msgstr "АТАУЫ"
+
+#: app/flatpak-builtins-build-update-repo.c:70
+msgid "A one-line comment for this repository"
+msgstr "Бұл репозиторий үшін бір жолдық түсініктеме"
+
+#: app/flatpak-builtins-build-update-repo.c:70
+#: app/flatpak-builtins-remote-add.c:78 app/flatpak-builtins-remote-modify.c:83
+msgid "COMMENT"
+msgstr "ТҮСІНІКТЕМЕ"
+
+#: app/flatpak-builtins-build-update-repo.c:71
+msgid "A full-paragraph description for this repository"
+msgstr "Бұл репозиторий үшін толық сипаттама"
+
+#: app/flatpak-builtins-build-update-repo.c:71
+#: app/flatpak-builtins-remote-add.c:79 app/flatpak-builtins-remote-modify.c:84
+msgid "DESCRIPTION"
+msgstr "СИПАТТАМА"
+
+#: app/flatpak-builtins-build-update-repo.c:72
+msgid "URL for a website for this repository"
+msgstr "Бұл репозиторийдің веб-сайты үшін URL"
+
+#: app/flatpak-builtins-build-update-repo.c:73
+msgid "URL for an icon for this repository"
+msgstr "Бұл репозиторийдің таңбашасы үшін URL"
+
+#: app/flatpak-builtins-build-update-repo.c:74
+msgid "Default branch to use for this repository"
+msgstr "Осы репозиторий үшін бастапқы тармақ"
+
+#: app/flatpak-builtins-build-update-repo.c:74
+#: app/flatpak-builtins-remote-add.c:82 app/flatpak-builtins-remote-modify.c:87
+#: app/flatpak-builtins-repo.c:713 app/flatpak-builtins-repo.c:714
+#: app/flatpak-builtins-run.c:70
+msgid "BRANCH"
+msgstr "ТАРМАҚ"
+
+#: app/flatpak-builtins-build-update-repo.c:75
+#: app/flatpak-builtins-remote-add.c:83 app/flatpak-builtins-remote-modify.c:88
+msgid "COLLECTION-ID"
+msgstr "КОЛЛЕКЦИЯ-ID"
+
+#. Translators: A sideload is when you install from a local USB drive rather than the Internet.
+#: app/flatpak-builtins-build-update-repo.c:77
+msgid ""
+"Permanently deploy collection ID to client remote configurations, only for "
+"sideload support"
+msgstr ""
+"Тек қатар жүктеуді қолдау үшін, коллекция ID-ін клиенттің қашықтағы "
+"конфигурацияларына тұрақты орналастыру"
+
+#: app/flatpak-builtins-build-update-repo.c:78
+msgid "Permanently deploy collection ID to client remote configurations"
+msgstr ""
+"Коллекция ID-ін клиенттің қашықтағы конфигурацияларына тұрақты орналастыру"
+
+#: app/flatpak-builtins-build-update-repo.c:79
+msgid "Name of authenticator for this repository"
+msgstr "Осы репозиторий үшін аутентификатор атауы"
+
+#: app/flatpak-builtins-build-update-repo.c:80
+msgid "Autoinstall authenticator for this repository"
+msgstr "Осы репозиторий үшін аутентификаторды автоматты орнату"
+
+#: app/flatpak-builtins-build-update-repo.c:81
+msgid "Don't autoinstall authenticator for this repository"
+msgstr "Осы репозиторий үшін аутентификаторды автоматты орнатпау"
+
+#: app/flatpak-builtins-build-update-repo.c:82
+#: app/flatpak-builtins-remote-add.c:89
+msgid "Authenticator option"
+msgstr "Аутентификатор опциясы"
+
+#: app/flatpak-builtins-build-update-repo.c:82
+#: app/flatpak-builtins-remote-add.c:89 app/flatpak-builtins-remote-modify.c:95
+msgid "KEY=VALUE"
+msgstr "КІЛТ=МӘН"
+
+#: app/flatpak-builtins-build-update-repo.c:83
+msgid "Import new default GPG public key from FILE"
+msgstr "ФАЙЛ-дан жаңа бастапқы GPG ашық кілтін импорттау"
+
+#: app/flatpak-builtins-build-update-repo.c:84
+msgid "GPG Key ID to sign the summary with"
+msgstr "Жиынтыққа қол қою үшін GPG кілт ID-і"
+
+#: app/flatpak-builtins-build-update-repo.c:86
+msgid "Generate delta files"
+msgstr "Дельта файлдарын жасау"
+
+#: app/flatpak-builtins-build-update-repo.c:88
+msgid "Don't update the appstream branch"
+msgstr "appstream тармағын жаңартпау"
+
+#: app/flatpak-builtins-build-update-repo.c:89
+msgid "Max parallel jobs when creating deltas (default: NUMCPUs)"
+msgstr ""
+"Дельталарды жасау кезіндегі максималды параллель жұмыстар (бастапқысы: "
+"NUMCPUs)"
+
+#: app/flatpak-builtins-build-update-repo.c:89
+msgid "NUM-JOBS"
+msgstr "ЖҰМЫС-САНЫ"
+
+#: app/flatpak-builtins-build-update-repo.c:90
+msgid "Don't create deltas matching refs"
+msgstr "Сілтемелерге сәйкес келетін дельталарды жасамау"
+
+#: app/flatpak-builtins-build-update-repo.c:91
+msgid "Prune unused objects"
+msgstr "Қолданылмайтын объектілерді тазалау"
+
+#: app/flatpak-builtins-build-update-repo.c:92
+msgid "Prune but don't actually remove anything"
+msgstr "Тазалау, бірақ іс жүзінде ештеңені өшірмеу"
+
+#: app/flatpak-builtins-build-update-repo.c:93
+msgid "Only traverse DEPTH parents for each commit (default: -1=infinite)"
+msgstr "Әр коммит үшін тек DEPTH аталықтарын өту (бастапқысы: -1=шексіз)"
+
+#: app/flatpak-builtins-build-update-repo.c:93
+msgid "DEPTH"
+msgstr "ТЕРЕҢДІК"
+
+#: app/flatpak-builtins-build-update-repo.c:223
+#, c-format
+msgid "Generating delta: %s (%.10s)\n"
+msgstr "Дельта жасалуда: %s (%.10s)\n"
+
+#: app/flatpak-builtins-build-update-repo.c:225
+#, c-format
+msgid "Generating delta: %s (%.10s-%.10s)\n"
+msgstr "Дельта жасалуда: %s (%.10s-%.10s)\n"
+
+#: app/flatpak-builtins-build-update-repo.c:233
+#, c-format
+msgid "Failed to generate delta %s (%.10s): "
+msgstr "%s (%.10s) дельтасын жасау сәтсіз аяқталды: "
+
+#: app/flatpak-builtins-build-update-repo.c:236
+#, c-format
+msgid "Failed to generate delta %s (%.10s-%.10s): "
+msgstr "%s (%.10s-%.10s) дельтасын жасау сәтсіз аяқталды: "
+
+#: app/flatpak-builtins-build-update-repo.c:492
+msgid "LOCATION - Update repository metadata"
+msgstr "ОРНЫ - Репозиторий метадеректерін жаңарту"
+
+#: app/flatpak-builtins-build-update-repo.c:609
+msgid "Updating appstream branch\n"
+msgstr "appstream тармағы жаңартылуда\n"
+
+#: app/flatpak-builtins-build-update-repo.c:638
+msgid "Updating summary\n"
+msgstr "Жиынтық жаңартылуда\n"
+
+#: app/flatpak-builtins-build-update-repo.c:664
+#, c-format
+msgid "Total objects: %u\n"
+msgstr "Жалпы объектілер: %u\n"
+
+#: app/flatpak-builtins-build-update-repo.c:666
+msgid "No unreachable objects\n"
+msgstr "Қол жетімсіз объектілер жоқ\n"
+
+#: app/flatpak-builtins-build-update-repo.c:668
+#, c-format
+msgid "Deleted %u objects, %s freed\n"
+msgstr "%u объект өшірілді, %s босатылды\n"
+
+#: app/flatpak-builtins-config.c:41
+msgid "List configuration keys and values"
+msgstr "Конфигурация кілттері мен мәндерін тізімдеу"
+
+#: app/flatpak-builtins-config.c:42
+msgid "Get configuration for KEY"
+msgstr "КІЛТ үшін конфигурацияны алу"
+
+#: app/flatpak-builtins-config.c:43
+msgid "Set configuration for KEY to VALUE"
+msgstr "КІЛТ үшін конфигурацияны МӘН-ге орнату"
+
+#: app/flatpak-builtins-config.c:44
+msgid "Unset configuration for KEY"
+msgstr "КІЛТ үшін конфигурацияны алып тастау"
+
+#: app/flatpak-builtins-config.c:149
+#, c-format
+msgid "'%s' does not look like a language/locale code"
+msgstr "'%s' тіл/локаль кодына ұқсамайды"
+
+#: app/flatpak-builtins-config.c:172
+#, c-format
+msgid "'%s' does not look like a language code"
+msgstr "'%s' тіл кодына ұқсамайды"
+
+#: app/flatpak-builtins-config.c:190
+#, c-format
+msgid "'%s' is not a valid value (use 'true' or 'false')"
+msgstr "'%s' жарамды мән емес ('true' немесе 'false' қолданыңыз)"
+
+#: app/flatpak-builtins-config.c:262
+#, c-format
+msgid "Unknown configure key '%s'"
+msgstr "Белгісіз конфигурация кілті '%s'"
+
+#: app/flatpak-builtins-config.c:284
+msgid "Too many arguments for --list"
+msgstr "--list үшін аргументтер тым көп"
+
+#: app/flatpak-builtins-config.c:314 app/flatpak-builtins-config.c:362
+msgid "You must specify KEY"
+msgstr "КІЛТ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-config.c:316
+msgid "Too many arguments for --get"
+msgstr "--get үшін аргументтер тым көп"
+
+#: app/flatpak-builtins-config.c:338
+msgid "You must specify KEY and VALUE"
+msgstr "КІЛТ және МӘН көрсетілуі тиіс"
+
+#: app/flatpak-builtins-config.c:340
+msgid "Too many arguments for --set"
+msgstr "--set үшін аргументтер тым көп"
+
+#: app/flatpak-builtins-config.c:364
+msgid "Too many arguments for --unset"
+msgstr "--unset үшін аргументтер тым көп"
+
+#: app/flatpak-builtins-config.c:383
+msgid "[KEY [VALUE]] - Manage configuration"
+msgstr "[КІЛТ [МӘН]] - Конфигурацияны басқару"
+
+#: app/flatpak-builtins-config.c:394
+msgid "Can only use one of --list, --get, --set or --unset"
+msgstr ""
+"--list, --get, --set немесе --unset опцияларының тек біреуін қолдануға болады"
+
+#: app/flatpak-builtins-config.c:408
+msgid "Must specify one of --list, --get, --set or --unset"
+msgstr ""
+"--list, --get, --set немесе --unset опцияларының біреуі көрсетілуі тиіс"
+
+#: app/flatpak-builtins-create-usb.c:45 app/flatpak-builtins-install.c:75
+#: app/flatpak-builtins-remote-info.c:57 app/flatpak-builtins-uninstall.c:59
+#: app/flatpak-builtins-update.c:65
+msgid "Look for app with the specified name"
+msgstr "Көрсетілген атауы бар қолданбаны іздеу"
+
+#: app/flatpak-builtins-create-usb.c:46
+msgid "Arch to copy"
+msgstr "Көшірілетін архитектура"
+
+#: app/flatpak-builtins-create-usb.c:47
+msgid "DEST"
+msgstr "МАҚСАТ"
+
+#: app/flatpak-builtins-create-usb.c:49
+msgid "Allow partial commits in the created repo"
+msgstr "Жасалған репозиторийде жартылай коммиттерге рұқсат беру"
+
+#: app/flatpak-builtins-create-usb.c:125 app/flatpak-builtins-create-usb.c:165
+#, c-format
+msgid ""
+"Warning: Related ref ‘%s’ is partially installed. Use --allow-partial to "
+"suppress this message.\n"
+msgstr ""
+"Ескерту: Қатысты ‘%s’ сілтемесі жартылай орнатылған. Бұл хабарды болдырмау "
+"үшін --allow-partial қолданыңыз.\n"
+
+#: app/flatpak-builtins-create-usb.c:158
+#, c-format
+msgid "Warning: Omitting related ref ‘%s’ because it is not installed.\n"
+msgstr ""
+"Ескерту: Қатысты ‘%s’ сілтемесі орнатылмағандықтан өткізіліп жіберілді.\n"
+
+#: app/flatpak-builtins-create-usb.c:175
+#, c-format
+msgid ""
+"Warning: Omitting related ref ‘%s’ because its remote ‘%s’ does not have a "
+"collection ID set.\n"
+msgstr ""
+"Ескерту: Қатысты ‘%s’ сілтемесі өткізіліп жіберілді, себебі оның ‘%s’ "
+"қашықтағы репозиторийінде коллекция ID-і орнатылмаған.\n"
+
+#: app/flatpak-builtins-create-usb.c:187
+#, c-format
+msgid "Warning: Omitting related ref ‘%s’ because it's extra-data.\n"
+msgstr ""
+"Ескерту: Қатысты ‘%s’ сілтемесі қосымша деректер болғандықтан өткізіліп "
+"жіберілді.\n"
+
+#: app/flatpak-builtins-create-usb.c:262 app/flatpak-builtins-create-usb.c:637
+#, c-format
+msgid ""
+"Remote ‘%s’ does not have a collection ID set, which is required for P2P "
+"distribution of ‘%s’."
+msgstr ""
+"‘%s’ қашықтағы репозиторийінде коллекция ID-і орнатылмаған, бұл ‘%s’ P2P "
+"таратылымы үшін қажет."
+
+#: app/flatpak-builtins-create-usb.c:272
+#, c-format
+msgid "Warning: Omitting ref ‘%s’ (runtime of ‘%s’) because it's extra-data.\n"
+msgstr ""
+"Ескерту: ‘%s’ сілтемесі (‘%s’ орындалу ортасы) қосымша деректер болғандықтан "
+"өткізіліп жіберілді.\n"
+
+#: app/flatpak-builtins-create-usb.c:484
+msgid "MOUNT-PATH [REF…] - Copy apps or runtimes onto removable media"
+msgstr ""
+"ТІРКЕУ-ЖОЛЫ [СІЛТЕМЕ…] - Қолданбаларды немесе орындалу орталарын алынбалы "
+"тасымалдағышқа көшіру"
+
+#: app/flatpak-builtins-create-usb.c:493
+msgid "MOUNT-PATH and REF must be specified"
+msgstr "ТІРКЕУ-ЖОЛЫ және СІЛТЕМЕ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-create-usb.c:607
+#, c-format
+msgid "Ref ‘%s’ found in multiple installations: %s. You must specify one."
+msgstr ""
+"‘%s’ сілтемесі бірнеше орнатылымда табылды: %s. Сіз біреуін көрсетуіңіз "
+"керек."
+
+#: app/flatpak-builtins-create-usb.c:620
+#, c-format
+msgid "Refs must all be in the same installation (found in %s and %s)."
+msgstr "Сілтемелердің бәрі бір орнатылымда болуы тиіс (%s және %s табылды)."
+
+#: app/flatpak-builtins-create-usb.c:670
+#, c-format
+msgid ""
+"Warning: Ref ‘%s’ is partially installed. Use --allow-partial to suppress "
+"this message.\n"
+msgstr ""
+"Ескерту: ‘%s’ сілтемесі жартылай орнатылған. Бұл хабарды болдырмау үшін --"
+"allow-partial қолданыңыз.\n"
+
+#: app/flatpak-builtins-create-usb.c:681
+#, c-format
+msgid "Installed ref ‘%s’ is extra-data, and cannot be distributed offline"
+msgstr ""
+"Орнатылған ‘%s’ сілтемесі қосымша дерек болып табылады және оны желіден тыс "
+"тарату мүмкін емес"
+
+#: app/flatpak-builtins-create-usb.c:721
+#, c-format
+msgid "Warning: Couldn't update repo metadata for remote ‘%s’: %s\n"
+msgstr ""
+"Ескерту: ‘%s’ қашықтағы репозиторийінің метадеректерін жаңарту мүмкін "
+"болмады: %s\n"
+
+#: app/flatpak-builtins-create-usb.c:751
+#, c-format
+msgid "Warning: Couldn't update appstream data for remote ‘%s’ arch ‘%s’: %s\n"
+msgstr ""
+"Ескерту: ‘%s’ қашықтағы репозиторийінің ‘%s’ архитектурасы үшін appstream "
+"деректерін жаңарту мүмкін болмады: %s\n"
+
+#. Print a warning if both appstream and appstream2 are missing
+#: app/flatpak-builtins-create-usb.c:784
+#, c-format
+msgid ""
+"Warning: Couldn't find appstream data for remote ‘%s’ arch ‘%s’: %s; %s\n"
+msgstr ""
+"Ескерту: ‘%s’ қашықтағы репозиторийінің ‘%s’ архитектурасы үшін appstream "
+"деректері табылмады: %s; %s\n"
+
+#. Appstream2 is only for efficiency, so just print a debug message
+#: app/flatpak-builtins-create-usb.c:790
+#, c-format
+msgid "Couldn't find appstream2 data for remote ‘%s’ arch ‘%s’: %s\n"
+msgstr ""
+"‘%s’ қашықтағы репозиторийінің ‘%s’ архитектурасы үшін appstream2 деректері "
+"табылмады: %s\n"
+
+#: app/flatpak-builtins-document-export.c:62
+msgid "Create a unique document reference"
+msgstr "Құжаттың бірегей сілтемесін жасау"
+
+#: app/flatpak-builtins-document-export.c:63
+msgid "Make the document transient for the current session"
+msgstr "Құжатты ағымдағы сессия үшін уақытша ету"
+
+#: app/flatpak-builtins-document-export.c:64
+msgid "Don't require the file to exist already"
+msgstr "Файлдың алдын ала болуын талап етпеу"
+
+#: app/flatpak-builtins-document-export.c:65
+msgid "Give the app read permissions"
+msgstr "Қолданбаға оқу рұқсатын беру"
+
+#: app/flatpak-builtins-document-export.c:66
+msgid "Give the app write permissions"
+msgstr "Қолданбаға жазу рұқсатын беру"
+
+#: app/flatpak-builtins-document-export.c:67
+msgid "Give the app delete permissions"
+msgstr "Қолданбаға өшіру рұқсатын беру"
+
+#: app/flatpak-builtins-document-export.c:68
+msgid "Give the app permissions to grant further permissions"
+msgstr "Қолданбаға әрі қарай рұқсаттар беру құқығын беру"
+
+#: app/flatpak-builtins-document-export.c:69
+msgid "Revoke read permissions of the app"
+msgstr "Қолданбаның оқу рұқсатын қайтарып алу"
+
+#: app/flatpak-builtins-document-export.c:70
+msgid "Revoke write permissions of the app"
+msgstr "Қолданбаның жазу рұқсатын қайтарып алу"
+
+#: app/flatpak-builtins-document-export.c:71
+msgid "Revoke delete permissions of the app"
+msgstr "Қолданбаның өшіру рұқсатын қайтарып алу"
+
+#: app/flatpak-builtins-document-export.c:72
+msgid "Revoke the permission to grant further permissions"
+msgstr "Әрі қарай рұқсаттар беру құқығын қайтарып алу"
+
+#: app/flatpak-builtins-document-export.c:73
+msgid "Add permissions for this app"
+msgstr "Осы қолданба үшін рұқсаттар қосу"
+
+#: app/flatpak-builtins-document-export.c:73
+msgid "APPID"
+msgstr "ҚОЛДАНБА_ID"
+
+#: app/flatpak-builtins-document-export.c:100
+msgid "FILE - Export a file to apps"
+msgstr "ФАЙЛ - Файлды қолданбаларға экспорттау"
+
+#: app/flatpak-builtins-document-export.c:109
+#: app/flatpak-builtins-document-info.c:72
+#: app/flatpak-builtins-document-unexport.c:67
+msgid "FILE must be specified"
+msgstr "ФАЙЛ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-document-info.c:63
+msgid "FILE - Get information about an exported file"
+msgstr "ФАЙЛ - Экспортталған файл туралы ақпарат алу"
+
+#: app/flatpak-builtins-document-info.c:100
+#: app/flatpak-builtins-document-unexport.c:94
+msgid "Not exported\n"
+msgstr "Экспортталмаған\n"
+
+#: app/flatpak-builtins-document-list.c:43 app/flatpak-builtins-history.c:53
+#: app/flatpak-builtins-list.c:54 app/flatpak-builtins-ps.c:43
+#: app/flatpak-builtins-remote-list.c:45 app/flatpak-builtins-remote-ls.c:59
+#: app/flatpak-builtins-search.c:38
+msgid "What information to show"
+msgstr "Қандай ақпаратты көрсету керек"
+
+#: app/flatpak-builtins-document-list.c:43 app/flatpak-builtins-history.c:53
+#: app/flatpak-builtins-list.c:54 app/flatpak-builtins-ps.c:43
+#: app/flatpak-builtins-remote-list.c:45 app/flatpak-builtins-remote-ls.c:59
+#: app/flatpak-builtins-search.c:38
+msgid "FIELD,…"
+msgstr "ӨРІС,…"
+
+#: app/flatpak-builtins-document-list.c:44 app/flatpak-builtins-history.c:54
+#: app/flatpak-builtins-list.c:52 app/flatpak-builtins-permission-list.c:43
+#: app/flatpak-builtins-permission-show.c:43 app/flatpak-builtins-ps.c:44
+#: app/flatpak-builtins-remote-list.c:46 app/flatpak-builtins-remote-ls.c:63
+#: app/flatpak-builtins-repo.c:717 app/flatpak-builtins-search.c:39
+msgid "Show output in JSON format"
+msgstr "Нәтижені JSON пішімінде көрсету"
+
+#: app/flatpak-builtins-document-list.c:49
+msgid "Show the document ID"
+msgstr "Құжат ID-ін көрсету"
+
+#: app/flatpak-builtins-document-list.c:50
+msgid "Path"
+msgstr "Жол"
+
+#: app/flatpak-builtins-document-list.c:50
+#: app/flatpak-builtins-document-list.c:51
+msgid "Show the document path"
+msgstr "Құжат жолын көрсету"
+
+#: app/flatpak-builtins-document-list.c:51 app/flatpak-builtins-list.c:66
+#: app/flatpak-builtins-remote-ls.c:74
+msgid "Origin"
+msgstr "Шығу тегі"
+
+#: app/flatpak-builtins-document-list.c:52 app/flatpak-builtins-history.c:62
+#: app/flatpak-builtins-ps.c:52
+msgid "Application"
+msgstr "Қолданба"
+
+#: app/flatpak-builtins-document-list.c:52
+msgid "Show applications with permission"
+msgstr "Рұқсаты бар қолданбаларды көрсету"
+
+#: app/flatpak-builtins-document-list.c:53
+#: app/flatpak-builtins-permission-list.c:182
+#: app/flatpak-builtins-permission-show.c:145
+msgid "Permissions"
+msgstr "Рұқсаттар"
+
+#: app/flatpak-builtins-document-list.c:53
+msgid "Show permissions for applications"
+msgstr "Қолданбалар үшін рұқсаттарды көрсету"
+
+#: app/flatpak-builtins-document-list.c:161
+msgid "No documents found\n"
+msgstr "Құжаттар табылмады\n"
+
+#: app/flatpak-builtins-document-list.c:180
+msgid "[APPID] - List exported files"
+msgstr "[ҚОЛДАНБА_ID] - Экспортталған файлдарды тізімдеу"
+
+#: app/flatpak-builtins-document-unexport.c:43
+msgid "Specify the document ID"
+msgstr "Құжат ID-ін көрсетіңіз"
+
+#: app/flatpak-builtins-document-unexport.c:58
+msgid "FILE - Unexport a file to apps"
+msgstr "ФАЙЛ - Файлды қолданбалар үшін экспорттаудан алып тастау"
+
+#: app/flatpak-builtins-enter.c:88
+msgid "INSTANCE COMMAND [ARGUMENT…] - Run a command inside a running sandbox"
+msgstr ""
+"ИНСТАНЦИЯ КОМАНДА [АРГУМЕНТ…] - Жұмыс істеп тұрған құмсалғыш ішінде "
+"команданы орындау"
+
+#: app/flatpak-builtins-enter.c:111
+msgid "INSTANCE and COMMAND must be specified"
+msgstr "ИНСТАНЦИЯ және КОМАНДА көрсетілуі тиіс"
+
+#: app/flatpak-builtins-enter.c:138
+#, c-format
+msgid "%s is neither a pid nor an application or instance ID"
+msgstr "%s не pid, не қолданба, не инстанция ID-і емес"
+
+#: app/flatpak-builtins-enter.c:144
+msgid "entering not supported (need unprivileged user namespaces, or sudo -E)"
+msgstr ""
+"кіруге қолдау көрсетілмейді (артықшылығы жоқ пайдаланушы атау кеңістіктері "
+"немесе sudo -E қажет)"
+
+#: app/flatpak-builtins-enter.c:145
+#, c-format
+msgid "No such pid %s"
+msgstr "Мұндай pid табылмады: %s"
+
+#: app/flatpak-builtins-enter.c:158
+msgid "Can't read cwd"
+msgstr "cwd оқу мүмкін емес"
+
+#: app/flatpak-builtins-enter.c:163
+msgid "Can't read root"
+msgstr "root оқу мүмкін емес"
+
+#: app/flatpak-builtins-enter.c:191
+#, c-format
+msgid "Invalid %s namespace for pid %d"
+msgstr "pid %2$d үшін жарамсыз %1$s атау кеңістігі"
+
+#: app/flatpak-builtins-enter.c:202
+#, c-format
+msgid "Invalid %s namespace for self"
+msgstr "Өзі үшін жарамсыз %s атау кеңістігі"
+
+#: app/flatpak-builtins-enter.c:216
+#, c-format
+msgid "Can't open %s namespace: %s"
+msgstr "%s атау кеңістігін ашу мүмкін емес: %s"
+
+#: app/flatpak-builtins-enter.c:226
+msgid "entering not supported (need unprivileged user namespaces)"
+msgstr ""
+"кіруге қолдау көрсетілмейді (привилегиясы жоқ пайдаланушы атау кеңістіктері "
+"қажет)"
+
+#: app/flatpak-builtins-enter.c:227
+#, c-format
+msgid "Can't enter %s namespace: %s"
+msgstr "%s атау кеңістігіне кіру мүмкін емес: %s"
+
+#: app/flatpak-builtins-enter.c:234
+msgid "Can't chdir"
+msgstr "chdir орындау мүмкін емес"
+
+#: app/flatpak-builtins-enter.c:237
+msgid "Can't chroot"
+msgstr "chroot орындау мүмкін емес"
+
+#: app/flatpak-builtins-enter.c:240
+msgid "Can't switch gid"
+msgstr "gid ауыстыру мүмкін емес"
+
+#: app/flatpak-builtins-enter.c:243
+msgid "Can't switch uid"
+msgstr "uid ауыстыру мүмкін емес"
+
+#: app/flatpak-builtins-history.c:50
+msgid "Only show changes after TIME"
+msgstr "Тек УАҚЫТ-тан кейінгі өзгерістерді көрсету"
+
+#: app/flatpak-builtins-history.c:50 app/flatpak-builtins-history.c:51
+msgid "TIME"
+msgstr "УАҚЫТ"
+
+#: app/flatpak-builtins-history.c:51
+msgid "Only show changes before TIME"
+msgstr "Тек УАҚЫТ-қа дейінгі өзгерістерді көрсету"
+
+#: app/flatpak-builtins-history.c:52
+msgid "Show newest entries first"
+msgstr "Ең жаңа жазбаларды бірінші көрсету"
+
+#: app/flatpak-builtins-history.c:59
+msgid "Time"
+msgstr "Уақыт"
+
+#: app/flatpak-builtins-history.c:59
+msgid "Show when the change happened"
+msgstr "Өзгерістің қашан болғанын көрсету"
+
+#: app/flatpak-builtins-history.c:60
+msgid "Change"
+msgstr "Өзгеріс"
+
+#: app/flatpak-builtins-history.c:60
+msgid "Show the kind of change"
+msgstr "Өзгеріс түрін көрсету"
+
+#: app/flatpak-builtins-history.c:61 app/flatpak-builtins-list.c:68
+#: app/flatpak-builtins-remote-ls.c:75 app/flatpak-builtins-repo.c:335
+msgid "Ref"
+msgstr "Сілтеме"
+
+#: app/flatpak-builtins-history.c:61 app/flatpak-builtins-list.c:68
+#: app/flatpak-builtins-remote-ls.c:75
+msgid "Show the ref"
+msgstr "Сілтемені көрсету"
+
+#: app/flatpak-builtins-history.c:62
+msgid "Show the application/runtime ID"
+msgstr "Қолданба/орындалу ортасы ID-ін көрсету"
+
+#: app/flatpak-builtins-history.c:63 app/flatpak-builtins-list.c:64
+#: app/flatpak-builtins-ps.c:53 app/flatpak-builtins-remote-ls.c:73
+#: app/flatpak-cli-transaction.c:1435
+msgid "Arch"
+msgstr "Архитектура"
+
+#: app/flatpak-builtins-history.c:63 app/flatpak-builtins-list.c:64
+#: app/flatpak-builtins-ps.c:53 app/flatpak-builtins-remote-ls.c:73
+msgid "Show the architecture"
+msgstr "Архитектураны көрсету"
+
+#: app/flatpak-builtins-history.c:64 app/flatpak-builtins-list.c:63
+#: app/flatpak-builtins-ps.c:54 app/flatpak-builtins-remote-ls.c:72
+#: app/flatpak-builtins-search.c:48 app/flatpak-cli-transaction.c:1438
+msgid "Branch"
+msgstr "Тармақ"
+
+#: app/flatpak-builtins-history.c:64 app/flatpak-builtins-list.c:63
+#: app/flatpak-builtins-remote-ls.c:72
+msgid "Show the branch"
+msgstr "Тармақты көрсету"
+
+#: app/flatpak-builtins-history.c:65 app/flatpak-builtins-list.c:67
+msgid "Installation"
+msgstr "Орнатылым"
+
+#: app/flatpak-builtins-history.c:65
+msgid "Show the affected installation"
+msgstr "Әсер еткен орнатылымды көрсету"
+
+#: app/flatpak-builtins-history.c:66 app/flatpak-cli-transaction.c:1452
+msgid "Remote"
+msgstr "Қашықтағы"
+
+#: app/flatpak-builtins-history.c:66
+msgid "Show the remote"
+msgstr "Қашықтағы репозиторийді көрсету"
+
+#: app/flatpak-builtins-history.c:67 app/flatpak-builtins-ps.c:55
+#: app/flatpak-builtins-remote-ls.c:76
+msgid "Commit"
+msgstr "Коммит"
+
+#: app/flatpak-builtins-history.c:67
+msgid "Show the current commit"
+msgstr "Ағымдағы коммитті көрсету"
+
+#: app/flatpak-builtins-history.c:68
+msgid "Old Commit"
+msgstr "Ескі коммит"
+
+#: app/flatpak-builtins-history.c:68
+msgid "Show the previous commit"
+msgstr "Алдыңғы коммитті көрсету"
+
+#: app/flatpak-builtins-history.c:69
+msgid "Show the remote URL"
+msgstr "Қашықтағы URL-ді көрсету"
+
+#: app/flatpak-builtins-history.c:70 app/flatpak-cli-transaction.c:700
+msgid "User"
+msgstr "Пайдаланушы"
+
+#: app/flatpak-builtins-history.c:70
+msgid "Show the user doing the change"
+msgstr "Өзгерісті жасаған пайдаланушыны көрсету"
+
+#: app/flatpak-builtins-history.c:71
+msgid "Tool"
+msgstr "Сайман"
+
+#: app/flatpak-builtins-history.c:71
+msgid "Show the tool that was used"
+msgstr "Қолданылған сайманды көрсету"
+
+#: app/flatpak-builtins-history.c:72 app/flatpak-builtins-list.c:62
+#: app/flatpak-builtins-remote-ls.c:71 app/flatpak-builtins-search.c:47
+msgid "Version"
+msgstr "Нұсқа"
+
+#: app/flatpak-builtins-history.c:72
+msgid "Show the Flatpak version"
+msgstr "Flatpak нұсқасын көрсету"
+
+#: app/flatpak-builtins-history.c:91
+#, c-format
+msgid "Failed to get journal data (%s): %s"
+msgstr "Журнал деректерін алу сәтсіз аяқталды (%s): %s"
+
+#: app/flatpak-builtins-history.c:146
+#, c-format
+msgid "Failed to open journal: %s"
+msgstr "Журналды ашу мүмкін болмады: %s"
+
+#: app/flatpak-builtins-history.c:153
+#, c-format
+msgid "Failed to add match to journal: %s"
+msgstr "Журналға сәйкестікті қосу мүмкін болмады: %s"
+
+#: app/flatpak-builtins-history.c:471
+msgid " - Show history"
+msgstr " - Тарихты көрсету"
+
+#: app/flatpak-builtins-history.c:490
+msgid "Failed to parse the --since option"
+msgstr "--since опциясын талдау сәтсіз аяқталды"
+
+#: app/flatpak-builtins-history.c:501
+msgid "Failed to parse the --until option"
+msgstr "--until опциясын талдау сәтсіз аяқталды"
+
+#: app/flatpak-builtins-info.c:56
+msgid "Show user installations"
+msgstr "Пайдаланушы орнатылымдарын көрсету"
+
+#: app/flatpak-builtins-info.c:57
+msgid "Show system-wide installations"
+msgstr "Жүйелік орнатылымдарды көрсету"
+
+#: app/flatpak-builtins-info.c:58
+msgid "Show specific system-wide installations"
+msgstr "Арнайы жүйелік орнатылымдарды көрсету"
+
+#: app/flatpak-builtins-info.c:59 app/flatpak-builtins-remote-info.c:59
+msgid "Show ref"
+msgstr "Сілтемені көрсету"
+
+#: app/flatpak-builtins-info.c:60 app/flatpak-builtins-remote-info.c:60
+msgid "Show commit"
+msgstr "Коммитті көрсету"
+
+#: app/flatpak-builtins-info.c:61
+msgid "Show origin"
+msgstr "Шығу тегін көрсету"
+
+#: app/flatpak-builtins-info.c:62
+msgid "Show size"
+msgstr "Өлшемін көрсету"
+
+#: app/flatpak-builtins-info.c:63 app/flatpak-builtins-remote-info.c:62
+msgid "Show metadata"
+msgstr "Метадеректерді көрсету"
+
+#: app/flatpak-builtins-info.c:64 app/flatpak-builtins-remote-info.c:63
+msgid "Show runtime"
+msgstr "Орындалу ортасын көрсету"
+
+#: app/flatpak-builtins-info.c:65 app/flatpak-builtins-remote-info.c:64
+msgid "Show sdk"
+msgstr "sdk көрсету"
+
+#: app/flatpak-builtins-info.c:66
+msgid "Show permissions"
+msgstr "Рұқсаттарды көрсету"
+
+#: app/flatpak-builtins-info.c:67
+msgid "Query file access"
+msgstr "Файлға қол жеткізуді сұрау"
+
+#: app/flatpak-builtins-info.c:67 app/flatpak-builtins-install.c:82
+#: app/flatpak-builtins-install.c:88 app/flatpak-builtins-preinstall.c:68
+#: app/flatpak-builtins-run.c:91 app/flatpak-builtins-run.c:92
+#: app/flatpak-builtins-update.c:67 app/flatpak-builtins-update.c:71
+msgid "PATH"
+msgstr "ЖОЛ"
+
+#: app/flatpak-builtins-info.c:68
+msgid "Show extensions"
+msgstr "Кеңейтулерді көрсету"
+
+#: app/flatpak-builtins-info.c:69
+msgid "Show location"
+msgstr "Орналасуын көрсету"
+
+#: app/flatpak-builtins-info.c:116
+msgid "NAME [BRANCH] - Get info about an installed app or runtime"
+msgstr ""
+"АТЫ [ТАРМАҚ] - Орнатылған қолданба немесе орындалу ортасы туралы ақпарат алу"
+
+#: app/flatpak-builtins-info.c:123 app/flatpak-builtins-remote-add.c:317
+#: app/flatpak-builtins-remote-delete.c:63
+msgid "NAME must be specified"
+msgstr "АТЫ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-info.c:196
+msgid "ref not present in origin"
+msgstr "сілтеме шығу тегінде жоқ"
+
+#: app/flatpak-builtins-info.c:211 app/flatpak-builtins-remote-info.c:217
+msgid "Warning: Commit has no flatpak metadata\n"
+msgstr "Ескерту: Коммитте flatpak метадеректері жоқ\n"
+
+#: app/flatpak-builtins-info.c:217 app/flatpak-builtins-info.c:259
+#: app/flatpak-builtins-info.c:455 app/flatpak-builtins-info.c:513
+#: app/flatpak-builtins-remote-info.c:236
+#: app/flatpak-builtins-remote-info.c:271
+msgid "ID:"
+msgstr "ID:"
+
+#: app/flatpak-builtins-info.c:218 app/flatpak-builtins-info.c:260
+#: app/flatpak-builtins-remote-info.c:237
+#: app/flatpak-builtins-remote-info.c:272
+msgid "Ref:"
+msgstr "Сілтеме:"
+
+#: app/flatpak-builtins-info.c:219 app/flatpak-builtins-info.c:261
+#: app/flatpak-builtins-remote-info.c:238
+#: app/flatpak-builtins-remote-info.c:273
+msgid "Arch:"
+msgstr "Архитектура:"
+
+#: app/flatpak-builtins-info.c:220 app/flatpak-builtins-info.c:262
+#: app/flatpak-builtins-remote-info.c:239
+#: app/flatpak-builtins-remote-info.c:274
+msgid "Branch:"
+msgstr "Тармақ:"
+
+#: app/flatpak-builtins-info.c:222 app/flatpak-builtins-info.c:264
+#: app/flatpak-builtins-remote-info.c:241
+#: app/flatpak-builtins-remote-info.c:276
+msgid "Version:"
+msgstr "Нұсқа:"
+
+#: app/flatpak-builtins-info.c:224 app/flatpak-builtins-info.c:266
+#: app/flatpak-builtins-remote-info.c:243
+#: app/flatpak-builtins-remote-info.c:278
+msgid "License:"
+msgstr "Лицензия:"
+
+#: app/flatpak-builtins-info.c:226 app/flatpak-builtins-info.c:269
+#: app/flatpak-builtins-remote-info.c:245
+#: app/flatpak-builtins-remote-info.c:280
+msgid "Collection:"
+msgstr "Коллекция:"
+
+#: app/flatpak-builtins-info.c:227 app/flatpak-builtins-info.c:270
+#: app/flatpak-builtins-info.c:458 app/flatpak-builtins-info.c:516
+msgid "Installation:"
+msgstr "Орнатылым:"
+
+#: app/flatpak-builtins-info.c:228 app/flatpak-builtins-info.c:271
+#: app/flatpak-builtins-info.c:459 app/flatpak-builtins-info.c:517
+#: app/flatpak-builtins-remote-info.c:249
+#: app/flatpak-builtins-remote-info.c:284
+msgid "Installed Size:"
+msgstr "Орнатылған өлшемі:"
+
+#: app/flatpak-builtins-info.c:231 app/flatpak-builtins-info.c:279
+#: app/flatpak-builtins-remote-info.c:252
+#: app/flatpak-builtins-remote-info.c:288
+msgid "Runtime:"
+msgstr "Орындалу ортасы:"
+
+#: app/flatpak-builtins-info.c:232 app/flatpak-builtins-info.c:288
+#: app/flatpak-builtins-remote-info.c:253
+#: app/flatpak-builtins-remote-info.c:293
+msgid "Sdk:"
+msgstr "Sdk:"
+
+#: app/flatpak-builtins-info.c:235 app/flatpak-builtins-info.c:313
+#: app/flatpak-builtins-remote-info.c:256
+#: app/flatpak-builtins-remote-info.c:319
+msgid "Date:"
+msgstr "Күні:"
+
+#: app/flatpak-builtins-info.c:237 app/flatpak-builtins-info.c:311
+#: app/flatpak-builtins-remote-info.c:258
+#: app/flatpak-builtins-remote-info.c:317
+msgid "Subject:"
+msgstr "Тақырыбы:"
+
+#: app/flatpak-builtins-info.c:240 app/flatpak-builtins-info.c:295
+msgid "Active commit:"
+msgstr "Белсенді коммит:"
+
+#: app/flatpak-builtins-info.c:241 app/flatpak-builtins-info.c:298
+msgid "Latest commit:"
+msgstr "Соңғы коммит:"
+
+#: app/flatpak-builtins-info.c:244 app/flatpak-builtins-info.c:303
+#: app/flatpak-builtins-info.c:457 app/flatpak-builtins-info.c:515
+#: app/flatpak-builtins-remote-info.c:259
+#: app/flatpak-builtins-remote-info.c:298
+msgid "Commit:"
+msgstr "Коммит:"
+
+#: app/flatpak-builtins-info.c:246 app/flatpak-builtins-info.c:308
+#: app/flatpak-builtins-remote-info.c:261
+#: app/flatpak-builtins-remote-info.c:303
+msgid "Parent:"
+msgstr "Ата-анасы:"
+
+#: app/flatpak-builtins-info.c:248 app/flatpak-builtins-info.c:321
+msgid "Alt-id:"
+msgstr "Alt-id:"
+
+#: app/flatpak-builtins-info.c:250 app/flatpak-builtins-info.c:325
+#: app/flatpak-builtins-remote-info.c:263
+#: app/flatpak-builtins-remote-info.c:308
+msgid "End-of-life:"
+msgstr "Қолдау мерзімі аяқталған:"
+
+#: app/flatpak-builtins-info.c:252 app/flatpak-builtins-info.c:330
+#: app/flatpak-builtins-remote-info.c:265
+#: app/flatpak-builtins-remote-info.c:313
+msgid "End-of-life-rebase:"
+msgstr "Қолдау мерзімі аяқталған соң ауысу:"
+
+#: app/flatpak-builtins-info.c:254 app/flatpak-builtins-info.c:317
+msgid "Subdirectories:"
+msgstr "Ішкі бумалар:"
+
+#: app/flatpak-builtins-info.c:255 app/flatpak-builtins-info.c:454
+#: app/flatpak-builtins-info.c:512
+msgid "Extension:"
+msgstr "Кеңейту:"
+
+#: app/flatpak-builtins-info.c:267 app/flatpak-builtins-info.c:456
+#: app/flatpak-builtins-info.c:514
+msgid "Origin:"
+msgstr "Шығу тегі:"
+
+#: app/flatpak-builtins-info.c:460 app/flatpak-builtins-info.c:522
+msgid "Subpaths:"
+msgstr "Ішкі жолдар:"
+
+#: app/flatpak-builtins-info.c:478
+msgid "unmaintained"
+msgstr "сүйемелденбейді"
+
+#: app/flatpak-builtins-info.c:480 app/flatpak-builtins-info.c:482
+msgid "unknown"
+msgstr "белгісіз"
+
+#: app/flatpak-builtins-install.c:68 app/flatpak-builtins-preinstall.c:57
+msgid "Don't pull, only install from local cache"
+msgstr "Тартпау, тек жергілікті кэштен орнату"
+
+#: app/flatpak-builtins-install.c:69 app/flatpak-builtins-preinstall.c:58
+#: app/flatpak-builtins-update.c:60
+msgid "Don't deploy, only download to local cache"
+msgstr "Орналастырмау, тек жергілікті кэшке жүктеп алу"
+
+#: app/flatpak-builtins-install.c:70 app/flatpak-builtins-preinstall.c:59
+msgid "Don't install related refs"
+msgstr "Қатысты сілтемелерді орнатпау"
+
+#: app/flatpak-builtins-install.c:71 app/flatpak-builtins-preinstall.c:60
+#: app/flatpak-builtins-update.c:62
+msgid "Don't verify/install runtime dependencies"
+msgstr "Орындалу ортасының тәуелділіктерін тексермеу/орнатпау"
+
+#: app/flatpak-builtins-install.c:72
+msgid "Don't automatically pin explicit installs"
+msgstr "Анық орнатылымдарды автоматты түрде бекітпеу"
+
+#: app/flatpak-builtins-install.c:73 app/flatpak-builtins-preinstall.c:61
+#: app/flatpak-builtins-update.c:63
+msgid "Don't use static deltas"
+msgstr "Статикалық дельталарды қолданбау"
+
+#: app/flatpak-builtins-install.c:76 app/flatpak-builtins-preinstall.c:62
+msgid "Additionally install the SDK used to build the given refs"
+msgstr ""
+"Сонымен қатар, берілген сілтемелерді құрастыру үшін қолданылған SDK-ны орнату"
+
+#: app/flatpak-builtins-install.c:77 app/flatpak-builtins-preinstall.c:63
+msgid ""
+"Additionally install the debug info for the given refs and their dependencies"
+msgstr ""
+"Сонымен қатар, берілген сілтемелер мен олардың тәуелділіктері үшін жөндеу "
+"ақпаратын орнату"
+
+#: app/flatpak-builtins-install.c:78
+msgid "Assume LOCATION is a .flatpak single-file bundle"
+msgstr "ОРНЫ-ны .flatpak бір файлдық дестесі деп есептеу"
+
+#: app/flatpak-builtins-install.c:79
+msgid "Assume LOCATION is a .flatpakref application description"
+msgstr "ОРНЫ-ны .flatpakref қолданба сипаттамасы деп есептеу"
+
+#: app/flatpak-builtins-install.c:80
+msgid "Assume LOCATION is containers-transports(5) reference to an OCI image"
+msgstr "ОРНЫ-ны OCI бейнесіне containers-transports(5) сілтемесі деп есептеу"
+
+#: app/flatpak-builtins-install.c:81
+msgid "Check bundle signatures with GPG key from FILE (- for stdin)"
+msgstr ""
+"Десте қолтаңбаларын ФАЙЛ-дан алынған GPG кілтімен тексеру (stdin үшін -)"
+
+#: app/flatpak-builtins-install.c:82
+msgid "Only install this subpath"
+msgstr "Тек осы ішкі жолды орнату"
+
+#: app/flatpak-builtins-install.c:83 app/flatpak-builtins-preinstall.c:64
+#: app/flatpak-builtins-uninstall.c:63 app/flatpak-builtins-update.c:68
+msgid "Automatically answer yes for all questions"
+msgstr "Барлық сұрақтарға автоматты түрде иә деп жауап беру"
+
+#: app/flatpak-builtins-install.c:84 app/flatpak-builtins-preinstall.c:65
+msgid "Uninstall first if already installed"
+msgstr "Егер орнатылған болса, алдымен өшіру"
+
+#: app/flatpak-builtins-install.c:85 app/flatpak-builtins-preinstall.c:66
+#: app/flatpak-builtins-uninstall.c:64 app/flatpak-builtins-update.c:69
+msgid "Produce minimal output and don't ask questions"
+msgstr "Минималды нәтиже шығару және сұрақтар қоймау"
+
+#: app/flatpak-builtins-install.c:86
+msgid "Update install if already installed"
+msgstr "Егер орнатылған болса, орнатылымды жаңарту"
+
+#. Translators: A sideload is when you install from a local USB drive rather than the Internet.
+#: app/flatpak-builtins-install.c:88 app/flatpak-builtins-preinstall.c:68
+#: app/flatpak-builtins-update.c:71
+msgid "Use this local repo for sideloads"
+msgstr "Қатар жүктеулер (sideloads) үшін осы жергілікті репозиторийді қолдану"
+
+#: app/flatpak-builtins-install.c:178
+msgid "Bundle filename must be specified"
+msgstr "Десте файл атауы көрсетілуі тиіс"
+
+#: app/flatpak-builtins-install.c:188
+msgid "Remote bundles are not supported"
+msgstr "Қашықтағы дестелерге қолдау көрсетілмейді"
+
+#: app/flatpak-builtins-install.c:231
+msgid "Filename or uri must be specified"
+msgstr "Файл атауы немесе uri көрсетілуі тиіс"
+
+#: app/flatpak-builtins-install.c:295
+msgid "Image location must be specified"
+msgstr "Бейне орны көрсетілуі тиіс"
+
+#: app/flatpak-builtins-install.c:345
+msgid "[LOCATION/REMOTE] [REF…] - Install applications or runtimes"
+msgstr ""
+"[ОРНЫ/ҚАШЫҚТАҒЫ] [СІЛТЕМЕ…] - Қолданбаларды немесе орындалу орталарын орнату"
+
+#: app/flatpak-builtins-install.c:378
+msgid "At least one REF must be specified"
+msgstr "Кем дегенде бір СІЛТЕМЕ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-install.c:392
+msgid "Looking for matches…\n"
+msgstr "Сәйкестіктерді іздеу…\n"
+
+#: app/flatpak-builtins-install.c:513
+#, c-format
+msgid "No remote refs found for ‘%s’"
+msgstr "‘%s’ үшін қашықтағы сілтемелер табылмады"
+
+#: app/flatpak-builtins-install.c:573 app/flatpak-builtins-uninstall.c:405
+#: common/flatpak-ref-utils.c:689 common/flatpak-ref-utils.c:1595
+#, c-format
+msgid "Invalid branch %s: %s"
+msgstr "Жарамсыз тармақ %s: %s"
+
+#: app/flatpak-builtins-install.c:606
+#, c-format
+msgid "Nothing matches %s in local repository for remote %s"
+msgstr ""
+"%2$s қашықтағы репозиторийінің жергілікті репозиторийінде %1$s сәйкес "
+"келетін ештеңе табылмады"
+
+#: app/flatpak-builtins-install.c:608
+#, c-format
+msgid "Nothing matches %s in remote %s"
+msgstr "%2$s қашықтағы репозиторийінде %1$s сәйкес келетін ештеңе табылмады"
+
+#: app/flatpak-builtins-install.c:629
+#, c-format
+msgid "Skipping: %s\n"
+msgstr "Өткізіп жіберу: %s\n"
+
+#: app/flatpak-builtins-kill.c:110
+#, c-format
+msgid "%s is not running"
+msgstr "%s жұмыс істеп тұрған жоқ"
+
+#: app/flatpak-builtins-kill.c:136
+msgid "INSTANCE - Stop a running application"
+msgstr "ИНСТАНЦИЯ - Жұмыс істеп тұрған қолданбаны тоқтату"
+
+#: app/flatpak-builtins-kill.c:144 app/flatpak-builtins-ps.c:256
+msgid "Extra arguments given"
+msgstr "Артық аргументтер берілген"
+
+#: app/flatpak-builtins-kill.c:150
+msgid "Must specify the app to kill"
+msgstr "Жойылатын (kill) қолданбаны көрсету керек"
+
+#: app/flatpak-builtins-list.c:47
+msgid "Show extra information"
+msgstr "Қосымша ақпаратты көрсету"
+
+#: app/flatpak-builtins-list.c:48
+msgid "List installed runtimes"
+msgstr "Орнатылған орындалу орталарын тізімдеу"
+
+#: app/flatpak-builtins-list.c:49
+msgid "List installed applications"
+msgstr "Орнатылған қолданбаларды тізімдеу"
+
+#: app/flatpak-builtins-list.c:50
+msgid "Arch to show"
+msgstr "Көрсетілетін архитектура"
+
+#: app/flatpak-builtins-list.c:51 app/flatpak-builtins-remote-ls.c:57
+msgid "List all refs (including locale/debug)"
+msgstr "Барлық сілтемелерді тізімдеу (соның ішінде локаль/жөндеу)"
+
+#: app/flatpak-builtins-list.c:53 app/flatpak-builtins-remote-ls.c:58
+msgid "List all applications using RUNTIME"
+msgstr "ОРЫНДАЛУ_ОРТАСЫН қолданатын барлық қолданбаларды тізімдеу"
+
+#: app/flatpak-builtins-list.c:59 app/flatpak-builtins-remote-list.c:51
+#: app/flatpak-builtins-remote-ls.c:68 app/flatpak-builtins-search.c:44
+msgid "Name"
+msgstr "Атауы"
+
+#: app/flatpak-builtins-list.c:59 app/flatpak-builtins-remote-list.c:51
+#: app/flatpak-builtins-remote-ls.c:68 app/flatpak-builtins-search.c:44
+msgid "Show the name"
+msgstr "Атауын көрсету"
+
+#: app/flatpak-builtins-list.c:60 app/flatpak-builtins-remote-list.c:60
+#: app/flatpak-builtins-remote-ls.c:69 app/flatpak-builtins-search.c:45
+msgid "Description"
+msgstr "Сипаттамасы"
+
+#: app/flatpak-builtins-list.c:60 app/flatpak-builtins-remote-ls.c:69
+#: app/flatpak-builtins-search.c:45
+msgid "Show the description"
+msgstr "Сипаттамасын көрсету"
+
+#: app/flatpak-builtins-list.c:61 app/flatpak-builtins-remote-ls.c:70
+#: app/flatpak-builtins-search.c:46
+msgid "Application ID"
+msgstr "Қолданба ID-і"
+
+#: app/flatpak-builtins-list.c:61 app/flatpak-builtins-ps.c:52
+#: app/flatpak-builtins-remote-ls.c:70 app/flatpak-builtins-search.c:46
+msgid "Show the application ID"
+msgstr "Қолданба ID-ін көрсету"
+
+#: app/flatpak-builtins-list.c:62 app/flatpak-builtins-remote-ls.c:71
+#: app/flatpak-builtins-search.c:47
+msgid "Show the version"
+msgstr "Нұсқаны көрсету"
+
+#: app/flatpak-builtins-list.c:65 app/flatpak-builtins-ps.c:56
+#: app/flatpak-builtins-remote-ls.c:77
+msgid "Runtime"
+msgstr "Орындалу ортасы"
+
+#: app/flatpak-builtins-list.c:65
+msgid "Show the used runtime"
+msgstr "Қолданылатын орындалу ортасын көрсету"
+
+#: app/flatpak-builtins-list.c:66 app/flatpak-builtins-remote-ls.c:74
+msgid "Show the origin remote"
+msgstr "Шығу тегі болып табылатын қашықтағы репозиторийді көрсету"
+
+#: app/flatpak-builtins-list.c:67
+msgid "Show the installation"
+msgstr "Орнатылымды көрсету"
+
+#: app/flatpak-builtins-list.c:69
+msgid "Active commit"
+msgstr "Белсенді коммит"
+
+#: app/flatpak-builtins-list.c:69 app/flatpak-builtins-remote-ls.c:76
+msgid "Show the active commit"
+msgstr "Белсенді коммитті көрсету"
+
+#: app/flatpak-builtins-list.c:70
+msgid "Latest commit"
+msgstr "Соңғы коммит"
+
+#: app/flatpak-builtins-list.c:70
+msgid "Show the latest commit"
+msgstr "Соңғы коммитті көрсету"
+
+#: app/flatpak-builtins-list.c:71 app/flatpak-builtins-remote-ls.c:78
+msgid "Installed size"
+msgstr "Орнатылған өлшемі"
+
+#: app/flatpak-builtins-list.c:71 app/flatpak-builtins-remote-ls.c:78
+msgid "Show the installed size"
+msgstr "Орнатылған өлшемін көрсету"
+
+#: app/flatpak-builtins-list.c:72 app/flatpak-builtins-remote-list.c:58
+#: app/flatpak-builtins-remote-ls.c:80 app/flatpak-builtins-repo.c:340
+msgid "Options"
+msgstr "Опциялар"
+
+#: app/flatpak-builtins-list.c:72 app/flatpak-builtins-remote-list.c:58
+#: app/flatpak-builtins-remote-ls.c:80
+msgid "Show options"
+msgstr "Опцияларды көрсету"
+
+#: app/flatpak-builtins-list.c:180
+#, c-format
+msgid "Unable to load details of %s: %s"
+msgstr "%s мәліметтерін жүктеу мүмкін емес: %s"
+
+#: app/flatpak-builtins-list.c:190
+#, c-format
+msgid "Unable to inspect current version of %s: %s"
+msgstr "%s ағымдағы нұсқасын тексеру мүмкін емес: %s"
+
+#: app/flatpak-builtins-list.c:408
+msgid " - List installed apps and/or runtimes"
+msgstr " - Орнатылған қолданбаларды және/немесе орындалу орталарын тізімдеу"
+
+#: app/flatpak-builtins-make-current.c:38
+msgid "Arch to make current for"
+msgstr "Ағымдағы қылатын архитектура"
+
+#: app/flatpak-builtins-make-current.c:58
+msgid "APP BRANCH - Make branch of application current"
+msgstr "ҚОЛДАНБА ТАРМАҚ - Қолданба тармағын ағымдағы ету"
+
+#: app/flatpak-builtins-make-current.c:69 app/flatpak-builtins-run.c:160
+msgid "APP must be specified"
+msgstr "ҚОЛДАНБА көрсетілуі тиіс"
+
+#: app/flatpak-builtins-make-current.c:84
+msgid "BRANCH must be specified"
+msgstr "ТАРМАҚ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-make-current.c:97
+#, c-format
+msgid "App %s branch %s is not installed"
+msgstr "%s қолданбасының %s тармағы орнатылмаған"
+
+#: app/flatpak-builtins-mask.c:42
+msgid "Remove matching masks"
+msgstr "Сәйкес келетін маскаларды өшіру"
+
+#: app/flatpak-builtins-mask.c:54
+msgid ""
+"[PATTERN…] - disable updates and automatic installation matching patterns"
+msgstr ""
+"[ШАБЛОН…] - Шаблондарға сәйкес келетін жаңартулар мен автоматты орнатуды "
+"сөндіру"
+
+#: app/flatpak-builtins-mask.c:73
+msgid "No masked patterns\n"
+msgstr "Маскаланған шаблондар жоқ\n"
+
+#: app/flatpak-builtins-mask.c:78
+msgid "Masked patterns:\n"
+msgstr "Маскаланған шаблондар:\n"
+
+#: app/flatpak-builtins-override.c:42
+msgid "Remove existing overrides"
+msgstr "Бар қайта анықтауларды өшіру"
+
+#: app/flatpak-builtins-override.c:43
+msgid "Show existing overrides"
+msgstr "Бар қайта анықтауларды көрсету"
+
+#: app/flatpak-builtins-override.c:59
+msgid "[APP] - Override settings [for application]"
+msgstr "[ҚОЛДАНБА] - [Қолданба үшін] баптауларды қайта анықтау"
+
+#: app/flatpak-builtins-permission-list.c:143
+msgid "[TABLE] [ID] - List permissions"
+msgstr "[КЕСТЕ] [ID] - Рұқсаттарды тізімдеу"
+
+#: app/flatpak-builtins-permission-list.c:179
+#: app/flatpak-builtins-permission-show.c:142
+msgid "Table"
+msgstr "Кесте"
+
+#: app/flatpak-builtins-permission-list.c:180
+#: app/flatpak-builtins-permission-show.c:143
+msgid "Object"
+msgstr "Объект"
+
+#: app/flatpak-builtins-permission-list.c:181
+#: app/flatpak-builtins-permission-show.c:144
+msgid "App"
+msgstr "Қолданба"
+
+#: app/flatpak-builtins-permission-list.c:183
+#: app/flatpak-builtins-permission-show.c:146
+msgid "Data"
+msgstr "Деректер"
+
+#: app/flatpak-builtins-permission-remove.c:120
+msgid "TABLE ID [APP_ID] - Remove item from permission store"
+msgstr "КЕСТЕ ID [ҚОЛДАНБА_ID] - Элементті рұқсаттар қоймасынан өшіру"
+
+#: app/flatpak-builtins-permission-remove.c:129
+#: app/flatpak-builtins-permission-set.c:120
+msgid "Too few arguments"
+msgstr "Аргументтер тым аз"
+
+#: app/flatpak-builtins-permission-reset.c:43
+msgid "Reset all permissions"
+msgstr "Барлық рұқсаттарды тастау"
+
+#: app/flatpak-builtins-permission-reset.c:144
+msgid "APP_ID - Reset permissions for an app"
+msgstr "ҚОЛДАНБА_ID - Қолданба рұқсаттарын тастау"
+
+#: app/flatpak-builtins-permission-reset.c:153
+#: app/flatpak-builtins-permission-show.c:124
+msgid "Wrong number of arguments"
+msgstr "Аргументтер саны қате"
+
+#: app/flatpak-builtins-permission-set.c:42
+msgid "Associate DATA with the entry"
+msgstr "Жазбамен ДЕРЕКТЕР-ді байланыстыру"
+
+#: app/flatpak-builtins-permission-set.c:42
+msgid "DATA"
+msgstr "ДЕРЕКТЕР"
+
+#: app/flatpak-builtins-permission-set.c:111
+msgid "TABLE ID APP_ID [PERMISSION...] - Set permissions"
+msgstr "КЕСТЕ ID ҚОЛДАНБА_ID [РҰҚСАТ...] - Рұқсаттарды орнату"
+
+#: app/flatpak-builtins-permission-set.c:132
+#, c-format
+msgid "Failed to parse '%s' as GVariant: "
+msgstr "'%s' мәнін GVariant ретінде өңдеу сәтсіз аяқталды: "
+
+#: app/flatpak-builtins-permission-show.c:115
+msgid "APP_ID - Show permissions for an app"
+msgstr "ҚОЛДАНБА_ID - Қолданба рұқсаттарын көрсету"
+
+#: app/flatpak-builtins-pin.c:44
+msgid "Remove matching pins"
+msgstr "Сәйкес келетін бекітулерді өшіру"
+
+#: app/flatpak-builtins-pin.c:56
+msgid "[PATTERN…] - disable automatic removal of runtimes matching patterns"
+msgstr ""
+"[ШАБЛОН…] - Шаблондарға сәйкес келетін орындалу орталарын автоматты өшіруді "
+"сөндіру"
+
+#: app/flatpak-builtins-pin.c:75
+msgid "No pinned patterns\n"
+msgstr "Бекітілген шаблондар жоқ\n"
+
+#: app/flatpak-builtins-pin.c:80
+msgid "Pinned patterns:\n"
+msgstr "Бекітілген шаблондар:\n"
+
+#: app/flatpak-builtins-preinstall.c:80
+msgid "- Install flatpaks that are part of the operating system"
+msgstr "- Операциялық жүйенің бөлігі болып табылатын flatpak-тарды орнату"
+
+#: app/flatpak-builtins-preinstall.c:118
+msgid "Nothing to do.\n"
+msgstr "Ештеңе істеу керек емес.\n"
+
+#: app/flatpak-builtins-ps.c:49
+msgid "Instance"
+msgstr "Инстанция"
+
+#: app/flatpak-builtins-ps.c:49
+msgid "Show the instance ID"
+msgstr "Инстанция ID-ін көрсету"
+
+#: app/flatpak-builtins-ps.c:50 app/flatpak-builtins-run.c:87
+msgid "PID"
+msgstr "PID"
+
+#: app/flatpak-builtins-ps.c:50
+msgid "Show the PID of the wrapper process"
+msgstr "Орауыш процестің PID-ін көрсету"
+
+#: app/flatpak-builtins-ps.c:51
+msgid "Child-PID"
+msgstr "Бала-PID"
+
+#: app/flatpak-builtins-ps.c:51
+msgid "Show the PID of the sandbox process"
+msgstr "Құмсалғыш процесінің PID-ін көрсету"
+
+#: app/flatpak-builtins-ps.c:54 app/flatpak-builtins-search.c:48
+msgid "Show the application branch"
+msgstr "Қолданба тармағын көрсету"
+
+#: app/flatpak-builtins-ps.c:55
+msgid "Show the application commit"
+msgstr "Қолданба коммитін көрсету"
+
+#: app/flatpak-builtins-ps.c:56
+msgid "Show the runtime ID"
+msgstr "Орындалу ортасы ID-ін көрсету"
+
+#: app/flatpak-builtins-ps.c:57
+msgid "R.-Branch"
+msgstr "О.О.-Тармағы"
+
+#: app/flatpak-builtins-ps.c:57
+msgid "Show the runtime branch"
+msgstr "Орындалу ортасының тармағын көрсету"
+
+#: app/flatpak-builtins-ps.c:58
+msgid "R.-Commit"
+msgstr "О.О.-Коммиті"
+
+#: app/flatpak-builtins-ps.c:58
+msgid "Show the runtime commit"
+msgstr "Орындалу ортасының коммитін көрсету"
+
+#: app/flatpak-builtins-ps.c:59
+msgid "Active"
+msgstr "Белсенді"
+
+#: app/flatpak-builtins-ps.c:59
+msgid "Show whether the app is active"
+msgstr "Қолданбаның белсенді екенін көрсету"
+
+#: app/flatpak-builtins-ps.c:60
+msgid "Background"
+msgstr "Фон"
+
+#: app/flatpak-builtins-ps.c:60
+msgid "Show whether the app is background"
+msgstr "Қолданбаның фонда екенін көрсету"
+
+#: app/flatpak-builtins-ps.c:246
+msgid " - Enumerate running sandboxes"
+msgstr " - Жұмыс істеп тұрған құмсалғыштарды санап шығу"
+
+#: app/flatpak-builtins-remote-add.c:66
+msgid "Do nothing if the provided remote exists"
+msgstr "Егер берілген қашықтағы репозиторий бар болса, ештеңе істемеу"
+
+#: app/flatpak-builtins-remote-add.c:67
+msgid "LOCATION specifies a configuration file, not the repo location"
+msgstr "ОРНЫ репозиторий орнын емес, конфигурация файлын білдіреді"
+
+#: app/flatpak-builtins-remote-add.c:72 app/flatpak-builtins-remote-modify.c:78
+msgid "Disable GPG verification"
+msgstr "GPG тексеруін сөндіру"
+
+#: app/flatpak-builtins-remote-add.c:73 app/flatpak-builtins-remote-modify.c:79
+msgid "Mark the remote as don't enumerate"
+msgstr "Қашықтағы репозиторийді санамау ретінде белгілеу"
+
+#: app/flatpak-builtins-remote-add.c:74 app/flatpak-builtins-remote-modify.c:80
+msgid "Mark the remote as don't use for deps"
+msgstr "Қашықтағы репозиторийді тәуелділіктер үшін қолданбау ретінде белгілеу"
+
+#: app/flatpak-builtins-remote-add.c:75 app/flatpak-builtins-remote-modify.c:81
+msgid "Set priority (default 1, higher is more prioritized)"
+msgstr ""
+"Приоритетті орнату (бастапқысы 1, неғұрлым жоғары болса, соғұрлым басым)"
+
+#: app/flatpak-builtins-remote-add.c:75 app/flatpak-builtins-remote-modify.c:81
+msgid "PRIORITY"
+msgstr "ПРИОРИТЕТ"
+
+#: app/flatpak-builtins-remote-add.c:76
+msgid "The named subset to use for this remote"
+msgstr "Осы қашықтағы репозиторий үшін қолданылатын аталған жиын"
+
+#: app/flatpak-builtins-remote-add.c:76 app/flatpak-builtins-remote-modify.c:71
+msgid "SUBSET"
+msgstr "ЖИЫН"
+
+#: app/flatpak-builtins-remote-add.c:77 app/flatpak-builtins-remote-modify.c:82
+msgid "A nice name to use for this remote"
+msgstr "Бұл қашықтағы репозиторий үшін қолданылатын жақсы атау"
+
+#: app/flatpak-builtins-remote-add.c:78 app/flatpak-builtins-remote-modify.c:83
+msgid "A one-line comment for this remote"
+msgstr "Бұл қашықтағы репозиторий үшін бір жолдық түсініктеме"
+
+#: app/flatpak-builtins-remote-add.c:79 app/flatpak-builtins-remote-modify.c:84
+msgid "A full-paragraph description for this remote"
+msgstr "Бұл қашықтағы репозиторий үшін толық сипаттама"
+
+#: app/flatpak-builtins-remote-add.c:80 app/flatpak-builtins-remote-modify.c:85
+msgid "URL for a website for this remote"
+msgstr "Бұл қашықтағы репозиторийдің веб-сайты үшін URL"
+
+#: app/flatpak-builtins-remote-add.c:81 app/flatpak-builtins-remote-modify.c:86
+msgid "URL for an icon for this remote"
+msgstr "Бұл қашықтағы репозиторийдің таңбашасы үшін URL"
+
+#: app/flatpak-builtins-remote-add.c:82 app/flatpak-builtins-remote-modify.c:87
+msgid "Default branch to use for this remote"
+msgstr "Осы қашықтағы репозиторий үшін бастапқы тармақ"
+
+#: app/flatpak-builtins-remote-add.c:84 app/flatpak-builtins-remote-modify.c:89
+msgid "Import GPG key from FILE (- for stdin)"
+msgstr "ФАЙЛ-дан GPG кілтін импорттау (stdin үшін -)"
+
+#: app/flatpak-builtins-remote-add.c:85 app/flatpak-builtins-remote-modify.c:90
+msgid "Load signatures from URL"
+msgstr "Қолтаңбаларды URL-ден жүктеу"
+
+#: app/flatpak-builtins-remote-add.c:86 app/flatpak-builtins-remote-modify.c:92
+msgid "Set path to local filter FILE"
+msgstr "Жергілікті ФАЙЛ сүзгісіне жолды орнату"
+
+#: app/flatpak-builtins-remote-add.c:87 app/flatpak-builtins-remote-modify.c:93
+msgid "Disable the remote"
+msgstr "Қашықтағы репозиторийді сөндіру"
+
+#: app/flatpak-builtins-remote-add.c:88 app/flatpak-builtins-remote-modify.c:94
+msgid "Name of authenticator"
+msgstr "Аутентификатор атауы"
+
+#: app/flatpak-builtins-remote-add.c:90 app/flatpak-builtins-remote-modify.c:96
+msgid "Autoinstall authenticator"
+msgstr "Аутентификаторды автоматты орнату"
+
+#: app/flatpak-builtins-remote-add.c:91 app/flatpak-builtins-remote-modify.c:97
+msgid "Don't autoinstall authenticator"
+msgstr "Аутентификаторды автоматты орнатпау"
+
+#: app/flatpak-builtins-remote-add.c:92 app/flatpak-builtins-remote-modify.c:99
+msgid "Don't follow the redirect set in the summary file"
+msgstr "Жиынтық файлында орнатылған қайта бағыттауды орындамау"
+
+#: app/flatpak-builtins-remote-add.c:261 app/flatpak-builtins-remote-add.c:268
+#, c-format
+msgid "Can't load uri %s: %s\n"
+msgstr "%s uri-ін жүктеу мүмкін емес: %s\n"
+
+#: app/flatpak-builtins-remote-add.c:276 common/flatpak-dir.c:4628
+#, c-format
+msgid "Can't load file %s: %s\n"
+msgstr "%s файлын жүктеу мүмкін емес: %s\n"
+
+#: app/flatpak-builtins-remote-add.c:304
+msgid "NAME LOCATION - Add a remote repository"
+msgstr "АТЫ ОРНЫ - Қашықтағы репозиторийді қосу"
+
+#: app/flatpak-builtins-remote-add.c:331
+msgid "GPG verification is required if collections are enabled"
+msgstr "Егер коллекциялар іске қосылса, GPG тексеруі міндетті"
+
+#: app/flatpak-builtins-remote-add.c:393
+#, c-format
+msgid "Remote %s already exists"
+msgstr "%s қашықтағы репозиторийі қазірдің өзінде бар"
+
+#: app/flatpak-builtins-remote-add.c:405
+#: app/flatpak-builtins-remote-modify.c:340
+#, c-format
+msgid "Invalid authenticator name %s"
+msgstr "Аутентификатор атауы жарамсыз: %s"
+
+#: app/flatpak-builtins-remote-add.c:422
+#, c-format
+msgid "Warning: Could not update extra metadata for '%s': %s\n"
+msgstr "Ескерту: '%s' үшін қосымша метадеректерді жаңарту мүмкін болмады: %s\n"
+
+#: app/flatpak-builtins-remote-delete.c:39
+msgid "Remove remote even if in use"
+msgstr "Қолданыста болса да, қашықтағы репозиторийді өшіру"
+
+#: app/flatpak-builtins-remote-delete.c:53
+msgid "NAME - Delete a remote repository"
+msgstr "АТЫ - Қашықтағы репозиторийді өшіру"
+
+#: app/flatpak-builtins-remote-delete.c:100
+#, c-format
+msgid "The following refs are installed from remote '%s':"
+msgstr "Келесі сілтемелер '%s' қашықтағы репозиторийінен орнатылған:"
+
+#: app/flatpak-builtins-remote-delete.c:101
+msgid "Remove them?"
+msgstr "Оларды өшіру керек пе?"
+
+#: app/flatpak-builtins-remote-delete.c:103
+#, c-format
+msgid "Can't remove remote '%s' with installed refs"
+msgstr ""
+"Орнатылған сілтемелері бар '%s' қашықтағы репозиторийін өшіру мүмкін емес"
+
+#: app/flatpak-builtins-remote-info.c:55
+msgid "Commit to show info for"
+msgstr "Ақпараты көрсетілетін коммит"
+
+#: app/flatpak-builtins-remote-info.c:58
+msgid "Display log"
+msgstr "Журналды көрсету"
+
+#: app/flatpak-builtins-remote-info.c:61
+msgid "Show parent"
+msgstr "Аталығын көрсету"
+
+#: app/flatpak-builtins-remote-info.c:65 app/flatpak-builtins-remote-ls.c:60
+msgid "Use local caches even if they are stale"
+msgstr "Жергілікті кэштер ескірген болса да, оларды қолдану"
+
+#. Translators: A sideload is when you install from a local USB drive rather than the Internet.
+#: app/flatpak-builtins-remote-info.c:67 app/flatpak-builtins-remote-ls.c:62
+msgid "Only list refs available as sideloads"
+msgstr "Тек қатар жүктеу ретінде қолжетімді сілтемелерді тізімдеу"
+
+#: app/flatpak-builtins-remote-info.c:114
+msgid ""
+" REMOTE REF - Show information about an application or runtime in a remote"
+msgstr ""
+" ҚАШЫҚТАҒЫ СІЛТЕМЕ - Қашықтағы репозиторийдегі қолданба немесе орындалу "
+"ортасы туралы ақпаратты көрсету"
+
+#: app/flatpak-builtins-remote-info.c:125
+msgid "REMOTE and REF must be specified"
+msgstr "ҚАШЫҚТАҒЫ және СІЛТЕМЕ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-remote-info.c:247
+#: app/flatpak-builtins-remote-info.c:282
+msgid "Download Size:"
+msgstr "Жүктеп алу өлшемі:"
+
+#: app/flatpak-builtins-remote-info.c:267
+#: app/flatpak-builtins-remote-info.c:325
+msgid "History:"
+msgstr "Тарихы:"
+
+#: app/flatpak-builtins-remote-info.c:348
+msgid " Commit:"
+msgstr " Коммит:"
+
+#: app/flatpak-builtins-remote-info.c:349
+msgid " Subject:"
+msgstr " Тақырыбы:"
+
+#: app/flatpak-builtins-remote-info.c:350
+msgid " Date:"
+msgstr " Күні:"
+
+#: app/flatpak-builtins-remote-info.c:383
+#, c-format
+msgid "Warning: Commit %s has no flatpak metadata\n"
+msgstr "Ескерту: %s коммитінде flatpak метадеректері жоқ\n"
+
+#: app/flatpak-builtins-remote-list.c:43
+msgid "Show remote details"
+msgstr "Қашықтағы репозиторий мәліметтерін көрсету"
+
+#: app/flatpak-builtins-remote-list.c:44
+msgid "Show disabled remotes"
+msgstr "Сөндірілген қашықтағы репозиторийлерді көрсету"
+
+#: app/flatpak-builtins-remote-list.c:52
+msgid "Title"
+msgstr "Атауы"
+
+#: app/flatpak-builtins-remote-list.c:52
+msgid "Show the title"
+msgstr "Атауын көрсету"
+
+#: app/flatpak-builtins-remote-list.c:53
+msgid "Show the URL"
+msgstr "URL-ді көрсету"
+
+#: app/flatpak-builtins-remote-list.c:54
+msgid "Show the collection ID"
+msgstr "Коллекция ID-ін көрсету"
+
+#: app/flatpak-builtins-remote-list.c:55 app/flatpak-builtins-repo.c:392
+msgid "Subset"
+msgstr "Жиын"
+
+#: app/flatpak-builtins-remote-list.c:55
+msgid "Show the subset"
+msgstr "Жиынды көрсету"
+
+#: app/flatpak-builtins-remote-list.c:56
+msgid "Filter"
+msgstr "Сүзгі"
+
+#: app/flatpak-builtins-remote-list.c:56
+msgid "Show filter file"
+msgstr "Сүзгі файлын көрсету"
+
+#: app/flatpak-builtins-remote-list.c:57
+msgid "Priority"
+msgstr "Басымдылық"
+
+#: app/flatpak-builtins-remote-list.c:57
+msgid "Show the priority"
+msgstr "Басымдылықты көрсету"
+
+#: app/flatpak-builtins-remote-list.c:59
+msgid "Comment"
+msgstr "Түсiнiктеме"
+
+#: app/flatpak-builtins-remote-list.c:59
+msgid "Show comment"
+msgstr "Түсініктемені көрсету"
+
+#: app/flatpak-builtins-remote-list.c:60
+msgid "Show description"
+msgstr "Сипаттамасын көрсету"
+
+#: app/flatpak-builtins-remote-list.c:61
+msgid "Homepage"
+msgstr "Үй беті"
+
+#: app/flatpak-builtins-remote-list.c:61
+msgid "Show homepage"
+msgstr "Үй бетін көрсету"
+
+#: app/flatpak-builtins-remote-list.c:62
+msgid "Icon"
+msgstr "Таңбаша"
+
+#: app/flatpak-builtins-remote-list.c:62
+msgid "Show icon"
+msgstr "Таңбашаны көрсету"
+
+#: app/flatpak-builtins-remote-list.c:231
+msgid " - List remote repositories"
+msgstr " - Қашықтағы репозиторийлерді тізімдеу"
+
+#: app/flatpak-builtins-remote-ls.c:52
+msgid "Show arches and branches"
+msgstr "Архитектуралар мен тармақтарды көрсету"
+
+#: app/flatpak-builtins-remote-ls.c:53
+msgid "Show only runtimes"
+msgstr "Тек орындалу орталарын көрсету"
+
+#: app/flatpak-builtins-remote-ls.c:54
+msgid "Show only apps"
+msgstr "Тек қолданбаларды көрсету"
+
+#: app/flatpak-builtins-remote-ls.c:55
+msgid "Show only those where updates are available"
+msgstr "Тек жаңартулары барларын көрсету"
+
+#: app/flatpak-builtins-remote-ls.c:56
+msgid "Limit to this arch (* for all)"
+msgstr "Осы архитектурамен шектеу (барлығы үшін *)"
+
+#: app/flatpak-builtins-remote-ls.c:77
+msgid "Show the runtime"
+msgstr "Орындалу ортасын көрсету"
+
+#: app/flatpak-builtins-remote-ls.c:79
+msgid "Download size"
+msgstr "Жүктеп алу өлшемі"
+
+#: app/flatpak-builtins-remote-ls.c:79
+msgid "Show the download size"
+msgstr "Жүктеп алу өлшемін көрсету"
+
+#: app/flatpak-builtins-remote-ls.c:391
+msgid " [REMOTE or URI] - Show available runtimes and applications"
+msgstr ""
+" [ҚАШЫҚТАҒЫ немесе URI] - Қолжетімді орындалу орталары мен қолданбаларды "
+"көрсету"
+
+#: app/flatpak-builtins-remote-modify.c:67
+msgid "Enable GPG verification"
+msgstr "GPG тексеруін іске қосу"
+
+#: app/flatpak-builtins-remote-modify.c:68
+msgid "Mark the remote as enumerate"
+msgstr "Қашықтағы репозиторийді санаулы ретінде белгілеу"
+
+#: app/flatpak-builtins-remote-modify.c:69
+msgid "Mark the remote as used for dependencies"
+msgstr ""
+"Қашықтағы репозиторийді тәуелділіктер үшін қолданылатын ретінде белгілеу"
+
+#: app/flatpak-builtins-remote-modify.c:70
+msgid "Set a new URL"
+msgstr "Жаңа URL орнату"
+
+#: app/flatpak-builtins-remote-modify.c:71
+msgid "Set a new subset to use"
+msgstr "Қолданылатын жаңа жиынды орнату"
+
+#: app/flatpak-builtins-remote-modify.c:72
+msgid "Enable the remote"
+msgstr "Қашықтағы репозиторийді іске қосу"
+
+#: app/flatpak-builtins-remote-modify.c:73
+msgid "Update extra metadata from the summary file"
+msgstr "Жиынтық файлынан қосымша метадеректерді жаңарту"
+
+#: app/flatpak-builtins-remote-modify.c:91
+msgid "Disable local filter"
+msgstr "Жергілікті сүзгіні сөндіру"
+
+#: app/flatpak-builtins-remote-modify.c:95
+msgid "Authenticator options"
+msgstr "Аутентификатор опциялары"
+
+#: app/flatpak-builtins-remote-modify.c:98
+msgid "Follow the redirect set in the summary file"
+msgstr "Жиынтық файлында орнатылған қайта бағыттауды орындау"
+
+#: app/flatpak-builtins-remote-modify.c:306
+msgid "NAME - Modify a remote repository"
+msgstr "АТЫ - Қашықтағы репозиторийді өзгерту"
+
+#: app/flatpak-builtins-remote-modify.c:316
+msgid "Remote NAME must be specified"
+msgstr "Қашықтағы АТЫ көрсетілуі тиіс"
+
+#: app/flatpak-builtins-remote-modify.c:327
+#, c-format
+msgid "Updating extra metadata from remote summary for %s\n"
+msgstr "%s үшін қашықтағы жиынтықтан қосымша метадеректер жаңартылуда\n"
+
+#: app/flatpak-builtins-remote-modify.c:330
+#, c-format
+msgid "Error updating extra metadata for '%s': %s\n"
+msgstr "'%s' үшін қосымша метадеректерді жаңарту қатесі: %s\n"
+
+#: app/flatpak-builtins-remote-modify.c:331
+#, c-format
+msgid "Could not update extra metadata for %s"
+msgstr "%s үшін қосымша метадеректерді жаңарту мүмкін болмады"
+
+#: app/flatpak-builtins-repair.c:43
+msgid "Don't make any changes"
+msgstr "Ешқандай өзгеріс жасамау"
+
+#: app/flatpak-builtins-repair.c:44
+msgid "Reinstall all refs"
+msgstr "Барлық сілтемелерді қайта орнату"
+
+#: app/flatpak-builtins-repair.c:68
+#, c-format
+msgid "Object missing: %s.%s\n"
+msgstr "Объект жоқ: %s.%s\n"
+
+#: app/flatpak-builtins-repair.c:76
+#, c-format
+msgid "Object invalid: %s.%s\n"
+msgstr "Объект жарамсыз: %s.%s\n"
+
+#: app/flatpak-builtins-repair.c:81
+#, c-format
+msgid "%s, deleting object\n"
+msgstr "%s, объект өшірілуде\n"
+
+#: app/flatpak-builtins-repair.c:146
+#, c-format
+msgid "Can't load object %s: %s\n"
+msgstr "%s объектісін жүктеу мүмкін емес: %s\n"
+
+#: app/flatpak-builtins-repair.c:228
+#, c-format
+msgid "Commit invalid %s: %s\n"
+msgstr "%s коммиті жарамсыз: %s\n"
+
+#: app/flatpak-builtins-repair.c:231
+#, c-format
+msgid "Deleting invalid commit %s: %s\n"
+msgstr "Жарамсыз %s коммиті өшірілуде: %s\n"
+
+#: app/flatpak-builtins-repair.c:261
+#, c-format
+msgid "Commit should be marked partial: %s\n"
+msgstr "Коммит жартылай деп белгіленуі тиіс: %s\n"
+
+#: app/flatpak-builtins-repair.c:264
+#, c-format
+msgid "Marking commit as partial: %s\n"
+msgstr "Коммитті жартылай деп белгілеу: %s\n"
+
+#: app/flatpak-builtins-repair.c:293
+#, c-format
+msgid "Problems loading data for %s: %s\n"
+msgstr "%s үшін деректерді жүктеу кезіндегі мәселелер: %s\n"
+
+#: app/flatpak-builtins-repair.c:306
+#, c-format
+msgid "Error reinstalling %s: %s\n"
+msgstr "%s қайта орнату қатесі: %s\n"
+
+#: app/flatpak-builtins-repair.c:327
+msgid "- Repair a flatpak installation"
+msgstr "- Flatpak орнатылымын жөндеу"
+
+#: app/flatpak-builtins-repair.c:406
+#, c-format
+msgid "Removing non-deployed ref %s…\n"
+msgstr "Орналастырылмаған %s сілтемесі өшірілуде…\n"
+
+#: app/flatpak-builtins-repair.c:411
+#, c-format
+msgid "Skipping non-deployed ref %s…\n"
+msgstr "Орналастырылмаған %s сілтемесі өткізіліп жіберілуде…\n"
+
+#: app/flatpak-builtins-repair.c:429
+#, c-format
+msgid "[%d/%d] Verifying %s…\n"
+msgstr "[%d/%d] %s тексерілуде…\n"
+
+#: app/flatpak-builtins-repair.c:435
+msgid "Dry run: "
+msgstr "Сынақ ретінде орындау: "
+
+#: app/flatpak-builtins-repair.c:440
+#, c-format
+msgid "Deleting ref %s due to missing objects\n"
+msgstr "Объектілер жоқ болғандықтан %s сілтемесі өшірілуде\n"
+
+#: app/flatpak-builtins-repair.c:444
+#, c-format
+msgid "Deleting ref %s due to invalid objects\n"
+msgstr "Объектілер жарамсыз болғандықтан %s сілтемесі өшірілуде\n"
+
+#: app/flatpak-builtins-repair.c:448
+#, c-format
+msgid "Deleting ref %s due to %d\n"
+msgstr "%2$d себебінен %1$s сілтемесі өшірілуде\n"
+
+#: app/flatpak-builtins-repair.c:464
+msgid "Checking remotes...\n"
+msgstr "Қашықтағы репозиторийлер тексерілуде...\n"
+
+#: app/flatpak-builtins-repair.c:482
+#, c-format
+msgid "Remote %s for ref %s is missing\n"
+msgstr "%2$s сілтемесі үшін %1$s қашықтағы репозиторийі жоқ\n"
+
+#: app/flatpak-builtins-repair.c:484
+#, c-format
+msgid "Remote %s for ref %s is disabled\n"
+msgstr "%2$s сілтемесі үшін %1$s қашықтағы репозиторийі сөндірілген\n"
+
+#: app/flatpak-builtins-repair.c:490
+msgid "Pruning objects\n"
+msgstr "Объектілер тазалануда\n"
+
+#: app/flatpak-builtins-repair.c:498
+msgid "Erasing .removed\n"
+msgstr ".removed жойылуда\n"
+
+#: app/flatpak-builtins-repair.c:523
+msgid "Reinstalling refs\n"
+msgstr "Сілтемелер қайта орнатылуда\n"
+
+#: app/flatpak-builtins-repair.c:525
+msgid "Reinstalling removed refs\n"
+msgstr "Өшірілген сілтемелер қайта орнатылуда\n"
+
+#: app/flatpak-builtins-repair.c:550
+#, c-format
+msgid "While removing appstream for %s: "
+msgstr "%s үшін appstream өшіру кезінде: "
+
+#: app/flatpak-builtins-repair.c:557
+#, c-format
+msgid "While deploying appstream for %s: "
+msgstr "%s үшін appstream орналастыру кезінде: "
+
+#: app/flatpak-builtins-repo.c:106
+#, c-format
+msgid "Repo mode: %s\n"
+msgstr "Репозиторий режимі: %s\n"
+
+#: app/flatpak-builtins-repo.c:113
+#, c-format
+msgid "Indexed summaries: %s\n"
+msgstr "Индекстелген жиынтықтар: %s\n"
+
+#: app/flatpak-builtins-repo.c:113 app/flatpak-builtins-repo.c:139
+#: app/flatpak-builtins-repo.c:172
+msgid "true"
+msgstr "true"
+
+#: app/flatpak-builtins-repo.c:113 app/flatpak-builtins-repo.c:139
+#: app/flatpak-builtins-repo.c:172
+msgid "false"
+msgstr "false"
+
+#: app/flatpak-builtins-repo.c:121
+msgid "Subsummaries: "
+msgstr "Ішкі жиынтықтар: "
+
+#: app/flatpak-builtins-repo.c:136
+#, c-format
+msgid "Cache version: %d\n"
+msgstr "Кэш нұсқасы: %d\n"
+
+#: app/flatpak-builtins-repo.c:139
+#, c-format
+msgid "Indexed deltas: %s\n"
+msgstr "Индекстелген дельталар: %s\n"
+
+#: app/flatpak-builtins-repo.c:142
+#, c-format
+msgid "Title: %s\n"
+msgstr "Тақырыбы: %s\n"
+
+#: app/flatpak-builtins-repo.c:145
+#, c-format
+msgid "Comment: %s\n"
+msgstr "Түсініктеме: %s\n"
+
+#: app/flatpak-builtins-repo.c:148
+#, c-format
+msgid "Description: %s\n"
+msgstr "Сипаттама: %s\n"
+
+#: app/flatpak-builtins-repo.c:151
+#, c-format
+msgid "Homepage: %s\n"
+msgstr "Үй беті: %s\n"
+
+#: app/flatpak-builtins-repo.c:154
+#, c-format
+msgid "Icon: %s\n"
+msgstr "Таңбаша: %s\n"
+
+#: app/flatpak-builtins-repo.c:157
+#, c-format
+msgid "Collection ID: %s\n"
+msgstr "Коллекция ID-і: %s\n"
+
+#: app/flatpak-builtins-repo.c:160
+#, c-format
+msgid "Default branch: %s\n"
+msgstr "Бастапқы тармақ: %s\n"
+
+#: app/flatpak-builtins-repo.c:163
+#, c-format
+msgid "Redirect URL: %s\n"
+msgstr "Қайта бағыттау URL-і: %s\n"
+
+#: app/flatpak-builtins-repo.c:166
+#, c-format
+msgid "Deploy collection ID: %s\n"
+msgstr "Коллекция ID-ін орналастыру: %s\n"
+
+#: app/flatpak-builtins-repo.c:169
+#, c-format
+msgid "Authenticator name: %s\n"
+msgstr "Аутентификатор атауы: %s\n"
+
+#: app/flatpak-builtins-repo.c:172
+#, c-format
+msgid "Authenticator install: %s\n"
+msgstr "Аутентификатор орнату: %s\n"
+
+#: app/flatpak-builtins-repo.c:180
+#, c-format
+msgid "GPG key hash: %s\n"
+msgstr "GPG кілт хэші: %s\n"
+
+#: app/flatpak-builtins-repo.c:184
+#, c-format
+msgid "%zd summary branches\n"
+msgstr "%zd жиынтық тармағы\n"
+
+#: app/flatpak-builtins-repo.c:336
+msgid "Installed"
+msgstr "Орнатылған"
+
+#. Translators: Download is used here as a noun
+#: app/flatpak-builtins-repo.c:338 app/flatpak-cli-transaction.c:1462
+msgid "Download"
+msgstr "Жүктеп алу"
+
+#: app/flatpak-builtins-repo.c:339
+msgid "Subsets"
+msgstr "Жиындар"
+
+#: app/flatpak-builtins-repo.c:393
+msgid "Digest"
+msgstr "Дайджест"
+
+#: app/flatpak-builtins-repo.c:394
+msgid "History length"
+msgstr "Тарих ұзындығы"
+
+#: app/flatpak-builtins-repo.c:711
+msgid "Print general information about the repository"
+msgstr "Репозиторий туралы жалпы ақпаратты шығару"
+
+#: app/flatpak-builtins-repo.c:712
+msgid "List the branches in the repository"
+msgstr "Репозиторийдегі тармақтарды тізімдеу"
+
+#: app/flatpak-builtins-repo.c:713
+msgid "Print metadata for a branch"
+msgstr "Тармақ үшін метадеректерді шығару"
+
+#: app/flatpak-builtins-repo.c:714
+msgid "Show commits for a branch"
+msgstr "Тармақ үшін коммиттерді көрсету"
+
+#: app/flatpak-builtins-repo.c:715
+msgid "Print information about the repo subsets"
+msgstr "Репо жиындары туралы ақпаратты шығару"
+
+#: app/flatpak-builtins-repo.c:716
+msgid "Limit information to subsets with this prefix"
+msgstr "Ақпаратты осы префиксі бар жиындармен шектеу"
+
+#: app/flatpak-builtins-repo.c:732
+msgid "LOCATION - Repository maintenance"
+msgstr "ОРНЫ - Репозиторийге техникалық қызмет көрсету"
+
+#: app/flatpak-builtins-run.c:68
+msgid "Command to run"
+msgstr "Орындалатын команда"
+
+#: app/flatpak-builtins-run.c:69
+msgid "Directory to run the command in"
+msgstr "Команда орындалатын бума"
+
+#: app/flatpak-builtins-run.c:70
+msgid "Branch to use"
+msgstr "Қолданылатын тармақ"
+
+#: app/flatpak-builtins-run.c:71
+msgid "Use development runtime"
+msgstr "Әзірлеуге арналған орындалу ортасын қолдану"
+
+#: app/flatpak-builtins-run.c:72
+msgid "Runtime to use"
+msgstr "Қолданылатын орындалу ортасы"
+
+#: app/flatpak-builtins-run.c:73
+msgid "Runtime version to use"
+msgstr "Қолданылатын орындалу ортасының нұсқасы"
+
+#: app/flatpak-builtins-run.c:76
+msgid "Log accessibility bus calls"
+msgstr "Арнайы мүмкіндіктер шинасының шақыруларын журналдау"
+
+#: app/flatpak-builtins-run.c:77
+msgid "Don't proxy accessibility bus calls"
+msgstr "Арнайы мүмкіндіктер шинасының шақыруларын проксилемеу"
+
+#: app/flatpak-builtins-run.c:78
+msgid "Proxy accessibility bus calls (default except when sandboxed)"
+msgstr ""
+"Арнайы мүмкіндіктер шинасының шақыруларын проксилеу (құмсалғышта болғаннан "
+"басқа жағдайда бастапқы)"
+
+#: app/flatpak-builtins-run.c:79
+msgid "Don't proxy session bus calls"
+msgstr "Сессия шинасының шақыруларын проксилемеу"
+
+#: app/flatpak-builtins-run.c:80
+msgid "Proxy session bus calls (default except when sandboxed)"
+msgstr ""
+"Сессия шинасының шақыруларын проксилеу (құмсалғышта болғаннан басқа жағдайда "
+"бастапқы)"
+
+#: app/flatpak-builtins-run.c:81
+msgid "Don't start portals"
+msgstr "Порталдарды іске қоспау"
+
+#: app/flatpak-builtins-run.c:82
+msgid "Enable file forwarding"
+msgstr "Файлды қайта бағыттауды іске қосу"
+
+#: app/flatpak-builtins-run.c:83
+msgid "Run specified commit"
+msgstr "Көрсетілген коммитті орындау"
+
+#: app/flatpak-builtins-run.c:84
+msgid "Use specified runtime commit"
+msgstr "Көрсетілген орындалу ортасының коммитін қолдану"
+
+#: app/flatpak-builtins-run.c:85
+msgid "Run completely sandboxed"
+msgstr "Толық құмсалғышта орындау"
+
+#: app/flatpak-builtins-run.c:87
+msgid "Use PID as parent pid for sharing namespaces"
+msgstr "Атау кеңістіктерін бөлісу үшін PID-ті аталық pid ретінде қолдану"
+
+#: app/flatpak-builtins-run.c:88
+msgid "Make processes visible in parent namespace"
+msgstr "Процестерді аталық атау кеңістігінде көрінетін ету"
+
+#: app/flatpak-builtins-run.c:89
+msgid "Share process ID namespace with parent"
+msgstr "Процесс ID атау кеңістігін аталықпен бөлісу"
+
+#: app/flatpak-builtins-run.c:90
+msgid "Write the instance ID to the given file descriptor"
+msgstr "Инстанция ID-ін берілген файл дескрипторына жазу"
+
+#: app/flatpak-builtins-run.c:91
+msgid "Use PATH instead of the app's /app"
+msgstr "Қолданбаның /app орнына ЖОЛ-ды қолдану"
+
+#: app/flatpak-builtins-run.c:92
+msgid "Use PATH instead of the runtime's /usr"
+msgstr "Орындалу ортасының /usr орнына ЖОЛ-ды қолдану"
+
+#: app/flatpak-builtins-run.c:93
+msgid "Clear all outside environment variables"
+msgstr "Барлық сыртқы орта айнымалыларын тазалау"
+
+#: app/flatpak-builtins-run.c:119
+msgid "APP [ARGUMENT…] - Run an app"
+msgstr "ҚОЛДАНБА [АРГУМЕНТ…] - Қолданбаны орындау"
+
+#: app/flatpak-builtins-run.c:270
+#, c-format
+msgid "runtime/%s/%s/%s not installed"
+msgstr "runtime/%s/%s/%s орнатылмаған"
+
+#: app/flatpak-builtins-search.c:37
+msgid "Arch to search for"
+msgstr "Ізделетін архитектура"
+
+#: app/flatpak-builtins-search.c:49
+msgid "Remotes"
+msgstr "Қашықтағы репозиторийлер"
+
+#: app/flatpak-builtins-search.c:49
+msgid "Show the remotes"
+msgstr "Қашықтағы репозиторийлерді көрсету"
+
+#: app/flatpak-builtins-search.c:244
+msgid "TEXT - Search remote apps/runtimes for text"
+msgstr "МӘТІН - Қашықтағы қолданбалардан/орындалу орталарынан мәтінді іздеу"
+
+#: app/flatpak-builtins-search.c:255
+msgid "TEXT must be specified"
+msgstr "МӘТІН көрсетілуі тиіс"
+
+#: app/flatpak-builtins-search.c:338
+msgid "No matches found"
+msgstr "Сәйкестіктер табылмады"
+
+#: app/flatpak-builtins-uninstall.c:54
+msgid "Arch to uninstall"
+msgstr "Өшірілетін архитектура"
+
+#: app/flatpak-builtins-uninstall.c:55
+msgid "Keep ref in local repository"
+msgstr "Сілтемені жергілікті репозиторийде сақтау"
+
+#: app/flatpak-builtins-uninstall.c:56
+msgid "Don't uninstall related refs"
+msgstr "Қатысты сілтемелерді өшірмеу"
+
+#: app/flatpak-builtins-uninstall.c:57
+msgid "Remove files even if running"
+msgstr "Жұмыс істеп тұрса да, файлдарды өшіру"
+
+#: app/flatpak-builtins-uninstall.c:60
+msgid "Uninstall all"
+msgstr "Барлығын өшіру"
+
+#: app/flatpak-builtins-uninstall.c:61
+msgid "Uninstall unused"
+msgstr "Қолданылмайтындарды өшіру"
+
+#: app/flatpak-builtins-uninstall.c:62
+msgid "Delete app data"
+msgstr "Қолданба деректерін өшіру"
+
+#: app/flatpak-builtins-uninstall.c:141
+#, c-format
+msgid "Delete data for %s?"
+msgstr "%s үшін деректерді өшіру керек пе?"
+
+#: app/flatpak-builtins-uninstall.c:220
+#, c-format
+msgid "Info: applications using the extension %s%s%s branch %s%s%s:\n"
+msgstr "Ақпарат: %s%s%s кеңейтуінің %s%s%s тармағын қолданатын қолданбалар:\n"
+
+#: app/flatpak-builtins-uninstall.c:223
+#, c-format
+msgid "Info: applications using the runtime %s%s%s branch %s%s%s:\n"
+msgstr ""
+"Ақпарат: %s%s%s орындалу ортасының %s%s%s тармағын қолданатын қолданбалар:\n"
+
+#: app/flatpak-builtins-uninstall.c:238
+msgid "Really remove?"
+msgstr "Шынымен өшіру керек пе?"
+
+#: app/flatpak-builtins-uninstall.c:255
+msgid "[REF…] - Uninstall applications or runtimes"
+msgstr "[СІЛТЕМЕ…] - Қолданбаларды немесе орындалу орталарын өшіру"
+
+#: app/flatpak-builtins-uninstall.c:264
+msgid "Must specify at least one REF, --unused, --all or --delete-data"
+msgstr ""
+"Кем дегенде бір СІЛТЕМЕ, --unused, --all немесе --delete-data көрсетілуі тиіс"
+
+#: app/flatpak-builtins-uninstall.c:267
+msgid "Must not specify REFs when using --all"
+msgstr "--all қолданғанда СІЛТЕМЕ-лер көрсетілмеуі тиіс"
+
+#: app/flatpak-builtins-uninstall.c:270
+msgid "Must not specify REFs when using --unused"
+msgstr "--unused қолданғанда СІЛТЕМЕ-лер көрсетілмеуі тиіс"
+
+#: app/flatpak-builtins-uninstall.c:336
+#, c-format
+msgid ""
+"\n"
+"These runtimes in installation '%s' are pinned and won't be removed; see "
+"flatpak-pin(1):\n"
+msgstr ""
+"\n"
+"'%s' орнатылымындағы мына орындалу орталары бекітілген (pinned) және "
+"өшірілмейді; flatpak-pin(1) қараңыз:\n"
+
+#: app/flatpak-builtins-uninstall.c:370
+msgid "Nothing unused to uninstall\n"
+msgstr "Өшіретін қолданылмайтын ештеңе жоқ\n"
+
+#: app/flatpak-builtins-uninstall.c:444
+#, c-format
+msgid "No installed refs found for ‘%s’"
+msgstr "‘%s’ үшін орнатылған сілтемелер табылмады"
+
+#: app/flatpak-builtins-uninstall.c:447
+#, c-format
+msgid " with arch ‘%s’"
+msgstr " ‘%s’ архитектурасымен"
+
+#: app/flatpak-builtins-uninstall.c:449
+#, c-format
+msgid " with branch ‘%s’"
+msgstr " ‘%s’ тармағымен"
+
+#: app/flatpak-builtins-uninstall.c:456
+#, c-format
+msgid "Warning: %s is not installed\n"
+msgstr "Ескерту: %s орнатылмаған\n"
+
+#: app/flatpak-builtins-uninstall.c:490
+msgid "None of the specified refs are installed"
+msgstr "Көрсетілген сілтемелердің ешқайсысы орнатылмаған"
+
+#: app/flatpak-builtins-uninstall.c:599
+msgid "No app data to delete\n"
+msgstr "Өшірілетін қолданба деректері жоқ\n"
+
+#: app/flatpak-builtins-update.c:56
+msgid "Arch to update for"
+msgstr "Жаңартылатын архитектура"
+
+#: app/flatpak-builtins-update.c:57
+msgid "Commit to deploy"
+msgstr "Орналастырылатын коммит"
+
+#: app/flatpak-builtins-update.c:58
+msgid "Remove old files even if running"
+msgstr "Жұмыс істеп тұрса да, ескі файлдарды өшіру"
+
+#: app/flatpak-builtins-update.c:59
+msgid "Don't pull, only update from local cache"
+msgstr "Тартпау, тек жергілікті кэштен жаңарту"
+
+#: app/flatpak-builtins-update.c:61
+msgid "Don't update related refs"
+msgstr "Қатысты сілтемелерді жаңартпау"
+
+#: app/flatpak-builtins-update.c:66
+msgid "Update appstream for remote"
+msgstr "Қашықтағы репозиторий үшін appstream жаңарту"
+
+#: app/flatpak-builtins-update.c:67
+msgid "Only update this subpath"
+msgstr "Тек осы ішкі жолды жаңарту"
+
+#: app/flatpak-builtins-update.c:90
+msgid "[REF…] - Update applications or runtimes"
+msgstr "[СІЛТЕМЕ…] - Қолданбаларды немесе орындалу орталарын жаңарту"
+
+#: app/flatpak-builtins-update.c:121
+msgid "With --commit, only one REF may be specified"
+msgstr "--commit қолданғанда, тек бір СІЛТЕМЕ көрсетілуі мүмкін"
+
+#: app/flatpak-builtins-update.c:162
+msgid "Looking for updates…\n"
+msgstr "Жаңартулар ізделуде…\n"
+
+#: app/flatpak-builtins-update.c:215
+#, c-format
+msgid "Unable to update %s: %s\n"
+msgstr "%s жаңарту мүмкін емес: %s\n"
+
+#: app/flatpak-builtins-update.c:274
+msgid "Nothing to update.\n"
+msgstr "Жаңартатын ештеңе жоқ.\n"
+
+#: app/flatpak-builtins-utils.c:337
+#, c-format
+msgid ""
+"Remote ‘%s’ found in multiple installations, unable to proceed in non-"
+"interactive mode"
+msgstr ""
+"‘%s’ қашықтағы репозиторийі бірнеше орнатылымда табылды, интерактивті емес "
+"режимде жалғастыру мүмкін емес"
+
+#: app/flatpak-builtins-utils.c:346
+#, c-format
+msgid "Remote ‘%s’ found in multiple installations:"
+msgstr "‘%s’ қашықтағы репозиторийі бірнеше орнатылымда табылды:"
+
+#: app/flatpak-builtins-utils.c:347 app/flatpak-builtins-utils.c:442
+#: app/flatpak-builtins-utils.c:538 app/flatpak-builtins-utils.c:540
+#: app/flatpak-builtins-utils.c:598
+msgid "Which do you want to use (0 to abort)?"
+msgstr "Қайсысын қолданғыңыз келеді (бас тарту үшін 0)?"
+
+#: app/flatpak-builtins-utils.c:349
+#, c-format
+msgid "No remote chosen to resolve ‘%s’ which exists in multiple installations"
+msgstr ""
+"Бірнеше орнатылымда бар ‘%s’ сәйкестігін шешу үшін ешқандай қашықтағы "
+"репозиторий таңдалмады"
+
+#: app/flatpak-builtins-utils.c:358
+#, c-format
+msgid ""
+"Remote \"%s\" not found\n"
+"Hint: Use flatpak remote-add to add a remote"
+msgstr ""
+"\"%s\" қашықтағы репозиторийі табылмады\n"
+"Кеңес: Қашықтағы репозиторийді қосу үшін flatpak remote-add қолданыңыз"
+
+#: app/flatpak-builtins-utils.c:364
+#, c-format
+msgid "Remote \"%s\" not found in the %s installation"
+msgstr "\"%s\" қашықтағы репозиторийі %s орнатылымынан табылмады"
+
+#: app/flatpak-builtins-utils.c:404
+#, c-format
+msgid "Multiple refs match ‘%s’, unable to proceed in non-interactive mode"
+msgstr ""
+"‘%s’ сұранысына бірнеше сілтеме сәйкес келеді, интерактивті емес режимде "
+"жалғастыру мүмкін емес"
+
+#. default to yes on Enter
+#: app/flatpak-builtins-utils.c:430
+#, c-format
+msgid ""
+"Found ref ‘%s’ in remote ‘%s’ (%s).\n"
+"Use this ref?"
+msgstr ""
+"‘%2$s’ (%3$s) қашықтағы репозиторийден ‘%1$s’ сілтемесі табылды.\n"
+"Осы сілтемені қолдану керек пе?"
+
+#: app/flatpak-builtins-utils.c:434 app/flatpak-builtins-utils.c:444
+#: app/flatpak-builtins-utils.c:522 app/flatpak-builtins-utils.c:543
+#, c-format
+msgid "No ref chosen to resolve matches for ‘%s’"
+msgstr "‘%s’ үшін сәйкестіктерді шешуге ешқандай сілтеме таңдалмады"
+
+#: app/flatpak-builtins-utils.c:440
+#, c-format
+msgid "Similar refs found for ‘%s’ in remote ‘%s’ (%s):"
+msgstr ""
+"‘%2$s’ (%3$s) қашықтағы репозиторийден ‘%1$s’ үшін ұқсас сілтемелер табылды:"
+
+#: app/flatpak-builtins-utils.c:488
+#, c-format
+msgid ""
+"Multiple installed refs match ‘%s’, unable to proceed in non-interactive mode"
+msgstr ""
+"‘%s’ сұранысына бірнеше орнатылған сілтеме сәйкес келеді, интерактивті емес "
+"режимде жалғастыру мүмкін емес"
+
+#. default to yes on Enter
+#: app/flatpak-builtins-utils.c:518
+#, c-format
+msgid "Found installed ref ‘%s’ (%s). Is this correct?"
+msgstr "Орнатылған ‘%s’ (%s) сілтемесі табылды. Бұл дұрыс па?"
+
+#: app/flatpak-builtins-utils.c:534
+msgid "All of the above"
+msgstr "Жоғарыдағылардың барлығы"
+
+#: app/flatpak-builtins-utils.c:535
+#, c-format
+msgid "Similar installed refs found for ‘%s’:"
+msgstr "‘%s’ үшін ұқсас орнатылған сілтемелер табылды:"
+
+#: app/flatpak-builtins-utils.c:579
+#, c-format
+msgid ""
+"Multiple remotes have refs matching ‘%s’, unable to proceed in non-"
+"interactive mode"
+msgstr ""
+"Бірнеше қашықтағы репозиторийде ‘%s’ сәйкес келетін сілтемелер бар, "
+"интерактивті емес режимде жалғастыру мүмкін емес"
+
+#: app/flatpak-builtins-utils.c:597
+#, c-format
+msgid "Remotes found with refs similar to ‘%s’:"
+msgstr ""
+"‘%s’ сілтемесіне ұқсас сілтемелері бар қашықтағы репозиторийлер табылды:"
+
+#: app/flatpak-builtins-utils.c:600
+#, c-format
+msgid "No remote chosen to resolve matches for ‘%s’"
+msgstr ""
+"‘%s’ үшін сәйкестіктерді шешуге ешқандай қашықтағы репозиторий таңдалмады"
+
+#: app/flatpak-builtins-utils.c:696 app/flatpak-builtins-utils.c:699
+#, c-format
+msgid "Updating appstream data for user remote %s"
+msgstr ""
+"Пайдаланушының %s қашықтағы репозиторийі үшін appstream деректері жаңартылуда"
+
+#: app/flatpak-builtins-utils.c:706 app/flatpak-builtins-utils.c:709
+#, c-format
+msgid "Updating appstream data for remote %s"
+msgstr "%s қашықтағы репозиторийі үшін appstream деректері жаңартылуда"
+
+#: app/flatpak-builtins-utils.c:717 app/flatpak-builtins-utils.c:719
+msgid "Error updating"
+msgstr "Жаңарту қатесі"
+
+#: app/flatpak-builtins-utils.c:755
+#, c-format
+msgid "Remote \"%s\" not found"
+msgstr "\"%s\" қашықтағы репозиторийі табылмады"
+
+#: app/flatpak-builtins-utils.c:796
+#, c-format
+msgid "Ambiguous suffix: '%s'."
+msgstr "Екіұшты суффикс: '%s'."
+
+#. Translators: don't translate the values
+#: app/flatpak-builtins-utils.c:798 app/flatpak-builtins-utils.c:813
+msgid "Possible values are :s[tart], :m[iddle], :e[nd] or :f[ull]"
+msgstr "Мүмкін мәндер: :s[tart], :m[iddle], :e[nd] немесе :f[ull]"
+
+#: app/flatpak-builtins-utils.c:811
+#, c-format
+msgid "Invalid suffix: '%s'."
+msgstr "Жарамсыз суффикс: '%s'."
+
+#: app/flatpak-builtins-utils.c:846
+#, c-format
+msgid "Ambiguous column: %s"
+msgstr "Екіұшты баған: %s"
+
+#: app/flatpak-builtins-utils.c:859
+#, c-format
+msgid "Unknown column: %s"
+msgstr "Белгісіз баған: %s"
+
+#: app/flatpak-builtins-utils.c:917
+msgid "Available columns:\n"
+msgstr "Қолжетімді бағандар:\n"
+
+#: app/flatpak-builtins-utils.c:927
+msgid "Show all columns"
+msgstr "Барлық бағандарды көрсету"
+
+#: app/flatpak-builtins-utils.c:928
+msgid "Show available columns"
+msgstr "Қолжетімді бағандарды көрсету"
+
+#: app/flatpak-builtins-utils.c:931
+msgid "Append :s[tart], :m[iddle], :e[nd] or :f[ull] to change ellipsization"
+msgstr ""
+"Көпнүктені өзгерту үшін :s[tart], :m[iddle], :e[nd] немесе :f[ull] жалғаңыз"
+
+#: app/flatpak-builtins-utils.c:1483
+#, c-format
+msgid "Unknown scheme in sideload location %s"
+msgstr "%s қатар жүктеу орнындағы схема белгісіз"
+
+#: app/flatpak-cli-transaction.c:96 app/flatpak-cli-transaction.c:102
+#, c-format
+msgid "Required runtime for %s (%s) found in remote %s\n"
+msgstr ""
+"%s (%s) үшін қажетті орындалу ортасы %s қашықтағы репозиторийінен табылды\n"
+
+#: app/flatpak-cli-transaction.c:104
+msgid "Do you want to install it?"
+msgstr "Оны орнатқыңыз келеді ме?"
+
+#: app/flatpak-cli-transaction.c:110
+#, c-format
+msgid "Required runtime for %s (%s) found in remotes:"
+msgstr ""
+"%s (%s) үшін қажетті орындалу ортасы мына қашықтағы репозиторийлерден "
+"табылды:"
+
+#: app/flatpak-cli-transaction.c:112
+msgid "Which do you want to install (0 to abort)?"
+msgstr "Қайсысын орнатқыңыз келеді (бас тарту үшін 0)?"
+
+#: app/flatpak-cli-transaction.c:132
+#, c-format
+msgid "Configuring %s as new remote '%s'\n"
+msgstr "%s жаңа '%s' қашықтағы репозиторийі ретінде конфигурациялануда\n"
+
+#. default to yes on Enter
+#: app/flatpak-cli-transaction.c:139
+#, c-format
+msgid ""
+"The remote '%s', referred to by '%s' at location %s contains additional "
+"applications.\n"
+"Should the remote be kept for future installations?"
+msgstr ""
+"%3$s орнындағы '%2$s' сілтеме жасаған '%1$s' қашықтағы репозиторийінде "
+"қосымша қолданбалар бар.\n"
+"Қашықтағы репозиторийді болашақ орнатылымдар үшін сақтау керек пе?"
+
+#. default to yes on Enter
+#: app/flatpak-cli-transaction.c:147
+#, c-format
+msgid ""
+"The application %s depends on runtimes from:\n"
+"  %s\n"
+"Configure this as new remote '%s'"
+msgstr ""
+"%s қолданбасы мына жердегі орындалу орталарына тәуелді:\n"
+"  %s\n"
+"Мұны жаңа '%s' қашықтағы репозиторийі ретінде конфигурациялау керек пе?"
+
+#. Formatted size/remaining time in seconds
+#: app/flatpak-cli-transaction.c:321
+#, c-format
+msgid "%s/s%s%s"
+msgstr "%s/с%s%s"
+
+#. Download progress percentage, use the appropriate
+#. percent format for your language
+#: app/flatpak-cli-transaction.c:359
+#, c-format
+msgid "%3d%%"
+msgstr "%3d%%"
+
+#: app/flatpak-cli-transaction.c:414
+msgid "Installing…"
+msgstr "Орнатылуда…"
+
+#: app/flatpak-cli-transaction.c:416
+#, c-format
+msgid "Installing %d/%d…"
+msgstr "%d/%d орнатылуда…"
+
+#: app/flatpak-cli-transaction.c:421
+msgid "Updating…"
+msgstr "Жаңартылуда…"
+
+#: app/flatpak-cli-transaction.c:423
+#, c-format
+msgid "Updating %d/%d…"
+msgstr "%d/%d жаңартылуда…"
+
+#: app/flatpak-cli-transaction.c:428
+msgid "Uninstalling…"
+msgstr "Өшірілуде…"
+
+#: app/flatpak-cli-transaction.c:430
+#, c-format
+msgid "Uninstalling %d/%d…"
+msgstr "%d/%d өшірілуде…"
+
+#: app/flatpak-cli-transaction.c:496 app/flatpak-quiet-transaction.c:161
+#, c-format
+msgid "Info: %s was skipped"
+msgstr "Ақпарат: %s өткізіліп жіберілді"
+
+#: app/flatpak-cli-transaction.c:519
+#, c-format
+msgid "Warning: %s%s%s already installed"
+msgstr "Ескерту: %s%s%s қазірдің өзінде орнатылған"
+
+#: app/flatpak-cli-transaction.c:522
+#, c-format
+msgid "Error: %s%s%s already installed"
+msgstr "Қате: %s%s%s қазірдің өзінде орнатылған"
+
+#: app/flatpak-cli-transaction.c:528
+#, c-format
+msgid "Warning: %s%s%s not installed"
+msgstr "Ескерту: %s%s%s орнатылмаған"
+
+#: app/flatpak-cli-transaction.c:531
+#, c-format
+msgid "Error: %s%s%s not installed"
+msgstr "Қате: %s%s%s орнатылмаған"
+
+#: app/flatpak-cli-transaction.c:537
+#, c-format
+msgid "Warning: %s%s%s needs a later flatpak version"
+msgstr "Ескерту: %s%s%s үшін кейінгі flatpak нұсқасы қажет"
+
+#: app/flatpak-cli-transaction.c:540
+#, c-format
+msgid "Error: %s%s%s needs a later flatpak version"
+msgstr "Қате: %s%s%s үшін кейінгі flatpak нұсқасы қажет"
+
+#: app/flatpak-cli-transaction.c:546
+msgid "Warning: Not enough disk space to complete this operation"
+msgstr "Ескерту: Бұл операцияны аяқтау үшін дискіде орын жеткіліксіз"
+
+#: app/flatpak-cli-transaction.c:548
+msgid "Error: Not enough disk space to complete this operation"
+msgstr "Қате: Бұл операцияны аяқтау үшін дискіде орын жеткіліксіз"
+
+#: app/flatpak-cli-transaction.c:553
+#, c-format
+msgid "Warning: %s"
+msgstr "Ескерту: %s"
+
+#: app/flatpak-cli-transaction.c:555
+#, c-format
+msgid "Error: %s"
+msgstr "Қате: %s"
+
+#: app/flatpak-cli-transaction.c:570
+#, c-format
+msgid "Failed to install %s%s%s: "
+msgstr "%s%s%s орнату сәтсіз аяқталды: "
+
+#: app/flatpak-cli-transaction.c:577
+#, c-format
+msgid "Failed to update %s%s%s: "
+msgstr "%s%s%s жаңарту сәтсіз аяқталды: "
+
+#: app/flatpak-cli-transaction.c:584
+#, c-format
+msgid "Failed to install bundle %s%s%s: "
+msgstr "%s%s%s дестесін орнату сәтсіз аяқталды: "
+
+#: app/flatpak-cli-transaction.c:591
+#, c-format
+msgid "Failed to uninstall %s%s%s: "
+msgstr "%s%s%s өшіру сәтсіз аяқталды: "
+
+#: app/flatpak-cli-transaction.c:642
+#, c-format
+msgid "Authentication required for remote '%s'\n"
+msgstr "'%s' қашықтағы репозиторийі үшін аутентификация қажет\n"
+
+#: app/flatpak-cli-transaction.c:643
+msgid "Open browser?"
+msgstr "Браузерді ашу керек пе?"
+
+#: app/flatpak-cli-transaction.c:699
+#, c-format
+msgid "Login required remote %s (realm %s)\n"
+msgstr "%s қашықтағы репозиторийі үшін кіру қажет (realm %s)\n"
+
+#: app/flatpak-cli-transaction.c:704
+msgid "Password"
+msgstr "Пароль"
+
+#. Only runtimes can be pinned
+#: app/flatpak-cli-transaction.c:759
+#, c-format
+msgid ""
+"\n"
+"Info: (pinned) runtime %s%s%s branch %s%s%s is end-of-life, in favor of "
+"%s%s%s branch %s%s%s\n"
+msgstr ""
+"\n"
+"Ақпарат: (бекітілген) %s%s%s орындалу ортасының %s%s%s тармағының қолдау "
+"мерзімі аяқталды, оның орнына %s%s%s орындалу ортасының %s%s%s тармағын "
+"қолданыңыз\n"
+
+#: app/flatpak-cli-transaction.c:765
+#, c-format
+msgid ""
+"\n"
+"Info: runtime %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch "
+"%s%s%s\n"
+msgstr ""
+"\n"
+"Ақпарат: %s%s%s орындалу ортасының %s%s%s тармағының қолдау мерзімі "
+"аяқталды, оның орнына %s%s%s орындалу ортасының %s%s%s тармағын қолданыңыз\n"
+
+#: app/flatpak-cli-transaction.c:768
+#, c-format
+msgid ""
+"\n"
+"Info: app %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch "
+"%s%s%s\n"
+msgstr ""
+"\n"
+"Ақпарат: %s%s%s қолданбасының %s%s%s тармағының қолдау мерзімі аяқталды, "
+"оның орнына %s%s%s қолданбасының %s%s%s тармағын қолданыңыз\n"
+
+#. Only runtimes can be pinned
+#: app/flatpak-cli-transaction.c:780
+#, c-format
+msgid ""
+"\n"
+"Info: (pinned) runtime %s%s%s branch %s%s%s is end-of-life, with reason:\n"
+msgstr ""
+"\n"
+"Ақпарат: (бекітілген) %s%s%s орындалу ортасының %s%s%s тармағының қолдау "
+"мерзімі аяқталды, себебі:\n"
+
+#: app/flatpak-cli-transaction.c:786
+#, c-format
+msgid ""
+"\n"
+"Info: runtime %s%s%s branch %s%s%s is end-of-life, with reason:\n"
+msgstr ""
+"\n"
+"Ақпарат: %s%s%s орындалу ортасының %s%s%s тармағының қолдау мерзімі "
+"аяқталды, себебі:\n"
+
+#: app/flatpak-cli-transaction.c:789
+#, c-format
+msgid ""
+"\n"
+"Info: app %s%s%s branch %s%s%s is end-of-life, with reason:\n"
+msgstr ""
+"\n"
+"Ақпарат: %s%s%s қолданбасының %s%s%s тармағының қолдау мерзімі аяқталды, "
+"себебі:\n"
+
+#: app/flatpak-cli-transaction.c:963
+msgid "Info: applications using this extension:\n"
+msgstr "Ақпарат: осы кеңейтуді қолданатын қолданбалар:\n"
+
+#: app/flatpak-cli-transaction.c:965
+msgid "Info: applications using this runtime:\n"
+msgstr "Ақпарат: осы орындалу ортасын қолданатын қолданбалар:\n"
+
+#: app/flatpak-cli-transaction.c:984
+msgid "Replace?"
+msgstr "Алмастыру керек пе?"
+
+#: app/flatpak-cli-transaction.c:987 app/flatpak-quiet-transaction.c:247
+msgid "Updating to rebased version\n"
+msgstr "Базасы ауыстырылған нұсқаға жаңартылуда\n"
+
+#: app/flatpak-cli-transaction.c:1011
+#, c-format
+msgid "Failed to rebase %s to %s: "
+msgstr "%s базасын %s мәніне ауыстыру сәтсіз аяқталды: "
+
+#: app/flatpak-cli-transaction.c:1277
+#, c-format
+msgid "New %s%s%s permissions:"
+msgstr "Жаңа %s%s%s рұқсаттары:"
+
+#: app/flatpak-cli-transaction.c:1279
+#, c-format
+msgid "%s%s%s permissions:"
+msgstr "%s%s%s рұқсаттары:"
+
+#: app/flatpak-cli-transaction.c:1343
+msgid "Warning: "
+msgstr "Ескерту: "
+
+#. translators: This is short for operation, the title of a one-char column
+#: app/flatpak-cli-transaction.c:1442
+msgid "Op"
+msgstr "Оп"
+
+#. Avoid resizing the download column too much,
+#. * by making the title as long as typical content
+#.
+#: app/flatpak-cli-transaction.c:1458 app/flatpak-cli-transaction.c:1503
+msgid "partial"
+msgstr "жартылай"
+
+#: app/flatpak-cli-transaction.c:1535
+msgid "Proceed with these changes to the user installation?"
+msgstr "Пайдаланушы орнатылымына осы өзгерістерді қолдану керек пе?"
+
+#: app/flatpak-cli-transaction.c:1537
+msgid "Proceed with these changes to the system installation?"
+msgstr "Жүйелік орнатылымға осы өзгерістерді қолдану керек пе?"
+
+#: app/flatpak-cli-transaction.c:1539
+#, c-format
+msgid "Proceed with these changes to the %s?"
+msgstr "%s орнатылымына осы өзгерістерді қолдану керек пе?"
+
+#: app/flatpak-cli-transaction.c:1711
+msgid "Changes complete."
+msgstr "Өзгерістер аяқталды."
+
+#: app/flatpak-cli-transaction.c:1713
+msgid "Uninstall complete."
+msgstr "Өшіру аяқталды."
+
+#: app/flatpak-cli-transaction.c:1715
+msgid "Installation complete."
+msgstr "Орнату аяқталды."
+
+#: app/flatpak-cli-transaction.c:1717
+msgid "Updates complete."
+msgstr "Жаңартулар аяқталды."
+
+#. For updates/!stop_on_first_error we already printed all errors so we make up
+#. a different one.
+#: app/flatpak-cli-transaction.c:1750
+msgid "There were one or more errors"
+msgstr "Бір немесе бірнеше қателер болды"
+
+#. translators: please keep the leading space
+#: app/flatpak-main.c:76
+msgid " Manage installed applications and runtimes"
+msgstr " Орнатылған қолданбалар мен орындалу орталарын басқару"
+
+#: app/flatpak-main.c:77
+msgid "Install an application or runtime"
+msgstr "Қолданбаны немесе орындалу ортасын орнату"
+
+#: app/flatpak-main.c:78
+msgid "Update an installed application or runtime"
+msgstr "Орнатылған қолданбаны немесе орындалу ортасын жаңарту"
+
+#: app/flatpak-main.c:81
+msgid "Uninstall an installed application or runtime"
+msgstr "Орнатылған қолданбаны немесе орындалу ортасын өшіру"
+
+#: app/flatpak-main.c:84
+msgid "Mask out updates and automatic installation"
+msgstr "Жаңартулар мен автоматты орнатуды маскалау"
+
+#: app/flatpak-main.c:85
+msgid "Pin a runtime to prevent automatic removal"
+msgstr "Автоматты өшіруді болдырмау үшін орындалу ортасын бекіту"
+
+#: app/flatpak-main.c:86
+msgid "List installed apps and/or runtimes"
+msgstr "Орнатылған қолданбаларды және/немесе орындалу орталарын тізімдеу"
+
+#: app/flatpak-main.c:87
+msgid "Show info for installed app or runtime"
+msgstr "Орнатылған қолданба немесе орындалу ортасы туралы ақпаратты көрсету"
+
+#: app/flatpak-main.c:88
+msgid "Show history"
+msgstr "Тарихты көрсету"
+
+#: app/flatpak-main.c:89
+msgid "Configure flatpak"
+msgstr "Flatpak баптау"
+
+#: app/flatpak-main.c:90
+msgid "Repair flatpak installation"
+msgstr "Flatpak орнатылымын жөндеу"
+
+#: app/flatpak-main.c:91
+msgid "Put applications or runtimes onto removable media"
+msgstr "Қолданбаларды немесе орындалу орталарын алынбалы тасымалдағышқа салу"
+
+#: app/flatpak-main.c:92
+msgid "Install flatpaks that are part of the operating system"
+msgstr "Операциялық жүйенің бөлігі болып табылатын flatpak-тарды орнату"
+
+#. translators: please keep the leading newline and space
+#: app/flatpak-main.c:95
+msgid ""
+"\n"
+" Find applications and runtimes"
+msgstr ""
+"\n"
+" Қолданбалар мен орындалу орталарын табу"
+
+#: app/flatpak-main.c:96
+msgid "Search for remote apps/runtimes"
+msgstr "Қашықтағы қолданбаларды/орындалу орталарын іздеу"
+
+#. translators: please keep the leading newline and space
+#: app/flatpak-main.c:99
+msgid ""
+"\n"
+" Manage running applications"
+msgstr ""
+"\n"
+" Жұмыс істеп тұрған қолданбаларды басқару"
+
+#: app/flatpak-main.c:100
+msgid "Run an application"
+msgstr "Қолданбаны орындау"
+
+#: app/flatpak-main.c:101
+msgid "Override permissions for an application"
+msgstr "Қолданба рұқсаттарын қайта анықтау"
+
+#: app/flatpak-main.c:102
+msgid "Specify default version to run"
+msgstr "Орындау үшін бастапқы нұсқаны көрсету"
+
+#: app/flatpak-main.c:103
+msgid "Enter the namespace of a running application"
+msgstr "Жұмыс істеп тұрған қолданбаның атау кеңістігіне кіру"
+
+#: app/flatpak-main.c:104
+msgid "Enumerate running applications"
+msgstr "Жұмыс істеп тұрған қолданбаларды санап шығу"
+
+#: app/flatpak-main.c:105
+msgid "Stop a running application"
+msgstr "Жұмыс істеп тұрған қолданбаны тоқтату"
+
+#. translators: please keep the leading newline and space
+#: app/flatpak-main.c:108
+msgid ""
+"\n"
+" Manage file access"
+msgstr ""
+"\n"
+" Файлға қол жеткізуді басқару"
+
+#: app/flatpak-main.c:109
+msgid "List exported files"
+msgstr "Экспортталған файлдарды тізімдеу"
+
+#: app/flatpak-main.c:110
+msgid "Grant an application access to a specific file"
+msgstr "Қолданбаға арнайы файлға қол жеткізу рұқсатын беру"
+
+#: app/flatpak-main.c:111
+msgid "Revoke access to a specific file"
+msgstr "Арнайы файлға қол жеткізу рұқсатын қайтарып алу"
+
+#: app/flatpak-main.c:112
+msgid "Show information about a specific file"
+msgstr "Арнайы файл туралы ақпаратты көрсету"
+
+#. translators: please keep the leading newline and space
+#: app/flatpak-main.c:116
+msgid ""
+"\n"
+" Manage dynamic permissions"
+msgstr ""
+"\n"
+" Динамикалық рұқсаттарды басқару"
+
+#: app/flatpak-main.c:117
+msgid "List permissions"
+msgstr "Рұқсаттарды тізімдеу"
+
+#: app/flatpak-main.c:118
+msgid "Remove item from permission store"
+msgstr "Элементті рұқсаттар қоймасынан өшіру"
+
+#: app/flatpak-main.c:120
+msgid "Set permissions"
+msgstr "Рұқсаттарды орнату"
+
+#: app/flatpak-main.c:121
+msgid "Show app permissions"
+msgstr "Қолданба рұқсаттарын көрсету"
+
+#: app/flatpak-main.c:122
+msgid "Reset app permissions"
+msgstr "Қолданба рұқсаттарын тастау"
+
+#. translators: please keep the leading newline and space
+#: app/flatpak-main.c:125
+msgid ""
+"\n"
+" Manage remote repositories"
+msgstr ""
+"\n"
+" Қашықтағы репозиторийлерді басқару"
+
+#: app/flatpak-main.c:126
+msgid "List all configured remotes"
+msgstr "Барлық конфигурацияланған қашықтағы репозиторийлерді тізімдеу"
+
+#: app/flatpak-main.c:127
+msgid "Add a new remote repository (by URL)"
+msgstr "Жаңа қашықтағы репозиторий қосу (URL арқылы)"
+
+#: app/flatpak-main.c:128
+msgid "Modify properties of a configured remote"
+msgstr "Конфигурацияланған қашықтағы репозиторийдің қасиеттерін өзгерту"
+
+#: app/flatpak-main.c:129
+msgid "Delete a configured remote"
+msgstr "Конфигурацияланған қашықтағы репозиторийді өшіру"
+
+#: app/flatpak-main.c:131
+msgid "List contents of a configured remote"
+msgstr "Конфигурацияланған қашықтағы репозиторийдің мазмұнын тізімдеу"
+
+#: app/flatpak-main.c:132
+msgid "Show information about a remote app or runtime"
+msgstr "Қашықтағы қолданба немесе орындалу ортасы туралы ақпаратты көрсету"
+
+#. translators: please keep the leading newline and space
+#: app/flatpak-main.c:135
+msgid ""
+"\n"
+" Build applications"
+msgstr ""
+"\n"
+" Қолданбаларды құрастыру"
+
+#: app/flatpak-main.c:136
+msgid "Initialize a directory for building"
+msgstr "Құрастыру үшін буманы инициализациялау"
+
+#: app/flatpak-main.c:137
+msgid "Run a build command inside the build dir"
+msgstr "Құрастыру бумасының ішінде құрастыру командасын орындау"
+
+#: app/flatpak-main.c:138
+msgid "Finish a build dir for export"
+msgstr "Экспорттау үшін құрастыру бумасын аяқтау"
+
+#: app/flatpak-main.c:139
+msgid "Export a build dir to a repository"
+msgstr "Құрастыру бумасын репозиторийге экспорттау"
+
+#: app/flatpak-main.c:140
+msgid "Create a bundle file from a ref in a local repository"
+msgstr "Жергілікті репозиторийдегі сілтемеден десте файлын жасау"
+
+#: app/flatpak-main.c:141
+msgid "Import a bundle file"
+msgstr "Десте файлын импорттау"
+
+#: app/flatpak-main.c:142
+msgid "Sign an application or runtime"
+msgstr "Қолданбаға немесе орындалу ортасына қол қою"
+
+#: app/flatpak-main.c:143
+msgid "Update the summary file in a repository"
+msgstr "Репозиторийдегі жиынтық файлын жаңарту"
+
+#: app/flatpak-main.c:144
+msgid "Create new commit based on existing ref"
+msgstr "Бар сілтеме негізінде жаңа коммит жасау"
+
+#: app/flatpak-main.c:145
+msgid "Show information about a repo"
+msgstr "Репо туралы ақпаратты көрсету"
+
+#: app/flatpak-main.c:162
+msgid "Show debug information, -vv for more detail"
+msgstr "Жөндеу ақпаратын көрсету, толығырақ мәлімет үшін -vv қолданыңыз"
+
+#: app/flatpak-main.c:163
+msgid "Show OSTree debug information"
+msgstr "OSTree жөндеу ақпаратын көрсету"
+
+#: app/flatpak-main.c:169
+msgid "Print version information and exit"
+msgstr "Нұсқа ақпаратын шығару және шығу"
+
+#: app/flatpak-main.c:170
+msgid "Print default arch and exit"
+msgstr "Бастапқы архитектураны шығару және шығу"
+
+#: app/flatpak-main.c:171
+msgid "Print supported arches and exit"
+msgstr "Қолдау көрсетілетін архитектураларды шығару және шығу"
+
+#: app/flatpak-main.c:172
+msgid "Print active gl drivers and exit"
+msgstr "Белсенді gl драйверлерін шығару және шығу"
+
+#: app/flatpak-main.c:173
+msgid "Print paths for system installations and exit"
+msgstr "Жүйелік орнатылымдардың жолдарын шығару және шығу"
+
+#: app/flatpak-main.c:174
+msgid "Print the updated environment needed to run flatpaks"
+msgstr "Flatpak-тарды орындау үшін қажетті жаңартылған ортаны шығару"
+
+#: app/flatpak-main.c:175
+msgid "Only include the system installation with --print-updated-env"
+msgstr "--print-updated-env опциясымен тек жүйелік орнатылымды қосу"
+
+#: app/flatpak-main.c:180
+msgid "Work on the user installation"
+msgstr "Пайдаланушы орнатылымымен жұмыс істеу"
+
+#: app/flatpak-main.c:181
+msgid "Work on the system-wide installation (default)"
+msgstr "Жүйелік орнатылыммен жұмыс істеу (бастапқы)"
+
+#: app/flatpak-main.c:182
+msgid "Work on a non-default system-wide installation"
+msgstr "Бастапқы емес жүйелік орнатылыммен жұмыс істеу"
+
+#: app/flatpak-main.c:212
+msgid "Builtin Commands:"
+msgstr "Кірістірілген командалар:"
+
+#: app/flatpak-main.c:298
+#, c-format
+msgid ""
+"Note that the directories %s are not in the search path set by the "
+"XDG_DATA_DIRS environment variable, so applications installed by Flatpak may "
+"not appear on your desktop until the session is restarted."
+msgstr ""
+"%s бумалары XDG_DATA_DIRS орта айнымалысы арқылы орнатылған іздеу жолында "
+"жоқ екенін ескеріңіз, сондықтан Flatpak арқылы орнатылған қолданбалар сессия "
+"қайта іске қосылғанша жұмыс үстеліңізде көрінбеуі мүмкін."
+
+#: app/flatpak-main.c:312
+#, c-format
+msgid ""
+"Note that the directory %s is not in the search path set by the "
+"XDG_DATA_DIRS environment variable, so applications installed by Flatpak may "
+"not appear on your desktop until the session is restarted."
+msgstr ""
+"%s бумасы XDG_DATA_DIRS орта айнымалысы арқылы орнатылған іздеу жолында жоқ "
+"екенін ескеріңіз, сондықтан Flatpak арқылы орнатылған қолданбалар сессия "
+"қайта іске қосылғанша жұмыс үстеліңізде көрінбеуі мүмкін."
+
+#: app/flatpak-main.c:381
+msgid ""
+"Refusing to operate under sudo with --user. Omit sudo to operate on the user "
+"installation, or use a root shell to operate on the root user's installation."
+msgstr ""
+"--user опциясымен sudo астында жұмыс істеуден бас тартылды. Пайдаланушы "
+"орнатылымында жұмыс істеу үшін sudo-ны алып тастаңыз немесе әкімші "
+"пайдаланушының орнатылымында жұмыс істеу үшін әкімші қоршамын қолданыңыз."
+
+#: app/flatpak-main.c:453
+msgid ""
+"Multiple installations specified for a command that works on one installation"
+msgstr ""
+"Бір орнатылымда жұмыс істейтін команда үшін бірнеше орнатылым көрсетілді"
+
+#: app/flatpak-main.c:504 app/flatpak-main.c:697
+#, c-format
+msgid "See '%s --help'"
+msgstr "'%s --help' қараңыз"
+
+#: app/flatpak-main.c:706
+#, c-format
+msgid "'%s' is not a flatpak command. Did you mean '%s%s'?"
+msgstr "'%s' flatpak командасы емес. Сіздің ойлағаныңыз '%s%s' бе?"
+
+#: app/flatpak-main.c:709
+#, c-format
+msgid "'%s' is not a flatpak command"
+msgstr "'%s' flatpak командасы емес"
+
+#: app/flatpak-main.c:824
+msgid "No command specified"
+msgstr "Команда көрсетілмеген"
+
+#: app/flatpak-main.c:980
+msgid "error:"
+msgstr "қате:"
+
+#: app/flatpak-quiet-transaction.c:77
+#, c-format
+msgid "Installing %s\n"
+msgstr "%s орнатылуда\n"
+
+#: app/flatpak-quiet-transaction.c:81
+#, c-format
+msgid "Updating %s\n"
+msgstr "%s жаңартылуда\n"
+
+#: app/flatpak-quiet-transaction.c:85
+#, c-format
+msgid "Uninstalling %s\n"
+msgstr "%s өшірілуде\n"
+
+#: app/flatpak-quiet-transaction.c:107
+#, c-format
+msgid "Warning: Failed to install %s: %s\n"
+msgstr "Ескерту: %s орнату сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:110
+#, c-format
+msgid "Error: Failed to install %s: %s\n"
+msgstr "Қате: %s орнату сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:116
+#, c-format
+msgid "Warning: Failed to update %s: %s\n"
+msgstr "Ескерту: %s жаңарту сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:119
+#, c-format
+msgid "Error: Failed to update %s: %s\n"
+msgstr "Қате: %s жаңарту сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:125
+#, c-format
+msgid "Warning: Failed to install bundle %s: %s\n"
+msgstr "Ескерту: %s дестесін орнату сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:128
+#, c-format
+msgid "Error: Failed to install bundle %s: %s\n"
+msgstr "Қате: %s дестесін орнату сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:134
+#, c-format
+msgid "Warning: Failed to uninstall %s: %s\n"
+msgstr "Ескерту: %s өшіру сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:137
+#, c-format
+msgid "Error: Failed to uninstall %s: %s\n"
+msgstr "Қате: %s өшіру сәтсіз аяқталды: %s\n"
+
+#: app/flatpak-quiet-transaction.c:166 common/flatpak-dir.c:11435
+#, c-format
+msgid "%s already installed"
+msgstr "%s қазірдің өзінде орнатылған"
+
+#: app/flatpak-quiet-transaction.c:168 common/flatpak-dir.c:3609
+#: common/flatpak-dir.c:4308 common/flatpak-dir.c:16891
+#: common/flatpak-dir.c:17181 common/flatpak-dir-utils.c:166
+#: common/flatpak-dir-utils.c:259 common/flatpak-transaction.c:2736
+#: common/flatpak-transaction.c:2791
+#, c-format
+msgid "%s not installed"
+msgstr "%s орнатылмаған"
+
+#: app/flatpak-quiet-transaction.c:170
+#, c-format
+msgid "%s needs a later flatpak version"
+msgstr "%s үшін кейінгі flatpak нұсқасы қажет"
+
+#: app/flatpak-quiet-transaction.c:172
+msgid "Not enough disk space to complete this operation"
+msgstr "Бұл операцияны аяқтау үшін дискіде орын жеткіліксіз"
+
+#: app/flatpak-quiet-transaction.c:239
+#, c-format
+msgid "Info: %s is end-of-life, in favor of %s\n"
+msgstr "Ақпарат: %s қолдау мерзімі аяқталған, оның орнына %s қолданыңыз\n"
+
+#: app/flatpak-quiet-transaction.c:241
+#, c-format
+msgid "Info: %s is end-of-life, with reason: %s\n"
+msgstr "Ақпарат: %s қолдау мерзімі аяқталған, себебі: %s\n"
+
+#: app/flatpak-quiet-transaction.c:251
+#, c-format
+msgid "Failed to rebase %s to %s: %s\n"
+msgstr "%s базасын %s мәніне ауыстыру сәтсіз аяқталды: %s\n"
+
+#: common/flatpak-auth.c:58
+#, c-format
+msgid "No authenticator configured for remote `%s`"
+msgstr ""
+"‘%s’ қашықтағы репозиторийі үшін ешқандай аутентификатор конфигурацияланбаған"
+
+#: common/flatpak-context.c:717 common/flatpak-context.c:729
+#, c-format
+msgid "Invalid permission syntax: %s"
+msgstr "Рұқсат синтаксисі жарамсыз: %s"
+
+#: common/flatpak-context.c:1249
+#, c-format
+msgid "Unknown share type %s, valid types are: %s"
+msgstr "Бөлісу түрі %s белгісіз, жарамды түрлері: %s"
+
+#: common/flatpak-context.c:1270
+#, c-format
+msgid "Unknown policy type %s, valid types are: %s"
+msgstr "Саясат түрі %s белгісіз, жарамды түрлері: %s"
+
+#: common/flatpak-context.c:1308
+#, c-format
+msgid "Invalid dbus name %s"
+msgstr "dbus атауы жарамсыз: %s"
+
+#: common/flatpak-context.c:1321
+#, c-format
+msgid "Unknown socket type %s, valid types are: %s"
+msgstr "Сокет түрі %s белгісіз, жарамды түрлері: %s"
+
+#: common/flatpak-context.c:1336
+#, c-format
+msgid "Unknown device type %s, valid types are: %s"
+msgstr "Құрылғы түрі %s белгісіз, жарамды түрлері: %s"
+
+#: common/flatpak-context.c:1350
+#, c-format
+msgid "Unknown feature type %s, valid types are: %s"
+msgstr "Мүмкіндік түрі %s белгісіз, жарамды түрлері: %s"
+
+#: common/flatpak-context.c:1882
+#, c-format
+msgid "Filesystem location \"%s\" contains \"..\""
+msgstr "Файлдық жүйе орны \"%s\" құрамында \"..\" бар"
+
+#: common/flatpak-context.c:1924
+msgid ""
+"--filesystem=/ is not available, use --filesystem=host for a similar result"
+msgstr ""
+"--filesystem=/ қолжетімді емес, ұқсас нәтиже үшін --filesystem=host "
+"қолданыңыз"
+
+#: common/flatpak-context.c:1958
+#, c-format
+msgid ""
+"Unknown filesystem location %s, valid locations are: host, host-os, host-"
+"etc, host-root, home, xdg-*[/…], ~/dir, /dir"
+msgstr ""
+"Файлдық жүйе орны %s белгісіз, жарамды орындар: host, host-os, host-etc, "
+"host-root, home, xdg-*[/…], ~/бума, /бума"
+
+#: common/flatpak-context.c:2057
+#, c-format
+msgid "Invalid syntax for %s: %s"
+msgstr "%s үшін синтаксис жарамсыз: %s"
+
+#: common/flatpak-context.c:2199
+msgid "fallback-x11 can not be conditional"
+msgstr "fallback-x11 шартты бола алмайды"
+
+#: common/flatpak-context.c:2375
+#, c-format
+msgid "Invalid env format %s"
+msgstr "Орта айнымалысының пішімі жарамсыз: %s"
+
+#: common/flatpak-context.c:2463
+#, c-format
+msgid "Environment variable name must not contain '=': %s"
+msgstr "Орта айнымалысының атауында '=' болмауы тиіс: %s"
+
+#: common/flatpak-context.c:2591 common/flatpak-context.c:2599
+msgid "--add-policy arguments must be in the form SUBSYSTEM.KEY=VALUE"
+msgstr "--add-policy аргументтері ІШКІ_ЖҮЙЕ.КІЛТ=МӘНІ түрінде болуы тиіс"
+
+#: common/flatpak-context.c:2606
+msgid "--add-policy values can't start with \"!\""
+msgstr "--add-policy мәндері \"!\" таңбасынан басталмауы тиіс"
+
+#: common/flatpak-context.c:2631 common/flatpak-context.c:2639
+msgid "--remove-policy arguments must be in the form SUBSYSTEM.KEY=VALUE"
+msgstr "--remove-policy аргументтері ІШКІ_ЖҮЙЕ.КІЛТ=МӘНІ түрінде болуы тиіс"
+
+#: common/flatpak-context.c:2646
+msgid "--remove-policy values can't start with \"!\""
+msgstr "--remove-policy мәндері \"!\" таңбасынан басталмауы тиіс"
+
+#: common/flatpak-context.c:2721
+msgid "Share with host"
+msgstr "Хостпен бөлісу"
+
+#: common/flatpak-context.c:2721 common/flatpak-context.c:2722
+msgid "SHARE"
+msgstr "БӨЛІСУ"
+
+#: common/flatpak-context.c:2722
+msgid "Unshare with host"
+msgstr "Хостпен бөлісуді тоқтату"
+
+#: common/flatpak-context.c:2723
+msgid "Require conditions to be met for a subsystem to get shared"
+msgstr "Ішкі жүйені бөлісу үшін шарттардың орындалуын талап ету"
+
+#: common/flatpak-context.c:2723
+msgid "SHARE:CONDITION"
+msgstr "БӨЛІСУ:ШАРТ"
+
+#: common/flatpak-context.c:2724
+msgid "Expose socket to app"
+msgstr "Сокетті қолданбаға ашу"
+
+#: common/flatpak-context.c:2724 common/flatpak-context.c:2725
+msgid "SOCKET"
+msgstr "СОКЕТ"
+
+#: common/flatpak-context.c:2725
+msgid "Don't expose socket to app"
+msgstr "Сокетті қолданбаға ашпау"
+
+#: common/flatpak-context.c:2726
+msgid "Require conditions to be met for a socket to get exposed"
+msgstr "Сокетті ашу үшін шарттардың орындалуын талап ету"
+
+#: common/flatpak-context.c:2726
+msgid "SOCKET:CONDITION"
+msgstr "СОКЕТ:ШАРТ"
+
+#: common/flatpak-context.c:2727
+msgid "Expose device to app"
+msgstr "Құрылғыны қолданбаға ашу"
+
+#: common/flatpak-context.c:2727 common/flatpak-context.c:2728
+msgid "DEVICE"
+msgstr "ҚҰРЫЛҒЫ"
+
+#: common/flatpak-context.c:2728
+msgid "Don't expose device to app"
+msgstr "Құрылғыны қолданбаға ашпау"
+
+#: common/flatpak-context.c:2729
+msgid "Require conditions to be met for a device to get exposed"
+msgstr "Құрылғыны ашу үшін шарттардың орындалуын талап ету"
+
+#: common/flatpak-context.c:2729
+msgid "DEVICE:CONDITION"
+msgstr "ҚҰРЫЛҒЫ:ШАРТ"
+
+#: common/flatpak-context.c:2730
+msgid "Allow feature"
+msgstr "Мүмкіндікке рұқсат беру"
+
+#: common/flatpak-context.c:2730 common/flatpak-context.c:2731
+msgid "FEATURE"
+msgstr "МҮМКІНДІК"
+
+#: common/flatpak-context.c:2731
+msgid "Don't allow feature"
+msgstr "Мүмкіндікке рұқсат бермеу"
+
+#: common/flatpak-context.c:2732
+msgid "Require conditions to be met for a feature to get allowed"
+msgstr "Мүмкіндікке рұқсат беру үшін шарттардың орындалуын талап ету"
+
+#: common/flatpak-context.c:2732
+msgid "FEATURE:CONDITION"
+msgstr "МҮМКІНДІК:ШАРТ"
+
+#: common/flatpak-context.c:2733
+msgid "Expose filesystem to app (:ro for read-only)"
+msgstr "Файлдық жүйені қолданбаға ашу (тек оқу үшін :ro)"
+
+#: common/flatpak-context.c:2733
+msgid "FILESYSTEM[:ro]"
+msgstr "ФАЙЛДЫҚ_ЖҮЙЕ[:ro]"
+
+#: common/flatpak-context.c:2734
+msgid "Don't expose filesystem to app"
+msgstr "Файлдық жүйені қолданбаға ашпау"
+
+#: common/flatpak-context.c:2734
+msgid "FILESYSTEM"
+msgstr "ФАЙЛДЫҚ_ЖҮЙЕ"
+
+#: common/flatpak-context.c:2735
+msgid "Set environment variable"
+msgstr "Орта айнымалысын орнату"
+
+#: common/flatpak-context.c:2735
+msgid "VAR=VALUE"
+msgstr "АЙНЫМАЛЫ=МӘН"
+
+#: common/flatpak-context.c:2736
+msgid "Read environment variables in env -0 format from FD"
+msgstr "Орта айнымалыларын FD-дан env -0 пішімінде оқу"
+
+#: common/flatpak-context.c:2736
+msgid "FD"
+msgstr "FD"
+
+#: common/flatpak-context.c:2737
+msgid "Remove variable from environment"
+msgstr "Айнымалыны ортадан өшіру"
+
+#: common/flatpak-context.c:2737
+msgid "VAR"
+msgstr "АЙНЫМАЛЫ"
+
+#: common/flatpak-context.c:2738
+msgid "Allow app to own name on the session bus"
+msgstr "Қолданбаға сессия шинасында атау иеленуге рұқсат беру"
+
+#: common/flatpak-context.c:2738 common/flatpak-context.c:2739
+#: common/flatpak-context.c:2740 common/flatpak-context.c:2741
+#: common/flatpak-context.c:2742 common/flatpak-context.c:2743
+#: common/flatpak-context.c:2744
+msgid "DBUS_NAME"
+msgstr "DBUS_АТАУЫ"
+
+#: common/flatpak-context.c:2739
+msgid "Allow app to talk to name on the session bus"
+msgstr "Қолданбаға сессия шинасындағы атаумен сөйлесуге рұқсат беру"
+
+#: common/flatpak-context.c:2740
+msgid "Don't allow app to talk to name on the session bus"
+msgstr "Қолданбаға сессия шинасындағы атаумен сөйлесуге рұқсат бермеу"
+
+#: common/flatpak-context.c:2741
+msgid "Allow app to own name on the system bus"
+msgstr "Қолданбаға жүйелік шинада атау иеленуге рұқсат беру"
+
+#: common/flatpak-context.c:2742
+msgid "Allow app to talk to name on the system bus"
+msgstr "Қолданбаға жүйелік шинадағы атаумен сөйлесуге рұқсат беру"
+
+#: common/flatpak-context.c:2743
+msgid "Don't allow app to talk to name on the system bus"
+msgstr "Қолданбаға жүйелік шинадағы атаумен сөйлесуге рұқсат бермеу"
+
+#: common/flatpak-context.c:2744
+msgid "Allow app to own name on the a11y bus"
+msgstr "Қолданбаға a11y шинасында атау иеленуге рұқсат беру"
+
+#: common/flatpak-context.c:2745
+msgid "Add generic policy option"
+msgstr "Жалпы саясат опциясын қосу"
+
+#: common/flatpak-context.c:2745 common/flatpak-context.c:2746
+msgid "SUBSYSTEM.KEY=VALUE"
+msgstr "ІШКІ_ЖҮЙЕ.КІЛТ=МӘНІ"
+
+#: common/flatpak-context.c:2746
+msgid "Remove generic policy option"
+msgstr "Жалпы саясат опциясын өшіру"
+
+#: common/flatpak-context.c:2747
+msgid "Add USB device to enumerables"
+msgstr "USB құрылғысын санаулыларға қосу"
+
+#: common/flatpak-context.c:2747 common/flatpak-context.c:2748
+msgid "VENDOR_ID:PRODUCT_ID"
+msgstr "ӨНДІРУШІ_ID:ӨНІМ_ID"
+
+#: common/flatpak-context.c:2748
+msgid "Add USB device to hidden list"
+msgstr "USB құрылғысын жасырын тізімге қосу"
+
+#: common/flatpak-context.c:2749
+msgid "A list of USB devices that are enumerable"
+msgstr "Саналатын USB құрылғыларының тізімі"
+
+#: common/flatpak-context.c:2749
+msgid "LIST"
+msgstr "ТІЗІМ"
+
+#: common/flatpak-context.c:2750
+msgid "File containing a list of USB devices to make enumerable"
+msgstr "Саналатын USB құрылғыларының тізімі бар файл"
+
+#: common/flatpak-context.c:2750 common/flatpak-context.c:2751
+msgid "FILENAME"
+msgstr "ФАЙЛ_АТАУЫ"
+
+#: common/flatpak-context.c:2751
+msgid "Persist home directory subpath"
+msgstr "Үй бумасының ішкі жолын тұрақты ету"
+
+#. This is not needed/used anymore, so hidden, but we accept it for backwards compat
+#: common/flatpak-context.c:2753
+msgid "Don't require a running session (no cgroups creation)"
+msgstr "Жұмыс істеп тұрған сессияны талап етпеу (cgroups жасалмауы)"
+
+#: common/flatpak-context.c:3784
+#, c-format
+msgid "Not replacing \"%s\" with tmpfs: %s"
+msgstr "\"%s\" мәні tmpfs-пен алмастырылмайды: %s"
+
+#: common/flatpak-context.c:3792
+#, c-format
+msgid "Not sharing \"%s\" with sandbox: %s"
+msgstr "\"%s\" құмсалғышпен бөлісілмейді: %s"
+
+#. Even if the error is one that we would normally silence, like
+#. * the path not existing, it seems reasonable to make more of a fuss
+#. * about the home directory not existing or otherwise being unusable,
+#. * so this is intentionally not using cannot_export()
+#: common/flatpak-context.c:3894
+#, c-format
+msgid "Not allowing home directory access: %s"
+msgstr "Үй бумасына қол жеткізуге рұқсат берілмейді: %s"
+
+#: common/flatpak-context.c:4128
+#, c-format
+msgid "Unable to provide a temporary home directory in the sandbox: %s"
+msgstr "Құмсалғыш ішінде уақытша үй бумасын қамтамасыз ету мүмкін емес: %s"
+
+#: common/flatpak-dir.c:442
+#, c-format
+msgid "Configured collection ID ‘%s’ not in summary file"
+msgstr "Конфигурацияланған ‘%s’ коллекция ID-і жиынтық файлында жоқ"
+
+#: common/flatpak-dir.c:587
+#, c-format
+msgid "Unable to load summary from remote %s: %s"
+msgstr "%s қашықтағы репозиторийден жиынтықты жүктеу мүмкін емес: %s"
+
+#: common/flatpak-dir.c:764 common/flatpak-dir.c:800 common/flatpak-dir.c:906
+#, c-format
+msgid "No such ref '%s' in remote %s"
+msgstr "%2$s қашықтағы репозиторийінде '%1$s' сілтемесі жоқ"
+
+#: common/flatpak-dir.c:891 common/flatpak-dir.c:1051 common/flatpak-dir.c:1080
+#: common/flatpak-dir.c:1092
+#, c-format
+msgid "No entry for %s in remote %s summary flatpak cache"
+msgstr "%2$s қашықтағы жиынтығының flatpak кэшінде %1$s үшін жазба жоқ"
+
+#: common/flatpak-dir.c:1069
+#, c-format
+msgid "No summary or Flatpak cache available for remote %s"
+msgstr ""
+"%s қашықтағы репозиторийі үшін ешқандай жиынтық немесе Flatpak кэші "
+"қолжетімді емес"
+
+#: common/flatpak-dir.c:1097
+#, c-format
+msgid "Missing xa.data in summary for remote %s"
+msgstr "%s қашықтағы репозиторийдің жиынтығында xa.data жоқ"
+
+#: common/flatpak-dir.c:1103 common/flatpak-dir.c:1533
+#, c-format
+msgid "Unsupported summary version %d for remote %s"
+msgstr ""
+"%2$s қашықтағы репозиторийі үшін қолдау көрсетілмейтін жиынтық нұсқасы %1$d"
+
+#: common/flatpak-dir.c:1200
+msgid "Remote OCI index has no registry uri"
+msgstr "Қашықтағы OCI индексінде тіркеу uri-і жоқ"
+
+#: common/flatpak-dir.c:1261
+#, c-format
+msgid "Couldn't find ref %s in remote %s"
+msgstr "%2$s қашықтағы репозиторийден %1$s сілтемесі табылмады"
+
+#: common/flatpak-dir.c:1285 common/flatpak-dir.c:1369
+#, c-format
+msgid "Commit has no requested ref ‘%s’ in ref binding metadata"
+msgstr ""
+"Коммиттің сілтемелерді байланыстыру метадеректерінде сұралған ‘%s’ сілтемесі "
+"жоқ"
+
+#: common/flatpak-dir.c:1400
+#, c-format
+msgid "Configured collection ID ‘%s’ not in binding metadata"
+msgstr ""
+"Байланыстыру метадеректерінде конфигурацияланған ‘%s’ коллекция ID-і жоқ"
+
+#: common/flatpak-dir.c:1436 common/flatpak-dir.c:5612
+#, c-format
+msgid "Couldn't find latest checksum for ref %s in remote %s"
+msgstr ""
+"%2$s қашықтағы репозиторийден %1$s сілтемесі үшін соңғы бақылау сомасы "
+"табылмады"
+
+#: common/flatpak-dir.c:1503 common/flatpak-dir.c:1539
+#, c-format
+msgid "No entry for %s in remote %s summary flatpak sparse cache"
+msgstr "%2$s қашықтағы жиынтығының flatpak сирек кэшінде %1$s үшін жазба жоқ"
+
+#: common/flatpak-dir.c:2527
+#, c-format
+msgid "Commit metadata for %s not matching expected metadata"
+msgstr "%s үшін коммит метадеректері күтілген метадеректерге сәйкес келмейді"
+
+#: common/flatpak-dir.c:2810
+msgid "Unable to connect to system bus"
+msgstr "Жүйелік шинаға қосылу мүмкін емес"
+
+#: common/flatpak-dir.c:3406
+msgid "User installation"
+msgstr "Пайдаланушы орнатылымы"
+
+#: common/flatpak-dir.c:3413
+#, c-format
+msgid "System (%s) installation"
+msgstr "Жүйелік (%s) орнатылым"
+
+#: common/flatpak-dir.c:3459
+#, c-format
+msgid "No overrides found for %s"
+msgstr "%s үшін қайта анықтаулар табылмады"
+
+#: common/flatpak-dir.c:3612
+#, c-format
+msgid "%s (commit %s) not installed"
+msgstr "%s (%s коммиті) орнатылмаған"
+
+#: common/flatpak-dir.c:4635
+#, c-format
+msgid "Error parsing system flatpakrepo file for %s: %s"
+msgstr "%s үшін жүйелік flatpakrepo файлын өңдеу қатесі: %s"
+
+#: common/flatpak-dir.c:4710
+#, c-format
+msgid "While opening repository %s: "
+msgstr "%s репозиторийін ашу кезінде: "
+
+#: common/flatpak-dir.c:4971
+#, c-format
+msgid "The config key %s is not set"
+msgstr "%s конфигурация кілті орнатылмаған"
+
+#: common/flatpak-dir.c:5107
+#, c-format
+msgid "No current %s pattern matching %s"
+msgstr "%2$s-ге сәйкес келетін ағымдағы %1$s шаблоны жоқ"
+
+#: common/flatpak-dir.c:5389
+msgid "No appstream commit to deploy"
+msgstr "Орналастыратын appstream коммиті жоқ"
+
+#: common/flatpak-dir.c:5908 common/flatpak-dir.c:7221
+#: common/flatpak-dir.c:10841 common/flatpak-dir.c:11578
+msgid "Can't pull from untrusted non-gpg verified remote"
+msgstr ""
+"Сенімсіз, gpg арқылы тексерілмеген қашықтағы репозиторийден тарту мүмкін емес"
+
+#: common/flatpak-dir.c:6331 common/flatpak-dir.c:6546
+msgid "Extra data not supported for non-gpg-verified local system installs"
+msgstr ""
+"gpg-тексерілмеген жергілікті жүйелік орнатылымдар үшін қосымша деректерге "
+"қолдау көрсетілмейді"
+
+#: common/flatpak-dir.c:6370 common/flatpak-dir.c:6737
+#, c-format
+msgid "Invalid checksum for extra data uri %s"
+msgstr "%s қосымша деректер uri-і үшін бақылау сомасы жарамсыз"
+
+#: common/flatpak-dir.c:6379
+#, c-format
+msgid "Empty name for extra data uri %s"
+msgstr "%s қосымша деректер uri-і үшін атау бос"
+
+#: common/flatpak-dir.c:6387
+#, c-format
+msgid "Unsupported extra data uri %s"
+msgstr "Қолдау көрсетілмейтін %s қосымша деректер uri-і"
+
+#: common/flatpak-dir.c:6416
+#, c-format
+msgid "Failed to load local extra-data %s: %s"
+msgstr "Жергілікті %s қосымша деректерін жүктеу мүмкін емес: %s"
+
+#: common/flatpak-dir.c:6424
+#, c-format
+msgid "Wrong size for extra-data %s"
+msgstr "%s қосымша деректерінің өлшемі қате"
+
+#: common/flatpak-dir.c:6443
+#, c-format
+msgid "While downloading %s: "
+msgstr "%s жүктеп алу кезінде: "
+
+#: common/flatpak-dir.c:6453
+#, c-format
+msgid "Wrong size for extra data %s"
+msgstr "%s қосымша деректері үшін қате өлшем"
+
+#: common/flatpak-dir.c:6462
+#, c-format
+msgid "Invalid checksum for extra data %s"
+msgstr "%s қосымша деректері үшін бақылау сомасы жарамсыз"
+
+#: common/flatpak-dir.c:7051 common/flatpak-dir.c:7304
+#, c-format
+msgid "While pulling %s from remote %s: "
+msgstr "%2$s қашықтағы репозиторийден %1$s тарту кезінде: "
+
+#: common/flatpak-dir.c:7245 common/flatpak-repo-utils.c:3886
+msgid "GPG signatures found, but none are in trusted keyring"
+msgstr ""
+"GPG қолтаңбалары табылды, бірақ олардың ешқайсысы сенімді кілттер жинағында "
+"жоқ"
+
+#: common/flatpak-dir.c:7262
+#, c-format
+msgid "Commit for ‘%s’ has no ref binding"
+msgstr "‘%s’ коммитінде сілтеме байланысы жоқ"
+
+#: common/flatpak-dir.c:7267
+#, c-format
+msgid "Commit for ‘%s’ is not in expected bound refs: %s"
+msgstr "‘%s’ коммиті күтілген байланысты сілтемелерде жоқ: %s"
+
+#: common/flatpak-dir.c:7443
+msgid "Only applications can be made current"
+msgstr "Тек қолданбаларды ағымдағы етуге болады"
+
+#: common/flatpak-dir.c:8147
+msgid "Not enough memory"
+msgstr "Жад жеткіліксіз"
+
+#: common/flatpak-dir.c:8166
+msgid "Failed to read from exported file"
+msgstr "Экспортталған файлдан оқу сәтсіз аяқталды"
+
+#: common/flatpak-dir.c:8356
+msgid "Error reading mimetype xml file"
+msgstr "mimetype xml файлын оқу қатесі"
+
+#: common/flatpak-dir.c:8361
+msgid "Invalid mimetype xml file"
+msgstr "mimetype xml файлы жарамсыз"
+
+#: common/flatpak-dir.c:8447
+#, c-format
+msgid "D-Bus service file '%s' has wrong name"
+msgstr "'%s' D-Bus қызмет файлының атауы қате"
+
+#: common/flatpak-dir.c:8602
+#, c-format
+msgid "Invalid Exec argument %s"
+msgstr "Exec аргументі жарамсыз: %s"
+
+#: common/flatpak-dir.c:9070
+msgid "While getting detached metadata: "
+msgstr "Бөлінген метадеректерді алу кезінде: "
+
+#: common/flatpak-dir.c:9075 common/flatpak-dir.c:9080
+#: common/flatpak-dir.c:9084
+msgid "Extra data missing in detached metadata"
+msgstr "Бөлінген метадеректерде қосымша деректер жоқ"
+
+#: common/flatpak-dir.c:9088
+msgid "While creating extradir: "
+msgstr "extradir жасау кезінде: "
+
+#: common/flatpak-dir.c:9109 common/flatpak-dir.c:9142
+msgid "Invalid checksum for extra data"
+msgstr "Қосымша деректер үшін бақылау сомасы жарамсыз"
+
+#: common/flatpak-dir.c:9138
+msgid "Wrong size for extra data"
+msgstr "Қосымша деректер өлшемі қате"
+
+#: common/flatpak-dir.c:9151
+#, c-format
+msgid "While writing extra data file '%s': "
+msgstr "'%s' қосымша деректер файлын жазу кезінде: "
+
+#: common/flatpak-dir.c:9159
+#, c-format
+msgid "Extra data %s missing in detached metadata"
+msgstr "Бөлінген метадеректерде %s қосымша деректері жоқ"
+
+#: common/flatpak-dir.c:9257
+msgid "Unable to get runtime key from metadata"
+msgstr "Метадеректерден орындалу ортасы кілтін алу мүмкін емес"
+
+#: common/flatpak-dir.c:9371
+#, c-format
+msgid "apply_extra script failed, exit status %d"
+msgstr "apply_extra скрипті сәтсіз аяқталды, шығу күйі %d"
+
+#. Translators: The placeholder is for an app ref.
+#: common/flatpak-dir.c:9551
+#, c-format
+msgid "Installing %s is not allowed by the policy set by your administrator"
+msgstr "%s орнатуға әкімші орнатқан саясатпен рұқсат берілмеген"
+
+#: common/flatpak-dir.c:9650
+#, c-format
+msgid "While trying to resolve ref %s: "
+msgstr "%s сілтемесін шешу кезінде: "
+
+#: common/flatpak-dir.c:9662
+#, c-format
+msgid "%s is not available"
+msgstr "%s қолжетімді емес"
+
+#: common/flatpak-dir.c:9674 common/flatpak-dir.c:11455
+#, c-format
+msgid "%s commit %s already installed"
+msgstr "%s %s коммиті қазірдің өзінде орнатылған"
+
+#: common/flatpak-dir.c:9681
+msgid "Can't create deploy directory"
+msgstr "Орналастыру бумасын жасау мүмкін емес"
+
+#: common/flatpak-dir.c:9689
+#, c-format
+msgid "Failed to read commit %s: "
+msgstr "%s коммитін оқу сәтсіз аяқталды: "
+
+#: common/flatpak-dir.c:9710
+#, c-format
+msgid "While trying to checkout %s into %s: "
+msgstr "%s-ді %s ішіне тексеріп шығу (checkout) кезінде: "
+
+#: common/flatpak-dir.c:9729
+msgid "While trying to checkout metadata subpath: "
+msgstr "Метадеректердің ішкі жолын тексеріп шығу (checkout) кезінде: "
+
+#: common/flatpak-dir.c:9761
+#, c-format
+msgid "While trying to checkout subpath ‘%s’: "
+msgstr "‘%s’ ішкі жолын тексеріп шығу (checkout) кезінде: "
+
+#: common/flatpak-dir.c:9771
+msgid "While trying to remove existing extra dir: "
+msgstr "Бар қосымша буманы өшіру кезінде: "
+
+#: common/flatpak-dir.c:9782
+msgid "While trying to apply extra data: "
+msgstr "Қосымша деректерді қолдану кезінде: "
+
+#: common/flatpak-dir.c:9809
+#, c-format
+msgid "Invalid commit ref %s: "
+msgstr "%s коммит сілтемесі жарамсыз: "
+
+#: common/flatpak-dir.c:9817 common/flatpak-dir.c:9829
+#, c-format
+msgid "Deployed ref %s does not match commit (%s)"
+msgstr "Орналастырылған %s сілтемесі коммитке (%s) сәйкес келмейді"
+
+#: common/flatpak-dir.c:9823
+#, c-format
+msgid "Deployed ref %s branch does not match commit (%s)"
+msgstr "Орналастырылған %s сілтеме тармағы коммитке (%s) сәйкес келмейді"
+
+#: common/flatpak-dir.c:10085 common/flatpak-installation.c:1909
+#, c-format
+msgid "%s branch %s already installed"
+msgstr "%s %s тармағы қазірдің өзінде орнатылған"
+
+#: common/flatpak-dir.c:10945
+#, c-format
+msgid "Could not unmount revokefs-fuse filesystem at %s: "
+msgstr "%s орнындағы revokefs-fuse файлдық жүйесін ажырату мүмкін болмады: "
+
+#: common/flatpak-dir.c:11249
+#, c-format
+msgid "This version of %s is already installed"
+msgstr "%s осы нұсқасы қазірдің өзінде орнатылған"
+
+#: common/flatpak-dir.c:11262
+msgid "Can't change remote during bundle install"
+msgstr "Дестені орнату кезінде қашықтағы репозиторийді өзгерту мүмкін емес"
+
+#: common/flatpak-dir.c:11531
+msgid "Can't update to a specific commit without root permissions"
+msgstr "root рұқсатынсыз арнайы коммитке жаңарту мүмкін емес"
+
+#: common/flatpak-dir.c:11812
+#, c-format
+msgid "Can't remove %s, it is needed for: %s"
+msgstr "%s өшіру мүмкін емес, ол мынау үшін қажет: %s"
+
+#: common/flatpak-dir.c:11872 common/flatpak-installation.c:2065
+#, c-format
+msgid "%s branch %s is not installed"
+msgstr "%s %s тармағы орнатылмаған"
+
+#: common/flatpak-dir.c:12125
+#, c-format
+msgid "%s commit %s not installed"
+msgstr "%s %s коммиті орнатылмаған"
+
+#: common/flatpak-dir.c:12461
+#, c-format
+msgid "Pruning repo failed: %s"
+msgstr "Репозиторийді тазалау сәтсіз аяқталды: %s"
+
+#: common/flatpak-dir.c:12629 common/flatpak-dir.c:12635
+#, c-format
+msgid "Failed to load filter '%s'"
+msgstr "'%s' сүзгісін жүктеу сәтсіз аяқталды"
+
+#: common/flatpak-dir.c:12641
+#, c-format
+msgid "Failed to parse filter '%s'"
+msgstr "'%s' сүзгісін өңдеу сәтсіз аяқталды"
+
+#: common/flatpak-dir.c:12923
+msgid "Failed to write summary cache: "
+msgstr "Жиынтық кэшін жазу сәтсіз аяқталды: "
+
+#: common/flatpak-dir.c:12942
+#, c-format
+msgid "No oci summary cached for remote '%s'"
+msgstr "'%s' қашықтағы репозиторийі үшін ешқандай oci жиынтығы кэштелмеген"
+
+#: common/flatpak-dir.c:13167
+#, c-format
+msgid "No cached summary for remote '%s'"
+msgstr "'%s' қашықтағы репозиторийі үшін ешқандай кэштелген жиынтық жоқ"
+
+#: common/flatpak-dir.c:13208
+#, c-format
+msgid "Invalid checksum for indexed summary %s read from %s"
+msgstr "%2$s-ден оқылған индекстелген %1$s жиынтығының бақылау сомасы жарамсыз"
+
+#: common/flatpak-dir.c:13281
+#, c-format
+msgid ""
+"Remote listing for %s not available; server has no summary file. Check the "
+"URL passed to remote-add was valid."
+msgstr ""
+"%s үшін қашықтағы тізім қолжетімді емес; серверде жиынтық файлы жоқ. remote-"
+"add үшін берілген URL дұрыстығын тексеріңіз."
+
+#: common/flatpak-dir.c:13658
+#, c-format
+msgid "Invalid checksum for indexed summary %s for remote '%s'"
+msgstr ""
+"'%2$s' қашықтағы репозиторийі үшін индекстелген %1$s жиынтығының бақылау "
+"сомасы жарамсыз"
+
+#: common/flatpak-dir.c:14348
+#, c-format
+msgid "Multiple branches available for %s, you must specify one of: "
+msgstr ""
+"%s үшін бірнеше тармақ қолжетімді, сіз мыналардың біреуін көрсетуіңіз керек: "
+
+#: common/flatpak-dir.c:14414
+#, c-format
+msgid "Nothing matches %s"
+msgstr "%s-ге сәйкес келетін ештеңе жоқ"
+
+#: common/flatpak-dir.c:14522
+#, c-format
+msgid "Can't find ref %s%s%s%s%s"
+msgstr "%s%s%s%s%s сілтемесі табылмады"
+
+#: common/flatpak-dir.c:14565
+#, c-format
+msgid "Error searching remote %s: %s"
+msgstr "%s қашықтағы репозиторийден іздеу қатесі: %s"
+
+#: common/flatpak-dir.c:14662
+#, c-format
+msgid "Error searching local repository: %s"
+msgstr "Жергілікті репозиторийден іздеу қатесі: %s"
+
+#: common/flatpak-dir.c:14799
+#, c-format
+msgid "%s/%s/%s not installed"
+msgstr "%s/%s/%s орнатылмаған"
+
+#: common/flatpak-dir.c:15002
+#, c-format
+msgid "Could not find installation %s"
+msgstr "%s орнатылымы табылмады"
+
+#: common/flatpak-dir.c:15572
+#, c-format
+msgid "Invalid file format, no %s group"
+msgstr "Файл пішімі жарамсыз, %s тобы жоқ"
+
+#: common/flatpak-dir.c:15577 common/flatpak-repo-utils.c:2836
+#, c-format
+msgid "Invalid version %s, only 1 supported"
+msgstr "Жарамсыз нұсқа %s, тек 1 қолдау көрсетіледі"
+
+#: common/flatpak-dir.c:15582 common/flatpak-dir.c:15587
+#, c-format
+msgid "Invalid file format, no %s specified"
+msgstr "Файл пішімі жарамсыз, %s көрсетілмеген"
+
+#. Check some minimal size so we don't get crap
+#: common/flatpak-dir.c:15607
+msgid "Invalid file format, gpg key invalid"
+msgstr "Файл пішімі жарамсыз, gpg кілті жарамсыз"
+
+#: common/flatpak-dir.c:15635 common/flatpak-repo-utils.c:2917
+msgid "Collection ID requires GPG key to be provided"
+msgstr "Коллекция ID-і GPG кілтінің берілуін талап етеді"
+
+#: common/flatpak-dir.c:15678
+#, c-format
+msgid "Runtime %s, branch %s is already installed"
+msgstr "%s орындалу ортасының %s тармағы қазірдің өзінде орнатылған"
+
+#: common/flatpak-dir.c:15679
+#, c-format
+msgid "App %s, branch %s is already installed"
+msgstr "%s қолданбасының %s тармағы қазірдің өзінде орнатылған"
+
+#: common/flatpak-dir.c:15913
+#, c-format
+msgid "Can't remove remote '%s' with installed ref %s (at least)"
+msgstr ""
+"Орнатылған %s сілтемесі (кем дегенде) болғандықтан, '%s' қашықтағы "
+"репозиторийін өшіру мүмкін емес"
+
+#: common/flatpak-dir.c:16016
+#, c-format
+msgid "Invalid character '/' in remote name: %s"
+msgstr "Қашықтағы репозиторий атауында жарамсыз '/' таңбасы бар: %s"
+
+#: common/flatpak-dir.c:16022
+#, c-format
+msgid "No configuration for remote %s specified"
+msgstr "%s қашықтағы репозиторийі үшін ешқандай конфигурация көрсетілмеген"
+
+#: common/flatpak-dir.c:17516
+#, c-format
+msgid "Skipping deletion of mirror ref (%s, %s)…\n"
+msgstr "Айна сілтемесін (%s, %s) өшіру өткізіліп жіберілуде…\n"
+
+#: common/flatpak-exports.c:931
+msgid "An absolute path is required"
+msgstr "Абсолюттік жол қажет"
+
+#: common/flatpak-exports.c:948
+#, c-format
+msgid "Unable to open path \"%s\": %s"
+msgstr "\"%s\" жолын ашу мүмкін емес: %s"
+
+#: common/flatpak-exports.c:955
+#, c-format
+msgid "Unable to get file type of \"%s\": %s"
+msgstr "\"%s\" файл түрін алу мүмкін емес: %s"
+
+#: common/flatpak-exports.c:964
+#, c-format
+msgid "File \"%s\" has unsupported type 0o%o"
+msgstr "\"%s\" файлының түрі 0o%o қолдау көрсетілмейді"
+
+#: common/flatpak-exports.c:970
+#, c-format
+msgid "Unable to get filesystem information for \"%s\": %s"
+msgstr "\"%s\" үшін файлдық жүйе ақпаратын алу мүмкін емес: %s"
+
+#: common/flatpak-exports.c:980
+#, c-format
+msgid "Ignoring blocking autofs path \"%s\""
+msgstr "Бөгеуші autofs \"%s\" жолы еленбейді"
+
+#: common/flatpak-exports.c:996 common/flatpak-exports.c:1009
+#: common/flatpak-exports.c:1022
+#, c-format
+msgid "Path \"%s\" is reserved by Flatpak"
+msgstr "\"%s\" жолы Flatpak үшін брондалған"
+
+#: common/flatpak-exports.c:1076
+#, c-format
+msgid "Unable to resolve symbolic link \"%s\": %s"
+msgstr "\"%s\" символдық сілтемесін шешу мүмкін емес: %s"
+
+#: common/flatpak-glib-backports.c:69
+msgid "Empty string is not a number"
+msgstr "Бос жол сан емес"
+
+#: common/flatpak-glib-backports.c:95
+#, c-format
+msgid "“%s” is not an unsigned number"
+msgstr "“%s” таңбасыз сан емес"
+
+#: common/flatpak-glib-backports.c:105
+#, c-format
+msgid "Number “%s” is out of bounds [%s, %s]"
+msgstr "“%s” саны [%s, %s] шегінен тыс"
+
+#: common/flatpak-image-source.c:83
+msgid "Only sha256 image checksums are supported"
+msgstr "Тек sha256 бейне бақылау сомаларына қолдау көрсетіледі"
+
+#: common/flatpak-image-source.c:100 common/flatpak-image-source.c:108
+msgid "Image is not a manifest"
+msgstr "Бейне манифест емес"
+
+#: common/flatpak-image-source.c:123
+msgid "No org.flatpak.ref found in image"
+msgstr "Бейне ішінен org.flatpak.ref табылмады"
+
+#: common/flatpak-image-source.c:148
+#, c-format
+msgid "Ref '%s' not found in registry"
+msgstr "'%s' сілтемесі тіркеуден табылмады"
+
+#: common/flatpak-image-source.c:157
+msgid "Multiple images in registry, specify a ref with --ref"
+msgstr "Тіркеуде бірнеше бейне бар, --ref арқылы сілтемені көрсетіңіз"
+
+#: common/flatpak-installation.c:832
+#, c-format
+msgid "Ref %s not installed"
+msgstr "%s сілтемесі орнатылмаған"
+
+#: common/flatpak-installation.c:873
+#, c-format
+msgid "App %s not installed"
+msgstr "%s қолданбасы орнатылмаған"
+
+#: common/flatpak-installation.c:1393
+#, c-format
+msgid "Remote '%s' already exists"
+msgstr "'%s' қашықтағы репозиторийі қазірдің өзінде бар"
+
+#: common/flatpak-installation.c:1944
+#, c-format
+msgid "As requested, %s was only pulled, but not installed"
+msgstr "Сұралғандай, %s тек тартылды, бірақ орнатылған жоқ"
+
+#: common/flatpak-instance.c:533 common/flatpak-instance.c:687
+#: common/flatpak-instance.c:728
+#, c-format
+msgid "Unable to create directory %s"
+msgstr "%s бумасын жасау мүмкін емес"
+
+#: common/flatpak-instance.c:554
+#, c-format
+msgid "Unable to lock %s"
+msgstr "%s құлыптау мүмкін емес"
+
+#: common/flatpak-instance.c:627
+#, c-format
+msgid "Unable to create temporary directory in %s"
+msgstr "%s ішінде уақытша бума жасау мүмкін емес"
+
+#: common/flatpak-instance.c:639
+#, c-format
+msgid "Unable to create file %s"
+msgstr "%s файлын жасау мүмкін емес"
+
+#: common/flatpak-instance.c:646
+#, c-format
+msgid "Unable to update symbolic link %s/%s"
+msgstr "%s/%s символдық сілтемесін жаңарту мүмкін емес"
+
+#: common/flatpak-oci-registry.c:1197
+msgid "Only Bearer authentication supported"
+msgstr "Тек Bearer аутентификациясына қолдау көрсетіледі"
+
+#: common/flatpak-oci-registry.c:1206
+msgid "Only realm in authentication request"
+msgstr "Аутентификация сұранысында тек realm бар"
+
+#: common/flatpak-oci-registry.c:1213
+msgid "Invalid realm in authentication request"
+msgstr "Аутентификация сұранысында realm жарамсыз"
+
+#: common/flatpak-oci-registry.c:1283
+#, c-format
+msgid "Authorization failed: %s"
+msgstr "Авторизация сәтсіз аяқталды: %s"
+
+#: common/flatpak-oci-registry.c:1285
+msgid "Authorization failed"
+msgstr "Авторизация сәтсіз аяқталды"
+
+#: common/flatpak-oci-registry.c:1289
+#, c-format
+msgid "Unexpected response status %d when requesting token: %s"
+msgstr "Токенді сұрау кезінде күтілмеген %d жауап күйі: %s"
+
+#: common/flatpak-oci-registry.c:1300
+msgid "Invalid authentication request response"
+msgstr "Аутентификация сұранысына жауап жарамсыз"
+
+#: common/flatpak-oci-registry.c:1731
+msgid "Flatpak was compiled without zstd support"
+msgstr "Flatpak zstd қолдауынсыз жинақталған"
+
+#: common/flatpak-oci-registry.c:1923 common/flatpak-oci-registry.c:1975
+#: common/flatpak-oci-registry.c:2004 common/flatpak-oci-registry.c:2059
+#: common/flatpak-oci-registry.c:2115 common/flatpak-oci-registry.c:2193
+msgid "Invalid delta file format"
+msgstr "Дельта файл пішімі жарамсыз"
+
+#: common/flatpak-oci-registry.c:3198 common/flatpak-oci-registry.c:3382
+msgid "Invalid OCI image config"
+msgstr "OCI бейне конфигурациясы жарамсыз"
+
+#: common/flatpak-oci-registry.c:3260 common/flatpak-oci-registry.c:3531
+#, c-format
+msgid "Wrong layer checksum, expected %s, was %s"
+msgstr "Қабаттың бақылау сомасы қате, %s күтілді, бірақ %s болды"
+
+#: common/flatpak-oci-registry.c:3359
+#, c-format
+msgid "No ref specified for OCI image %s"
+msgstr "%s OCI бейнесі үшін сілтеме көрсетілмеген"
+
+#: common/flatpak-oci-registry.c:3369
+#, c-format
+msgid "Wrong ref (%s) specified for OCI image %s, expected %s"
+msgstr "%2$s OCI бейнесі үшін %1$s сілтемесі қате, %3$s күтілді"
+
+#: common/flatpak-progress.c:236
+#, c-format
+msgid "Downloading metadata: %u/(estimating) %s"
+msgstr "Метадеректер жүктелуде: %u/(шамамен) %s"
+
+#: common/flatpak-progress.c:260
+#, c-format
+msgid "Downloading: %s/%s"
+msgstr "Жүктелуде: %s/%s"
+
+#: common/flatpak-progress.c:280
+#, c-format
+msgid "Downloading extra data: %s/%s"
+msgstr "Қосымша деректер жүктелуде: %s/%s"
+
+#: common/flatpak-progress.c:285
+#, c-format
+msgid "Downloading files: %d/%d %s"
+msgstr "Файлдар жүктелуде: %1$d/%2$d %3$s"
+
+#: common/flatpak-ref-utils.c:122
+msgid "Name can't be empty"
+msgstr "Атау бос болмауы тиіс"
+
+#: common/flatpak-ref-utils.c:129
+msgid "Name can't be longer than 255 characters"
+msgstr "Атау 255 таңбадан ұзын болмауы тиіс"
+
+#: common/flatpak-ref-utils.c:142
+msgid "Name can't start with a period"
+msgstr "Атау нүктеден басталмауы тиіс"
+
+#: common/flatpak-ref-utils.c:148
+#, c-format
+msgid "Name can't start with %c"
+msgstr "Атау %c таңбасынан басталмауы тиіс"
+
+#: common/flatpak-ref-utils.c:164
+msgid "Name can't end with a period"
+msgstr "Атау нүктемен аяқталмауы тиіс"
+
+#: common/flatpak-ref-utils.c:171 common/flatpak-ref-utils.c:183
+msgid "Only last name segment can contain -"
+msgstr "Тек соңғы атау сегментінде - болуы мүмкін"
+
+#: common/flatpak-ref-utils.c:174
+#, c-format
+msgid "Name segment can't start with %c"
+msgstr "Атау сегменті %c таңбасынан басталмауы тиіс"
+
+#: common/flatpak-ref-utils.c:186
+#, c-format
+msgid "Name can't contain %c"
+msgstr "Атауда %c болмауы тиіс"
+
+#: common/flatpak-ref-utils.c:195
+msgid "Names must contain at least 2 periods"
+msgstr "Атауларда кем дегенде 2 нүкте болуы тиіс"
+
+#: common/flatpak-ref-utils.c:312
+msgid "Arch can't be empty"
+msgstr "Архитектура бос болмауы тиіс"
+
+#: common/flatpak-ref-utils.c:323
+#, c-format
+msgid "Arch can't contain %c"
+msgstr "Архитектурада %c болмауы тиіс"
+
+#: common/flatpak-ref-utils.c:385
+msgid "Branch can't be empty"
+msgstr "Тармақ бос болмауы тиіс"
+
+#: common/flatpak-ref-utils.c:395
+#, c-format
+msgid "Branch can't start with %c"
+msgstr "Тармақ %c таңбасынан басталмауы тиіс"
+
+#: common/flatpak-ref-utils.c:405
+#, c-format
+msgid "Branch can't contain %c"
+msgstr "Тармақта %c болмауы тиіс"
+
+#: common/flatpak-ref-utils.c:615 common/flatpak-ref-utils.c:865
+msgid "Ref too long"
+msgstr "Сілтеме тым ұзын"
+
+#: common/flatpak-ref-utils.c:627
+msgid "Invalid remote name"
+msgstr "Қашықтағы репозиторий атауы жарамсыз"
+
+#: common/flatpak-ref-utils.c:641
+#, c-format
+msgid "%s is not application or runtime"
+msgstr "%s қолданба немесе орындалу ортасы емес"
+
+#: common/flatpak-ref-utils.c:650 common/flatpak-ref-utils.c:667
+#: common/flatpak-ref-utils.c:683
+#, c-format
+msgid "Wrong number of components in %s"
+msgstr "%s ішіндегі компоненттер саны қате"
+
+#: common/flatpak-ref-utils.c:656
+#, c-format
+msgid "Invalid name %.*s: %s"
+msgstr "Жарамсыз атау %.*s: %s"
+
+#: common/flatpak-ref-utils.c:673
+#, c-format
+msgid "Invalid arch: %.*s: %s"
+msgstr "Жарамсыз архитектура: %.*s: %s"
+
+#: common/flatpak-ref-utils.c:816
+#, c-format
+msgid "Invalid name %s: %s"
+msgstr "Жарамсыз атау %s: %s"
+
+#: common/flatpak-ref-utils.c:834
+#, c-format
+msgid "Invalid arch: %s: %s"
+msgstr "Жарамсыз архитектура: %s: %s"
+
+#: common/flatpak-ref-utils.c:853
+#, c-format
+msgid "Invalid branch: %s: %s"
+msgstr "Жарамсыз тармақ: %s: %s"
+
+#: common/flatpak-ref-utils.c:962 common/flatpak-ref-utils.c:970
+#: common/flatpak-ref-utils.c:978
+#, c-format
+msgid "Wrong number of components in partial ref %s"
+msgstr "Жартылай %s сілтемесіндегі компоненттер саны қате"
+
+#: common/flatpak-ref-utils.c:1298
+msgid " development platform"
+msgstr " әзірлеу платформасы"
+
+#: common/flatpak-ref-utils.c:1300
+msgid " platform"
+msgstr " платформа"
+
+#: common/flatpak-ref-utils.c:1302
+msgid " application base"
+msgstr " қолданба негізі"
+
+#: common/flatpak-ref-utils.c:1305
+msgid " debug symbols"
+msgstr " жөндеу таңбалары"
+
+#: common/flatpak-ref-utils.c:1307
+msgid " sourcecode"
+msgstr " бастапқы код"
+
+#: common/flatpak-ref-utils.c:1309
+msgid " translations"
+msgstr " аудармалар"
+
+#: common/flatpak-ref-utils.c:1311
+msgid " docs"
+msgstr " құжаттама"
+
+#: common/flatpak-ref-utils.c:1578
+#, c-format
+msgid "Invalid id %s: %s"
+msgstr "Жарамсыз id %s: %s"
+
+#: common/flatpak-remote.c:1216
+#, c-format
+msgid "Bad remote name: %s"
+msgstr "Қашықтағы репозиторий атауы қате: %s"
+
+#: common/flatpak-remote.c:1220
+msgid "No URL specified"
+msgstr "URL көрсетілмеген"
+
+#: common/flatpak-remote.c:1266
+msgid "GPG verification must be enabled when a collection ID is set"
+msgstr "Коллекция ID-і орнатылған кезде GPG тексеруі іске қосылуы тиіс"
+
+#: common/flatpak-repo-utils.c:344
+msgid "No extra data sources"
+msgstr "Қосымша дерек көздері жоқ"
+
+#: common/flatpak-repo-utils.c:2817
+#, c-format
+msgid "Invalid %s: Missing group ‘%s’"
+msgstr "Жарамсыз %s: ‘%s’ тобы жоқ"
+
+#: common/flatpak-repo-utils.c:2826
+#, c-format
+msgid "Invalid %s: Missing key ‘%s’"
+msgstr "Жарамсыз %s: ‘%s’ кілті жоқ"
+
+#: common/flatpak-repo-utils.c:2876
+msgid "Invalid gpg key"
+msgstr "GPG кілті жарамсыз"
+
+#: common/flatpak-repo-utils.c:3217
+#, c-format
+msgid "Error copying 64x64 icon for component %s: %s\n"
+msgstr "%s компоненті үшін 64x64 таңбашасын көшіру қатесі: %s\n"
+
+#: common/flatpak-repo-utils.c:3223
+#, c-format
+msgid "Error copying 128x128 icon for component %s: %s\n"
+msgstr "%s компоненті үшін 128x128 таңбашасын көшіру қатесі: %s\n"
+
+#: common/flatpak-repo-utils.c:3362
+#, c-format
+msgid "%s is end-of-life, ignoring for appstream"
+msgstr "%s қолдау мерзімі аяқталған, appstream үшін еленбейді"
+
+#: common/flatpak-repo-utils.c:3397
+#, c-format
+msgid "No appstream data for %s: %s\n"
+msgstr "%s үшін appstream деректері жоқ: %s\n"
+
+#: common/flatpak-repo-utils.c:3744
+msgid "Invalid bundle, no ref in metadata"
+msgstr "Десте жарамсыз, метадеректерде сілтеме жоқ"
+
+#: common/flatpak-repo-utils.c:3846
+#, c-format
+msgid "Collection ‘%s’ of bundle doesn’t match collection ‘%s’ of remote"
+msgstr ""
+"Дестенің ‘%s’ коллекциясы қашықтағы репозиторийдің ‘%s’ коллекциясына сәйкес "
+"келмейді"
+
+#: common/flatpak-repo-utils.c:3923
+msgid "Metadata in header and app are inconsistent"
+msgstr "Тақырыптама және қолданбадағы метадеректер сәйкес емес"
+
+#: common/flatpak-run.c:891
+msgid "No systemd user session available, cgroups not available"
+msgstr "systemd пайдаланушы сессиясы қолжетімді емес, cgroups қолжетімді емес"
+
+#: common/flatpak-run.c:1432
+msgid "Unable to allocate instance id"
+msgstr "Инстанция id-ін бөлу мүмкін емес"
+
+#: common/flatpak-run.c:1568 common/flatpak-run.c:1578
+#, c-format
+msgid "Failed to open flatpak-info file: %s"
+msgstr "flatpak-info файлын ашу сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:1607
+#, c-format
+msgid "Failed to open bwrapinfo.json file: %s"
+msgstr "bwrapinfo.json файлын ашу сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:1632
+#, c-format
+msgid "Failed to write to instance id fd: %s"
+msgstr "Инстанция id fd-ге жазу сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:2015
+msgid "Initialize seccomp failed"
+msgstr "Seccomp инициализациясы сәтсіз аяқталды"
+
+#: common/flatpak-run.c:2054
+#, c-format
+msgid "Failed to add architecture to seccomp filter: %s"
+msgstr "Архитектураны seccomp сүзгісіне қосу сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:2062
+#, c-format
+msgid "Failed to add multiarch architecture to seccomp filter: %s"
+msgstr "Мультиархитектураны seccomp сүзгісіне қосу сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:2094 common/flatpak-run.c:2111
+#: common/flatpak-run.c:2133
+#, c-format
+msgid "Failed to block syscall %d: %s"
+msgstr "%d жүйелік шақыруын бөгеу сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:2166
+#, c-format
+msgid "Failed to export bpf: %s"
+msgstr "bpf экспорттау сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:2468
+#, c-format
+msgid "Failed to open ‘%s’"
+msgstr "‘%s’ ашу мүмкін болмады"
+
+#: common/flatpak-run.c:2478
+#, c-format
+msgid ""
+"Directory forwarding needs version 4 of the document portal (have version %d)"
+msgstr ""
+"Буманы қайта бағыттау үшін құжат порталының 4-нұсқасы қажет (%d нұсқасы бар)"
+
+#: common/flatpak-run.c:2796
+#, c-format
+msgid "ldconfig failed, exit status %d"
+msgstr "ldconfig сәтсіз аяқталды, шығу күйі %d"
+
+#: common/flatpak-run.c:2803
+msgid "Can't open generated ld.so.cache"
+msgstr "Жасалған ld.so.cache файлын ашу мүмкін емес"
+
+#. Translators: The placeholder is for an app ref.
+#: common/flatpak-run.c:2926
+#, c-format
+msgid "Running %s is not allowed by the policy set by your administrator"
+msgstr "%s орындауға әкімші орнатқан саясатпен рұқсат берілмеген"
+
+#: common/flatpak-run.c:3065
+msgid ""
+"\"flatpak run\" is not intended to be run as `sudo flatpak run`. Use `sudo "
+"-i` or `su -l` instead and invoke \"flatpak run\" from inside the new shell."
+msgstr ""
+"\"flatpak run\" командасы `sudo flatpak run` ретінде орындауға арналмаған. "
+"Оның орнына `sudo -i` немесе `su -l` қолданыңыз және жаңа қоршам ішінен "
+"\"flatpak run\" шақырыңыз."
+
+#: common/flatpak-run.c:3261
+#, c-format
+msgid "Failed to migrate from %s: %s"
+msgstr "%s-ден көшіру сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:3282
+#, c-format
+msgid "Failed to migrate old app data directory %s to new name %s: %s"
+msgstr ""
+"Ескі қолданба деректер бумасын %s жаңа %s атауына көшіру сәтсіз аяқталды: %s"
+
+#: common/flatpak-run.c:3291
+#, c-format
+msgid "Failed to create symlink while migrating %s: %s"
+msgstr "%s көшіру кезінде символдық сілтеме жасау сәтсіз аяқталды: %s"
+
+#: common/flatpak-run-dbus.c:46
+msgid "Failed to open app info file"
+msgstr "Қолданба ақпараты файлын ашу сәтсіз аяқталды"
+
+#: common/flatpak-run-dbus.c:149
+msgid "Unable to create sync pipe"
+msgstr "Синхрондау арнасын (pipe) жасау мүмкін емес"
+
+#: common/flatpak-run-dbus.c:185
+msgid "Failed to sync with dbus proxy"
+msgstr "dbus проксиімен синхрондау сәтсіз аяқталды"
+
+#: common/flatpak-transaction.c:2275
+#, c-format
+msgid "Warning: Problem looking for related refs: %s"
+msgstr "Ескерту: Қатысты сілтемелерді іздеу мәселесі: %s"
+
+#: common/flatpak-transaction.c:2493
+#, c-format
+msgid "The application %s requires the runtime %s which was not found"
+msgstr "%s қолданбасы %s орындалу ортасын талап етеді, ол табылмады"
+
+#: common/flatpak-transaction.c:2509
+#, c-format
+msgid "The application %s requires the runtime %s which is not installed"
+msgstr "%s қолданбасы %s орындалу ортасын талап етеді, ол орнатылмаған"
+
+#: common/flatpak-transaction.c:2641
+#, c-format
+msgid "Can't uninstall %s which is needed by %s"
+msgstr "%2$s үшін қажет %1$s өшіру мүмкін емес"
+
+#: common/flatpak-transaction.c:2740
+#, c-format
+msgid "Remote %s disabled, ignoring %s update"
+msgstr "%s қашықтағы репозиторийі сөндірілген, %s жаңартуы еленбейді"
+
+#: common/flatpak-transaction.c:2773
+#, c-format
+msgid "%s is already installed"
+msgstr "%s қазірдің өзінде орнатылған"
+
+#: common/flatpak-transaction.c:2776
+#, c-format
+msgid "%s is already installed from remote %s"
+msgstr "%s қазірдің өзінде %s қашықтағы репозиторийден орнатылған"
+
+#: common/flatpak-transaction.c:3120
+#, c-format
+msgid "Invalid .flatpakref: %s"
+msgstr ".flatpakref жарамсыз: %s"
+
+#: common/flatpak-transaction.c:3161
+msgid "Warning: Could not mark already installed apps as preinstalled"
+msgstr ""
+"Ескерту: Орнатылып қойған қолданбаларды алдын ала орнатылған деп белгілеу "
+"мүмкін болмады"
+
+#: common/flatpak-transaction.c:3382
+#, c-format
+msgid "Error updating remote metadata for '%s': %s"
+msgstr "'%s' үшін қашықтағы метадеректерді жаңарту қатесі: %s"
+
+#: common/flatpak-transaction.c:3885
+#, c-format
+msgid ""
+"Warning: Treating remote fetch error as non-fatal since %s is already "
+"installed: %s"
+msgstr ""
+"Ескерту: %s қазірдің өзінде орнатылғандықтан, қашықтағы алу қатесі "
+"критикалық емес деп есептеледі: %s"
+
+#: common/flatpak-transaction.c:4209
+#, c-format
+msgid "No authenticator installed for remote '%s'"
+msgstr "'%s' қашықтағы репозиторийі үшін ешқандай аутентификатор орнатылмаған"
+
+#: common/flatpak-transaction.c:4313 common/flatpak-transaction.c:4320
+#, c-format
+msgid "Failed to get tokens for ref: %s"
+msgstr "Сілтеме үшін токендерді алу сәтсіз аяқталды: %s"
+
+#: common/flatpak-transaction.c:4315 common/flatpak-transaction.c:4322
+msgid "Failed to get tokens for ref"
+msgstr "Сілтеме үшін токендерді алу сәтсіз аяқталды"
+
+#: common/flatpak-transaction.c:4580
+#, c-format
+msgid "Ref %s from %s matches more than one transaction operation"
+msgstr ""
+"%2$s ішіндегі %1$s сілтемесі бірден көп транзакция операциясына сәйкес келеді"
+
+#: common/flatpak-transaction.c:4581 common/flatpak-transaction.c:4591
+msgid "any remote"
+msgstr "кез келген қашықтағы репозиторий"
+
+#: common/flatpak-transaction.c:4590
+#, c-format
+msgid "No transaction operation found for ref %s from %s"
+msgstr ""
+"%2$s ішіндегі %1$s сілтемесі үшін ешқандай транзакция операциясы табылмады"
+
+#: common/flatpak-transaction.c:4713
+#, c-format
+msgid "Flatpakrepo URL %s not file, HTTP or HTTPS"
+msgstr "Flatpakrepo URL-і %s файл, HTTP немесе HTTPS емес"
+
+#: common/flatpak-transaction.c:4719
+#, c-format
+msgid "Can't load dependent file %s: "
+msgstr "Тәуелді %s файлын жүктеу мүмкін емес: "
+
+#: common/flatpak-transaction.c:4727
+#, c-format
+msgid "Invalid .flatpakrepo: %s"
+msgstr ".flatpakrepo жарамсыз: %s"
+
+#: common/flatpak-transaction.c:5454
+msgid "Transaction already executed"
+msgstr "Транзакция қазірдің өзінде орындалған"
+
+#: common/flatpak-transaction.c:5469
+msgid ""
+"Refusing to operate on a user installation as root! This can lead to "
+"incorrect file ownership and permission errors."
+msgstr ""
+"Root ретінде пайдаланушы орнатылымында жұмыс істеуден бас тартылды! Бұл файл "
+"иелігі мен рұқсаттарының қате болуына әкелуі мүмкін."
+
+#: common/flatpak-transaction.c:5567 common/flatpak-transaction.c:5580
+msgid "Aborted by user"
+msgstr "Пайдаланушымен тоқтатылды"
+
+#: common/flatpak-transaction.c:5605
+#, c-format
+msgid "Skipping %s due to previous error"
+msgstr "Алдыңғы қатеге байланысты %s өткізіліп жіберілуде"
+
+#: common/flatpak-transaction.c:5659
+#, c-format
+msgid "Aborted due to failure (%s)"
+msgstr "Сәтсіздікке байланысты тоқтатылды (%s)"
+
+#: common/flatpak-uri.c:118
+#, no-c-format
+msgid "Invalid %-encoding in URI"
+msgstr "URI-дегі %-кодтау жарамсыз"
+
+#: common/flatpak-uri.c:135
+msgid "Illegal character in URI"
+msgstr "URI-дегі рұқсат етілмеген таңба"
+
+#: common/flatpak-uri.c:169
+msgid "Non-UTF-8 characters in URI"
+msgstr "URI-дегі UTF-8 емес таңбалар"
+
+#: common/flatpak-uri.c:275
+#, c-format
+msgid "Invalid IPv6 address ‘%.*s’ in URI"
+msgstr "URI-дегі жарамсыз IPv6 адресі ‘%.*s’"
+
+#: common/flatpak-uri.c:330
+#, c-format
+msgid "Illegal encoded IP address ‘%.*s’ in URI"
+msgstr "URI-дегі қате кодталған IP адресі ‘%.*s’"
+
+#: common/flatpak-uri.c:342
+#, c-format
+msgid "Illegal internationalized hostname ‘%.*s’ in URI"
+msgstr "URI-дегі рұқсат етілмеген интернационалдандырылған хост атауы ‘%.*s’"
+
+#: common/flatpak-uri.c:374 common/flatpak-uri.c:386
+#, c-format
+msgid "Could not parse port ‘%.*s’ in URI"
+msgstr "URI-дегі ‘%.*s’ портын өңдеу мүмкін емес"
+
+#: common/flatpak-uri.c:393
+#, c-format
+msgid "Port ‘%.*s’ in URI is out of range"
+msgstr "URI-дегі ‘%.*s’ порты шектен тыс"
+
+#: common/flatpak-uri.c:910
+msgid "URI is not absolute, and no base URI was provided"
+msgstr "URI абсолютті емес және ешқандай базалық URI берілмеген"
+
+#: common/flatpak-usb.c:83
+msgid "USB device query 'all' must not have data"
+msgstr "USB құрылғысының 'all' сұранысында деректер болмауы тиіс"
+
+#: common/flatpak-usb.c:102
+msgid "USB query rule 'cls' must be in the form CLASS:SUBCLASS or CLASS:*"
+msgstr ""
+"USB 'cls' сұраныс ережесі CLASS:SUBCLASS немесе CLASS:* түрінде болуы тиіс"
+
+#: common/flatpak-usb.c:111
+msgid "Invalid USB class"
+msgstr "USB класы жарамсыз"
+
+#: common/flatpak-usb.c:125
+msgid "Invalid USB subclass"
+msgstr "USB ішкі класы жарамсыз"
+
+#: common/flatpak-usb.c:141 common/flatpak-usb.c:148
+msgid "USB query rule 'dev' must have a valid 4-digit hexadecimal product id"
+msgstr ""
+"USB 'dev' сұраныс ережесінде жарамды 4 таңбалы он алтылық өнім id-і болуы "
+"тиіс"
+
+#: common/flatpak-usb.c:164 common/flatpak-usb.c:171
+msgid "USB query rule 'vnd' must have a valid 4-digit hexadecimal vendor id"
+msgstr ""
+"USB 'vnd' сұраныс ережесінде жарамды 4 таңбалы он алтылық өндіруші id-і "
+"болуы тиіс"
+
+#: common/flatpak-usb.c:205
+msgid "USB device queries must be in the form TYPE:DATA"
+msgstr "USB құрылғысының сұраныстары ТҮРІ:ДЕРЕКТЕР пішімінде болуы тиіс"
+
+#: common/flatpak-usb.c:225
+#, c-format
+msgid "Unknown USB query rule %s"
+msgstr "USB сұранысының %s ережесі белгісіз"
+
+#: common/flatpak-usb.c:248
+msgid "Empty USB query"
+msgstr "USB сұранысы бос"
+
+#: common/flatpak-usb.c:274
+msgid "Multiple USB query rules of the same type is not supported"
+msgstr "Бірдей түрдегі бірнеше USB сұраныс ережелеріне қолдау көрсетілмейді"
+
+#: common/flatpak-usb.c:283
+msgid "'all' must not contain extra query rules"
+msgstr "'all' құрамында артық сұраныс ережелері болмауы тиіс"
+
+#: common/flatpak-usb.c:291
+msgid "USB queries with 'dev' must also specify vendors"
+msgstr "'dev' бар USB сұраныстары өндірушілерді де көрсетуі тиіс"
+
+#: common/flatpak-utils.c:712
+msgid "Glob can't match apps"
+msgstr "Глоб қолданбаларға сәйкес келе алмайды"
+
+#: common/flatpak-utils.c:737
+msgid "Empty glob"
+msgstr "Глоб бос"
+
+#: common/flatpak-utils.c:756
+msgid "Too many segments in glob"
+msgstr "Глобта сегменттер тым көп"
+
+#: common/flatpak-utils.c:777
+#, c-format
+msgid "Invalid glob character '%c'"
+msgstr "Глоб таңбасы жарамсыз: '%c'"
+
+#: common/flatpak-utils.c:831
+#, c-format
+msgid "Missing glob on line %d"
+msgstr "%d жолында глоб жоқ"
+
+#: common/flatpak-utils.c:835
+#, c-format
+msgid "Trailing text on line %d"
+msgstr "%d жолының соңында артық мәтін бар"
+
+#: common/flatpak-utils.c:839
+#, c-format
+msgid "on line %d"
+msgstr "%d жолында"
+
+#: common/flatpak-utils.c:861
+#, c-format
+msgid "Unexpected word '%s' on line %d"
+msgstr "%2$d жолында күтілмеген '%1$s' сөзі"
+
+#: common/flatpak-utils.c:2088
+#, c-format
+msgid "Invalid require-flatpak argument %s"
+msgstr "require-flatpak аргументі жарамсыз: %s"
+
+#: common/flatpak-utils.c:2098 common/flatpak-utils.c:2117
+#, c-format
+msgid "%s needs a later flatpak version (%s)"
+msgstr "%s үшін кейінгі flatpak нұсқасы қажет (%s)"
+
+#: oci-authenticator/flatpak-oci-authenticator.c:291
+msgid "Not a oci remote, missing summary.xa.oci-repository"
+msgstr "oci қашықтағы репозиторийі емес, summary.xa.oci-repository жоқ"
+
+#: oci-authenticator/flatpak-oci-authenticator.c:477
+msgid "Not a OCI remote"
+msgstr "OCI қашықтағы репозиторийі емес"
+
+#: oci-authenticator/flatpak-oci-authenticator.c:488
+msgid "Invalid token"
+msgstr "Токен жарамсыз"
+
+#: portal/flatpak-portal.c:2373
+msgid "No portal support found"
+msgstr "Портал қолдауы табылмады"
+
+#: portal/flatpak-portal.c:2379
+msgid "Deny"
+msgstr "Тыйым салу"
+
+#: portal/flatpak-portal.c:2381
+msgid "Update"
+msgstr "Жаңарту"
+
+#: portal/flatpak-portal.c:2386
+#, c-format
+msgid "Update %s?"
+msgstr "%s жаңарту керек пе?"
+
+#: portal/flatpak-portal.c:2398
+msgid "The application wants to update itself."
+msgstr "Қолданба өз-өзін жаңартқысы келеді."
+
+#: portal/flatpak-portal.c:2399
+msgid "Update access can be changed any time from the privacy settings."
+msgstr ""
+"Жаңарту рұқсатын кез келген уақытта жекелік баптауларынан өзгертуге болады."
+
+#: portal/flatpak-portal.c:2424
+msgid "Application update not allowed"
+msgstr "Қолданбаны жаңартуға рұқсат жоқ"
+
+#: portal/flatpak-portal.c:2582
+msgid "Self update not supported, new version requires new permissions"
+msgstr ""
+"Өзін-өзі жаңартуға қолдау көрсетілмейді, жаңа нұсқа жаңа рұқсаттарды талап "
+"етеді"
+
+#: portal/flatpak-portal.c:2765 portal/flatpak-portal.c:2783
+msgid "Update ended unexpectedly"
+msgstr "Жаңарту күтпеген жерден аяқталды"
+
+#. SECURITY:
+#. - Normal users need admin authentication to install software
+#. system-wide.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to install without authenticating.
+#: system-helper/org.freedesktop.Flatpak.policy.in:23
+msgid "Install signed application"
+msgstr "Қол қойылған қолданбаны орнату"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:24
+#: system-helper/org.freedesktop.Flatpak.policy.in:42
+msgid "Authentication is required to install software"
+msgstr "Бағдарламалық қамтаманы орнату үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users need admin authentication to install software
+#. system-wide.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to install without authenticating.
+#: system-helper/org.freedesktop.Flatpak.policy.in:41
+msgid "Install signed runtime"
+msgstr "Қол қойылған орындалу ортасын орнату"
+
+#. SECURITY:
+#. - Normal users do not require admin authentication to update an
+#. app as the commit will be signed, and the action is required
+#. to update the system when unattended.
+#. - Changing this to anything other than 'yes' will break unattended
+#. updates.
+#: system-helper/org.freedesktop.Flatpak.policy.in:60
+msgid "Update signed application"
+msgstr "Қол қойылған қолданбаны жаңарту"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:61
+#: system-helper/org.freedesktop.Flatpak.policy.in:80
+msgid "Authentication is required to update software"
+msgstr "Бағдарламалық қамтаманы жаңарту үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users do not require admin authentication to update a
+#. runtime as the commit will be signed, and the action is required
+#. to update the system when unattended.
+#. - Changing this to anything other than 'yes' will break unattended
+#. updates.
+#: system-helper/org.freedesktop.Flatpak.policy.in:79
+msgid "Update signed runtime"
+msgstr "Қол қойылған орындалу ортасын жаңарту"
+
+#. SECURITY:
+#. - Normal users do not need authentication to update metadata
+#. from signed repositories.
+#: system-helper/org.freedesktop.Flatpak.policy.in:94
+msgid "Update remote metadata"
+msgstr "Қашықтағы метадеректерді жаңарту"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:95
+msgid "Authentication is required to update remote info"
+msgstr "Қашықтағы ақпаратты жаңарту үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users do not need authentication to modify the
+#. OSTree repository
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to modify repos without authenticating.
+#: system-helper/org.freedesktop.Flatpak.policy.in:111
+msgid "Update system repository"
+msgstr "Жүйелік репозиторийді жаңарту"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:112
+msgid "Authentication is required to modify a system repository"
+msgstr "Жүйелік репозиторийді өзгерту үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users need admin authentication to install software
+#. system-wide.
+#: system-helper/org.freedesktop.Flatpak.policy.in:126
+msgid "Install bundle"
+msgstr "Дестені орнату"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:127
+msgid "Authentication is required to install software from $(path)"
+msgstr ""
+"$(path) орнынан бағдарламалық қамтаманы орнату үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users need admin authentication to uninstall software
+#. system-wide.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to uninstall without authenticating.
+#: system-helper/org.freedesktop.Flatpak.policy.in:144
+msgid "Uninstall runtime"
+msgstr "Орындалу ортасын өшіру"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:145
+msgid "Authentication is required to uninstall software"
+msgstr "Бағдарламалық қамтаманы өшіру үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users need admin authentication to uninstall software
+#. system-wide.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to uninstall without authenticating.
+#: system-helper/org.freedesktop.Flatpak.policy.in:161
+msgid "Uninstall app"
+msgstr "Қолданбаны өшіру"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:162
+msgid "Authentication is required to uninstall $(ref)"
+msgstr "$(ref) өшіру үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users need admin authentication to configure system-wide
+#. software repositories.
+#: system-helper/org.freedesktop.Flatpak.policy.in:177
+msgid "Configure Remote"
+msgstr "Қашықтағы репозиторийді баптау"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:178
+msgid "Authentication is required to configure software repositories"
+msgstr ""
+"Бағдарламалық қамтама репозиторийлерін баптау үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users need admin authentication to configure the system-wide
+#. Flatpak installation.
+#: system-helper/org.freedesktop.Flatpak.policy.in:192
+msgid "Configure"
+msgstr "Баптау"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:193
+msgid "Authentication is required to configure software installation"
+msgstr "Бағдарламалық қамтама орнатылымын баптау үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users do not require admin authentication to update
+#. appstream data as it will be signed, and the action is required
+#. to update the system when unattended.
+#. - Changing this to anything other than 'yes' will break unattended
+#. updates.
+#: system-helper/org.freedesktop.Flatpak.policy.in:210
+msgid "Update appstream"
+msgstr "appstream жаңарту"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:211
+msgid "Authentication is required to update information about software"
+msgstr ""
+"Бағдарламалық қамтама туралы ақпаратты жаңарту үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Normal users do not require admin authentication to update
+#. metadata as it will be signed, and the action is required
+#. to update the system when unattended.
+#. - Changing this to anything other than 'yes' will break unattended
+#. updates.
+#: system-helper/org.freedesktop.Flatpak.policy.in:228
+msgid "Update metadata"
+msgstr "Метадеректерді жаңарту"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:229
+msgid "Authentication is required to update metadata"
+msgstr "Метадеректерді жаңарту үшін аутентификация қажет"
+
+#. SECURITY:
+#. - Authorisation to actually install software is controlled by
+#. org.freedesktop.Flatpak.app-install.
+#. - This action is checked after app-install, as it can only be done
+#. once the app’s data (including its content rating) has been
+#. downloaded.
+#. - This action is checked to see if the installation should be allowed
+#. based on whether the app being installed has content which doesn’t
+#. comply with the user’s parental controls policy (the content is
+#. ‘too extreme’).
+#. - It is checked only if an app has too extreme content for the user
+#. who is trying to install it (in which case, the app is ‘unsafe’).
+#. - Typically, normal users will need admin permission to install apps
+#. with extreme content; admins will be able to install it without
+#. additional checks.
+#. - In order to configure the policy so that admins can install safe and
+#. unsafe software anywhere without authorisation, and non-admins can
+#. install safe software in their user or system dirs without
+#. authorisation, but need authorisation to install unsafe software
+#. anywhere:
+#. * Unconditionally return `yes` from `app-install`.
+#. * Return `auth_admin` from `override-parental-controls` for users
+#. not in `@privileged_group@`, and `yes` for users in it.
+#. * Set the malcontent `is-{user,system}-installation-allowed`
+#. properties of all non-admins’ parental controls policies to true.
+#. - In order to configure the policy so that admins can install safe and
+#. unsafe software anywhere without authorisation, and non-admins can
+#. install safe software in their user dir without authorisation, but
+#. need authorisation to install safe software in the system dir or to
+#. install unsafe software anywhere:
+#. * Unconditionally return `yes` from `app-install`.
+#. * Return `auth_admin` from `override-parental-controls` for users
+#. not in `@privileged_group@`, and `yes` for users in it.
+#. * Set the malcontent `is-user-installation-allowed` property of all
+#. non-admins’ parental controls policies to true.
+#. * Set the malcontent `is-system-installation-allowed` property of
+#. all non-admins’ parental controls policies to false.
+#. - In order to configure the policy so that all users (including
+#. admins) can install safe software anywhere without authorisation,
+#. but need authorisation to install unsafe software anywhere (i.e.
+#. applying parental controls to admins too):
+#. * Unconditionally return `yes` from `app-install`.
+#. * Unconditionally return `auth_admin` from `override-parental-controls`.
+#. * Set the malcontent `is-user-installation-allowed` property of all
+#. users’ parental controls policies to true.
+#. * Set the malcontent `is-system-installation-allowed` property of
+#. all users’ parental controls policies to true.
+#: system-helper/org.freedesktop.Flatpak.policy.in:287
+msgid "Override parental controls for installs"
+msgstr "Орнату үшін ата-аналық бақылауды қайта анықтау"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:288
+msgid ""
+"Authentication is required to install software which is restricted by your "
+"parental controls policy"
+msgstr ""
+"Ата-аналық бақылау саясатымен шектелген бағдарламалық қамтаманы орнату үшін "
+"аутентификация қажет"
+
+#. SECURITY:
+#. - This is like org.freedesktop.Flatpak.override-parental-controls, but
+#. it’s queried for app updates, whereas the former is queried for app
+#. installs.
+#. - As with the above action, this one is only queried if
+#. org.freedesktop.Flatpak.app-update has allowed the app update, and
+#. only if the app being updated has too extreme content for the user
+#. who is trying to update it.
+#. - The default policy for this is to *allow* updates to ‘too extreme’
+#. apps by default, on the basis that having an out-of-date (i.e.
+#. insecure or unsupported) app is a worse outcome than automatically
+#. installing an update which has radically different content from the
+#. version of the app which the parent originally vetted and installed.
+#: system-helper/org.freedesktop.Flatpak.policy.in:313
+msgid "Override parental controls for updates"
+msgstr "Жаңартулар үшін ата-аналық бақылауды қайта анықтау"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:314
+msgid ""
+"Authentication is required to update software which is restricted by your "
+"parental controls policy"
+msgstr ""
+"Ата-аналық бақылау саясатымен шектелген бағдарламалық қамтаманы жаңарту үшін "
+"аутентификация қажет"


### PR DESCRIPTION
Hello,

Dear maintainers, please review submitted PR which adds Kazakh (kk) translation to both LINGUAS file and as kk.po itself.

The original template is taken from https://l10n.gnome.org/vertimus/flatpak/main/po/kk

Thank you!

PS: Please squash the commits as I uploaded the translation via GitHub web UI and edited LINGUAS separately, thus resulting in two commits.