### PR TITLE
subprojects: Update dbus-proxy.wrap to v0.1.7

### DIFF
--- a/subprojects/dbus-proxy.wrap
+++ b/subprojects/dbus-proxy.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/flatpak/xdg-dbus-proxy
-# 0.1.6
-revision = 1c1989e56f94b9eb3b7567f8a6e8a0aa16cba496
+# 0.1.7
+revision = 6a170fa77e3cbecb48f9dd2478fe5c0a119eb467
 depth = 1


### PR DESCRIPTION
Versions up to 0.1.6 contain a security vulnerability, so let's bump it to a version which does not.

/cc @smcv 