### PR TITLE
portal: Reinstate checks for whether we can use an app-supplied fd

### DIFF
--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -588,6 +588,48 @@ peek_fd_for_handle (GUnixFDList *fd_list,
   return TRUE;
 }
 
+static char *
+bubblewrap_remap_path (const char *path)
+{
+  if (g_str_has_prefix (path, "/newroot/"))
+    path = path + strlen ("/newroot");
+  return g_strdup (path);
+}
+
+static char *
+verify_proc_self_fd (const char *proc_path,
+                     GError **error)
+{
+  char path_buffer[PATH_MAX + 1];
+  ssize_t symlink_size;
+
+  symlink_size = readlink (proc_path, path_buffer, PATH_MAX);
+  if (symlink_size < 0)
+    return glnx_null_throw_errno_prefix (error, "readlink");
+
+  path_buffer[symlink_size] = 0;
+
+  /* All normal paths start with /, but some weird things
+     don't, such as socket:[27345] or anon_inode:[eventfd].
+     We don't support any of these */
+  if (path_buffer[0] != '/')
+    return glnx_null_throw (error, "%s resolves to non-absolute path %s",
+                            proc_path, path_buffer);
+
+  /* File descriptors to actually deleted files have " (deleted)"
+     appended to them. This also happens to some fake fd types
+     like shmem which are "/<name> (deleted)". All such
+     files are considered invalid. Unfortunately this also
+     matches files with filenames that actually end in " (deleted)",
+     but there is not much to do about this. */
+  if (g_str_has_suffix (path_buffer, " (deleted)"))
+    return glnx_null_throw (error, "%s resolves to deleted path %s",
+                            proc_path, path_buffer);
+
+  /* remap from sandbox to host if needed */
+  return bubblewrap_remap_path (path_buffer);
+}
+
 static gboolean
 validate_opath_fd (int        fd,
                    gboolean   needs_writable,
@@ -624,6 +666,40 @@ validate_opath_fd (int        fd,
   /* Must be able to access readable and potentially writable */
   if (faccessat (fd, "", access_mode, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW) != 0)
     return glnx_throw_errno_prefix (error, "Bad access mode");
+
+  return TRUE;
+}
+
+static gboolean
+check_fd_exposable (int fd,
+                    GError **error)
+{
+  g_autofree char *proc_path = NULL;
+  struct stat st_buf;
+  struct stat real_st_buf;
+  g_autofree char *path = NULL;
+
+  /* Must be able to fstat */
+  if (fstat (fd, &st_buf) < 0)
+    return glnx_throw_errno_prefix (error, "fstat");
+
+  proc_path = g_strdup_printf ("/proc/self/fd/%d", fd);
+
+  /* Must be able to read valid path from /proc/self/fd */
+  /* This is an absolute and (at least at open time) symlink-expanded path */
+  path = verify_proc_self_fd (proc_path, error);
+  if (path == NULL)
+    return FALSE;
+
+  /* Verify that this is the same file as the app opened */
+  if (stat (path, &real_st_buf) < 0 ||
+      st_buf.st_dev != real_st_buf.st_dev ||
+      st_buf.st_ino != real_st_buf.st_ino)
+    {
+      /* Different files on the inside and the outside, reject the request */
+      return glnx_throw (error,
+                         "different file inside and outside sandbox");
+    }
 
   return TRUE;
 }
@@ -1328,6 +1404,14 @@ handle_spawn (PortalFlatpak         *object,
               return G_DBUS_METHOD_INVOCATION_HANDLED;
             }
 
+          if (!check_fd_exposable (handle_fd, &error))
+            {
+              g_info ("Unable to get path for sandbox-exposed fd %d, ignoring: %s",
+                      handle_fd, error->message);
+              g_clear_error (&error);
+              continue;
+            }
+
           g_array_append_val (expose_fds, handle_fd);
         }
     }
@@ -1357,6 +1441,14 @@ handle_spawn (PortalFlatpak         *object,
                                                      "No file descriptor for handle %d",
                                                      handle);
               return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+
+          if (!check_fd_exposable (handle_fd, &error))
+            {
+              g_info ("Unable to get path for sandbox-exposed fd %d, ignoring: %s",
+                      handle_fd, error->message);
+              g_clear_error (&error);
+              continue;
             }
 
           g_array_append_val (expose_fds_ro, handle_fd);
@@ -1405,6 +1497,14 @@ handle_spawn (PortalFlatpak         *object,
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
+      if (!check_fd_exposable (handle_fd, &error))
+        {
+          g_prefix_error (&error, "Unable to use /app fd %d as path: ", handle_fd);
+          g_info ("%s", error->message);
+          g_dbus_method_invocation_return_gerror (invocation, error);
+          return G_DBUS_METHOD_INVOCATION_HANDLED;
+        }
+
       remapped_fd = fd_map_remap_fd (fd_map, &max_fd, handle_fd);
 
       g_ptr_array_add (flatpak_argv, g_strdup_printf ("--app-fd=%d",
@@ -1423,6 +1523,14 @@ handle_spawn (PortalFlatpak         *object,
 
       if (!peek_fd_for_handle (fd_list, handle, &handle_fd, &error))
         {
+          g_dbus_method_invocation_return_gerror (invocation, error);
+          return G_DBUS_METHOD_INVOCATION_HANDLED;
+        }
+
+      if (!check_fd_exposable (handle_fd, &error))
+        {
+          g_prefix_error (&error, "Unable to use /usr fd %d as path: ", handle_fd);
+          g_info ("%s", error->message);
           g_dbus_method_invocation_return_gerror (invocation, error);
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -867,16 +867,11 @@ handle_spawn (PortalFlatpak         *object,
 
       g_variant_get_child (arg_fds, i, "{uh}", &dest_fd, &handle);
 
-      if (handle >= fds_len || handle < 0)
+      if (!peek_fd_for_handle (fd_list, handle, &handle_fd, &error))
         {
-          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
-                                                 G_DBUS_ERROR_INVALID_ARGS,
-                                                 "No file descriptor for handle %d",
-                                                 handle);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
-
-      handle_fd = fds[handle];
 
       fd_map_entry.to = dest_fd;
       fd_map_entry.from = handle_fd;
@@ -1411,19 +1406,15 @@ handle_spawn (PortalFlatpak         *object,
     {
       int remapped_fd;
       gint32 handle = g_variant_get_handle (app_fd);
+      int handle_fd = -1;
 
-      if (handle >= fds_len || handle < 0)
+      if (!peek_fd_for_handle (fd_list, handle, &handle_fd, &error))
         {
-          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
-                                                 G_DBUS_ERROR_INVALID_ARGS,
-                                                 "No file descriptor for handle %d",
-                                                 handle);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      g_assert (fds != NULL);   /* otherwise fds_len would be 0 */
-
-      remapped_fd = fd_map_remap_fd (fd_map, &max_fd, fds[handle]);
+      remapped_fd = fd_map_remap_fd (fd_map, &max_fd, handle_fd);
 
       g_ptr_array_add (flatpak_argv, g_strdup_printf ("--app-fd=%d",
                                                       remapped_fd));
@@ -1437,19 +1428,15 @@ handle_spawn (PortalFlatpak         *object,
     {
       int remapped_fd;
       gint32 handle = g_variant_get_handle (usr_fd);
+      int handle_fd = -1;
 
-      if (handle >= fds_len || handle < 0)
+      if (!peek_fd_for_handle (fd_list, handle, &handle_fd, &error))
         {
-          g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
-                                                 G_DBUS_ERROR_INVALID_ARGS,
-                                                 "No file descriptor for handle %d",
-                                                 handle);
+          g_dbus_method_invocation_return_gerror (invocation, error);
           return G_DBUS_METHOD_INVOCATION_HANDLED;
         }
 
-      g_assert (fds != NULL);   /* otherwise fds_len would be 0 */
-
-      remapped_fd = fd_map_remap_fd (fd_map, &max_fd, fds[handle]);
+      remapped_fd = fd_map_remap_fd (fd_map, &max_fd, handle_fd);
 
       g_ptr_array_add (flatpak_argv, g_strdup_printf ("--usr-fd=%d",
                                                       remapped_fd));

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -551,6 +551,44 @@ child_setup_func (gpointer user_data)
 }
 
 static gboolean
+peek_fd_for_handle (GUnixFDList *fd_list,
+                    gint32 handle,
+                    int *fd_out,
+                    GError **error)
+{
+  const int *fds;
+  int fds_len = 0;
+
+  if (fd_list == NULL)
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "No file descriptors attached to message");
+      return FALSE;
+    }
+
+  if (handle < 0)
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "Invalid handle %d", handle);
+      return FALSE;
+    }
+
+  fds = g_unix_fd_list_peek_fds (fd_list, &fds_len);
+
+  if (handle >= fds_len)
+    {
+      g_set_error (error, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,
+                   "Handle %d out of range for message", handle);
+      return FALSE;
+    }
+
+  if (fd_out != NULL)
+    *fd_out = fds[handle];
+
+  return TRUE;
+}
+
+static gboolean
 validate_opath_fd (int        fd,
                    gboolean   needs_writable,
                    GError   **error)
@@ -1281,16 +1319,22 @@ handle_spawn (PortalFlatpak         *object,
       for (i = 0; i < len; i++)
         {
           gint32 handle;
+          int handle_fd = -1;
 
           g_variant_get_child (sandbox_expose_fd, i, "h", &handle);
-          if (handle >= 0 && handle < fds_len &&
-              validate_opath_fd (fds[handle], TRUE, &error))
+
+          if (!peek_fd_for_handle (fd_list, handle, &handle_fd, &error))
             {
-              g_array_append_val (expose_fds, fds[handle]);
+              g_dbus_method_invocation_return_gerror (invocation, error);
+              return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+
+          if (validate_opath_fd (handle_fd, TRUE, &error))
+            {
+              g_array_append_val (expose_fds, handle_fd);
             }
           else
             {
-              g_debug ("Invalid sandbox expose fd: %s", error->message);
               g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                                      G_DBUS_ERROR_INVALID_ARGS,
                                                      "No valid file descriptor for handle %d",
@@ -1307,12 +1351,19 @@ handle_spawn (PortalFlatpak         *object,
       for (i = 0; i < len; i++)
         {
           gint32 handle;
+          int handle_fd = -1;
 
           g_variant_get_child (sandbox_expose_fd_ro, i, "h", &handle);
-          if (handle >= 0 && handle < fds_len &&
-              validate_opath_fd (fds[handle], FALSE, &error))
+
+          if (!peek_fd_for_handle (fd_list, handle, &handle_fd, &error))
             {
-              g_array_append_val (expose_fds_ro, fds[handle]);
+              g_dbus_method_invocation_return_gerror (invocation, error);
+              return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+
+          if (validate_opath_fd (handle_fd, FALSE, &error))
+            {
+              g_array_append_val (expose_fds_ro, handle_fd);
             }
           else
             {

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -662,8 +662,6 @@ handle_spawn (PortalFlatpak         *object,
   PidData *pid_data;
   InstanceIdReadData *instance_id_read_data = NULL;
   gsize i, j, n_fds, n_envs;
-  const gint *fds = NULL;
-  gint fds_len = 0;
   g_autoptr(GArray) fd_map = NULL;
   g_auto(GStrv) env = NULL;
   gint32 max_fd;
@@ -710,9 +708,6 @@ handle_spawn (PortalFlatpak         *object,
 
   child_setup_data.instance_id_fd = -1;
   child_setup_data.env_fd = -1;
-
-  if (fd_list != NULL)
-    fds = g_unix_fd_list_peek_fds (fd_list, &fds_len);
 
   app_info = g_object_get_data (G_OBJECT (invocation), "app-info");
   g_assert (app_info != NULL);
@@ -853,7 +848,7 @@ handle_spawn (PortalFlatpak         *object,
   g_info ("Running spawn command %s", arg_argv[0]);
 
   n_fds = 0;
-  if (fds != NULL)
+  if (fd_list != NULL)
     n_fds = g_variant_n_children (arg_fds);
 
   fd_map = g_array_sized_new (FALSE, FALSE, sizeof (FdMapEntry), n_fds);

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1406,8 +1406,8 @@ handle_spawn (PortalFlatpak         *object,
 
           if (!check_fd_exposable (handle_fd, &error))
             {
-              g_info ("Unable to get path for sandbox-exposed fd %d, ignoring: %s",
-                      handle_fd, error->message);
+              g_warning ("Unable to get path for sandbox-exposed fd %d, ignoring: %s",
+                         handle_fd, error->message);
               g_clear_error (&error);
               continue;
             }
@@ -1445,8 +1445,8 @@ handle_spawn (PortalFlatpak         *object,
 
           if (!check_fd_exposable (handle_fd, &error))
             {
-              g_info ("Unable to get path for sandbox-exposed fd %d, ignoring: %s",
-                      handle_fd, error->message);
+              g_warning ("Unable to get path for sandbox-exposed fd %d, ignoring: %s",
+                         handle_fd, error->message);
               g_clear_error (&error);
               continue;
             }

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1319,11 +1319,7 @@ handle_spawn (PortalFlatpak         *object,
               return G_DBUS_METHOD_INVOCATION_HANDLED;
             }
 
-          if (validate_opath_fd (handle_fd, TRUE, &error))
-            {
-              g_array_append_val (expose_fds, handle_fd);
-            }
-          else
+          if (!validate_opath_fd (handle_fd, TRUE, &error))
             {
               g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                                      G_DBUS_ERROR_INVALID_ARGS,
@@ -1331,6 +1327,8 @@ handle_spawn (PortalFlatpak         *object,
                                                      handle);
               return G_DBUS_METHOD_INVOCATION_HANDLED;
             }
+
+          g_array_append_val (expose_fds, handle_fd);
         }
     }
 
@@ -1351,11 +1349,7 @@ handle_spawn (PortalFlatpak         *object,
               return G_DBUS_METHOD_INVOCATION_HANDLED;
             }
 
-          if (validate_opath_fd (handle_fd, FALSE, &error))
-            {
-              g_array_append_val (expose_fds_ro, handle_fd);
-            }
-          else
+          if (!validate_opath_fd (handle_fd, FALSE, &error))
             {
               g_debug ("Invalid sandbox expose ro fd: %s", error->message);
               g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
@@ -1364,6 +1358,8 @@ handle_spawn (PortalFlatpak         *object,
                                                      handle);
               return G_DBUS_METHOD_INVOCATION_HANDLED;
             }
+
+          g_array_append_val (expose_fds_ro, handle_fd);
         }
     }
 


### PR DESCRIPTION
* portal: Factor out a function to validate fds attached to D-Bus message
    
    Previously, if one of the handles in sandbox-expose-fd or
    sandbox-expose-fd-ro was out of range, we'd dereference error->message
    while error was NULL, and crash. Instead, use a function that checks
    for each error condition separately, and ends up with the error set
    on any failure.
    
    This intentionally doesn't check against validate_opath_fd, which we
    do separately: we only want to do that for fds that are to be re-exposed
    into a sandbox, but not for the app-fd, usr-fd or array of fds to inherit.

* portal: Use peek_fd_for_handle for inherited fds, app_fd, usr_fd
    
    These only need to check that the handle is in range, and don't need
    to validate it as an O_PATH fd.

* portal: Remove fds array and fds_len
    
    Now that all accesses to the fd list are going through
    peek_fd_for_handle(), we don't need this.

* portal: Early-return if validate_opath_fd() fails
    
    This pattern will allow us to add more checks after validate_opath_fd(),
    but before actually using the fd.

* portal: Reinstate checks for whether we can use an app-supplied fd
    
    These were part of get_path_for_fd() before commit 3c500145
    "portal: Use --bind-fd, --app-fd and --usr-fd options to avoid races".
    If these checks would fail, then the equivalent in bwrap is also going
    to fail, but we have the opportunity to provide better error messages
    here.
    
    For the /app and /usr fds, we always reported errors from these checks
    as an error; continue to do so.
    
    For the sandbox expose fds, a historical quirk of this code is that if
    these checks failed, we would merely log at g_info() level and ignore
    the request to expose the fd in the sandbox. With hindsight this was
    probably not appropriate, but apps are relying on it now: for example,
    org.gnome.Epiphany asks to expose files from /app and /usr in the
    subsandbox. When we ignored those requests (because /app and /usr
    have a different meaning on the host system), the app worked as
    intended anyway, because the subsandbox has access to the app's /app
    and the runtime's /usr whether they're explicitly added or not.
    
    Helps: https://github.com/flatpak/flatpak/issues/6584

* portal: Bump up log level for inability to expose fds to warning
    
    Ideally we probably want the apps that are affected by this to stop
    passing paths below /app or /usr, or non-filesystem objects, to the
    `flatpak-spawn --sandbox-expose` family of options: it's misleading
    if the app explicitly tells us to expose a path in the sandbox, but
    then we neither do so nor report a warning or error.
