### PR TITLE
Exclude EOL refs from fuzzy matching

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -40,6 +40,8 @@
 #include "flatpak-utils-private.h"
 #include "flatpak-error.h"
 #include "flatpak-chain-input-stream-private.h"
+#include "flatpak-repo-utils-private.h"
+#include "flatpak-variant-impl-private.h"
 
 static char *opt_arch;
 static char **opt_gpg_file;
@@ -325,6 +327,77 @@ install_image (FlatpakDir      *dir,
   return TRUE;
 }
 
+static GPtrArray *
+resolve_fuzzy_rebased_refs (FlatpakRemoteState  *state,
+                            GPtrArray           *refs,
+                            gboolean            *out_auto_resolved_rebase,
+                            char               **out_explicit_install_ref,
+                            GError             **error)
+{
+  g_autoptr(GPtrArray) resolved_refs = g_ptr_array_new_with_free_func ((GDestroyNotify) flatpak_decomposed_unref);
+  gboolean auto_resolved_rebase = FALSE;
+  g_autofree char *explicit_install_ref = NULL;
+  gboolean multiple_explicit_install_refs = FALSE;
+
+  for (size_t i = 0; i < refs->len; i++)
+    {
+      g_autoptr(FlatpakDecomposed) rebased_ref = NULL;
+      FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
+      FlatpakDecomposed *resolved_ref = ref;
+      VarMetadataRef sparse_cache;
+
+      if (!flatpak_remote_state_lookup_sparse_cache (state, flatpak_decomposed_get_ref (ref), &sparse_cache, NULL))
+        goto add;
+
+      const char *rebased_ref_str = var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLIFE_REBASE, NULL);
+
+      if (rebased_ref_str == NULL)
+        goto add;
+
+      rebased_ref = flatpak_decomposed_new_from_ref (rebased_ref_str, error);
+
+      if (rebased_ref == NULL)
+        return NULL;
+
+      if (flatpak_remote_state_lookup_ref (state, rebased_ref_str,
+                                           NULL, NULL, NULL, NULL, NULL, NULL))
+        {
+          resolved_ref = rebased_ref;
+          auto_resolved_rebase = TRUE;
+
+          if (explicit_install_ref == NULL)
+            explicit_install_ref = g_strdup (flatpak_decomposed_get_ref (ref));
+          else if (g_strcmp0 (explicit_install_ref, flatpak_decomposed_get_ref (ref)) != 0)
+            multiple_explicit_install_refs = TRUE;
+        }
+
+    add:
+      if (!g_ptr_array_find_with_equal_func (resolved_refs, resolved_ref,
+                                             (GEqualFunc) flatpak_decomposed_equal, NULL))
+        g_ptr_array_add (resolved_refs, flatpak_decomposed_ref (resolved_ref));
+    }
+
+  if (out_auto_resolved_rebase != NULL)
+    *out_auto_resolved_rebase = auto_resolved_rebase;
+
+  if (out_explicit_install_ref != NULL && !multiple_explicit_install_refs)
+    *out_explicit_install_ref = g_steal_pointer (&explicit_install_ref);
+
+  return g_steal_pointer (&resolved_refs);
+}
+
+static void
+print_auto_resolved_rebase_warning (const char *old_ref,
+                                    const char *new_ref)
+{
+  if (old_ref != NULL)
+    g_printerr (_("Warning: %s is end-of-life and has been replaced by %s. Specify the full ref explicitly to install it.\n"),
+                old_ref, new_ref);
+  else
+    g_printerr (_("Warning: one or more matching refs are end-of-life and have been replaced by %s. To install one of the end-of-life refs explicitly, use its full ref.\n"),
+                new_ref);
+}
+
 gboolean
 flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
@@ -556,7 +629,9 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
       g_autofree char *ref = NULL;
       g_autoptr(GPtrArray) refs = NULL;
       g_autoptr(GError) local_error = NULL;
+      g_autofree char *explicit_install_ref = NULL;
       FindMatchingRefsFlags matching_refs_flags;
+      gboolean auto_resolved_rebase = FALSE;
 
       if (!flatpak_allow_fuzzy_matching (pref))
         matching_refs_flags = FIND_MATCHING_REFS_FLAGS_NONE;
@@ -600,6 +675,14 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
                                                cancellable, error);
           if (refs == NULL)
             return FALSE;
+
+          if (matching_refs_flags & FIND_MATCHING_REFS_FLAGS_FUZZY)
+            {
+              refs = resolve_fuzzy_rebased_refs (state, refs, &auto_resolved_rebase,
+                                                 &explicit_install_ref, error);
+              if (refs == NULL)
+                return FALSE;
+            }
         }
 
       if (refs->len == 0)
@@ -611,7 +694,16 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
           return FALSE;
         }
 
-      if (!flatpak_resolve_matching_refs (remote, dir, opt_yes, refs, id, opt_noninteractive, &ref, error))
+      if (auto_resolved_rebase && refs->len == 1)
+        {
+          FlatpakDecomposed *chosen_ref = g_ptr_array_index (refs, 0);
+
+          if (!opt_noninteractive)
+            print_auto_resolved_rebase_warning (explicit_install_ref,
+                                                flatpak_decomposed_get_ref (chosen_ref));
+          ref = flatpak_decomposed_dup_ref (chosen_ref);
+        }
+      else if (!flatpak_resolve_matching_refs (remote, dir, opt_yes, refs, id, opt_noninteractive, &ref, error))
         return FALSE;
 
       if (!flatpak_transaction_add_install (transaction, remote, ref, (const char **) opt_subpaths, &local_error))

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -453,7 +453,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
               if (!flatpak_allow_fuzzy_matching (argv[1]))
                 matching_refs_flags = FIND_MATCHING_REFS_FLAGS_NONE;
               else
-                matching_refs_flags = FIND_MATCHING_REFS_FLAGS_FUZZY;
+                matching_refs_flags = FIND_MATCHING_REFS_FLAGS_FUZZY |
+                                      FIND_MATCHING_REFS_FLAGS_EXCLUDE_EOL;
 
               for (j = 0; remotes[j] != NULL; j++)
                 {
@@ -560,7 +561,8 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
       if (!flatpak_allow_fuzzy_matching (pref))
         matching_refs_flags = FIND_MATCHING_REFS_FLAGS_NONE;
       else
-        matching_refs_flags = FIND_MATCHING_REFS_FLAGS_FUZZY;
+        matching_refs_flags = FIND_MATCHING_REFS_FLAGS_FUZZY |
+                              FIND_MATCHING_REFS_FLAGS_EXCLUDE_EOL;
 
       if (matching_refs_flags & FIND_MATCHING_REFS_FLAGS_FUZZY)
         {

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -550,10 +550,40 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
                                                             &matched_kinds, &id, &arch, &branch);
 
                   if (opt_no_pull)
-                    refs = flatpak_dir_find_local_refs (this_dir, this_remote, id, branch, this_default_branch, arch,
-                                                        flatpak_get_default_arch (),
-                                                        matched_kinds, matching_refs_flags,
-                                                        cancellable, &local_error);
+                    {
+                      g_autoptr(FlatpakRemoteState) local_state = NULL;
+
+                      refs = flatpak_dir_find_local_refs (this_dir, this_remote, id, branch, this_default_branch, arch,
+                                                          flatpak_get_default_arch (),
+                                                          matched_kinds, matching_refs_flags,
+                                                          cancellable, &local_error);
+
+                      if (refs == NULL)
+                        continue;
+
+                      local_state = flatpak_dir_get_remote_state_optional (this_dir, this_remote, TRUE, cancellable, NULL);
+
+                      if (local_state != NULL && (matching_refs_flags & FIND_MATCHING_REFS_FLAGS_EXCLUDE_EOL))
+                        {
+                          for (guint k = refs->len; k > 0; k--)
+                            {
+                              FlatpakDecomposed *matched_ref = g_ptr_array_index (refs, k - 1);
+                              VarMetadataRef sparse_cache;
+                              const char *eol, *eol_rebase;
+
+                              if (!flatpak_remote_state_lookup_sparse_cache (local_state,
+                                                                             flatpak_decomposed_get_ref (matched_ref),
+                                                                             &sparse_cache, NULL))
+                                continue;
+
+                              eol       = var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLIFE, NULL);
+                              eol_rebase = var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLIFE_REBASE, NULL);
+
+                              if (eol != NULL && eol_rebase == NULL)
+                                g_ptr_array_remove_index (refs, k - 1);
+                            }
+                        }
+                    }
                   else
                     {
                       g_autoptr(FlatpakRemoteState) state = get_remote_state (this_dir, this_remote, FALSE, FALSE,
@@ -656,10 +686,48 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
         }
 
       if (opt_no_pull)
-        refs = flatpak_dir_find_local_refs (dir, remote, id, branch, default_branch, arch,
-                                            flatpak_get_default_arch (),
-                                            matched_kinds, matching_refs_flags,
-                                            cancellable, error);
+        {
+          g_autoptr(FlatpakRemoteState) local_state = NULL;
+
+          refs = flatpak_dir_find_local_refs (dir, remote, id, branch, default_branch, arch,
+                                              flatpak_get_default_arch (),
+                                              matched_kinds, matching_refs_flags,
+                                              cancellable, error);
+
+          if (refs == NULL)
+            return FALSE;
+
+          local_state = flatpak_dir_get_remote_state_optional (dir, remote, TRUE, cancellable, NULL);
+
+          if (local_state != NULL && (matching_refs_flags & FIND_MATCHING_REFS_FLAGS_EXCLUDE_EOL))
+            {
+              for (guint k = refs->len; k > 0; k--)
+                {
+                  FlatpakDecomposed *matched_ref = g_ptr_array_index (refs, k - 1);
+                  VarMetadataRef sparse_cache;
+                  const char *eol, *eol_rebase;
+
+                  if (!flatpak_remote_state_lookup_sparse_cache (local_state,
+                                                                 flatpak_decomposed_get_ref (matched_ref),
+                                                                 &sparse_cache, NULL))
+                    continue;
+
+                  eol       = var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLIFE, NULL);
+                  eol_rebase = var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLIFE_REBASE, NULL);
+
+                  if (eol != NULL && eol_rebase == NULL)
+                    g_ptr_array_remove_index (refs, k - 1);
+                }
+            }
+
+          if (local_state != NULL && (matching_refs_flags & FIND_MATCHING_REFS_FLAGS_FUZZY))
+            {
+              refs = resolve_fuzzy_rebased_refs (local_state, refs, &auto_resolved_rebase,
+                                                 &explicit_install_ref, error);
+              if (refs == NULL)
+                return FALSE;
+            }
+        }
       else
         {
           g_autoptr(FlatpakRemoteState) state = NULL;

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -387,15 +387,15 @@ resolve_fuzzy_rebased_refs (FlatpakRemoteState  *state,
 }
 
 static void
-print_auto_resolved_rebase_warning (const char *old_ref,
-                                    const char *new_ref)
+print_auto_resolved_rebase_info (const char *old_ref,
+                                 const char *new_ref)
 {
   if (old_ref != NULL)
-    g_printerr (_("Warning: %s is end-of-life and has been replaced by %s. Specify the full ref explicitly to install it.\n"),
-                old_ref, new_ref);
+    g_print (_("Info: %s is end-of-life and has been replaced by %s. Specify the full ref explicitly to install it.\n"),
+             old_ref, new_ref);
   else
-    g_printerr (_("Warning: one or more matching refs are end-of-life and have been replaced by %s. To install one of the end-of-life refs explicitly, use its full ref.\n"),
-                new_ref);
+    g_print (_("Info: one or more matching refs are end-of-life and have been replaced by %s. To install one of the end-of-life refs explicitly, use its full ref.\n"),
+             new_ref);
 }
 
 gboolean
@@ -699,12 +699,15 @@ flatpak_builtin_install (int argc, char **argv, GCancellable *cancellable, GErro
           FlatpakDecomposed *chosen_ref = g_ptr_array_index (refs, 0);
 
           if (!opt_noninteractive)
-            print_auto_resolved_rebase_warning (explicit_install_ref,
-                                                flatpak_decomposed_get_ref (chosen_ref));
+            print_auto_resolved_rebase_info (explicit_install_ref,
+                                             flatpak_decomposed_get_ref (chosen_ref));
           ref = flatpak_decomposed_dup_ref (chosen_ref);
         }
       else if (!flatpak_resolve_matching_refs (remote, dir, opt_yes, refs, id, opt_noninteractive, &ref, error))
         return FALSE;
+
+      if (!(matching_refs_flags & FIND_MATCHING_REFS_FLAGS_FUZZY))
+        flatpak_transaction_add_no_eol_rebase_ref (transaction, ref);
 
       if (!flatpak_transaction_add_install (transaction, remote, ref, (const char **) opt_subpaths, &local_error))
         {

--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -756,16 +756,16 @@ print_eol_info_message (FlatpakDir        *dir,
       if (is_pinned)
         {
           /* Only runtimes can be pinned */
-          g_print (_("\nInfo: (pinned) runtime %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch %s%s%s\n"),
+          g_print (_("\nWarning: (pinned) runtime %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch %s%s%s\n"),
                    on, ref_name, off, on, ref_branch, off, on, eolr_name, off, on, eolr_branch, off);
         }
       else
         {
           if (flatpak_decomposed_is_runtime (ref))
-            g_print (_("\nInfo: runtime %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch %s%s%s\n"),
+            g_print (_("\nWarning: runtime %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch %s%s%s\n"),
                      on, ref_name, off, on, ref_branch, off, on, eolr_name, off, on, eolr_branch, off);
           else
-            g_print (_("\nInfo: app %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch %s%s%s\n"),
+            g_print (_("\nWarning: app %s%s%s branch %s%s%s is end-of-life, in favor of %s%s%s branch %s%s%s\n"),
                      on, ref_name, off, on, ref_branch, off, on, eolr_name, off, on, eolr_branch, off);
         }
     }
@@ -777,16 +777,16 @@ print_eol_info_message (FlatpakDir        *dir,
       if (is_pinned)
         {
           /* Only runtimes can be pinned */
-          g_print (_("\nInfo: (pinned) runtime %s%s%s branch %s%s%s is end-of-life, with reason:\n"),
+          g_print (_("\nWarning: (pinned) runtime %s%s%s branch %s%s%s is end-of-life, with reason:\n"),
                    on, ref_name, off, on, ref_branch, off);
         }
       else
         {
           if (flatpak_decomposed_is_runtime (ref))
-            g_print (_("\nInfo: runtime %s%s%s branch %s%s%s is end-of-life, with reason:\n"),
+            g_print (_("\nWarning: runtime %s%s%s branch %s%s%s is end-of-life, with reason:\n"),
                      on, ref_name, off, on, ref_branch, off);
           else
-            g_print (_("\nInfo: app %s%s%s branch %s%s%s is end-of-life, with reason:\n"),
+            g_print (_("\nWarning: app %s%s%s branch %s%s%s is end-of-life, with reason:\n"),
                      on, ref_name, off, on, ref_branch, off);
         }
       g_print ("   %s\n", escaped_reason);
@@ -903,6 +903,7 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
   EolAction action = EOL_UNDECIDED;
   EolAction old_action = EOL_UNDECIDED;
   gboolean can_rebase = rebased_to_ref != NULL && remote != NULL;
+  gboolean no_eol_rebase = flatpak_transaction_ref_no_eol_rebase (transaction, ref_str);
   g_autoptr(FlatpakInstallation) installation = flatpak_transaction_get_installation (transaction);
   g_autoptr(FlatpakDir) dir = flatpak_installation_get_dir (installation, NULL);
 
@@ -977,7 +978,9 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
             }
         }
 
-      if (rebased_to_ref && remote)
+      if (no_eol_rebase && can_rebase)
+        action = EOL_NO_REBASE;
+      else if (rebased_to_ref && remote)
         {
           /* The context for this prompt is in print_eol_info_message() */
           if (self->disable_interaction ||

--- a/app/flatpak-quiet-transaction.c
+++ b/app/flatpak-quiet-transaction.c
@@ -236,9 +236,9 @@ end_of_lifed_with_rebase (FlatpakTransaction *transaction,
   g_autoptr(FlatpakRef) rref = flatpak_ref_parse (ref, NULL);
 
   if (rebased_to_ref)
-    g_print (_("Info: %s is end-of-life, in favor of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
+    g_print (_("Warning: %s is end-of-life, in favor of %s\n"), flatpak_ref_get_name (rref), rebased_to_ref);
   else if (reason)
-    g_print (_("Info: %s is end-of-life, with reason: %s\n"), flatpak_ref_get_name (rref), reason);
+    g_print (_("Warning: %s is end-of-life, with reason: %s\n"), flatpak_ref_get_name (rref), reason);
 
   if (rebased_to_ref && remote)
     {

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -352,6 +352,7 @@ typedef enum {
 typedef enum {
   FIND_MATCHING_REFS_FLAGS_NONE = 0,
   FIND_MATCHING_REFS_FLAGS_FUZZY = (1 << 0),
+  FIND_MATCHING_REFS_FLAGS_EXCLUDE_EOL = (1 << 1),
 } FindMatchingRefsFlags;
 
 GQuark       flatpak_dir_error_quark (void);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14487,6 +14487,27 @@ flatpak_dir_find_remote_refs (FlatpakDir           *self,
   if (matched_refs == NULL)
     return NULL;
 
+  if (flags & FIND_MATCHING_REFS_FLAGS_EXCLUDE_EOL)
+    {
+      for (size_t i = matched_refs->len; i-- > 0;)
+        {
+          FlatpakDecomposed *matched_ref = g_ptr_array_index (matched_refs, i);
+          const char *matched_ref_str = flatpak_decomposed_get_ref (matched_ref);
+          VarMetadataRef sparse_cache;
+          const char *eol;
+          const char *eol_rebase;
+
+          if (!flatpak_remote_state_lookup_sparse_cache (state, matched_ref_str, &sparse_cache, NULL))
+            continue;
+
+          eol = var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLIFE, NULL);
+          eol_rebase = var_metadata_lookup_string (sparse_cache, FLATPAK_SPARSE_CACHE_KEY_ENDOFLIFE_REBASE, NULL);
+
+          if (eol != NULL && eol_rebase == NULL)
+            g_ptr_array_remove_index (matched_refs, i);
+        }
+    }
+
   /* If we can't match anything and we had an error downloading (offline?), report that as its more helpful */
   if (matched_refs->len == 0 && state->summary_fetch_error)
     {

--- a/common/flatpak-transaction-private.h
+++ b/common/flatpak-transaction-private.h
@@ -31,6 +31,10 @@ FlatpakRemoteState *flatpak_transaction_ensure_remote_state (FlatpakTransaction 
                                                              GError                        **error);
 
 FlatpakDecomposed * flatpak_transaction_operation_get_decomposed (FlatpakTransactionOperation *self);
+void                flatpak_transaction_add_no_eol_rebase_ref   (FlatpakTransaction          *self,
+                                                                 const char                  *ref);
+gboolean            flatpak_transaction_ref_no_eol_rebase       (FlatpakTransaction          *self,
+                                                                 const char                  *ref);
 
 #include "flatpak-dir-private.h"
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -171,6 +171,7 @@ typedef struct _FlatpakTransactionPrivate
   FlatpakInstallation         *installation;
   FlatpakDir                  *dir;
   GHashTable                  *last_op_for_ref;
+  GHashTable                  *no_eol_rebase_refs;
   GHashTable                  *remote_states; /* (element-type utf8 FlatpakRemoteState) */
   GPtrArray                   *extra_dependency_dirs;
   GPtrArray                   *extra_sideload_repos;
@@ -1062,6 +1063,7 @@ flatpak_transaction_finalize (GObject *object)
   g_list_free_full (priv->images, (GDestroyNotify) image_data_free);
   g_free (priv->default_arch);
   g_hash_table_unref (priv->last_op_for_ref);
+  g_hash_table_unref (priv->no_eol_rebase_refs);
   g_hash_table_unref (priv->remote_states);
   g_list_free_full (priv->ops, (GDestroyNotify) g_object_unref);
   g_clear_object (&priv->dir);
@@ -1542,12 +1544,63 @@ flatpak_transaction_init (FlatpakTransaction *self)
   FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
 
   priv->last_op_for_ref = g_hash_table_new_full ((GHashFunc)flatpak_decomposed_hash, (GEqualFunc)flatpak_decomposed_equal, (GDestroyNotify) flatpak_decomposed_unref, NULL);
+  priv->no_eol_rebase_refs = g_hash_table_new_full ((GHashFunc) flatpak_decomposed_hash, (GEqualFunc) flatpak_decomposed_equal, (GDestroyNotify) flatpak_decomposed_unref, NULL);
   priv->remote_states = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, (GDestroyNotify) flatpak_remote_state_unref);
   priv->added_origin_remotes = g_ptr_array_new_with_free_func (g_free);
   priv->extra_dependency_dirs = g_ptr_array_new_with_free_func (g_object_unref);
   priv->extra_sideload_repos = g_ptr_array_new_with_free_func (g_free);
   priv->sideload_image_collections = g_ptr_array_new_with_free_func (g_object_unref);
   priv->can_run = TRUE;
+}
+
+void
+flatpak_transaction_add_no_eol_rebase_ref (FlatpakTransaction *self,
+                                           const char         *ref)
+{
+  FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
+  g_autoptr(FlatpakDecomposed) decomposed = NULL;
+
+  g_return_if_fail (FLATPAK_IS_TRANSACTION (self));
+  g_return_if_fail (ref != NULL);
+
+  decomposed = flatpak_decomposed_new_from_ref (ref, NULL);
+  g_return_if_fail (decomposed != NULL);
+
+  g_hash_table_add (priv->no_eol_rebase_refs, g_steal_pointer (&decomposed));
+}
+
+gboolean
+flatpak_transaction_ref_no_eol_rebase (FlatpakTransaction *self,
+                                       const char         *ref)
+{
+  FlatpakTransactionPrivate *priv = flatpak_transaction_get_instance_private (self);
+  g_autoptr(FlatpakDecomposed) decomposed = NULL;
+  GHashTableIter iter;
+  gpointer key;
+
+  g_return_val_if_fail (FLATPAK_IS_TRANSACTION (self), FALSE);
+  g_return_val_if_fail (ref != NULL, FALSE);
+
+  decomposed = flatpak_decomposed_new_from_ref (ref, NULL);
+  if (decomposed == NULL)
+    return FALSE;
+
+  if (g_hash_table_contains (priv->no_eol_rebase_refs, decomposed))
+    return TRUE;
+
+  if (!flatpak_decomposed_id_is_subref (decomposed))
+    return FALSE;
+
+  g_hash_table_iter_init (&iter, priv->no_eol_rebase_refs);
+  while (g_hash_table_iter_next (&iter, &key, NULL))
+    {
+      FlatpakDecomposed *marked_ref = key;
+
+      if (flatpak_decomposed_id_is_subref_of (decomposed, marked_ref))
+        return TRUE;
+    }
+
+  return FALSE;
 }
 
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -487,7 +487,7 @@ fi
 assert_not_file_has_content install-log "No ref chosen to resolve matches for ‘fuzzyrebasedold’"
 assert_not_file_has_content install-log "Replace\\?"
 assert_file_has_content install-log "Proceed with these changes to the .*installation\\?"
-assert_file_has_content install-log "Warning: app/org\\.test\\.FuzzyRebasedOld/$ARCH/master is end-of-life and has been replaced by app/org\\.test\\.FuzzyRebasedNew/$ARCH/master"
+assert_file_has_content install-log "Info: app/org\\.test\\.FuzzyRebasedOld/$ARCH/master is end-of-life and has been replaced by app/org\\.test\\.FuzzyRebasedNew/$ARCH/master"
 assert_file_has_content install-log "Specify the full ref explicitly to install it\\."
 
 ${FLATPAK} ${U} install --app -y test-repo fuzzyrebasedold >&2
@@ -498,7 +498,23 @@ assert_not_file_has_content list-log "org\.test\.FuzzyRebasedOld/"
 
 ${FLATPAK} ${U} uninstall -y fuzzyrebasednew >&2
 
-ok "fuzzy install handles eol refs"
+if ${FLATPAK} ${U} install --app test-repo org.test.FuzzyRebasedOld > install-log 2>&1; then
+    assert_not_reached "install of exact rebased app id should still require the transaction confirmation"
+fi
+assert_not_file_has_content install-log "Replace\\?"
+assert_not_file_has_content install-log "Specify the full ref explicitly to install it\\."
+assert_file_has_content install-log "Warning: app org\\.test\\.FuzzyRebasedOld branch master is end-of-life, in favor of org\\.test\\.FuzzyRebasedNew branch master"
+assert_file_has_content install-log "Proceed with these changes to the .*installation\\?"
+
+${FLATPAK} ${U} install --app -y test-repo org.test.FuzzyRebasedOld >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyRebasedOld/"
+assert_not_file_has_content list-log "org\.test\.FuzzyRebasedNew/"
+
+${FLATPAK} ${U} uninstall -y fuzzyrebasedold >&2
+
+ok "install handles eol refs"
 
 if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
     REBASE_COLLECTION_ID=org.test.Collection.rebase

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..47"
+echo "1..48"
 
 #Regular repo
 setup_repo
@@ -453,6 +453,33 @@ ${FLATPAK} ${U} uninstall -y org.test.Hello >&2
 EXPORT_ARGS="" make_updated_app
 
 ok "eol build-export"
+
+make_updated_app test "" master "" org.test.FuzzyInstall
+EXPORT_ARGS="--end-of-life=Legacy-reason" make_updated_app test "" master "" org.test.FuzzyInstallOld
+
+if ${FLATPAK} ${U} install --app test-repo fuzzyinstallold > install-log 2>&1; then
+    assert_not_reached "fuzzy install of end-of-life ref should fail"
+fi
+assert_file_has_content install-log "Nothing matches fuzzyinstallold in remote test-repo"
+
+${FLATPAK} ${U} install --app -y test-repo fuzzyinstall >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyInstall/"
+assert_not_file_has_content list-log "org\.test\.FuzzyInstallOld/"
+
+${FLATPAK} ${U} uninstall -y org.test.FuzzyInstall >&2
+
+${FLATPAK} ${U} install -y test-repo org.test.FuzzyInstallOld > install-log
+assert_file_has_content install-log "org\.test\.FuzzyInstallOld"
+assert_file_has_content install-log "end-of-life"
+
+${FLATPAK} ${U} uninstall -y fuzzyinstallold >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_not_file_has_content list-log "org\.test\.FuzzyInstallOld/"
+
+ok "fuzzy install filters eol refs"
 
 if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
     REBASE_COLLECTION_ID=org.test.Collection.rebase

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -456,6 +456,8 @@ ok "eol build-export"
 
 make_updated_app test "" master "" org.test.FuzzyInstall
 EXPORT_ARGS="--end-of-life=Legacy-reason" make_updated_app test "" master "" org.test.FuzzyInstallOld
+make_updated_app test "" master "" org.test.FuzzyRebasedNew
+EXPORT_ARGS="--end-of-life-rebase=org.test.FuzzyRebasedNew" make_updated_app test "" master "" org.test.FuzzyRebasedOld
 
 if ${FLATPAK} ${U} install --app test-repo fuzzyinstallold > install-log 2>&1; then
     assert_not_reached "fuzzy install of end-of-life ref should fail"
@@ -479,7 +481,24 @@ ${FLATPAK} ${U} uninstall -y fuzzyinstallold >&2
 ${FLATPAK} ${U} list --columns=ref > list-log
 assert_not_file_has_content list-log "org\.test\.FuzzyInstallOld/"
 
-ok "fuzzy install filters eol refs"
+if ${FLATPAK} ${U} install --app test-repo fuzzyrebasedold > install-log 2>&1; then
+    assert_not_reached "fuzzy install of rebased ref should still require the transaction confirmation"
+fi
+assert_not_file_has_content install-log "No ref chosen to resolve matches for ‘fuzzyrebasedold’"
+assert_not_file_has_content install-log "Replace\\?"
+assert_file_has_content install-log "Proceed with these changes to the .*installation\\?"
+assert_file_has_content install-log "Warning: app/org\\.test\\.FuzzyRebasedOld/$ARCH/master is end-of-life and has been replaced by app/org\\.test\\.FuzzyRebasedNew/$ARCH/master"
+assert_file_has_content install-log "Specify the full ref explicitly to install it\\."
+
+${FLATPAK} ${U} install --app -y test-repo fuzzyrebasedold >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyRebasedNew/"
+assert_not_file_has_content list-log "org\.test\.FuzzyRebasedOld/"
+
+${FLATPAK} ${U} uninstall -y fuzzyrebasednew >&2
+
+ok "fuzzy install handles eol refs"
 
 if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
     REBASE_COLLECTION_ID=org.test.Collection.rebase

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..48"
+echo "1..50"
 
 #Regular repo
 setup_repo
@@ -515,6 +515,83 @@ assert_not_file_has_content list-log "org\.test\.FuzzyRebasedNew/"
 ${FLATPAK} ${U} uninstall -y fuzzyrebasedold >&2
 
 ok "install handles eol refs"
+
+# --no-pull variants: pre-populate the local cache via --no-deploy
+
+${FLATPAK} ${U} install -y --no-deploy test-repo org.test.FuzzyInstall >&2
+${FLATPAK} ${U} install -y --no-deploy test-repo org.test.FuzzyInstallOld >&2
+${FLATPAK} ${U} install -y --no-deploy test-repo org.test.FuzzyRebasedNew >&2
+${FLATPAK} ${U} install -y --no-deploy test-repo org.test.FuzzyRebasedOld >&2
+
+if ${FLATPAK} ${U} install --no-pull --app test-repo fuzzyinstallold > install-log 2>&1; then
+    assert_not_reached "fuzzy --no-pull install of end-of-life ref should fail"
+fi
+assert_file_has_content install-log "Nothing matches fuzzyinstallold in local repository for remote test-repo"
+
+${FLATPAK} ${U} install --no-pull --app -y test-repo fuzzyinstall >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyInstall/"
+assert_not_file_has_content list-log "org\.test\.FuzzyInstallOld/"
+
+${FLATPAK} ${U} uninstall -y org.test.FuzzyInstall >&2
+
+${FLATPAK} ${U} install --no-pull --app -y test-repo fuzzyrebasedold >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyRebasedNew/"
+
+${FLATPAK} ${U} uninstall -y fuzzyrebasednew >&2
+
+${FLATPAK} ${U} install --no-pull --app -y test-repo org.test.FuzzyRebasedOld >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyRebasedOld/"
+
+${FLATPAK} ${U} uninstall -y fuzzyrebasedold >&2
+
+ok "install handles eol refs with --no-pull"
+
+# --noninteractive variants
+
+if ${FLATPAK} ${U} install --noninteractive --app test-repo fuzzyinstallold > install-log 2>&1; then
+    assert_not_reached "noninteractive fuzzy install of end-of-life ref should fail"
+fi
+assert_file_has_content install-log "Nothing matches fuzzyinstallold in remote test-repo"
+
+${FLATPAK} ${U} install --noninteractive --app test-repo fuzzyinstall >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyInstall/"
+assert_not_file_has_content list-log "org\.test\.FuzzyInstallOld/"
+
+${FLATPAK} ${U} uninstall -y org.test.FuzzyInstall >&2
+
+${FLATPAK} ${U} install --noninteractive --app test-repo fuzzyrebasedold >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyRebasedNew/"
+assert_not_file_has_content list-log "org\.test\.FuzzyRebasedOld/"
+
+${FLATPAK} ${U} uninstall -y fuzzyrebasednew >&2
+
+${FLATPAK} ${U} install --noninteractive --app test-repo org.test.FuzzyRebasedOld >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyRebasedNew/"
+assert_not_file_has_content list-log "org\.test\.FuzzyRebasedOld/"
+
+${FLATPAK} ${U} uninstall -y fuzzyrebasednew >&2
+
+${FLATPAK} ${U} install --noninteractive --app test-repo "app/org.test.FuzzyRebasedOld/$ARCH/master" >&2
+
+${FLATPAK} ${U} list --columns=ref > list-log
+assert_file_has_content list-log "org\.test\.FuzzyRebasedNew/"
+assert_not_file_has_content list-log "org\.test\.FuzzyRebasedOld/"
+
+${FLATPAK} ${U} uninstall -y fuzzyrebasednew >&2
+
+ok "install handles eol refs with --noninteractive"
 
 if [ x${USE_COLLECTIONS_IN_SERVER-} == xyes ] ; then
     REBASE_COLLECTION_ID=org.test.Collection.rebase


### PR DESCRIPTION
This will remove EOL-ed refs from matched lists, avoiding awkward interaction where user either chooses something no longer maintained or will be immediately asked to rebase to the new ID.