### PR TITLE
common/flatpak-dir.c: fix build when HAVE_LIBSYSTEMD but not USE_SYSTEM_HELPER

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -17463,7 +17463,11 @@ static void
   va_list args;
 
   installation = source ? source : flatpak_dir_get_name_cached (self);
+#ifdef USE_SYSTEM_HELPER
   subject = self->subject ? polkit_subject_to_string (self->subject) : g_strdup ("(none)");
+#else
+  subject = g_strdup ("(none)");
+#endif
 
   len = g_snprintf (message, sizeof (message), "%s: ", installation);
 


### PR DESCRIPTION
polkit_subject_to_string() is called inside the HAVE_LIBSYSTEMD guard in flatpak_dir_log(), but <polkit/polkit.h> is only included when USE_SYSTEM_HELPER is defined. This causes a build failure on configurations that have libsystemd but no system helper.

Guard the polkit call with USE_SYSTEM_HELPER and fall back to "(none)" so the subject string is always valid for the sd_journal_send() call.

fixes:
```c
[1/9] Compiling C object common/libflatpak-common.a.p/flatpak-dir.c.o
FAILED: [code=1] common/libflatpak-common.a.p/flatpak-dir.c.o
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -Icommon/libflatpak-common.a.p -Icommon -I../common -I. -I.. -Isubprojects/libglnx -I../subprojects/libglnx -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/glib-2.0 -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/glib-2.0/include -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/libmount -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/blkid -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/gio-unix-2.0 -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/libassuan-3.0.2/usr/include -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/json-glib-1.0 -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/ostree-2026.1/usr/include/ostree-1 -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/xz-5.8.3/usr/include -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/libxml2 -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/gpgme-2.0.1/usr/include -fvisibility=hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -include config.h -Werror=shadow -Werror=empty-body -Werror=strict-prototypes -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=init-self -Werror=missing-declarations -Werror=return-type -Werror=overflow -Werror=int-conversion -Werror=incompatible-pointer-types -Werror=misleading-indentation -Werror=missing-include-dirs -Wno-sign-compare -Wno-error=sign-compare -Wno-cast-function-type -Wno-error=cast-function-type -Wno-missing-field-initializers -Wno-error=missing-field-initializers -Wno-unused-parameter -Wno-error=unused-parameter -fvisibility=hidden -Werror=format=2 -Werror=format-security -Werror=format-nonliteral -march=x86-64-v3 -Wall -pipe -O2 -fomit-frame-pointer -DNDEBUG -fPIC -pthread -DPCRE2_STATIC -MD -MQ common/libflatpak-common.a.p/flatpak-dir.c.o -MF common/libflatpak-common.a.p/flatpak-dir.c.o.d -o common/libflatpak-common.a.p/flatpak-dir.c.o -c ../common/flatpak-dir.c
../common/flatpak-dir.c: In function 'flatpak_dir_log':
../common/flatpak-dir.c:17466:29: error: implicit declaration of function 'polkit_subject_to_string'; did you mean 'ostree_object_to_string'? [-Wimplicit-function-declaration]
17466 |   subject = self->subject ? polkit_subject_to_string (self->subject) : g_strdup ("(none)");
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~
      |                             ostree_object_to_string
../common/flatpak-dir.c:17466:70: error: pointer/integer type mismatch in conditional expression [-Wint-conversion]
17466 |   subject = self->subject ? polkit_subject_to_string (self->subject) : g_strdup ("(none)");
      |                                                                      ^
```