### PR TITLE
tests: add missing assertions after second flatpak_usb_parse_usb_list…

### DIFF
--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -535,6 +535,8 @@ test_usb_list (void)
   g_hash_table_remove_all (enumerable);
   g_hash_table_remove_all (hidden);
   ret = flatpak_usb_parse_usb_list (list, enumerable, hidden, &error);
+  g_assert (ret);
+  g_assert_no_error (error);
   g_assert_cmpint (g_hash_table_size (hidden), ==, 4);
   g_assert_cmpint (g_hash_table_size (enumerable), ==, 0);
 }


### PR DESCRIPTION
… call

The call to flatpak_usb_parse_usb_list() lacked the
g_assert(ret) and g_assert_no_error(error) guards that are present
on the first call.