### PR TITLE
Improve error handling and printed output of `flatpak-coredumpctl`

### DIFF
--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -57,7 +57,7 @@ class CoreDumper():
                 with open(stderr.name, "r") as stderrf:
                     stderr = stderrf.read()
                 executable, = re.findall(".*Executable: (.*)", stderr)
-                if not executable.startswith("/newroot/") and not executable.startswith("/app/"):
+                if not executable.startswith(("/newroot/", "/app/")):
                     print(f"Executable {executable} doesn't seem to be a flatpaked application.",
                         file=sys.stderr)
                 executable = executable.replace("/newroot", "")

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -47,7 +47,7 @@ class CoreDumper():
                 with open(stderr.name, 'r') as stderrf:
                     stderr = stderrf.read()
                 executable, = re.findall(".*Executable: (.*)", stderr)
-                if not executable.startswith("/newroot"):
+                if not executable.startswith("/newroot/") and not executable.startswith("/app/"):
                     print("Executable %s doesn't seem to be a flatpaked application." % executable,
                         file=sys.stderr)
                 executable = executable.replace("/newroot", "")

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -32,7 +32,7 @@ class CoreDumper():
 
         # We need access to the host from the sandbox to run.
         flatpak_command = ["flatpak", "build" if self.build_directory else "run", "--filesystem=home",
-                           "--filesystem=%s" % tempfile.gettempdir()] + shlex.split(self.extra_flatpak_args)
+                           f"--filesystem={tempfile.gettempdir()}"] + shlex.split(self.extra_flatpak_args)
         if not self.build_directory:
             flatpak_command.extend(["--command=gdb",
                                     "--devel", self.app])
@@ -41,21 +41,31 @@ class CoreDumper():
 
         with tempfile.NamedTemporaryFile() as coredump:
             with tempfile.NamedTemporaryFile() as stderr:
-                subprocess.check_call(["coredumpctl", "dump"] + shlex.split(self.coredumpctl_matches),
-                                      stdout=coredump, stderr=stderr)
+                try:
+                    subprocess.check_call(["coredumpctl", "dump"] + shlex.split(self.coredumpctl_matches),
+                                          stdout=coredump, stderr=stderr)
+                except subprocess.CalledProcessError as e:
+                    stderr.seek(0)
+                    err_output = stderr.read().decode(errors="replace")
+
+                    print("Failed to retrieve coredump via coredumpctl.", file=sys.stderr)
+                    if err_output:
+                        print(f"Reason:\n{err_output}", file=sys.stderr)
+
+                    sys.exit(e.returncode)
 
                 with open(stderr.name, "r") as stderrf:
                     stderr = stderrf.read()
                 executable, = re.findall(".*Executable: (.*)", stderr)
                 if not executable.startswith("/newroot/") and not executable.startswith("/app/"):
-                    print("Executable %s doesn't seem to be a flatpaked application." % executable,
+                    print(f"Executable {executable} doesn't seem to be a flatpaked application.",
                         file=sys.stderr)
                 executable = executable.replace("/newroot", "")
                 flatpak_command.extend([executable, coredump.name])
                 flatpak_command.extend(shlex.split(self.gdb_arguments))
 
-                print('Running: `"%s"`' % '" "'.join(flatpak_command))
-                subprocess.check_call(flatpak_command)
+                print(f"Running: `{shlex.join(flatpak_command)}`")
+                subprocess.run(flatpak_command)
 
 
 if __name__ == "__main__":
@@ -69,7 +79,7 @@ if __name__ == "__main__":
                         help="Extra argument to pass to flatpak")
     parser.add_argument("app", nargs="?",
                         help="The flatpak application to use. eg. `org.gnome.Epiphany//3.28`.")
-    parser.add_argument("-m", '--coredumpctl-matches', default="", nargs="?",
+    parser.add_argument("-m", "--coredumpctl-matches", default="", nargs="?",
                         help="Coredumpctl matches, see `man coredumpctl` for more information.")
     parser.add_argument("--gdb-arguments", default="",
                         help="Arguments to pass to gdb.")

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -25,7 +25,7 @@ class CoreDumper():
         return True
 
     def run(self):
-        if not shutil.which('coredumpctl'):
+        if not shutil.which("coredumpctl"):
             print("'coredumpctl' not present on the system, can't run.",
                   file=sys.stderr)
             sys.exit(1)
@@ -35,7 +35,7 @@ class CoreDumper():
                            "--filesystem=%s" % tempfile.gettempdir()] + shlex.split(self.extra_flatpak_args)
         if not self.build_directory:
             flatpak_command.extend(["--command=gdb",
-                                    '--devel', self.app])
+                                    "--devel", self.app])
         else:
             flatpak_command.extend([self.build_directory, "gdb"])
 
@@ -44,7 +44,7 @@ class CoreDumper():
                 subprocess.check_call(["coredumpctl", "dump"] + shlex.split(self.coredumpctl_matches),
                                       stdout=coredump, stderr=stderr)
 
-                with open(stderr.name, 'r') as stderrf:
+                with open(stderr.name, "r") as stderrf:
                     stderr = stderrf.read()
                 executable, = re.findall(".*Executable: (.*)", stderr)
                 if not executable.startswith("/newroot/") and not executable.startswith("/app/"):
@@ -62,17 +62,17 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         "Debug in gdb an application that crashed inside flatpak."
         " It uses (and thus requires) coredumpctl to retrieve the coredump file.")
-    parser.add_argument('-b', '--build-directory', default=None,
+    parser.add_argument("-b", "--build-directory", default=None,
                         help="The build directory to use. It allows you to retrieve a coredump"
                         " for applications being built")
-    parser.add_argument('--extra-flatpak-args', default="",
+    parser.add_argument("--extra-flatpak-args", default="",
                         help="Extra argument to pass to flatpak")
-    parser.add_argument('app', nargs='?',
-                        help='The flatpak application to use. eg. `org.gnome.Epiphany//3.28`.')
-    parser.add_argument('-m', '--coredumpctl-matches', default="", nargs="?",
-                        help='Coredumpctl matches, see `man coredumpctl` for more information.')
-    parser.add_argument('--gdb-arguments', default="",
-                        help='Arguments to pass to gdb.')
+    parser.add_argument("app", nargs="?",
+                        help="The flatpak application to use. eg. `org.gnome.Epiphany//3.28`.")
+    parser.add_argument("-m", '--coredumpctl-matches', default="", nargs="?",
+                        help="Coredumpctl matches, see `man coredumpctl` for more information.")
+    parser.add_argument("--gdb-arguments", default="",
+                        help="Arguments to pass to gdb.")
 
     coredumper = CoreDumper()
     options = parser.parse_args(namespace=coredumper)

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -65,7 +65,7 @@ class CoreDumper():
                 flatpak_command.extend(shlex.split(self.gdb_arguments))
 
                 print(f"Running: `{shlex.join(flatpak_command)}`")
-                subprocess.run(flatpak_command)
+                sys.exit(subprocess.run(flatpak_command).returncode)
 
 
 if __name__ == "__main__":

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -69,7 +69,7 @@ class CoreDumper():
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(description=
         "Debug in gdb an application that crashed inside flatpak."
         " It uses (and thus requires) coredumpctl to retrieve the coredump file.")
     parser.add_argument("-b", "--build-directory", default=None,

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
+import sys
+
+if sys.version_info < (3, 10):
+    print(
+        f'A minimum Python version of at least 3.10 is required, '
+        f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro} was found',
+        file=sys.stderr
+    )
+    sys.exit(1)
+
 import argparse
 import re
 import shutil
-import sys
 import subprocess
 import shlex
 import tempfile

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -49,32 +49,27 @@ class CoreDumper():
             flatpak_command.extend([self.build_directory, "gdb"])
 
         with tempfile.NamedTemporaryFile() as coredump:
-            with tempfile.NamedTemporaryFile() as stderr:
-                try:
-                    subprocess.check_call(["coredumpctl", "dump"] + shlex.split(self.coredumpctl_matches),
-                                          stdout=coredump, stderr=stderr)
-                except subprocess.CalledProcessError as e:
-                    stderr.seek(0)
-                    err_output = stderr.read().decode(errors="replace")
+            dumpres = subprocess.run(
+                ["coredumpctl", "dump"] + shlex.split(self.coredumpctl_matches),
+                stdout=coredump, stderr=subprocess.PIPE, text=True
+            )
+            if dumpres.returncode != 0:
+                print("Failed to retrieve coredump via coredumpctl.", file=sys.stderr)
+                if dumpres.stderr:
+                    print(f"Reason:\n{dumpres.stderr}", file=sys.stderr)
 
-                    print("Failed to retrieve coredump via coredumpctl.", file=sys.stderr)
-                    if err_output:
-                        print(f"Reason:\n{err_output}", file=sys.stderr)
+                sys.exit(dumpres.returncode)
 
-                    sys.exit(e.returncode)
+            executable, = re.findall(".*Executable: (.*)", dumpres.stderr)
+            if not executable.startswith(("/newroot/", "/app/")):
+                print(f"Executable {executable} doesn't seem to be a flatpaked application.",
+                    file=sys.stderr)
+            executable = executable.replace("/newroot", "")
+            flatpak_command.extend([executable, coredump.name])
+            flatpak_command.extend(shlex.split(self.gdb_arguments))
 
-                with open(stderr.name, "r") as stderrf:
-                    stderr = stderrf.read()
-                executable, = re.findall(".*Executable: (.*)", stderr)
-                if not executable.startswith(("/newroot/", "/app/")):
-                    print(f"Executable {executable} doesn't seem to be a flatpaked application.",
-                        file=sys.stderr)
-                executable = executable.replace("/newroot", "")
-                flatpak_command.extend([executable, coredump.name])
-                flatpak_command.extend(shlex.split(self.gdb_arguments))
-
-                print(f"Running: `{shlex.join(flatpak_command)}`")
-                sys.exit(subprocess.run(flatpak_command).returncode)
+            print(f"Running: `{shlex.join(flatpak_command)}`")
+            sys.exit(subprocess.run(flatpak_command).returncode)
 
 
 if __name__ == "__main__":

--- a/scripts/flatpak-coredumpctl
+++ b/scripts/flatpak-coredumpctl
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     coredumper = CoreDumper()
     options = parser.parse_args(namespace=coredumper)
     if not coredumper.clean_args():
-        parser.print_help()
+        parser.print_help(sys.stderr)
         sys.exit(1)
 
     coredumper.run()


### PR DESCRIPTION
Fixes #6270

This is the first of a few planned PRs to fix and improve `flatpak-coredumpctl`. 

Changes made by this PR:
1. Strings are now consistently quoted with double quotes. They were very inconsistent before. I chose double quotes because they seemed a bit more common throughout the file, and there were more strings that contained single quotes inside the string than the other way around.
2. printf-style format strings have been replaced with f-strings for readability.
3. When printing the flatpak command, `shlex.join` is used to present a more readable output.

Before: 
```
Running: `"flatpak" "run" "--filesystem=home" "--filesystem=/tmp" "--command=gdb" "--devel" "net.odamex.Odamex" "/app/bin/odamex" "/tmp/tmpwhotdzk2"`
```
After:
```
Running: `flatpak run --filesystem=home --filesystem=/tmp --command=gdb --devel net.odamex.Odamex /app/bin/odamex /tmp/tmpgn2_hiwl`
```

4. The ""Executable [exe] doesn't seem to be a flatpaked application." error message is now only printed if the path does not start with "/newroot" or "/app". Previously it only checked for "/newroot", which is no longer present, due to changes in bwrap. This meant the warning was printed out even if the executable was in a Flatpak.
5. When running `coredumpctl dump`, exceptions are now caught, with the error message from `coredumpctl` being printed out. Previously the exception was uncaught, leading to the output seen in #6270.
6. Similarly, the flatpak command uses subprocess.run instead of subprocess.check_call. Instead of raising an exception, it calls sys.exit with the return code from the flatpak command.

I couldn't find any documentation anywhere about the targeted Python version for `flatpak-coredumpctl` or `flatpak-bisect`. The changes in this PR have a minimum required version of 3.8 because of `shlex.join` and f-strings. The current version is compatible with down to 3.3.

Example output:
Flatpak does not exist/is not installed:
<img width="1830" height="684" alt="image" src="https://github.com/user-attachments/assets/548d631e-2840-41bc-beb6-cc4867464827" />

-m finds no matches:
<img width="1422" height="652" alt="image" src="https://github.com/user-attachments/assets/b33c1f6a-da7b-47b2-ad41-be9556a7a960" />
