### PR TITLE
tests: call g_test_skip() when root-owned directory is absent in test_claim_per_app_temp_directory

### DIFF
--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -58,6 +58,10 @@ assert_next_is_os_release (FlatpakBwrap *bwrap,
       g_assert_cmpuint (i, <, bwrap->argv->len);
       g_assert_cmpstr (bwrap->argv->pdata[i++], ==, "/run/host/os-release");
     }
+  else
+    {
+      g_test_message ("neither /etc/os-release nor /usr/lib/os-release exists on this host");
+    }
 
   return i;
 }

--- a/tests/test-instance.c
+++ b/tests/test-instance.c
@@ -440,6 +440,10 @@ test_claim_per_app_temp_directory (void)
       g_assert_false (ok);
       g_clear_error (&error);
     }
+  else
+    {
+      g_test_message ("pre-create /tmp/flatpak-com.example.App-OwnedByRoot as root to enable this check");
+    }
 
   glnx_close_fd (&fd);
   g_assert_no_errno (unlink (non_directory_path));


### PR DESCRIPTION
Make sure the test suite knows, that this test is skipped