### PR TITLE
tests: Suppress an unused-result warning

### DIFF
--- a/tests/apply-extra-static.c
+++ b/tests/apply-extra-static.c
@@ -9,7 +9,8 @@ int main(void) {
     int fd = open("/app/extra/ran", O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (fd < 0)
         return 1;
-    write(fd, msg, sizeof(msg) - 1);
+    ssize_t ret = write(fd, msg, sizeof(msg) - 1);
+    (void)ret;
     close(fd);
     return 0;
 }


### PR DESCRIPTION
The warning seems to happen with GCC 11 but not with GCC 13 or newer.

A simple void cast still leaves the warning enabled due to a bug or intentional choice in GCC [1], so it is assigned to a variable first and then void-ed.

[1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425

https://github.com/flatpak/flatpak/actions/runs/25602255382/job/75158068690#step:6:188