### PR TITLE
Fix regression installing NoRuntime extensions such as openh264

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev bubblewrap xdg-dbus-proxy \
-        meson ninja-build libyaml-dev libstemmer-dev gperf itstool libmalcontent-0-dev libxau-dev libgdk-pixbuf2.0-dev openssl
+        meson ninja-build libyaml-dev libstemmer-dev gperf itstool libmalcontent-0-dev libxau-dev libgdk-pixbuf2.0-dev openssl libc6-dev
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
@@ -96,7 +96,7 @@ jobs:
         libfuse-dev ostree libostree-dev libarchive-dev libzstd-dev libcap-dev libattr1-dev libdw-dev libelf-dev python3-pyparsing \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev
+        libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev e2fslibs-dev libc6-dev
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
@@ -169,7 +169,7 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang e2fslibs-dev meson socat libxau-dev libgdk-pixbuf2.0-dev \
-        xmlto
+        xmlto libc6-dev
     - name: Check out flatpak
       uses: actions/checkout@v4
       with:
@@ -212,7 +212,7 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libcurl4-openssl-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev \
-        valgrind e2fslibs-dev meson libxau-dev libgdk-pixbuf2.0-dev
+        valgrind e2fslibs-dev meson libxau-dev libgdk-pixbuf2.0-dev libc6-dev
     - name: Check out flatpak
       uses: actions/checkout@v4
       with:

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9317,10 +9317,14 @@ apply_extra_data (FlatpakDir   *self,
   run_flags |= FLATPAK_RUN_FLAG_NO_PROC;
 
   glnx_autofd int usr_fd = -1;
-  usr_fd = open (flatpak_file_get_path_cached (runtime_files),
-                 O_PATH | O_CLOEXEC | O_NOFOLLOW);
-  if (usr_fd < 0)
-    return glnx_throw_errno_prefix (error, "Failed to open runtime files");
+
+  if (runtime_files != NULL)
+    {
+      usr_fd = open (flatpak_file_get_path_cached (runtime_files),
+                     O_PATH | O_CLOEXEC | O_NOFOLLOW);
+      if (usr_fd < 0)
+        return glnx_throw_errno_prefix (error, "Failed to open runtime files");
+    }
 
   if (!flatpak_run_setup_base_argv (bwrap, usr_fd, NULL, runtime_arch,
                                     run_flags, error))

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -1657,6 +1657,10 @@ flatpak_run_add_app_info_args (FlatpakBwrap           *bwrap,
   return TRUE;
 }
 
+/*
+ * @runtime_fd: the /usr for the runtime, or -1 if running with no runtime,
+ *  perhaps to unpack extra-data
+ */
 static void
 add_tzdata_args (FlatpakBwrap *bwrap,
                  int           runtime_fd)
@@ -1669,6 +1673,8 @@ add_tzdata_args (FlatpakBwrap *bwrap,
   glnx_autofd int zoneinfo_fd = -1;
   g_autoptr(GError) error = NULL;
 
+  g_return_if_fail (runtime_fd >= -1);
+
   raw_timezone = flatpak_get_timezone ();
   timezone_content = g_strdup_printf ("%s\n", raw_timezone);
   localtime_content = g_strconcat ("../usr/share/zoneinfo/", raw_timezone, NULL);
@@ -1677,10 +1683,11 @@ add_tzdata_args (FlatpakBwrap *bwrap,
 
   tzdir_fd = glnx_chaseat (AT_FDCWD, tzdir, GLNX_CHASE_MUST_BE_DIRECTORY, NULL);
 
-  zoneinfo_fd = glnx_chaseat (runtime_fd, "share/zoneinfo",
-                              GLNX_CHASE_RESOLVE_BENEATH |
-                              GLNX_CHASE_MUST_BE_DIRECTORY,
-                              NULL);
+  if (runtime_fd >= 0)
+    zoneinfo_fd = glnx_chaseat (runtime_fd, "share/zoneinfo",
+                                GLNX_CHASE_RESOLVE_BENEATH |
+                                GLNX_CHASE_MUST_BE_DIRECTORY,
+                                NULL);
 
   /* Check for host /usr/share/zoneinfo */
   if (tzdir_fd >= 0 && zoneinfo_fd >= 0)
@@ -1691,7 +1698,7 @@ add_tzdata_args (FlatpakBwrap *bwrap,
                               "--symlink", localtime_content, "/etc/localtime",
                               NULL);
     }
-  else
+  else if (runtime_fd >= 0)
     {
       g_autofree char *runtime_zoneinfo = NULL;
       glnx_autofd int runtime_zoneinfo_fd = -1;
@@ -2190,6 +2197,10 @@ setup_seccomp (FlatpakBwrap   *bwrap,
 }
 #endif
 
+/*
+ * @runtime_fd: the /usr for the runtime, or -1 if running with no runtime,
+ *  perhaps to unpack extra-data
+ */
 static void
 flatpak_run_setup_usr_links (FlatpakBwrap *bwrap,
                              int          runtime_fd,
@@ -2253,6 +2264,10 @@ static const char *const sysfs_dirs[] =
   "/sys/devices"
 };
 
+/*
+ * @runtime_fd: the /usr for the runtime, or -1 if running with no runtime,
+ *  perhaps to unpack extra-data
+ */
 gboolean
 flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
                              int             runtime_fd,
@@ -2273,7 +2288,7 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
   gboolean bwrap_unprivileged = flatpak_bwrap_is_unprivileged ();
   gsize i;
 
-  g_return_val_if_fail (runtime_fd >= 0, FALSE);
+  g_return_val_if_fail (runtime_fd >= -1, FALSE);
 
   /* Disable recursive userns for all flatpak processes, as we need this
    * to guarantee that the sandbox can't restructure the filesystem.
@@ -2382,7 +2397,8 @@ flatpak_run_setup_base_argv (FlatpakBwrap   *bwrap,
   else if (g_file_test ("/var/lib/dbus/machine-id", G_FILE_TEST_EXISTS))
     flatpak_bwrap_add_args (bwrap, "--ro-bind", "/var/lib/dbus/machine-id", "/etc/machine-id", NULL);
 
-  if ((flags & FLATPAK_RUN_FLAG_WRITABLE_ETC) == 0)
+  if (runtime_fd >= 0
+      && (flags & FLATPAK_RUN_FLAG_WRITABLE_ETC) == 0)
     {
       g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
       struct dirent *dent;

--- a/tests/apply-extra-static.c
+++ b/tests/apply-extra-static.c
@@ -1,0 +1,15 @@
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+static const char msg[] = "noruntime-extra-data\n";
+
+int main(void) {
+    mkdir("/app/extra", 0755);
+    int fd = open("/app/extra/ran", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0)
+        return 1;
+    write(fd, msg, sizeof(msg) - 1);
+    close(fd);
+    return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -289,6 +289,21 @@ executable(
   install_dir : installed_testdir,
 )
 
+if cc.links('#include <stdio.h>\nint main(void) { printf("test"); return 0; }',
+            args: ['-static'],
+            name: 'static libc')
+  executable(
+    'apply-extra-static',
+    'apply-extra-static.c',
+    install : get_option('installed_tests'),
+    install_dir : installed_testdir,
+    override_options : ['b_sanitize=none'],
+    link_args : ['-static'],
+  )
+else
+  warning('static libc not available, apply-extra-static will be skipped')
+endif
+
 subdir('share/xdg-desktop-portal/portals')
 subdir('services')
 subdir('test-keyring')

--- a/tests/test-extra-data.sh
+++ b/tests/test-extra-data.sh
@@ -45,7 +45,7 @@ curl "${EXTRA_DATA_URL}" -o "${DOWNLOADED_EXTRA_DATA}"
 EXTRA_DATA_SIZE=$(stat --printf="%s" "${DOWNLOADED_EXTRA_DATA}")
 EXTRA_DATA_SHA256=$(sha256sum "${DOWNLOADED_EXTRA_DATA}" | cut -f1 -d' ')
 
-echo "1..2"
+echo "1..3"
 
 # build the app with the extra data
 EXTRA_DATA="--extra-data=test:${EXTRA_DATA_SHA256}:${EXTRA_DATA_SIZE}:${EXTRA_DATA_SIZE}:${EXTRA_DATA_URL}"
@@ -96,3 +96,44 @@ assert_file_has_content out "extra-data-test-content"
 ${FLATPAK} ${U} uninstall -y org.test.Hello >&2
 
 ok "install extra data app with oci"
+
+build_extra_data_noruntime_app() {
+    local repo="$1"
+    local branch="$2"
+
+    DIR="$(mktemp -d)"
+    ARCH="$(flatpak --default-arch)"
+
+    mkdir -p "${DIR}/files/bin"
+
+    cp "${G_TEST_BUILDDIR}/apply-extra-static" "${DIR}/files/bin/apply_extra"
+    chmod +x "${DIR}/files/bin/apply_extra"
+
+    cat > "${DIR}/metadata" <<EOF
+[Application]
+name=org.test.ExtraDataNoRuntime
+runtime=org.test.Platform/${ARCH}/${branch}
+
+[Extra Data]
+NoRuntime=true
+uri=${EXTRA_DATA_URL}
+size=${EXTRA_DATA_SIZE}
+checksum=${EXTRA_DATA_SHA256}
+EOF
+
+    flatpak build-finish "${DIR}" >&2
+    flatpak build-export ${FL_GPGARGS} "${repo}" "${DIR}" "${branch}" >&2
+    rm -rf "${DIR}"
+}
+
+if test -f "${G_TEST_BUILDDIR}/apply-extra-static"; then
+    build_extra_data_noruntime_app repos/test ${BRANCH}
+    update_repo ${REPONAME} ${COLLECTION_ID}
+    ${FLATPAK} ${U} install --or-update -y ${REPONAME}-repo org.test.ExtraDataNoRuntime ${BRANCH} >&2
+    DEPLOY_DIR="$(${FLATPAK} ${U} info --show-location org.test.ExtraDataNoRuntime)"
+    assert_file_has_content "${DEPLOY_DIR}/files/extra/ran" "^noruntime-extra-data$"
+    ${FLATPAK} ${U} uninstall -y org.test.ExtraDataNoRuntime >&2
+    ok "install+run extra data app with NoRuntime"
+else
+    ok "# SKIP install+run extra data app with NoRuntime apply-extra-static not found"
+fi


### PR DESCRIPTION
* run: Cope with an empty runtime
    
    When FlatpakDir runs extra-data helpers in apply_extra_data(),
    if the helper is statically linked, it might not need a runtime at all.
    For example the helper for openh264 falls into this category.
    
    Fixes: ac62ebe3 "run: Use O_PATH fds for the runtime and app deploy directories"  
    Helps: https://github.com/flatpak/flatpak/issues/6583

* dir: In apply_extra_data(), don't assume there is always a runtime
    
    org.freedesktop.Platform.openh264 is one example of an extension that
    runs a statically-linked extra-data helper, with no runtime. Only open
    the runtime if there is one.
    
    Fixes: ac62ebe3 "run: Use O_PATH fds for the runtime and app deploy directories"  
    Resolves: https://github.com/flatpak/flatpak/issues/6583