### PR TITLE
libtest: Allow adding a new ref to an existing temporary ostree repo

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -336,7 +336,7 @@ make_runtime () {
         RUNTIME_REPO=${TEST_DATA_DIR}/runtime-repo
         (
             flock -s 200
-            if [ ! -d ${RUNTIME_REPO} ]; then
+            if [ ! -f "${RUNTIME_REPO}/refs/heads/${RUNTIME_REF}" ]; then
                 $(dirname $0)/make-test-runtime.sh ${RUNTIME_REPO} org.test.Platform ${BRANCH} "" "" > /dev/null
             fi
         ) 200>${TEST_DATA_DIR}/runtime-repo-lock


### PR DESCRIPTION
When we run `tests/test-run-custom.sh` as a build-time test, we expect to already have the necessary runtimes, apps, etc. in `${builddir}/tests/runtime-repo`. However, when running "as-installed" tests, we're using a fresh temporary ostree repo for each test. Merely having the repo exist is not enough: for some tests, and in particular `tests/test-run-custom.sh`, it needs to have more than one runtime available.

Resolves: https://github.com/flatpak/flatpak/issues/6591