### PR TITLE
http: Resume interrupted GOutputStream downloads on retry

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -31,6 +31,7 @@
 
 #include <sys/types.h>
 #include <sys/xattr.h>
+#include <unistd.h>
 #include <curl/curl.h>
 
 /* These macros came from 7.43.0, but we want to check
@@ -93,6 +94,7 @@ typedef struct
   /* Output from the request, set even on http server errors */
 
   guint64               downloaded_bytes;
+  guint64               resume_offset;
   int                   status;
   char                  *hdr_content_type;
   char                  *hdr_www_authenticate;
@@ -136,6 +138,7 @@ reset_load_uri_data (LoadUriData *data)
   g_clear_error (&data->error);
   data->status = 0;
   data->downloaded_bytes = 0;
+  data->resume_offset = 0;
   if (data->content)
     g_string_set_size (data->content, 0);
 
@@ -150,6 +153,123 @@ reset_load_uri_data (LoadUriData *data)
   /* Reset the progress */
   if (data->progress)
     data->progress (0, data->user_data);
+}
+
+/* Reset between retries when resuming a partial GOutputStream download.
+ * Unlike reset_load_uri_data(), this accumulates downloaded_bytes into
+ * resume_offset (used for the Range request) and resets downloaded_bytes
+ * to zero so subsequent writes don't double-count already-received bytes. */
+static void
+reset_load_uri_data_for_resume (LoadUriData *data)
+{
+  g_clear_error (&data->error);
+  data->status = 0;
+
+  clear_load_uri_data_headers (data);
+
+  data->resume_offset += data->downloaded_bytes;
+  data->downloaded_bytes = 0;
+
+  if (data->progress)
+    data->progress (data->resume_offset, data->user_data);
+}
+
+static guint64
+load_uri_data_progress_bytes (LoadUriData *data)
+{
+  return data->resume_offset + data->downloaded_bytes;
+}
+
+static gboolean
+seek_output_stream (GOutputStream  *out,
+                    guint64         offset,
+                    GCancellable   *cancellable,
+                    GError        **error)
+{
+  if (G_IS_SEEKABLE (out) && g_seekable_can_seek (G_SEEKABLE (out)))
+    return g_seekable_seek (G_SEEKABLE (out), offset, G_SEEK_SET, cancellable, error);
+
+  if (G_IS_UNIX_OUTPUT_STREAM (out))
+    {
+      int fd = g_unix_output_stream_get_fd (G_UNIX_OUTPUT_STREAM (out));
+
+      if (lseek (fd, (off_t) offset, SEEK_SET) < 0)
+        return glnx_throw_errno_prefix (error, "lseek");
+
+      return TRUE;
+    }
+
+  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Output stream cannot be seeked");
+  return FALSE;
+}
+
+static gboolean
+reset_output_stream (GOutputStream  *out,
+                     GCancellable   *cancellable,
+                     GError        **error)
+{
+  if (G_IS_SEEKABLE (out) &&
+      g_seekable_can_seek (G_SEEKABLE (out)) &&
+      g_seekable_can_truncate (G_SEEKABLE (out)))
+    {
+      if (!g_seekable_truncate (G_SEEKABLE (out), 0, cancellable, error))
+        return FALSE;
+
+      return g_seekable_seek (G_SEEKABLE (out), 0, G_SEEK_SET, cancellable, error);
+    }
+
+  if (G_IS_UNIX_OUTPUT_STREAM (out))
+    {
+      int fd = g_unix_output_stream_get_fd (G_UNIX_OUTPUT_STREAM (out));
+
+      if (ftruncate (fd, 0) < 0)
+        return glnx_throw_errno_prefix (error, "ftruncate");
+
+      if (lseek (fd, 0, SEEK_SET) < 0)
+        return glnx_throw_errno_prefix (error, "lseek");
+
+      return TRUE;
+    }
+
+  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Output stream cannot be reset");
+  return FALSE;
+}
+
+static gboolean
+flatpak_http_error_is_retryable (const GError *error)
+{
+  return error != NULL &&
+         (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
+          g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
+          g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
+          g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT) ||
+          g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
+          g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
+          g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE));
+}
+
+static gboolean
+load_uri_data_should_resume (LoadUriData *data,
+                             const GError *error)
+{
+  if (!flatpak_http_error_is_retryable (error))
+    return FALSE;
+
+  if (data->resume_offset > 0 && data->downloaded_bytes == 0 && data->status == 0)
+    return TRUE;
+
+  if (data->hdr_content_encoding && data->hdr_content_encoding[0])
+    return FALSE;
+
+  if (data->status == 206)
+    return TRUE;
+
+  if (data->downloaded_bytes == 0)
+    return FALSE;
+
+  return data->status == 200 && data->resume_offset == 0;
 }
 
 /* Free allocated data at end of full repeated download */
@@ -496,7 +616,7 @@ _write_cb (void *content_data,
   if (g_get_monotonic_time () - data->last_progress_time > 1 * G_USEC_PER_SEC)
     {
       if (data->progress)
-        data->progress (data->downloaded_bytes, data->user_data);
+        data->progress (load_uri_data_progress_bytes (data), data->user_data);
       data->last_progress_time = g_get_monotonic_time ();
     }
 
@@ -599,6 +719,15 @@ set_error_from_curl (GError        **error,
     case CURLE_OPERATION_TIMEDOUT:
       code = G_IO_ERROR_TIMED_OUT;
       break;
+    case CURLE_GOT_NOTHING:
+    case CURLE_RECV_ERROR:
+    case CURLE_SEND_ERROR:
+      code = G_IO_ERROR_CONNECTION_CLOSED;
+      break;
+    case CURLE_RANGE_ERROR:
+    case CURLE_PARTIAL_FILE:
+      code = G_IO_ERROR_PARTIAL_INPUT;
+      break;
     default:
       code =  G_IO_ERROR_FAILED;
     }
@@ -631,6 +760,7 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *session,
   curl_easy_setopt (curl, CURLOPT_CAINFO, NULL);
   curl_easy_setopt (curl, CURLOPT_SSLCERT, NULL);
   curl_easy_setopt (curl, CURLOPT_SSLKEY, NULL);
+  curl_easy_setopt (curl, CURLOPT_RESUME_FROM_LARGE, (curl_off_t) data->resume_offset);
 
   if (data->certificates)
     {
@@ -696,6 +826,9 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *session,
 
   curl_easy_setopt (session->curl, CURLOPT_HTTPHEADER, NULL); /* Don't point to freed list */
 
+  curl_easy_getinfo (session->curl, CURLINFO_RESPONSE_CODE, &response);
+  data->status = response;
+
   if (res != CURLE_OK)
     {
       set_error_from_curl (error, uri, res, data->cancellable);
@@ -716,12 +849,15 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *session,
       g_clear_pointer (&data->out, g_object_unref);
     }
 
+  if (data->resume_offset > 0 && data->status != 206)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT,
+                           "Server did not honor Range header");
+      return FALSE;
+    }
+
   if (data->progress)
-    data->progress (data->downloaded_bytes, data->user_data);
-
-  curl_easy_getinfo (session->curl, CURLINFO_RESPONSE_CODE, &response);
-
-  data->status = response;
+    data->progress (load_uri_data_progress_bytes (data), data->user_data);
 
   if ((data->flags & FLATPAK_HTTP_FLAGS_NOCHECK_STATUS) == 0 &&
       !check_http_status (data->status, error))
@@ -747,17 +883,11 @@ static gboolean
 flatpak_http_should_retry_request (const GError *error,
                                    guint         n_retries_remaining)
 {
-  if (error == NULL || n_retries_remaining == 0)
+  if (n_retries_remaining == 0)
     return FALSE;
 
   /* Return TRUE for transient errors. */
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT) ||
-      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
-      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
-      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE))
+  if (flatpak_http_error_is_retryable (error))
     {
       g_info ("Should retry request (remaining: %u retries), due to transient error: %s",
               n_retries_remaining, error->message);
@@ -903,8 +1033,28 @@ flatpak_download_http_uri (FlatpakHttpSession    *http_session,
     {
       if (n_retries_remaining < DEFAULT_N_NETWORK_RETRIES)
         {
+          gboolean resume = load_uri_data_should_resume (&data, local_error);
           g_clear_error (&local_error);
-          reset_load_uri_data (&data);
+          if ((data.downloaded_bytes > 0 || data.resume_offset > 0) &&
+              data.out != NULL)
+            {
+              if (resume)
+                {
+                  reset_load_uri_data_for_resume (&data);
+                  if (!seek_output_stream (data.out, data.resume_offset,
+                                           cancellable, &local_error))
+                    break;
+                }
+              else
+                {
+                  if (!reset_output_stream (data.out, cancellable, &local_error))
+                    break;
+
+                  reset_load_uri_data (&data);
+                }
+            }
+          else
+            reset_load_uri_data (&data);
         }
 
       success =  flatpak_download_http_uri_once (http_session, &data, uri, &local_error);
@@ -913,11 +1063,6 @@ flatpak_download_http_uri (FlatpakHttpSession    *http_session,
         break;
 
       g_assert (local_error != NULL);
-
-      /* If the output stream has already been written to we can't retry.
-       * TODO: use a range request to resume the download */
-      if (data.downloaded_bytes > 0)
-        break;
     }
   while (flatpak_http_should_retry_request (local_error, n_retries_remaining--));
 

--- a/tests/http-utils-test-server.py
+++ b/tests/http-utils-test-server.py
@@ -22,7 +22,22 @@ def parse_http_date(date):
     else:
         return None
 
+def gzip_with_sync_flush(contents_bytes):
+    buf = BytesIO()
+    gzfile = gzip.GzipFile(mode='wb', fileobj=buf)
+    half = max(1, len(contents_bytes) // 2)
+
+    gzfile.write(contents_bytes[:half])
+    gzfile.flush(zlib.Z_SYNC_FLUSH)
+    split = len(buf.getvalue())
+    gzfile.write(contents_bytes[half:])
+    gzfile.close()
+
+    return buf.getvalue(), split
+
 class RequestHandler(http_server.BaseHTTPRequestHandler):
+    request_counts = {}
+
     def do_GET(self):
         parts = self.path.split('?', 1)
         path = parts[0]
@@ -49,6 +64,164 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
                 response = 304
             add_headers['Etag'] = etag
 
+        contents = "path=" + self.path + "\n"
+
+        if 'partial-fail-non-206-on-resume' in query:
+            n_requests = RequestHandler.request_counts.get(self.path, 0)
+            RequestHandler.request_counts[self.path] = n_requests + 1
+
+            contents_bytes = contents.encode('utf-8')
+            range_header = self.headers.get("Range")
+            if range_header and range_header.startswith("bytes="):
+                self.send_response(204)
+                self.end_headers()
+            elif n_requests == 0:
+                half = max(1, len(contents_bytes) // 2)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes[:half])
+                self.wfile.flush()
+                self.connection.shutdown(2)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes)
+            return
+
+        if 'compressed-partial-fail' in query:
+            n_requests = RequestHandler.request_counts.get(self.path, 0)
+            RequestHandler.request_counts[self.path] = n_requests + 1
+            range_seen_key = self.path + ':range-seen'
+            range_header = self.headers.get("Range")
+
+            if RequestHandler.request_counts.get(range_seen_key, 0) > 0:
+                contents_bytes = b"unexpected range retry\n"
+                self.send_response(500)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes)
+                return
+
+            if range_header and range_header.startswith("bytes="):
+                RequestHandler.request_counts[range_seen_key] = 1
+                contents_bytes = b"unexpected range\n"
+                self.send_response(500)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes)
+                return
+
+            contents_bytes = (contents + ("data\n" * 4096)).encode('utf-8')
+            compressed, split = gzip_with_sync_flush(contents_bytes)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=UTF-8")
+            self.send_header("Content-Encoding", "gzip")
+            self.send_header("Content-Length", str(len(compressed)))
+            self.end_headers()
+
+            if n_requests == 0:
+                self.wfile.write(compressed[:split])
+                self.wfile.flush()
+                self.connection.shutdown(2)
+            else:
+                self.wfile.write(compressed)
+            return
+
+        if 'empty-reply-then-ok' in query:
+            n_requests = RequestHandler.request_counts.get(self.path, 0)
+            RequestHandler.request_counts[self.path] = n_requests + 1
+
+            if n_requests == 0:
+                self.connection.close()
+                return
+
+        if 'error-then-ok' in query:
+            n_requests = RequestHandler.request_counts.get(self.path, 0)
+            RequestHandler.request_counts[self.path] = n_requests + 1
+
+            if n_requests == 0:
+                contents_bytes = b"server-error\n"
+                self.send_response(500)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes)
+                return
+
+        if 'partial-fail-no-body-on-resume' in query:
+            n_requests = RequestHandler.request_counts.get(self.path, 0)
+            RequestHandler.request_counts[self.path] = n_requests + 1
+
+            contents_bytes = contents.encode('utf-8')
+            range_header = self.headers.get("Range")
+            if range_header and range_header.startswith("bytes="):
+                byte_range = range_header[len("bytes="):]
+                start = int(byte_range.split('-')[0])
+                remainder = contents_bytes[start:]
+                self.send_response(206)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Range",
+                                 "bytes %d-%d/%d" % (start, len(contents_bytes) - 1, len(contents_bytes)))
+                self.send_header("Content-Length", str(len(remainder)))
+                self.end_headers()
+
+                if n_requests == 1:
+                    self.wfile.flush()
+                    self.connection.shutdown(2)
+                else:
+                    self.wfile.write(remainder)
+            elif n_requests == 0:
+                half = max(1, len(contents_bytes) // 2)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes[:half])
+                self.wfile.flush()
+                self.connection.shutdown(2)
+            else:
+                contents_bytes = b"unexpected restart\n"
+                self.send_response(500)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes)
+            return
+
+        if 'partial-fail' in query:
+            # On the first request, send half the content then close the
+            # connection to simulate a transient network failure mid-download.
+            # On a retry with a Range header (resume), serve the remainder.
+            contents_bytes = contents.encode('utf-8')
+            range_header = self.headers.get("Range")
+            if range_header and range_header.startswith("bytes="):
+                byte_range = range_header[len("bytes="):]
+                start = int(byte_range.split('-')[0])
+                remainder = contents_bytes[start:]
+                self.send_response(206)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Range",
+                                 "bytes %d-%d/%d" % (start, len(contents_bytes) - 1, len(contents_bytes)))
+                self.send_header("Content-Length", str(len(remainder)))
+                self.end_headers()
+                self.wfile.write(remainder)
+            else:
+                half = max(1, len(contents_bytes) // 2)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=UTF-8")
+                self.send_header("Content-Length", str(len(contents_bytes)))
+                self.end_headers()
+                self.wfile.write(contents_bytes[:half])
+                self.wfile.flush()
+                self.connection.shutdown(2)
+            return
+
         self.send_response(response)
         for k, v in list(add_headers.items()):
             self.send_header(k, v)
@@ -64,8 +237,6 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
 
         if response == 200:
             self.send_header("Content-Type", "text/plain; charset=UTF-8")
-
-        contents = "path=" + self.path + "\n"
 
         if not 'ignore-accept-encoding' in query:
             accept_encoding = self.headers.get("Accept-Encoding")

--- a/tests/httpdownload.c
+++ b/tests/httpdownload.c
@@ -1,0 +1,111 @@
+/* Small test helper that exercises flatpak_download_http_uri() */
+
+#include "libglnx.h"
+#include "common/flatpak-utils-http-private.h"
+#include "common/flatpak-utils-private.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <gio/gunixoutputstream.h>
+#include <glib/gstdio.h>
+
+static void
+progress_cb (guint64  downloaded_bytes,
+             gpointer user_data)
+{
+  GString *progress = user_data;
+
+  if (progress->len > 0)
+    g_string_append_c (progress, ',');
+
+  g_string_append_printf (progress, "%" G_GUINT64_FORMAT, downloaded_bytes);
+}
+
+int
+main (int argc, char *argv[])
+{
+  g_autoptr(FlatpakHttpSession) session = flatpak_create_http_session (PACKAGE_STRING);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GFile) dest_file = NULL;
+  g_autoptr(GOutputStream) out_stream = NULL;
+  g_autoptr(GString) progress = NULL;
+  gboolean use_unix_output_stream = FALSE;
+  gboolean print_progress = FALSE;
+  const char *url, *dest;
+  int arg = 1;
+
+  while (arg < argc && g_str_has_prefix (argv[arg], "--"))
+    {
+      if (strcmp (argv[arg], "--unix-output-stream") == 0)
+        use_unix_output_stream = TRUE;
+      else if (strcmp (argv[arg], "--progress") == 0)
+        print_progress = TRUE;
+      else
+        {
+          g_printerr ("Unknown option %s\n", argv[arg]);
+          return 1;
+        }
+
+      arg++;
+    }
+
+  if (argc - arg != 2)
+    {
+      g_printerr ("Usage: httpdownload [--unix-output-stream] [--progress] URL DEST\n");
+      return 1;
+    }
+
+  url = argv[arg++];
+  dest = argv[arg++];
+  progress = g_string_new ("");
+
+  if (use_unix_output_stream)
+    {
+      int fd = g_open (dest, O_CREAT | O_TRUNC | O_WRONLY, 0600);
+
+      if (fd == -1)
+        {
+          g_printerr ("Failed to open %s: %s\n", dest, g_strerror (errno));
+          return 1;
+        }
+
+      out_stream = g_unix_output_stream_new (fd, TRUE);
+    }
+  else
+    {
+      dest_file = g_file_new_for_path (dest);
+      out_stream = (GOutputStream *) g_file_replace (dest_file, NULL, FALSE,
+                                                     G_FILE_CREATE_REPLACE_DESTINATION,
+                                                     NULL, &error);
+    }
+
+  if (out_stream == NULL)
+    {
+      g_printerr ("Failed to open %s: %s\n", dest, error->message);
+      return 1;
+    }
+
+  if (!flatpak_download_http_uri (session, url, NULL,
+                                  FLATPAK_HTTP_FLAGS_NONE,
+                                  G_OUTPUT_STREAM (out_stream),
+                                  NULL,
+                                  print_progress ? progress_cb : NULL, progress,
+                                  NULL, &error))
+    {
+      g_printerr ("%s\n", error->message);
+      return 1;
+    }
+
+  if (!g_output_stream_close (G_OUTPUT_STREAM (out_stream), NULL, &error))
+    {
+      g_printerr ("Failed to close %s: %s\n", dest, error->message);
+      return 1;
+    }
+
+  if (print_progress)
+    g_print ("Download succeeded; progress=%s\n", progress->str);
+  else
+    g_print ("Download succeeded\n");
+
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -200,9 +200,25 @@ executable(
   install_dir : installed_testdir,
 )
 
-executable(
+httpcache = executable(
   'httpcache',
   'httpcache.c',
+  dependencies : [
+    base_deps,
+    json_glib_dep,
+    libflatpak_common_dep,
+    libflatpak_common_base_dep,
+    libglnx_dep,
+    libostree_dep,
+  ],
+  include_directories : [common_include_directories],
+  install : get_option('installed_tests'),
+  install_dir : installed_testdir,
+)
+
+httpdownload = executable(
+  'httpdownload',
+  'httpdownload.c',
   dependencies : [
     base_deps,
     json_glib_dep,
@@ -367,7 +383,7 @@ tests = {
   'completion': {},
   'config': {},
   'build-update-repo': {},
-  'http-utils': {},
+  'http-utils': {'depends': [httpcache, httpdownload]},
   'run': {'wrap': [
     'user,nodeltas',
     'user,deltas',
@@ -419,9 +435,10 @@ tests = {
 wrapped_tests = []
 foreach name, testcase : tests
   script = 'test-@0@.sh'.format(name)
+  test_depends = testcase.get('depends', [])
 
   if not testcase.has_key('wrap')
-    wrapped_tests += {'name': script, 'script': script}
+    wrapped_tests += {'name': script, 'script': script, 'depends': test_depends}
     continue
   endif
 
@@ -429,6 +446,7 @@ foreach name, testcase : tests
     wrapped_tests += {
       'name': 'test-@0@@@1@.wrap'.format(name, wrap),
       'script': script,
+      'depends': test_depends,
     }
   endforeach
 endforeach
@@ -490,7 +508,7 @@ foreach testcase : wrapped_tests
       name,
       tap_test,
       args : [meson.current_source_dir() / name],
-      depends : runtime_repo,
+      depends : [runtime_repo] + testcase.get('depends', []),
       env : test_env,
       is_parallel : is_parallel,
       protocol : 'tap',

--- a/tests/test-http-utils.sh
+++ b/tests/test-http-utils.sh
@@ -65,7 +65,7 @@ have_xattrs() {
     setfattr -n user.testvalue -v somevalue $1/test-xattrs > /dev/null 2>&1
 }
 
-echo "1..6"
+echo "1..13"
 
 # Without anything else, cached for 30 minutes
 assert_ok "/" $test_tmpdir/output
@@ -125,6 +125,83 @@ assert_streq $contents path=/compress?ignore-accept-encoding
 rm -f $test_tmpdir/output*
 
 ok 'compress after download'
+
+# Test that a partial download is resumed on retry
+out=$(${test_builddir}/httpdownload --progress "http://localhost:$port/?partial-fail" $test_tmpdir/output || :)
+case "$out" in
+    "Download succeeded; progress="*) ;;
+    *)
+        echo "Expected successful progress output, got '$out'" >&2
+        exit 1
+        ;;
+esac
+contents=$(cat $test_tmpdir/output)
+assert_streq "$contents" "path=/?partial-fail"
+progress=${out#Download succeeded; progress=}
+last_progress=${progress##*,}
+expected_size=$(stat -c %s $test_tmpdir/output)
+assert_streq "$last_progress" "$expected_size"
+rm -f $test_tmpdir/output*
+
+ok 'partial download resume'
+
+# Test retrying a receive-side network error that returns no response.
+out=$(${test_builddir}/httpdownload "http://localhost:$port/?empty-reply-then-ok" $test_tmpdir/output || :)
+assert_streq "$out" "Download succeeded"
+contents=$(cat $test_tmpdir/output)
+assert_streq "$contents" "path=/?empty-reply-then-ok"
+rm -f $test_tmpdir/output*
+
+ok 'empty reply retry'
+
+# Test that an interrupted resumed request retries from the previous offset
+# even if the 206 response delivered no additional body bytes.
+out=$(${test_builddir}/httpdownload "http://localhost:$port/?partial-fail-no-body-on-resume" $test_tmpdir/output || :)
+assert_streq "$out" "Download succeeded"
+contents=$(cat $test_tmpdir/output)
+assert_streq "$contents" "path=/?partial-fail-no-body-on-resume"
+rm -f $test_tmpdir/output*
+
+ok 'partial download resume after empty 206 retry'
+
+# Test that a resumed request receiving a successful non-206 response does
+# not succeed with only the previously downloaded prefix.
+out=$(${test_builddir}/httpdownload "http://localhost:$port/?partial-fail-non-206-on-resume" $test_tmpdir/output || :)
+assert_streq "$out" "Download succeeded"
+contents=$(cat $test_tmpdir/output)
+assert_streq "$contents" "path=/?partial-fail-non-206-on-resume"
+rm -f $test_tmpdir/output*
+
+ok 'partial download reset after non-206 resume response'
+
+# Test that downloads are not resumed when curl decodes Content-Encoding,
+# because Range offsets address encoded bytes, not callback output bytes.
+out=$(${test_builddir}/httpdownload "http://localhost:$port/?compressed-partial-fail" $test_tmpdir/output || :)
+assert_streq "$out" "Download succeeded"
+read -r first_line < $test_tmpdir/output
+assert_streq "$first_line" "path=/?compressed-partial-fail"
+rm -f $test_tmpdir/output*
+
+ok 'compressed partial download reset before retry'
+
+# Test that a partial download can be resumed for the fd-based output
+# streams used by OCI registry downloads.
+out=$(${test_builddir}/httpdownload --unix-output-stream "http://localhost:$port/?partial-fail" $test_tmpdir/output || :)
+assert_streq "$out" "Download succeeded"
+contents=$(cat $test_tmpdir/output)
+assert_streq "$contents" "path=/?partial-fail"
+rm -f $test_tmpdir/output*
+
+ok 'partial download resume with unix output stream'
+
+# Test that a retryable HTTP error body is discarded before retrying.
+out=$(${test_builddir}/httpdownload "http://localhost:$port/?error-then-ok" $test_tmpdir/output || :)
+assert_streq "$out" "Download succeeded"
+contents=$(cat $test_tmpdir/output)
+assert_streq "$contents" "path=/?error-then-ok"
+rm -f $test_tmpdir/output*
+
+ok 'http error body reset before retry'
 
 # Testing that things work without xattr support
 


### PR DESCRIPTION
When flatpak_download_http_uri() retries after a network interruption, seek the output stream back to resume_offset so curl can append the remainder rather than restarting from byte 0.