### PR TITLE
Assert that --app-fd, --env-fd, etc. don't pass into the sandbox

### DIFF
--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -80,7 +80,11 @@ option_bind_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      /* Don't close these fds! */
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--bind-fd");
@@ -103,7 +107,10 @@ option_ro_bind_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--ro-bind-fd");
@@ -126,7 +133,10 @@ opt_instance_id_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--instance-id-fd");
@@ -148,7 +158,10 @@ opt_app_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--app-fd");
@@ -170,7 +183,10 @@ opt_usr_fd_cb (const char  *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   if (!flatpak_set_cloexec (fd))
     return glnx_throw_errno_prefix (error, "--usr-fd");

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -75,19 +75,10 @@ option_bind_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      /* Don't close these fds! */
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--bind-fd");
 
   g_array_append_val (opt_bind_fds, fd);
   fd = -1; /* ownership transferred to GArray */
@@ -102,18 +93,10 @@ option_ro_bind_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--ro-bind-fd");
 
   g_array_append_val (opt_ro_bind_fds, fd);
   fd = -1; /* ownership transferred to GArray */
@@ -128,18 +111,10 @@ opt_instance_id_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--instance-id-fd");
 
   opt_instance_id_fd = g_steal_fd (&fd);
   return TRUE;
@@ -153,18 +128,10 @@ opt_app_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--app-fd");
 
   opt_app_fd = g_steal_fd (&fd);
   return TRUE;
@@ -178,18 +145,10 @@ opt_usr_fd_cb (const char  *option_name,
 {
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--usr-fd");
 
   opt_usr_fd = g_steal_fd (&fd);
   return TRUE;

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2439,7 +2439,11 @@ option_env_fd_cb (const gchar *option_name,
     return FALSE;
 
   if (fd < 3)
-    return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    {
+      /* Don't close these fds! */
+      fd = -1;
+      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
+    }
 
   /* This is not strictly necessary, because we're going to close it after
    * parsing the environment block, but let's be consistent with other fd

--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -2434,24 +2434,10 @@ option_env_fd_cb (const gchar *option_name,
   FlatpakContext *context = data;
   glnx_autofd int fd = -1;
 
-  fd = flatpak_parse_fd (value, error);
+  fd = flatpak_accept_fd_argument (option_name, value, error);
+
   if (fd < 0)
     return FALSE;
-
-  if (fd < 3)
-    {
-      /* Don't close these fds! */
-      fd = -1;
-      return glnx_throw (error, "File descriptors 0, 1, 2 are reserved");
-    }
-
-  /* This is not strictly necessary, because we're going to close it after
-   * parsing the environment block, but let's be consistent with other fd
-   * arguments that we need to avoid being inherited by the "payload"
-   * command. This is also a convenient place to validate that it's an
-   * open fd. */
-  if (!flatpak_set_cloexec (fd))
-    return glnx_throw_errno_prefix (error, "--env-fd");
 
   return flatpak_context_parse_env_fd (context, fd, error);
 }

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -389,6 +389,7 @@ char * flatpak_get_path_for_fd (int      fd,
 #define FLATPAK_MESSAGE_ID "c7b39b1e006b464599465e105b361485"
 
 gboolean flatpak_set_cloexec (int fd);
+gboolean flatpak_unset_cloexec (int fd);
 
 int flatpak_accept_fd_argument (const char  *option_name,
                                 const char  *value,

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -390,4 +390,8 @@ char * flatpak_get_path_for_fd (int      fd,
 
 gboolean flatpak_set_cloexec (int fd);
 
+int flatpak_accept_fd_argument (const char  *option_name,
+                                const char  *value,
+                                GError     **error);
+
 #endif /* __FLATPAK_UTILS_H__ */

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2672,6 +2672,53 @@ flatpak_set_cloexec (int fd)
 }
 
 /*
+ * flatpak_accept_fd_argument:
+ * @option_name: Name of a command-line option such as `--env-fd`
+ * @value: Value of the command-line option
+ *
+ * Parse a command-line argument whose value is a file descriptor to be
+ * used internally by Flatpak.
+ *
+ * The file descriptor must be 3 or higher (cannot be stdin, stdout
+ * or stderr).
+ *
+ * The file descriptor is set to be close-on-execute (CLOEXEC).
+ * If child processes are meant to inherit it, the caller must clear the
+ * close-on-execute flag, or duplicate the fd.
+ *
+ * Returns: A file descriptor to be closed by the caller, or -1 on error
+ */
+int
+flatpak_accept_fd_argument (const char  *option_name,
+                            const char  *value,
+                            GError     **error)
+{
+  glnx_autofd int fd = -1;
+
+  fd = flatpak_parse_fd (value, error);
+
+  if (fd < 0)
+    {
+      g_prefix_error (error, "%s: ", option_name);
+      return -1;
+    }
+
+  if (fd < 3)
+    {
+      /* We don't want to close stdin, stdout or stderr */
+      fd = -1;
+      return glnx_fd_throw (error,
+                            "%s: Cannot use reserved file descriptor 0, 1 or 2",
+                            option_name);
+    }
+
+  if (!flatpak_set_cloexec (fd))
+    return glnx_fd_throw_errno_prefix (error, "%s", option_name);
+
+  return g_steal_fd (&fd);
+}
+
+/*
  * Attempt to discover the filesystem path corresponding to @fd.
  *
  * If @fd points to an existing file, return the absolute path of that

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2671,6 +2671,23 @@ flatpak_set_cloexec (int fd)
   return TRUE;
 }
 
+/* Sets errno on failure. */
+gboolean
+flatpak_unset_cloexec (int fd)
+{
+  int flags = fcntl (fd, F_GETFD);
+
+  if (flags == -1)
+    return FALSE;
+
+  flags &= ~FD_CLOEXEC;
+
+  if (fcntl (fd, F_SETFD, flags) < 0)
+    return FALSE;
+
+  return TRUE;
+}
+
 /*
  * flatpak_accept_fd_argument:
  * @option_name: Name of a command-line option such as `--env-fd`

--- a/tests/assert-fds-open.c
+++ b/tests/assert-fds-open.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <dirent.h>
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * assert-fds-open FD...
+ *
+ * Assert that exactly the given file descriptors are open, and that no
+ * other file descriptor is open.
+ */
+int
+main (int    argc,
+      char **argv)
+{
+  DIR *dir = NULL;
+  struct dirent *entry;
+  char *dirfd_str = NULL;
+  bool failed = false;
+  int i;
+
+  dir = opendir ("/proc/self/fd");
+
+  if (dir == NULL)
+    err (1, "opendir");
+
+  if (asprintf (&dirfd_str, "%d", dirfd (dir)) < 0)
+    err (1, "asprintf");
+
+  fprintf (stderr, "Asserting that exactly the desired fds are open...\n");
+
+  while ((entry = readdir (dir)) != NULL)
+    {
+      bool found = false;
+
+      if (strcmp (entry->d_name, ".") == 0)
+        continue;
+
+      if (strcmp (entry->d_name, "..") == 0)
+        continue;
+
+      if (strcmp (entry->d_name, dirfd_str) == 0)
+        continue;
+
+      for (i = 1; i < argc; i++)
+        {
+          if (argv[i] != NULL && strcmp (entry->d_name, argv[i]) == 0)
+            {
+              fprintf (stderr, "fd %s is open as expected\n", entry->d_name);
+              argv[i] = NULL;
+              found = true;
+              break;
+            }
+        }
+
+      if (!found)
+        {
+          fprintf (stderr, "fd %s should not have been open\n", entry->d_name);
+          failed = true;
+        }
+    }
+
+  for (i = 1; i < argc; i++)
+    {
+      if (argv[i] != NULL)
+        {
+          fprintf (stderr, "fd %s should have been open\n", argv[i]);
+          failed = true;
+        }
+    }
+
+  closedir (dir);
+  free (dirfd_str);
+  return failed ? 1 : 0;
+}

--- a/tests/close-fds-except.c
+++ b/tests/close-fds-except.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <glib.h>
+
+#include "libglnx.h"
+
+#include "flatpak-utils-private.h"
+
+/*
+ * close-fds-except [FD...] -- COMMAND [ARG...]
+ *
+ * Run COMMAND [ARG...] with all fds closed, except for stdin, stdout,
+ * stderr and each FD given.
+ */
+int
+main (int    argc,
+      char **argv)
+{
+  int i;
+
+  g_debug ("Running command with all fds >= 3 closed, except as specified");
+  g_fdwalk_set_cloexec (3);
+
+  for (i = 1; i < argc; i++)
+    {
+      g_autoptr(GError) error = NULL;
+      const char *arg = argv[i];
+      int fd;
+
+      if (strcmp (arg, "--") == 0)
+        {
+          i++;
+
+          if (i >= argc)
+            {
+              g_printerr ("close-fds-except: COMMAND is required\n");
+              return 125;
+            }
+
+          g_debug ("execvp %s", argv[i]);
+
+          execvp (argv[i], &argv[i]);
+          /* If still here, execvp failed */
+          return 125;
+        }
+
+      fd = flatpak_parse_fd (arg, &error);
+
+      if (fd < 0)
+        {
+          g_printerr ("close-fds-except: %s\n", error->message);
+          return 125;
+        }
+
+      g_debug ("Leaving %d inheritable", fd);
+
+      if (!flatpak_unset_cloexec (fd))
+        {
+          g_printerr ("close-fds-except: fd %d: %s\n", fd, g_strerror (errno));
+          return 125;
+        }
+   }
+
+  g_printerr ("close-fds-except: -- separator not found\n");
+  return 125;
+}

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -83,6 +83,14 @@ for i in `cat $LIBS`; do
 done
 ln -s bash ${DIR}/usr/bin/sh
 
+if [ -n "${G_TEST_BUILDDIR:-}" ]; then
+    test_builddir="${G_TEST_BUILDDIR}"
+else
+    test_builddir=$(dirname $0)
+fi
+
+cp "${test_builddir}/assert-fds-open" "${DIR}/usr/bin"
+
 # This only exists so we can update the runtime
 cat > ${DIR}/usr/bin/runtime_hello.sh <<EOF
 #!/bin/sh

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -187,6 +187,19 @@ foreach testcase : c_tests
 endforeach
 
 executable(
+  'close-fds-except',
+  'close-fds-except.c',
+  dependencies : [
+    base_deps,
+    libflatpak_common_dep,
+    libflatpak_common_base_dep,
+    libglnx_dep,
+  ],
+  install : get_option('installed_tests'),
+  install_dir : installed_testdir,
+)
+
+executable(
   'hold-lock',
   'hold-lock.c',
   dependencies : [

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -58,18 +58,28 @@ tap_test = find_program(
   files(project_source_root / 'buildutil/tap-test'),
 )
 
+assert_fds_open = executable(
+  'assert-fds-open',
+  'assert-fds-open.c',
+  override_options : ['b_sanitize=none'],
+  install : get_option('installed_tests'),
+  install_dir : installed_testdir,
+)
+
 if can_run_host_binaries
   runtime_repo = custom_target(
     'runtime-repo',
     build_by_default : false,
     command : [
+      'env',
+      'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
       files('make-runtime-repos'),
       project_build_root / 'app',
       files('make-test-runtime.sh'),
       project_build_root / 'tests/runtime-repo',
       '@OUTPUT@',
     ],
-    depends : [flatpak_exe],
+    depends : [flatpak_exe, assert_fds_open],
     output : 'runtime-repo.stamp',
   )
 endif

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -10,6 +10,7 @@ else
 fi
 
 skip_revokefs_without_fuse
+original_cmd_prefix="$CMD_PREFIX"
 
 reset_overrides () {
     ${FLATPAK} override --user --reset org.test.Hello
@@ -170,6 +171,16 @@ else
   # The secret doesn't end up in bubblewrap's cmdline where other users
   # could see it
   assert_not_file_has_content out 3047225e-5e38-4357-b21c-eac83b7e8ea6
+
+  # The --env-fd isn't inherited by the command
+  CMD_PREFIX="${test_builddir}/close-fds-except 3 4 -- $original_cmd_prefix"
+  ${CMD_PREFIX} flatpak run --command=assert-fds-open \
+      --env-fd=3 \
+      --env-fd=4 \
+      org.test.Hello \
+      0 1 2 \
+      3<env.3 4<env.4 >&2
+  CMD_PREFIX="$original_cmd_prefix"
 
   # libpreload.so will abort() if it gets loaded into the `flatpak run`
   # or `bwrap` processes, so if this succeeds, everything's OK

--- a/tests/test-run-custom.sh
+++ b/tests/test-run-custom.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 
 skip_without_bwrap
 skip_revokefs_without_fuse
+original_cmd_prefix="$CMD_PREFIX"
 
 echo "1..11"
 
@@ -61,6 +62,10 @@ assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ! run --app-path="" --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
 
+CMD_PREFIX="${test_builddir}/close-fds-except -- $original_cmd_prefix"
+run --app-path="" --command=assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
+
 ok "empty app path"
 
 run --app-path=custom-app/files --command=/app/bin/hello.sh org.test.Hello > hello_out
@@ -74,6 +79,10 @@ assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ! run --app-path=custom-app/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
 
+CMD_PREFIX="${test_builddir}/close-fds-except -- $original_cmd_prefix"
+run --app-path=custom-app/files --command=assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
+
 ok "custom app path"
 
 ! run --app-path=path-which-does-not-exist org.test.Hello > /dev/null
@@ -83,6 +92,12 @@ ok "bad custom app path"
 exec 3< custom-app/files
 run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandboxCUSTOM$'
+exec 3>&-
+
+exec 3< custom-app/files
+CMD_PREFIX="${test_builddir}/close-fds-except 3 -- $original_cmd_prefix"
+run --app-fd=3 --command=assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
 exec 3>&-
 
 ! run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
@@ -100,6 +115,11 @@ assert_file_has_content hello_out '^Hello world, from a runtimeCUSTOM$'
 run --usr-path=custom-runtime/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtime$'
 
+CMD_PREFIX="${test_builddir}/close-fds-except -- $original_cmd_prefix"
+run --usr-path=custom-runtime/files \
+    --command=/run/parent/usr/bin/assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
+
 ok "custom usr path"
 
 ! run --usr-path=path-which-does-not-exist org.test.Hello > /dev/null
@@ -114,6 +134,12 @@ exec 3>&-
 exec 3< custom-runtime/files
 run --usr-fd=3 --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtimeCUSTOM$'
+exec 3>&-
+
+exec 3< custom-runtime/files
+CMD_PREFIX="${test_builddir}/close-fds-except 3 -- $original_cmd_prefix"
+run --usr-fd=3 --command=/run/parent/usr/bin/assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
 exec 3>&-
 
 ! run --usr-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
@@ -136,6 +162,11 @@ run --usr-path=custom-runtime/files --app-path=custom-app/files \
     --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtime$'
 
+CMD_PREFIX="${test_builddir}/close-fds-except -- $original_cmd_prefix"
+run --usr-path=custom-runtime/files --app-path=custom-app/files \
+    --command=/run/parent/usr/bin/assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
+
 ok "custom usr and app path"
 
 ! run --usr-path=custom-runtime/files --app-path="" \
@@ -152,6 +183,11 @@ assert_file_has_content hello_out '^Hello world, from a sandbox$'
 run --usr-path=custom-runtime/files --app-path="" \
     --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtime$'
+
+CMD_PREFIX="${test_builddir}/close-fds-except -- $original_cmd_prefix"
+run --usr-path=custom-runtime/files --app-path="" \
+    --command=/run/parent/usr/bin/assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
 
 ok "custom usr and empty app path"
 
@@ -174,6 +210,14 @@ exec 3>&-
 
 exec 3< "${path}"
 ! run --ro-bind-fd=3 --command=bash org.test.Hello -c "echo baz > ${path}" > /dev/null
+exec 3>&-
+
+exec 3> "${path}3"
+exec 4> "${path}4"
+CMD_PREFIX="${test_builddir}/close-fds-except 3 4 -- $original_cmd_prefix"
+run --ro-bind-fd=3 --bind-fd=4 --command=assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
+exec 4>&-
 exec 3>&-
 
 ok "bind-fd and ro-bind-fd"

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -23,8 +23,9 @@ set -euo pipefail
 
 skip_without_bwrap
 skip_revokefs_without_fuse
+original_cmd_prefix="$CMD_PREFIX"
 
-echo "1..27"
+echo "1..29"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -85,6 +86,18 @@ run org.test.Hello &> hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ok "hello"
+
+CMD_PREFIX="${test_builddir}/close-fds-except -- $original_cmd_prefix"
+run --command=assert-fds-open org.test.Hello 0 1 2 >&2
+CMD_PREFIX="$original_cmd_prefix"
+
+ok "no extraneous fds open"
+
+CMD_PREFIX="${test_builddir}/close-fds-except 3 9 -- $original_cmd_prefix"
+run --command=assert-fds-open org.test.Hello 0 1 2 3 9 3>/dev/null 9</dev/null >&2
+CMD_PREFIX="$original_cmd_prefix"
+
+ok "extra fds can be inherited"
 
 # This should try and fail to run e.g. /usr/bin/--tmpfs, which will
 # exit with a nonzero status because there is no such executable.


### PR DESCRIPTION
Based on #6598 to avoid conflicts.

* utils: Add flatpak_unset_cloexec()

* tests: Add a helper to close all inherited fds, with exceptions
    
    We don't know what fds our tests are going to inherit from the user or
    the test framework, but we can use this wrapper to enforce that none
    of them are passed to Flatpak, allowing us to make assertions about
    what fds remain open.

* tests: Add a helper to assert that a specified set of fds are open

* tests: Assert that extraneous fds aren't inherited into the sandbox