### PR TITLE
run: Add /dev/kfd to dri device permission

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -494,6 +494,8 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
             /* nvidia OpenCL/CUDA */
             "/dev/nvidia-uvm",
             "/dev/nvidia-uvm-tools",
+            /* AMD ROCm/OpenCL */
+            "/dev/kfd",
           };
 
           for (i = 0; i < G_N_ELEMENTS (dri_devices); i++)

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -299,8 +299,9 @@ sockets=!x11;x11;if:x11:!has-wayland;
 
                             <varlistentry><term><option>dri</option></term>
                             <listitem><para>
-                                Graphics direct rendering
-                                (<filename>/dev/dri</filename>).
+                                GPU graphics and compute
+                                (<filename>/dev/dri</filename>), including
+                                vendor specific render and compute devices.
                                 Available since 0.3.
                             </para></listitem></varlistentry>
 


### PR DESCRIPTION
/dev/kfd is used for AMD ROCm/OpenCL compute. Add it to the dri device list so apps can request GPU compute access without needing --device=all.

Fixes: https://github.com/flatpak/flatpak/issues/5383

A bit unsure about the wording in docs