### PR TITLE
Handle bearer token expiry during OCI pulls

### DIFF
--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -3213,24 +3213,38 @@ flatpak_mirror_image_from_oci (FlatpakOciRegistry    *dst_registry,
         }
     }
 
+  guint64 already_present_size = 0;
+  guint32 already_present_count = 0;
+
   for (i = 0; manifest->layers[i] != NULL; i++)
     {
       FlatpakOciDescriptor *layer = manifest->layers[i];
       FlatpakOciDescriptor *delta_layer = NULL;
+      const char *blob_digest;
+      guint64 layer_size;
+      g_autofree char *dst_subpath = NULL;
+      struct stat stbuf;
 
       if (delta_manifest)
         delta_layer = flatpak_oci_manifest_find_delta_for (delta_manifest, old_diffid, image_config->rootfs.diff_ids[i]);
 
-      if (delta_layer)
-        progress_data.total_size += delta_layer->size;
-      else
-        progress_data.total_size += layer->size;
+      blob_digest = delta_layer ? delta_layer->digest : layer->digest;
+      layer_size = delta_layer ? delta_layer->size : layer->size;
+
+      dst_subpath = get_digest_subpath (dst_registry, NULL, FALSE, FALSE, blob_digest, NULL);
+      if (dst_subpath != NULL &&
+          fstatat (dst_registry->dfd, dst_subpath, &stbuf, AT_SYMLINK_NOFOLLOW) == 0)
+        {
+          already_present_size += layer_size;
+          already_present_count++;
+        }
+      progress_data.total_size += layer_size;
       progress_data.n_layers++;
     }
 
   if (progress_cb)
-    progress_cb (progress_data.total_size, 0,
-                 progress_data.n_layers, progress_data.pulled_layers,
+    progress_cb (progress_data.total_size, already_present_size,
+                 progress_data.n_layers, already_present_count,
                  progress_user_data);
 
   for (i = 0; manifest->layers[i] != NULL; i++)

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -3233,7 +3233,7 @@ flatpak_mirror_image_from_oci (FlatpakOciRegistry    *dst_registry,
 
       dst_subpath = get_digest_subpath (dst_registry, NULL, FALSE, FALSE, blob_digest, NULL);
       if (dst_subpath != NULL &&
-          fstatat (dst_registry->dfd, dst_subpath, &stbuf, AT_SYMLINK_NOFOLLOW) == 0)
+          glnx_fstatat (dst_registry->dfd, dst_subpath, &stbuf, AT_SYMLINK_NOFOLLOW, NULL))
         {
           already_present_size += layer_size;
           already_present_count++;

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -5630,7 +5630,7 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
               op->requested_token &&
               op_may_need_token (op))
             {
-              GList single_op_list = { .data = op, .next = NULL, .prev = NULL };
+              g_autoptr(GList) single_op_list = g_list_prepend (NULL, op);
 
               g_info ("Got 401 during %s of %s, re-requesting token and retrying",
                       op->kind == FLATPAK_TRANSACTION_OPERATION_INSTALL ? "install" : "update",
@@ -5639,7 +5639,7 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
 
               op_clear_token (op);
 
-              if (request_tokens_for_remote (self, op->remote, &single_op_list,
+              if (request_tokens_for_remote (self, op->remote, single_op_list,
                                              cancellable, &local_error) &&
                   _run_op_kind (self, op, state,
                                 &needs_prune, &needs_triggers, &needs_cache_drop,

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3738,6 +3738,13 @@ op_may_need_token (FlatpakTransactionOperation *op)
      op->kind == FLATPAK_TRANSACTION_OPERATION_INSTALL_OR_UPDATE);
 }
 
+static void
+op_clear_token (FlatpakTransactionOperation *op)
+{
+  g_clear_pointer (&op->resolved_token, g_free);
+  op->requested_token = FALSE;
+}
+
 /* Resolving an operation means figuring out the target commit
    checksum and the metadata for that commit, so that we can handle
    dependencies from it, and verify versions. */
@@ -5615,7 +5622,33 @@ flatpak_transaction_real_run (FlatpakTransaction *self,
       if (res && !_run_op_kind (self, op, state,
                                 &needs_prune, &needs_triggers, &needs_cache_drop,
                                 cancellable, &local_error))
-        res = FALSE;
+        {
+          res = FALSE;
+
+          if (g_error_matches (local_error, FLATPAK_HTTP_ERROR,
+                               FLATPAK_HTTP_ERROR_UNAUTHORIZED) &&
+              op->requested_token &&
+              op_may_need_token (op))
+            {
+              GList single_op_list = { .data = op, .next = NULL, .prev = NULL };
+
+              g_info ("Got 401 during %s of %s, re-requesting token and retrying",
+                      op->kind == FLATPAK_TRANSACTION_OPERATION_INSTALL ? "install" : "update",
+                      flatpak_decomposed_get_ref (op->ref));
+              g_clear_error (&local_error);
+
+              op_clear_token (op);
+
+              if (request_tokens_for_remote (self, op->remote, &single_op_list,
+                                             cancellable, &local_error) &&
+                  _run_op_kind (self, op, state,
+                                &needs_prune, &needs_triggers, &needs_cache_drop,
+                                cancellable, &local_error))
+                {
+                  res = TRUE;
+                }
+            }
+        }
 
       if (res)
         {


### PR DESCRIPTION
When pulling large OCI images, the bearer token can expire between HTTP requests within a single transaction. Previously this was a fatal error because requested_token prevented re-authentication. This adds retry-on-401 logic in flatpak_transaction_real_run: when _run_op_kind fails with FLATPAK_HTTP_ERROR_UNAUTHORIZED for an install or update operation that previously obtained a token, the stale token is cleared, a fresh one is re-requested through the D-Bus authenticator, and the operation is retried once.

As a related change, flatpak_mirror_image_from_oci now detects blobs already present in the destination registry and accounts for them in the initial progress calculation. Without this, the retry would cause the progress bar to jump back to near-zero before immediately completing, since previously-downloaded blobs are skipped instantly by flatpak_oci_registry_mirror_blob but were still counted as pending work in the progress total.

Related to https://github.com/flatpak/flatpak/issues/4862