### PR TITLE
tests: add test-run-custom.sh to test matrix source

### DIFF
--- a/tests/update-test-matrix
+++ b/tests/update-test-matrix
@@ -37,6 +37,7 @@ TEST_MATRIX_SOURCE=(
 	'tests/test-repair.sh' \
 	'tests/test-extra-data.sh{user+system}' \
 	'tests/test-preinstall.sh' \
+	'tests/test-run-custom.sh{user+system}' \
 )
 
 "${tests_srcdir}/expand-test-matrix.sh" --meson "${TEST_MATRIX_SOURCE[*]}" > "${tests_srcdir}/test-matrix/meson.build"


### PR DESCRIPTION
test-run-custom.sh was only manually appended to test-matrix/meson.build and would be lost on regeneration. Add it to update-test-matrix so it is properly managed.