### PR TITLE
dir: Succeed ensure_repo with allow_empty when system helper fails

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -4767,11 +4767,19 @@ _flatpak_dir_ensure_repo (FlatpakDir   *self,
 
       if (flatpak_dir_use_system_helper (self, NULL))
         {
+          g_autoptr(GError) local_error = NULL;
+
           if (!system_helper_maybe_ensure_repo (self, ensure_flags, allow_empty, cancellable, error))
             return FALSE;
 
-          if (!ensure_repo_opened (repo, cancellable, error))
-            return FALSE;
+          if (!ensure_repo_opened (repo, cancellable, &local_error))
+            {
+              if (allow_empty)
+                return TRUE;
+
+              g_propagate_error (error, g_steal_pointer (&local_error));
+              return FALSE;
+            }
         }
       else
         {


### PR DESCRIPTION
If _flatpak_dir_ensure_repo is called with allow_empty=true, it is allowed to fail to create the repo, and is supposed to return success in that case.

The system helper handles this correctly, but we then call to ensure_repo_opened no matter if the repo actuall exists and return an error when it does not, no matter if allow_empty is set or not.

Closes: #6618