### PR TITLE
feat: Add `--no-scope` to `flatpak run`

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -62,6 +62,7 @@ static int opt_instance_id_fd = -1;
 static char *opt_app_path;
 static char *opt_usr_path;
 static gboolean opt_clear_env;
+static gboolean opt_no_scope;
 
 static GOptionEntry options[] = {
   { "arch", 0, 0, G_OPTION_ARG_STRING, &opt_arch, N_("Arch to use"), N_("ARCH") },
@@ -91,6 +92,7 @@ static GOptionEntry options[] = {
   { "app-path", 0, 0, G_OPTION_ARG_FILENAME, &opt_app_path, N_("Use PATH instead of the app's /app"), N_("PATH") },
   { "usr-path", 0, 0, G_OPTION_ARG_FILENAME, &opt_usr_path, N_("Use PATH instead of the runtime's /usr"), N_("PATH") },
   { "clear-env", 0, 0, G_OPTION_ARG_NONE, &opt_clear_env, N_("Clear all outside environment variables"), NULL },
+  { "no-scope", 0, 0, G_OPTION_ARG_NONE, &opt_no_scope, N_("Don't run inside a transient systemd scope"), NULL },
   { NULL }
 };
 
@@ -312,6 +314,8 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
     flags |= FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY;
   if (!opt_clear_env)
     flags |= FLATPAK_RUN_FLAG_CLEAR_ENV;
+  if (opt_no_scope)
+    flags |= FLATPAK_RUN_FLAG_NO_SCOPE;
 
   if (!flatpak_run_app (app_deploy ? app_ref : runtime_ref,
                         app_deploy,

--- a/common/flatpak-common-types-private.h
+++ b/common/flatpak-common-types-private.h
@@ -50,6 +50,7 @@ typedef enum {
   FLATPAK_RUN_FLAG_PARENT_EXPOSE_PIDS = (1 << 20),
   FLATPAK_RUN_FLAG_PARENT_SHARE_PIDS  = (1 << 21),
   FLATPAK_RUN_FLAG_CLEAR_ENV          = (1 << 22),
+  FLATPAK_RUN_FLAG_NO_SCOPE           = (1 << 23),
 } FlatpakRunFlags;
 
 typedef struct FlatpakDir             FlatpakDir;

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -539,7 +539,8 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
 
   /* Must run this before spawning the dbus proxy, to ensure it
      ends up in the app cgroup */
-  if (instance_id)
+  if (instance_id &&
+      (flags & FLATPAK_RUN_FLAG_NO_SCOPE) == 0)
     {
       if (!flatpak_run_in_transient_unit (app_id, instance_id, &my_error))
         {

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -938,6 +938,14 @@ key=v1;v2;
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--no-scope</option></term>
+
+                <listitem><para>
+                    Don't run inside a transient systemd scope
+                </para></listitem>
+            </varlistentry>
+
         </variablelist>
 
     </refsect1>


### PR DESCRIPTION
Don't run an app inside a transient systemd scope. It fixes #5870 and #6497.