### PR TITLE
selinux: flatpak.if should be installed in `distributed` (bsc#1262051)

### DIFF
--- a/selinux/meson.build
+++ b/selinux/meson.build
@@ -17,5 +17,5 @@ custom_target(
 
 install_data(
   'flatpak.if',
-  install_dir : get_option('datadir') / 'selinux' / 'devel' / 'include' / 'contrib',
+  install_dir : get_option('datadir') / 'selinux' / 'devel' / 'include' / 'distributed',
 )


### PR DESCRIPTION
selinux: flatpak.if should be installed in `distributed instead of `contrib`. Otherwise interfaces might clash with the interfaces from the main policy on fedora and openSUSE.

See the independent policy guideline:
https://fedoraproject.org/wiki/SELinux/IndependentPolicy#Using_custom_interfaces

And:
https://bugzilla.opensuse.org/show_bug.cgi?id=1262051