### PR TITLE
tests: Fix checks where we expect a command to fail

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -961,7 +961,7 @@ handle_install_bundle (FlatpakSystemHelper   *object,
       return G_DBUS_METHOD_INVOCATION_HANDLED;
     }
 
-  reinstall = !!(arg_flags & FLATPAK_HELPER_INSTALL_BUNDLE_FLAGS_NO_INTERACTION);
+  reinstall = (arg_flags & FLATPAK_HELPER_INSTALL_BUNDLE_FLAGS_REINSTALL) != 0;
   if (!flatpak_dir_install_bundle (system, reinstall, bundle_file, arg_remote, &ref, NULL, &error))
     {
       flatpak_invocation_return_error (invocation, error, "Error installing bundle");

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -283,6 +283,10 @@ assert_remote_has_no_config () {
     } 3> /dev/null
 }
 
+assert_not () {
+    "$@" && exit 1 || true
+}
+
 export FL_GPG_HOMEDIR=${TEST_DATA_DIR}/gpghome
 export FL_GPG_HOMEDIR2=${TEST_DATA_DIR}/gpghome2
 mkdir -p ${FL_GPG_HOMEDIR}

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -283,6 +283,15 @@ assert_remote_has_no_config () {
     } 3> /dev/null
 }
 
+assert_fail () {
+    if "$@"; then
+        { { local BASH_XTRACEFD=3; } 2> /dev/null
+            echo "Command '$*' should not have succeeded at $(basename ${BASH_SOURCE[1]}):${BASH_LINENO[0]}" >&2
+            exit 1
+        } 3> /dev/null
+    fi
+}
+
 export FL_GPG_HOMEDIR=${TEST_DATA_DIR}/gpghome
 export FL_GPG_HOMEDIR2=${TEST_DATA_DIR}/gpghome2
 mkdir -p ${FL_GPG_HOMEDIR}

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -49,7 +49,7 @@ ${FLATPAK} uninstall ${U} -y org.test.Hello >&2
 ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak >&2
 
 # Installing again without reinstall option should fail...
-! ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak >&2
+assert_not ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak >&2
 # Now with reinstall option it should pass...
 ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak --reinstall >&2
 

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -49,7 +49,7 @@ ${FLATPAK} uninstall ${U} -y org.test.Hello >&2
 ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak >&2
 
 # Installing again without reinstall option should fail...
-! ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak >&2
+assert_fail ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak >&2
 # Now with reinstall option it should pass...
 ${FLATPAK} install ${U} -y --bundle bundles/hello.flatpak --reinstall >&2
 

--- a/tests/test-preinstall.sh
+++ b/tests/test-preinstall.sh
@@ -101,7 +101,7 @@ ok "no config"
 # make sure nothing is installed
 ${FLATPAK} ${U} list --columns=ref > list-log
 assert_file_empty list-log
-! ostree config --repo=$XDG_DATA_HOME/flatpak/repo get --group "core" xa.preinstalled &> /dev/null
+assert_not ostree config --repo=$XDG_DATA_HOME/flatpak/repo get --group "core" xa.preinstalled &> /dev/null
 
 # The preinstall config wants org.test.Hello.
 cp hello-install.preinstall $FLATPAK_DATA_DIR/preinstall.d/
@@ -278,7 +278,7 @@ ${FLATPAK} ${U} uninstall -y --all >&2
 # make sure nothing is installed
 ${FLATPAK} ${U} list --columns=ref > list-log
 assert_file_empty list-log
-! ostree config --repo=$XDG_DATA_HOME/flatpak/repo get --group "core" xa.preinstalled &> /dev/null
+ostree config --repo=$XDG_DATA_HOME/flatpak/repo unset --group "core" xa.preinstalled
 
 # The preinstall config wants org.test.Hello.
 cp hello-install.preinstall $FLATPAK_DATA_DIR/preinstall.d/

--- a/tests/test-preinstall.sh
+++ b/tests/test-preinstall.sh
@@ -101,7 +101,7 @@ ok "no config"
 # make sure nothing is installed
 ${FLATPAK} ${U} list --columns=ref > list-log
 assert_file_empty list-log
-! ostree config --repo=$XDG_DATA_HOME/flatpak/repo get --group "core" xa.preinstalled &> /dev/null
+assert_fail ostree config --repo=$XDG_DATA_HOME/flatpak/repo get --group "core" xa.preinstalled
 
 # The preinstall config wants org.test.Hello.
 cp hello-install.preinstall $FLATPAK_DATA_DIR/preinstall.d/
@@ -278,7 +278,7 @@ ${FLATPAK} ${U} uninstall -y --all >&2
 # make sure nothing is installed
 ${FLATPAK} ${U} list --columns=ref > list-log
 assert_file_empty list-log
-! ostree config --repo=$XDG_DATA_HOME/flatpak/repo get --group "core" xa.preinstalled &> /dev/null
+ostree config --repo=$XDG_DATA_HOME/flatpak/repo unset --group "core" xa.preinstalled
 
 # The preinstall config wants org.test.Hello.
 cp hello-install.preinstall $FLATPAK_DATA_DIR/preinstall.d/

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -138,12 +138,12 @@ port=$(cat httpd-port)
 echo "bad key" > badkey
 
 gpg2_repo_url=$(ostree config --repo=$FL_DIR/repo get --group 'remote "test-gpg2-repo"' url)
-gpg2_repo_key=$(cat "$FL_DIR/repo/test-gpg2-repo.trustedkeys.gpg")
+cp "$FL_DIR/repo/test-gpg2-repo.trustedkeys.gpg" gpg2_repo_key
 ${FLATPAK} ${U} remote-modify --gpg-import=badkey test-gpg2-repo >&2 || true
 gpg2_repo_url2=$(ostree config --repo=$FL_DIR/repo get --group 'remote "test-gpg2-repo"' url)
-gpg2_repo_key2=$(cat "$FL_DIR/repo/test-gpg2-repo.trustedkeys.gpg")
+cp "$FL_DIR/repo/test-gpg2-repo.trustedkeys.gpg" gpg2_repo_key2
 
-if [[ "${gpg2_repo_url}" != "${gpg2_repo_url2}" || "${gpg2_repo_key}" != "${gpg2_repo_key2}" ]]; then
+if [[ "${gpg2_repo_url}" != "${gpg2_repo_url2}" ]] || ! diff -q gpg2_repo_key gpg2_repo_key2 > /dev/null 2>&1; then
   assert_not_reached "remote-modify failed but remote was modified"
 fi
 

--- a/tests/test-run-custom.sh
+++ b/tests/test-run-custom.sh
@@ -51,7 +51,7 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 
 ok "setup"
 
-! run --app-path="" --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_fail run --app-path="" --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 run --app-path="" --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtime$'
@@ -59,7 +59,7 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 run --app-path="" --command=/run/parent/app/bin/hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
-! run --app-path="" --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
+assert_fail run --app-path="" --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
 
 ok "empty app path"
 
@@ -72,11 +72,11 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 run --app-path=custom-app/files --command=/run/parent/app/bin/hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
-! run --app-path=custom-app/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
+assert_fail run --app-path=custom-app/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
 
 ok "custom app path"
 
-! run --app-path=path-which-does-not-exist org.test.Hello > /dev/null
+assert_fail run --app-path=path-which-does-not-exist org.test.Hello > /dev/null
 
 ok "bad custom app path"
 
@@ -85,7 +85,7 @@ run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandboxCUSTOM$'
 exec 3>&-
 
-! run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_fail run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 ok "custom app fd"
 
@@ -95,14 +95,14 @@ assert_file_has_content hello_out '^Hello world, from a sandbox$'
 run --usr-path=custom-runtime/files --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtimeCUSTOM$'
 
-! run --usr-path=custom-runtime/files --command=/run/parent/app/bin/hello.sh org.test.Hello > /dev/null
+assert_fail run --usr-path=custom-runtime/files --command=/run/parent/app/bin/hello.sh org.test.Hello > /dev/null
 
 run --usr-path=custom-runtime/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtime$'
 
 ok "custom usr path"
 
-! run --usr-path=path-which-does-not-exist org.test.Hello > /dev/null
+assert_fail run --usr-path=path-which-does-not-exist org.test.Hello > /dev/null
 
 ok "bad custom usr path"
 
@@ -116,7 +116,7 @@ run --usr-fd=3 --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtimeCUSTOM$'
 exec 3>&-
 
-! run --usr-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_fail run --usr-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 ok "custom usr fd"
 
@@ -138,8 +138,8 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 
 ok "custom usr and app path"
 
-! run --usr-path=custom-runtime/files --app-path="" \
-    --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_fail run --usr-path=custom-runtime/files --app-path="" \
+               --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 run --usr-path=custom-runtime/files --app-path="" \
     --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
@@ -173,7 +173,7 @@ assert_file_has_content hello_out '^baz$'
 exec 3>&-
 
 exec 3< "${path}"
-! run --ro-bind-fd=3 --command=bash org.test.Hello -c "echo baz > ${path}" > /dev/null
+assert_fail run --ro-bind-fd=3 --command=bash org.test.Hello -c "echo baz > ${path}" > /dev/null
 exec 3>&-
 
 ok "bind-fd and ro-bind-fd"

--- a/tests/test-run-custom.sh
+++ b/tests/test-run-custom.sh
@@ -51,7 +51,7 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 
 ok "setup"
 
-! run --app-path="" --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_not run --app-path="" --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 run --app-path="" --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtime$'
@@ -59,7 +59,7 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 run --app-path="" --command=/run/parent/app/bin/hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
-! run --app-path="" --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
+assert_not run --app-path="" --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
 
 ok "empty app path"
 
@@ -72,11 +72,11 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 run --app-path=custom-app/files --command=/run/parent/app/bin/hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
-! run --app-path=custom-app/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
+assert_not run --app-path=custom-app/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > /dev/null
 
 ok "custom app path"
 
-! run --app-path=path-which-does-not-exist org.test.Hello > /dev/null
+assert_not run --app-path=path-which-does-not-exist org.test.Hello > /dev/null
 
 ok "bad custom app path"
 
@@ -85,7 +85,7 @@ run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandboxCUSTOM$'
 exec 3>&-
 
-! run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_not run --app-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 ok "custom app fd"
 
@@ -95,14 +95,14 @@ assert_file_has_content hello_out '^Hello world, from a sandbox$'
 run --usr-path=custom-runtime/files --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtimeCUSTOM$'
 
-! run --usr-path=custom-runtime/files --command=/run/parent/app/bin/hello.sh org.test.Hello > /dev/null
+assert_not run --usr-path=custom-runtime/files --command=/run/parent/app/bin/hello.sh org.test.Hello > /dev/null
 
 run --usr-path=custom-runtime/files --command=/run/parent/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtime$'
 
 ok "custom usr path"
 
-! run --usr-path=path-which-does-not-exist org.test.Hello > /dev/null
+assert_not run --usr-path=path-which-does-not-exist org.test.Hello > /dev/null
 
 ok "bad custom usr path"
 
@@ -116,7 +116,7 @@ run --usr-fd=3 --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a runtimeCUSTOM$'
 exec 3>&-
 
-! run --usr-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_not run --usr-fd=3 --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 ok "custom usr fd"
 
@@ -138,8 +138,8 @@ assert_file_has_content hello_out '^Hello world, from a runtime$'
 
 ok "custom usr and app path"
 
-! run --usr-path=custom-runtime/files --app-path="" \
-    --command=/app/bin/hello.sh org.test.Hello > /dev/null
+assert_not run --usr-path=custom-runtime/files --app-path="" \
+               --command=/app/bin/hello.sh org.test.Hello > /dev/null
 
 run --usr-path=custom-runtime/files --app-path="" \
     --command=/usr/bin/runtime_hello.sh org.test.Hello > hello_out
@@ -173,7 +173,7 @@ assert_file_has_content hello_out '^baz$'
 exec 3>&-
 
 exec 3< "${path}"
-! run --ro-bind-fd=3 --command=bash org.test.Hello -c "echo baz > ${path}" > /dev/null
+assert_not run --ro-bind-fd=3 --command=bash org.test.Hello -c "echo baz > ${path}" > /dev/null
 exec 3>&-
 
 ok "bind-fd and ro-bind-fd"


### PR DESCRIPTION
    tests: Fix checks where we expect a command to fail
    
    I was convinced that the pattern `! command` with -e aborts when
    `command` fails. This is not the case (the result of `false` is the same
    as `! true` but somehow this doesn't matter).
    
    Fix the tests and use `command && false`. One could also use `command &&
    assert_not_reached "message"` but who has time to write error messages
    for all the cases.

with it fixed, it revealed a real bug:

    system-helper: Fix checking if the reinstall flag was passed in