### PR TITLE
Avoid closing fds 0/1/2, reduce duplication handling fd arguments

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -80,7 +80,11 @@ option_bind_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      /* Don't close these fds! */
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--bind-fd");
@@ -103,7 +107,10 @@ option_ro_bind_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--ro-bind-fd");
@@ -126,7 +133,10 @@ opt_instance_id_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--instance-id-fd");
@@ -148,7 +158,10 @@ opt_app_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--app-fd");
@@ -170,7 +183,10 @@ opt_usr_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--usr-fd");

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -75,19 +75,10 @@ option_bind_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      /* Don't close these fds! */
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--bind-fd");
 
   g_array_append_val (opt_bind_fds, fd);
   fd = -1; /* ownership transferred to GArray */
@@ -102,18 +93,10 @@ option_ro_bind_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--ro-bind-fd");
 
   g_array_append_val (opt_ro_bind_fds, fd);
   fd = -1; /* ownership transferred to GArray */
@@ -128,18 +111,10 @@ opt_instance_id_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--instance-id-fd");
 
   opt_instance_id_fd = g_steal_fd (&fd);
   return TRUE;
@@ -153,18 +128,10 @@ opt_app_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--app-fd");
 
   opt_app_fd = g_steal_fd (&fd);
   return TRUE;
@@ -178,18 +145,10 @@ opt_usr_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--usr-fd");
 
   opt_usr_fd = g_steal_fd (&fd);
   return TRUE;

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2439,7 +2439,11 @@ option_env_fd_cb (const gchar *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      /* Don't close these fds! */
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   /* This is not strictly necessary, because we're going to close it after
    * parsing the environment block, but let's be consistent with other fd

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2434,24 +2434,10 @@ option_env_fd_cb (const gchar *option_name,
   FlatpakContext *context = data;
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      /* Don't close these fds! */
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  /* This is not strictly necessary, because we're going to close it after
-   * parsing the environment block, but let's be consistent with other fd
-   * arguments that we need to avoid being inherited by the "payload"
-   * command. This is also a convenient place to validate that it's an
-   * open fd. */
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--env-fd");
 
   return flatpak_context_parse_env_fd (context, fd, error);
 }

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -390,4 +390,8 @@ char * flatpak_get_path_for_fd (int      fd,
 
 gboolean flatpak_set_cloexec (int fd);
 
+int flatpak_accept_fd_argument (const char  *option_name,
+                                const char  *value,
+                                GError     **error);
+
 #endif /* __FLATPAK_UTILS_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2672,6 +2672,53 @@ flatpak_set_cloexec (int fd)
 }
 
 /*
+ * flatpak_accept_fd_argument:
+ * @option_name: Name of a command-line option such as `--env-fd`
+ * @value: Value of the command-line option
+ *
+ * Parse a command-line argument whose value is a file descriptor to be
+ * used internally by Flatpak.
+ *
+ * The file descriptor must be 3 or higher (cannot be stdin, stdout
+ * or stderr).
+ *
+ * The file descriptor is set to be close-on-execute (CLOEXEC).
+ * If child processes are meant to inherit it, the caller must clear the
+ * close-on-execute flag, or duplicate the fd.
+ *
+ * Returns: A file descriptor to be closed by the caller, or -1 on error
+ */
+int
+flatpak_accept_fd_argument (const char  *option_name,
+                            const char  *value,
+                            GError     **error)
+{
+  glnx_autofd int fd = -1;
+
+  fd = flatpak_parse_fd (value, error);
+
+  if (fd < 0)
+    {
+      g_prefix_error (error, "%s: ", option_name);
+      return -1;
+    }
+
+  if (fd < 3)
+    {
+      /* We don't want to close stdin, stdout or stderr */
+      fd = -1;
+      return glnx_fd_throw (error,
+                            "%s: Cannot use reserved file descriptor 0, 1 or 2",
+                            option_name);
+    }
+
+  if (!flatpak_set_cloexec (fd))
+    return glnx_fd_throw_errno_prefix (error, "%s", option_name);
+
+  return g_steal_fd (&fd);
+}
+
+/*
  * Attempt to discover the filesystem path corresponding to @fd.
  *
  * If @fd points to an existing file, return the absolute path of that


### PR DESCRIPTION
Follow-up after fixing #6582.

* app, context: Never close fds 0, 1 or 2
    
    These fds are stdin, stdout and stderr respectively, and are expected
    to remain open at all times (if they are not needed then they can point
    to /dev/null, but they should always be open). If the user gives us
    `--env-fd=2` or similar, we don't want to close fd 2 before exiting
    unsuccessfully: that would give us nowhere to display the error message.
    
* app, context: Factor out flatpak_accept_fd_argument()