### PR TITLE
portal: Ignore unusable paths

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -3010,42 +3010,6 @@ open_namespace_fd_if_needed (const char *path,
   return -1;
 }
 
-static char *
-get_path_for_fd (int        fd,
-                 GError   **error)
-{
-  g_autofree char *proc_path = NULL;
-  g_autofree char *path = NULL;
-
-  proc_path = g_strdup_printf ("/proc/self/fd/%d", fd);
-  path = glnx_readlinkat_malloc (AT_FDCWD, proc_path, NULL, error);
-  if (path == NULL)
-    return NULL;
-
-  /* All normal paths start with /, but some weird things
-     don't, such as socket:[27345] or anon_inode:[eventfd].
-     We don't support any of these */
-  if (path[0] != '/')
-    {
-      return glnx_null_throw (error, "%s resolves to non-absolute path %s",
-                              proc_path, path);
-    }
-
-  /* File descriptors to actually deleted files have " (deleted)"
-     appended to them. This also happens to some fake fd types
-     like shmem which are "/<name> (deleted)". All such
-     files are considered invalid. Unfortunately this also
-     matches files with filenames that actually end in " (deleted)",
-     but there is not much to do about this. */
-  if (g_str_has_suffix (path, " (deleted)"))
-    {
-      return glnx_null_throw (error, "%s resolves to deleted path %s",
-                              proc_path, path);
-    }
-
-  return g_steal_pointer (&path);
-}
-
 FlatpakContextShares
 flatpak_run_compute_allowed_shares (FlatpakContext *context)
 {
@@ -3312,7 +3276,7 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
     {
       g_autofree char *path = NULL;
 
-      path = get_path_for_fd (custom_runtime_fd, &my_error);
+      path = flatpak_get_path_for_fd (custom_runtime_fd, &my_error);
       if (path == NULL)
         {
           return flatpak_fail_error (error, FLATPAK_ERROR,
@@ -3440,7 +3404,7 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
     {
       g_autofree char *path = NULL;
 
-      path = get_path_for_fd (custom_app_fd, error);
+      path = flatpak_get_path_for_fd (custom_app_fd, error);
       if (path == NULL)
         return glnx_prefix_error (error, "Cannot convert custom app fd to path");
 
@@ -3753,7 +3717,7 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
 
       /* We get the path the fd refers to, to determine to mount point
        * destination inside the sandbox */
-      path = get_path_for_fd (fd, error);
+      path = flatpak_get_path_for_fd (fd, error);
       if (!path)
         return FALSE;
 
@@ -3770,7 +3734,7 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
 
       /* We get the path the fd refers to, to determine to mount point
        * destination inside the sandbox */
-      path = get_path_for_fd (fd, error);
+      path = flatpak_get_path_for_fd (fd, error);
       if (!path)
         return FALSE;
 

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -383,6 +383,9 @@ void flatpak_add_test (const char *path, flatpak_test_fn fn);
 FLATPAK_EXTERN
 void flatpak_add_all_tests (void);
 
+char * flatpak_get_path_for_fd (int      fd,
+                                GError **error);
+
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 gboolean flatpak_set_cloexec (int fd);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2670,3 +2670,53 @@ flatpak_set_cloexec (int fd)
 
   return TRUE;
 }
+
+/*
+ * Attempt to discover the filesystem path corresponding to @fd.
+ *
+ * If @fd points to an existing file, return the absolute path of that
+ * file in the environment where it was opened. Note that this is not
+ * necessarily a valid path in the current namespace, if it was
+ * transferred via fd-passing from a process in a different filesystem
+ * namespace.
+ *
+ * If @fd points to a deleted file, or to a socket, fifo, memfd or similar
+ * non-filesystem object, set an error and return %NULL.
+ *
+ * Returns: (type filename) (transfer full) (nullable):
+ */
+char *
+flatpak_get_path_for_fd (int        fd,
+                         GError   **error)
+{
+  g_autofree char *proc_path = NULL;
+  g_autofree char *path = NULL;
+
+  proc_path = g_strdup_printf ("/proc/self/fd/%d", fd);
+  path = glnx_readlinkat_malloc (AT_FDCWD, proc_path, NULL, error);
+  if (path == NULL)
+    return NULL;
+
+  /* All normal paths start with /, but some weird things
+     don't, such as socket:[27345] or anon_inode:[eventfd].
+     We don't support any of these */
+  if (path[0] != '/')
+    {
+      return glnx_null_throw (error, "%s resolves to non-absolute path %s",
+                              proc_path, path);
+    }
+
+  /* File descriptors to actually deleted files have " (deleted)"
+     appended to them. This also happens to some fake fd types
+     like shmem which are "/<name> (deleted)". All such
+     files are considered invalid. Unfortunately this also
+     matches files with filenames that actually end in " (deleted)",
+     but there is not much to do about this. */
+  if (g_str_has_suffix (path, " (deleted)"))
+    {
+      return glnx_null_throw (error, "%s resolves to deleted path %s",
+                              proc_path, path);
+    }
+
+  return g_steal_pointer (&path);
+}

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -557,7 +557,9 @@ validate_opath_fd (int        fd,
 {
   int fd_flags;
   struct stat st_buf;
+  struct stat real_st_buf;
   int access_mode;
+  g_autofree char *path = NULL;
 
   /* Must be able to get fd flags */
   fd_flags = fcntl (fd, F_GETFL);
@@ -575,6 +577,24 @@ validate_opath_fd (int        fd,
   /* Must be able to fstat */
   if (fstat (fd, &st_buf) < 0)
     return glnx_throw_errno_prefix (error, "Failed to fstat");
+
+  path = flatpak_get_path_for_fd (fd, error);
+  if (path == NULL)
+    return FALSE;
+
+  /* Verify that this is the same file as the app opened.
+   * Note that this is not security relevant because flatpak-run/bwrap will
+   * check things and abort if something is off. We do this only for backwards
+   * compatibility reasons: we need to be able to ignore the issue instead of
+   * aborting the entire sandbox setup later. */
+  if (stat (path, &real_st_buf) < 0 ||
+      st_buf.st_dev != real_st_buf.st_dev ||
+      st_buf.st_ino != real_st_buf.st_ino)
+    {
+      /* Different files on the inside and the outside, reject the request */
+      return glnx_throw (error,
+                         "different file inside and outside sandbox");
+    }
 
   access_mode = R_OK;
   if (S_ISDIR (st_buf.st_mode))

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1283,8 +1283,17 @@ handle_spawn (PortalFlatpak         *object,
           gint32 handle;
 
           g_variant_get_child (sandbox_expose_fd, i, "h", &handle);
-          if (handle >= 0 && handle < fds_len &&
-              validate_opath_fd (fds[handle], TRUE, &error))
+          if (handle >= fds_len || handle < 0)
+            {
+              g_debug ("Invalid sandbox-expose-fd handle %d", handle);
+              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+                                                     G_DBUS_ERROR_INVALID_ARGS,
+                                                     "No file descriptor for handle %d",
+                                                     handle);
+              return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+
+          if (validate_opath_fd (fds[handle], TRUE, &error))
             {
               g_array_append_val (expose_fds, fds[handle]);
             }
@@ -1309,8 +1318,17 @@ handle_spawn (PortalFlatpak         *object,
           gint32 handle;
 
           g_variant_get_child (sandbox_expose_fd_ro, i, "h", &handle);
-          if (handle >= 0 && handle < fds_len &&
-              validate_opath_fd (fds[handle], FALSE, &error))
+          if (handle >= fds_len || handle < 0)
+            {
+              g_debug ("Invalid sandbox-expose-ro-fd handle %d", handle);
+              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
+                                                     G_DBUS_ERROR_INVALID_ARGS,
+                                                     "No file descriptor for handle %d",
+                                                     handle);
+              return G_DBUS_METHOD_INVOCATION_HANDLED;
+            }
+
+          if (validate_opath_fd (fds[handle], FALSE, &error))
             {
               g_array_append_val (expose_fds_ro, fds[handle]);
             }

--- a/portal/flatpak-portal.c
+++ b/portal/flatpak-portal.c
@@ -1299,12 +1299,9 @@ handle_spawn (PortalFlatpak         *object,
             }
           else
             {
-              g_debug ("Invalid sandbox expose fd: %s", error->message);
-              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
-                                                     G_DBUS_ERROR_INVALID_ARGS,
-                                                     "No valid file descriptor for handle %d",
-                                                     handle);
-              return G_DBUS_METHOD_INVOCATION_HANDLED;
+              g_info ("unable to validate sandbox-expose-fd %d, ignoring: %s",
+                      fds[handle], error->message);
+              g_clear_error (&error);
             }
         }
     }
@@ -1334,12 +1331,9 @@ handle_spawn (PortalFlatpak         *object,
             }
           else
             {
-              g_debug ("Invalid sandbox expose ro fd: %s", error->message);
-              g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
-                                                     G_DBUS_ERROR_INVALID_ARGS,
-                                                     "No file descriptor for handle %d",
-                                                     handle);
-              return G_DBUS_METHOD_INVOCATION_HANDLED;
+              g_info ("unable to validate sandbox-expose-ro-fd %d, ignoring: %s",
+                      fds[handle], error->message);
+              g_clear_error (&error);
             }
         }
     }


### PR DESCRIPTION
* utils: Move flatpak_get_path_for_fd to here
    
    This was originally in flatpak-portal, then was duplicated into
    flatpak-run in commit ac62ebe3 "run: Use O_PATH fds for the runtime and
    app deploy directories", and subsequently removed from the portal in
    commit 3c500145 "portal: Use --bind-fd, --app-fd and --usr-fd options to
    avoid races". Now we want to use it in the portal again.
    
    Helps: https://github.com/flatpak/flatpak/issues/6584
    Co-authored-by: @swick 

* portal: Avoid crash if sandbox-expose-[ro-]fd is out of range
    
    If the handle is not in the range `0 <= handle < fds_len`, but no
    GError is set, we'd have crashed when we dereferenced error->message.
    Instead, log an error and early-return, matching what we do for
    app-fd, usr-fd and the array of inheritable fds.
    
    Fixes: 3c500145 "portal: Use --bind-fd, --app-fd and --usr-fd options to avoid races"  
    Helps: https://github.com/flatpak/flatpak/issues/6584
    Co-authored-by: @swick

* portal: Log and ignore unusable sandbox-expose fds instead of erroring
    
    For the sandbox expose fds, a historical quirk of this code is that if
    the checks in get_path_for_fd() failed, we would merely log at g_info()
    level (usually only shown when debugging the portal), and otherwise
    silently ignore the request to expose the fd in the sandbox.
    
    With hindsight this was probably not the right thing to do, but apps
    could well be relying on it now. For example, there are indications
    that Epiphany might send a memfd from the main instance to a subsandbox,
    which never actually worked, but will break that subsandbox process
    if that's treated as a fatal error.
    
    Fixes: 3c500145 "portal: Use --bind-fd, --app-fd and --usr-fd options to avoid races"  
    Helps: https://github.com/flatpak/flatpak/issues/6584  
    Co-authored-by: @swick 

* portal: Reinstate flatpak_get_path_for_fd() checks
    
    As with the previous commit, historically we would debug-log but
    otherwise silently ignore attempts to expose a file in a sandboxed
    subsandbox that doesn't have a suitable path.
    
    For example, org.gnome.Epiphany (or possibly WebKitGTK) asks to expose
    files from /app and /usr in the subsandbox. When we ignored those
    requests (because /app and /usr have a different meaning on the host
    system), the app worked as intended anyway, because the subsandbox has
    access to the app's /app and the runtime's /usr whether they're
    explicitly added or not, so it all worked out OK. However, treating
    this as a fatal error (as it arguably should have been) broke
    Epiphany's subsandboxes.
    
    Fixes: 3c500145 "portal: Use --bind-fd, --app-fd and --usr-fd options to avoid races"  
    Resolves: https://github.com/flatpak/flatpak/issues/6584  
    Co-authored-by: @swick 