### PR TITLE
Improve Flatpak-Upgrade-From handling

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6146,6 +6146,18 @@ repo_pull (OstreeRepo                           *self,
                                  &current_checksum, cancellable, error))
     return FALSE;
 
+  /* The remote tracking ref may be absent (e.g. the remote was removed and
+   * re-added, the app was installed from a bundle, or the ref was deleted by
+   * ostree-prune/flatpak-repair).  Fall back to the deploy/ ref that flatpak
+   * always writes on every successful deploy so that Flatpak-Upgrade-From is
+   * still sent correctly on the next update. */
+  if (current_checksum == NULL && dir != NULL)
+    {
+      g_autofree char *deploy_ref = g_strconcat ("deploy/", ref_to_fetch, NULL);
+      flatpak_repo_resolve_rev (self, NULL, NULL, deploy_ref, TRUE,
+                                &current_checksum, cancellable, NULL);
+    }
+
   if (current_checksum != NULL &&
       !ostree_repo_load_commit (self, current_checksum, &old_commit, NULL, error))
     return FALSE;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -409,6 +409,7 @@ tests = {
   'extra-data': {'wrap': ['user', 'system']},
   'preinstall': {},
   'run-custom': {'wrap': ['user', 'system']},
+  'upgrade-from-header': {'wrap': ['user', 'system', 'system-norevokefs']},
 }
 
 wrapped_tests = []

--- a/tests/test-upgrade-from-header.sh
+++ b/tests/test-upgrade-from-header.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+. "$(dirname "$0")"/libtest.sh
+
+skip_without_bwrap
+skip_revokefs_without_fuse
+
+echo "1..4"
+
+# Override the httpd function to enable header logging before setup_repo calls
+# it. The web-server.py will log Flatpak-Ref and Flatpak-Upgrade-From headers
+# to httpd-headers-log.
+httpd () {
+    if [ $# -eq 0 ] ; then
+        set web-server.py repos "$(pwd)"/httpd-headers-log
+    fi
+
+    COMMAND=$1
+    shift
+
+    rm -f httpd-pipe
+    mkfifo httpd-pipe
+    PYTHONUNBUFFERED=1 "$(dirname "$0")"/$COMMAND "$@" 3> httpd-pipe 2>&1 | tee -a httpd-log >&2 &
+    read < httpd-pipe
+}
+
+touch httpd-headers-log
+
+setup_repo
+
+truncate -s 0 httpd-headers-log
+
+install_repo
+
+APP_REF="app/org.test.Hello/${ARCH}/master"
+
+assert_not_file_has_content httpd-headers-log "Flatpak-Upgrade-From"
+
+ok "no Flatpak-Upgrade-From header on fresh install"
+
+assert_file_has_content httpd-headers-log "Flatpak-Ref: ${APP_REF}"
+
+ok "Flatpak-Ref header sent on fresh install"
+
+INSTALLED_COMMIT=$(${FLATPAK} ${U} info --show-commit org.test.Hello)
+
+make_updated_app
+truncate -s 0 httpd-headers-log
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+assert_file_has_content httpd-headers-log "Flatpak-Upgrade-From: ${INSTALLED_COMMIT}"
+
+ok "Flatpak-Upgrade-From header sent with correct commit hash on update"
+
+assert_file_has_content httpd-headers-log "Flatpak-Ref: ${APP_REF}"
+
+ok "Flatpak-Ref header sent on update"

--- a/tests/test-upgrade-from-header.sh
+++ b/tests/test-upgrade-from-header.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..4"
+echo "1..6"
 
 # Override the httpd function to enable header logging before setup_repo calls
 # it. The web-server.py will log Flatpak-Ref and Flatpak-Upgrade-From headers
@@ -58,3 +58,33 @@ ok "Flatpak-Upgrade-From header sent with correct commit hash on update"
 assert_file_has_content httpd-headers-log "Flatpak-Ref: ${APP_REF}"
 
 ok "Flatpak-Ref header sent on update"
+
+# Scenario: the remote tracking ref in the local OSTree repo is missing.
+#
+# That ref can be absent when, for example:
+#   - the remote was removed and re-added without re-installing the app
+#   - the app was installed from a bundle (no remote tracking ref ever written)
+#   - the ref was deleted by ostree-prune or flatpak-repair
+
+INSTALLED_COMMIT2=$(${FLATPAK} ${U} info --show-commit org.test.Hello)
+
+REMOTE_REF_FILE="${FL_DIR}/repo/refs/remotes/test-repo/app/org.test.Hello/${ARCH}/master"
+assert_has_file "${REMOTE_REF_FILE}"
+cp "${REMOTE_REF_FILE}" "${REMOTE_REF_FILE}.bak"
+rm -f "${REMOTE_REF_FILE}"
+
+make_updated_app test "" master UPDATED2
+truncate -s 0 httpd-headers-log
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+# Restore the ref so cleanup does not trip over a partially-inconsistent repo.
+mv "${REMOTE_REF_FILE}.bak" "${REMOTE_REF_FILE}"
+
+assert_file_has_content httpd-headers-log "Flatpak-Upgrade-From: ${INSTALLED_COMMIT2}"
+
+ok "Flatpak-Upgrade-From header sent when remote tracking ref is missing"
+
+assert_file_has_content httpd-headers-log "Flatpak-Ref: ${APP_REF}"
+
+ok "Flatpak-Ref header sent when remote tracking ref is missing"

--- a/tests/web-server.py
+++ b/tests/web-server.py
@@ -15,6 +15,8 @@ from io import BytesIO
 import sys
 
 class RequestHandler(http_server.SimpleHTTPRequestHandler):
+    headers_log_file = None
+
     def handle_tokens(self):
         need_token_path = self.translate_path(self.path) + ".need_token"
         if os.path.isfile(need_token_path):
@@ -34,14 +36,26 @@ class RequestHandler(http_server.SimpleHTTPRequestHandler):
                 return True
         return False
 
+    def log_flatpak_headers(self):
+        if self.headers_log_file is None:
+            return
+
+        for name in ("Flatpak-Ref", "Flatpak-Upgrade-From", "Flatpak-Is-Update"):
+            value = self.headers.get(name)
+            if value is not None:
+                with open(self.headers_log_file, 'a+') as f:
+                    f.write("%s: %s\n" % (name, value))
+
     def do_GET(self):
+        self.log_flatpak_headers()
         if self.handle_tokens():
             return None
         self.headers.__delitem__("If-Modified-Since")
         return super().do_GET()
 
-def run(dir):
+def run(dir, headers_log=None):
     RequestHandler.protocol_version = "HTTP/1.0"
+    RequestHandler.headers_log_file = headers_log
     httpd = http_server.HTTPServer( ("127.0.0.1", 0), RequestHandler)
     host, port = httpd.socket.getsockname()[:2]
     with open("httpd-port", 'w') as file:
@@ -59,7 +73,10 @@ def run(dir):
 
 if __name__ == '__main__':
     dir = None
+    headers_log = None
     if len(sys.argv) >= 2 and len(sys.argv[1]) > 0:
         dir = sys.argv[1]
+    if len(sys.argv) >= 3 and len(sys.argv[2]) > 0:
+        headers_log = sys.argv[2]
 
-    run(dir)
+    run(dir, headers_log)


### PR DESCRIPTION
This adds tests for the basic header handling.

Then tests for the headers when the ref file got removed. (fails at this point)

Then a commit to fix that case.