### PR TITLE
context: Removing the last conditional allows the permission

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -230,12 +230,15 @@ flatpak_permission_remove_conditional (FlatpakPermission *permission,
      remove everything from the lower layer */
   permission->reset = TRUE;
 
-  if (!g_ptr_array_find_with_equal_func (permission->conditionals,
-                                         condition,
-                                         g_str_equal, &index))
-    return;
+  if (g_ptr_array_find_with_equal_func (permission->conditionals,
+                                        condition,
+                                        g_str_equal, &index))
+    {
+      g_ptr_array_remove_index (permission->conditionals, index);
+    }
 
-  g_ptr_array_remove_index (permission->conditionals, index);
+  if (permission->conditionals->len == 0)
+    permission->allowed = TRUE;
 }
 
 static void


### PR DESCRIPTION
We on purpose do not allow removing conditionals in the new permission system, however, the fallback-x11 socket permission with --nosocket is essentially just that.

The flatpak_permission_remove_conditional is exactly for this purpose, but it has a bug: if the last conditional is removed, the permission becomes unconditionally not allowed.

We have to check if the just removed the last conditional and explicitly allow it then.

Fixes: #6556