### PR TITLE
dir: Include found refs in "ref binding metadata" errors

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -1269,6 +1269,7 @@ flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
       g_autofree char *oci_digest = NULL;
       const char *oci_repository = NULL;
       const char *delta_url = NULL;
+      const char *source_ref = NULL;
 
       metadata = var_ref_info_get_metadata (latest_rev_info);
       oci_repository = var_metadata_lookup_string (metadata, "xa.oci-repository", NULL);
@@ -1280,9 +1281,12 @@ flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
       if (image_source == NULL)
         return NULL;
 
-      if (g_strcmp0 (flatpak_image_source_get_ref (image_source), ref) != 0)
+      source_ref = flatpak_image_source_get_ref (image_source);
+      if (g_strcmp0 (source_ref, ref) != 0)
         {
-          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Commit has no requested ref ‘%s’ in ref binding metadata"),  ref);
+          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                              _("Commit has no requested ref ‘%s’ in ref binding metadata (found: ‘%s’)"),
+                              ref, source_ref ?: "");
           return NULL;
         }
 
@@ -1366,7 +1370,16 @@ flatpak_remote_state_fetch_commit_object (FlatpakRemoteState *self,
           (g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_REF_BINDING, "^a&s", &commit_refs) &&
            !g_strv_contains ((const char * const *) commit_refs, ref)))
         {
-          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Commit has no requested ref ‘%s’ in ref binding metadata"),  ref);
+          const char *xa_ref_v[] = { xa_ref, NULL };
+          g_auto(GStrv) found = NULL;
+          g_autofree char *found_s = NULL;
+
+          found = flatpak_strv_merge ((char **) xa_ref_v, (char **) commit_refs);
+          found_s = g_strjoinv (", ", (char **) found);
+
+          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA,
+                              _("Commit has no requested ref ‘%s’ in ref binding metadata (found: ‘%s’)"),
+                              ref, found_s);
           return NULL;
         }
 


### PR DESCRIPTION
I accidentally screwed up the arch I passed to a `flatpak update` invocation and was very confused as to what actually went wrong. Adding the actual refs in the commit should help make failure cause more obvious.