### PR TITLE
[1.16] Silence lseek() errors on fds inherited by extra-data helpers

### DIFF
--- a/common/flatpak-bwrap.c
+++ b/common/flatpak-bwrap.c
@@ -533,7 +533,8 @@ flatpak_bwrap_child_setup (GArray *fd_array,
          us use the same fd_array multiple times */
       if (lseek (fd, 0, SEEK_SET) < 0)
         {
-          /* Ignore the error, this happens on e.g. pipe fds */
+          /* Ignore the error, not all fds are seekable
+           * (for example pipes and O_PATH fds are not) */
         }
 
       fcntl (fd, F_SETFD, 0);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8324,30 +8324,6 @@ extract_extra_data (FlatpakDir   *self,
   return TRUE;
 }
 
-static void
-child_setup (gpointer user_data)
-{
-  GArray *fd_array = user_data;
-  int i;
-
-  /* If no fd_array was specified, don't care. */
-  if (fd_array == NULL)
-    return;
-
-  /* Otherwise, mark not - close-on-exec all the fds in the array */
-  for (i = 0; i < fd_array->len; i++)
-    {
-      int fd = g_array_index (fd_array, int, i);
-
-      /* We also seek all fds to the start, because this lets
-         us use the same fd_array multiple times */
-      if (lseek (fd, 0, SEEK_SET) < 0)
-        g_printerr ("lseek error in child setup");
-
-      fcntl (fd, F_SETFD, 0);
-    }
-}
-
 static gboolean
 apply_extra_data (FlatpakDir   *self,
                   GFile        *checkoutdir,
@@ -8521,7 +8497,7 @@ apply_extra_data (FlatpakDir   *self,
                      (char **) bwrap->argv->pdata,
                      bwrap->envp,
                      G_SPAWN_SEARCH_PATH,
-                     child_setup, bwrap->fds,
+                     flatpak_bwrap_child_setup_inherit_fds_cb, bwrap->fds,
                      NULL, NULL,
                      &exit_status,
                      error))

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,2 +1,3 @@
+/.wraplock
 bubblewrap/
 dbus-proxy/


### PR DESCRIPTION
1.16 backport of #6609 (and also #6610, which is trivial), fixing #6608.

#6608 is only cosmetic and only affects a small number of apps, so there's no urgency to it; but technically it's a regression that resulted from fixing CVE-2026-34078, so let's get it fixed in the next 1.16.x release.