### PR TITLE
oci: Retry on 401 by refreshing the bearer token

### DIFF
--- a/common/flatpak-auth-private.h
+++ b/common/flatpak-auth-private.h
@@ -42,8 +42,13 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoFlatpakAuthenticator, g_object_unref)
 typedef FlatpakAuthenticatorRequest AutoFlatpakAuthenticatorRequest;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoFlatpakAuthenticatorRequest, g_object_unref)
 
+GDBusConnection *            flatpak_auth_connection_new            (GCancellable                 *cancellable,
+                                                                     GError                      **error);
+void                         flatpak_auth_connection_close          (GDBusConnection              *connection);
+
 FlatpakAuthenticator *       flatpak_auth_new_for_remote            (FlatpakDir                   *dir,
                                                                      const char                   *remote,
+                                                                     GDBusConnection              *connection,
                                                                      GCancellable                 *cancellable,
                                                                      GError                      **error);
 FlatpakAuthenticatorRequest *flatpak_auth_create_request            (FlatpakAuthenticator         *authenticator,

--- a/common/flatpak-auth.c
+++ b/common/flatpak-auth.c
@@ -29,6 +29,7 @@
 FlatpakAuthenticator *
 flatpak_auth_new_for_remote (FlatpakDir *dir,
                              const char *remote,
+                             GDBusConnection *connection,
                              GCancellable *cancellable,
                              GError **error)
 {
@@ -82,11 +83,11 @@ flatpak_auth_new_for_remote (FlatpakDir *dir,
 
   auth_options = g_variant_ref_sink (g_variant_builder_end (auth_options_builder));
 
-  authenticator = flatpak_authenticator_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
-                                                                G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
-                                                                name,
-                                                                FLATPAK_AUTHENTICATOR_OBJECT_PATH,
-                                                                cancellable, error);
+  authenticator = flatpak_authenticator_proxy_new_sync (connection,
+                                                        G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
+                                                        name,
+                                                        FLATPAK_AUTHENTICATOR_OBJECT_PATH,
+                                                        cancellable, error);
   if (authenticator == NULL)
     return NULL;
 
@@ -126,22 +127,22 @@ flatpak_auth_create_request (FlatpakAuthenticator *authenticator,
 {
   static int next_token = 0;
   g_autofree char *request_path = NULL;
-  GDBusConnection *bus;
+  GDBusConnection *connection;
   FlatpakAuthenticatorRequest *request;
   g_autofree char *token = NULL;
 
   token = g_strdup_printf ("%d", ++next_token);
-  bus = g_dbus_proxy_get_connection (G_DBUS_PROXY (authenticator));
+  connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (authenticator));
 
-  request_path = flatpak_auth_create_request_path (g_dbus_connection_get_unique_name (bus), token, error);
+  request_path = flatpak_auth_create_request_path (g_dbus_connection_get_unique_name (connection), token, error);
   if (request_path == NULL)
     return NULL;
 
-  request = flatpak_authenticator_request_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
-                                                                  G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
-                                                                  g_dbus_proxy_get_name (G_DBUS_PROXY (authenticator)),
-                                                                  request_path,
-                                                                  cancellable, error);
+  request = flatpak_authenticator_request_proxy_new_sync (connection,
+                                                          G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
+                                                          g_dbus_proxy_get_name (G_DBUS_PROXY (authenticator)),
+                                                          request_path,
+                                                          cancellable, error);
   if (request == NULL)
     return NULL;
 
@@ -180,4 +181,38 @@ flatpak_auth_request_ref_tokens (FlatpakAuthenticator *authenticator,
     }
 
   return TRUE;
+}
+
+GDBusConnection *
+flatpak_auth_connection_new (GCancellable *cancellable,
+                             GError **error)
+{
+  g_autofree char *address = NULL;
+  GDBusConnection *connection;
+
+  address = g_dbus_address_get_for_bus_sync (G_BUS_TYPE_SESSION, NULL, error);
+  if (address == NULL)
+    return NULL;
+
+  connection = g_dbus_connection_new_for_address_sync (address,
+                                                       G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT |
+                                                       G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
+                                                       NULL,
+                                                       cancellable, error);
+  if (connection == NULL)
+    return NULL;
+
+  return connection;
+}
+
+void
+flatpak_auth_connection_close (GDBusConnection *connection)
+{
+  if (connection == NULL)
+    return;
+
+  if (!g_dbus_connection_is_closed (connection))
+    g_dbus_connection_close_sync (connection, NULL, NULL);
+
+  g_object_unref (connection);
 }

--- a/common/flatpak-common-types-private.h
+++ b/common/flatpak-common-types-private.h
@@ -59,5 +59,6 @@ typedef struct _FlatpakImageSource    FlatpakImageSource;
 typedef struct FlatpakOciRegistry     FlatpakOciRegistry;
 typedef struct _FlatpakOciManifest    FlatpakOciManifest;
 typedef struct _FlatpakOciImage       FlatpakOciImage;
+typedef struct _FlatpakTokenProvider  FlatpakTokenProvider;
 
 #endif /* __FLATPAK_COMMON_TYPES_H__ */

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -62,6 +62,13 @@ GType flatpak_deploy_get_type (void);
 
 typedef struct _PolkitSubject PolkitSubject;
 
+#define FLATPAK_TYPE_TOKEN_PROVIDER flatpak_token_provider_get_type ()
+G_DECLARE_FINAL_TYPE (FlatpakTokenProvider, flatpak_token_provider, FLATPAK, TOKEN_PROVIDER, GObject)
+
+const char *flatpak_token_provider_get_token      (FlatpakTokenProvider *self);
+gboolean    flatpak_token_provider_refresh_token  (FlatpakTokenProvider *self,
+                                                    GCancellable        *cancellable);
+
 typedef struct
 {
   FlatpakDecomposed *ref;
@@ -160,25 +167,25 @@ gboolean flatpak_remote_state_lookup_sparse_cache (FlatpakRemoteState *self,
                                                    const char         *ref,
                                                    VarMetadataRef     *out_metadata,
                                                    GError            **error);
-GVariant *flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
-                                                FlatpakDir         *dir,
-                                                const char         *ref,
-                                                const char         *opt_commit,
-                                                const char         *token,
-                                                char              **out_commit,
-                                                GCancellable       *cancellable,
-                                                GError            **error);
+GVariant *flatpak_remote_state_load_ref_commit (FlatpakRemoteState   *self,
+                                                FlatpakDir           *dir,
+                                                const char           *ref,
+                                                const char           *opt_commit,
+                                                FlatpakTokenProvider *token_provider,
+                                                char                **out_commit,
+                                                GCancellable         *cancellable,
+                                                GError              **error);
 void flatpak_remote_state_add_sideload_dir (FlatpakRemoteState *self,
                                             GFile              *path);
 void flatpak_remote_state_add_sideload_image_collection (FlatpakRemoteState     *self,
                                                          FlatpakImageCollection *image_collection);
-FlatpakImageSource * flatpak_remote_state_fetch_image_source (FlatpakRemoteState  *self,
-                                                              FlatpakDir          *dir,
-                                                              const char          *ref,
-                                                              const char          *opt_rev,
-                                                              const char          *token,
-                                                              GCancellable        *cancellable,
-                                                              GError             **error);
+FlatpakImageSource * flatpak_remote_state_fetch_image_source (FlatpakRemoteState   *self,
+                                                              FlatpakDir           *dir,
+                                                              const char           *ref,
+                                                              const char           *opt_rev,
+                                                              FlatpakTokenProvider *token_provider,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
 
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDir, g_object_unref)
@@ -611,7 +618,7 @@ gboolean              flatpak_dir_pull                                      (Fla
                                                                              GFile                         *sideload_repo,
                                                                              FlatpakImageSource            *opt_image_source,
                                                                              GBytes                        *require_metadata,
-                                                                             const char                    *token,
+                                                                             FlatpakTokenProvider          *token_provider,
                                                                              OstreeRepo                    *repo,
                                                                              FlatpakPullFlags               flatpak_flags,
                                                                              OstreeRepoPullFlags            flags,
@@ -735,7 +742,7 @@ gboolean              flatpak_dir_install                                   (Fla
                                                                              GFile                         *sideload_repo,
                                                                              FlatpakImageSource            *opt_image_source,
                                                                              GBytes                        *require_metadata,
-                                                                             const char                    *token,
+                                                                             FlatpakTokenProvider          *token_provider,
                                                                              FlatpakProgress               *progress,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
@@ -783,7 +790,7 @@ gboolean              flatpak_dir_update                                    (Fla
                                                                              GFile                         *sideload_repo,
                                                                              FlatpakImageSource            *opt_image_source,
                                                                              GBytes                        *require_metadata,
-                                                                             const char                    *token,
+                                                                             FlatpakTokenProvider          *token_provider,
                                                                              FlatpakProgress               *progress,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -62,6 +62,13 @@ GType flatpak_deploy_get_type (void);
 
 typedef struct _PolkitSubject PolkitSubject;
 
+#define FLATPAK_TYPE_TOKEN_PROVIDER flatpak_token_provider_get_type ()
+G_DECLARE_FINAL_TYPE (FlatpakTokenProvider, flatpak_token_provider, FLATPAK, TOKEN_PROVIDER, GObject)
+
+const char *flatpak_token_provider_get_token      (FlatpakTokenProvider *self);
+gboolean    flatpak_token_provider_refresh_token  (FlatpakTokenProvider *self,
+                                                   GCancellable         *cancellable);
+
 typedef struct
 {
   FlatpakDecomposed *ref;
@@ -160,25 +167,25 @@ gboolean flatpak_remote_state_lookup_sparse_cache (FlatpakRemoteState *self,
                                                    const char         *ref,
                                                    VarMetadataRef     *out_metadata,
                                                    GError            **error);
-GVariant *flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
-                                                FlatpakDir         *dir,
-                                                const char         *ref,
-                                                const char         *opt_commit,
-                                                const char         *token,
-                                                char              **out_commit,
-                                                GCancellable       *cancellable,
-                                                GError            **error);
+GVariant *flatpak_remote_state_load_ref_commit (FlatpakRemoteState   *self,
+                                                FlatpakDir           *dir,
+                                                const char           *ref,
+                                                const char           *opt_commit,
+                                                FlatpakTokenProvider *token_provider,
+                                                char                **out_commit,
+                                                GCancellable         *cancellable,
+                                                GError              **error);
 void flatpak_remote_state_add_sideload_dir (FlatpakRemoteState *self,
                                             GFile              *path);
 void flatpak_remote_state_add_sideload_image_collection (FlatpakRemoteState     *self,
                                                          FlatpakImageCollection *image_collection);
-FlatpakImageSource * flatpak_remote_state_fetch_image_source (FlatpakRemoteState  *self,
-                                                              FlatpakDir          *dir,
-                                                              const char          *ref,
-                                                              const char          *opt_rev,
-                                                              const char          *token,
-                                                              GCancellable        *cancellable,
-                                                              GError             **error);
+FlatpakImageSource * flatpak_remote_state_fetch_image_source (FlatpakRemoteState   *self,
+                                                              FlatpakDir           *dir,
+                                                              const char           *ref,
+                                                              const char           *opt_rev,
+                                                              FlatpakTokenProvider *token_provider,
+                                                              GCancellable         *cancellable,
+                                                              GError              **error);
 
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDir, g_object_unref)
@@ -613,7 +620,7 @@ gboolean              flatpak_dir_pull                                      (Fla
                                                                              GFile                         *sideload_repo,
                                                                              FlatpakImageSource            *opt_image_source,
                                                                              GBytes                        *require_metadata,
-                                                                             const char                    *token,
+                                                                             FlatpakTokenProvider          *token_provider,
                                                                              OstreeRepo                    *repo,
                                                                              FlatpakPullFlags               flatpak_flags,
                                                                              OstreeRepoPullFlags            flags,
@@ -738,7 +745,7 @@ gboolean              flatpak_dir_install                                   (Fla
                                                                              GFile                         *sideload_repo,
                                                                              FlatpakImageSource            *opt_image_source,
                                                                              GBytes                        *require_metadata,
-                                                                             const char                    *token,
+                                                                             FlatpakTokenProvider          *token_provider,
                                                                              FlatpakProgress               *progress,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);
@@ -786,7 +793,7 @@ gboolean              flatpak_dir_update                                    (Fla
                                                                              GFile                         *sideload_repo,
                                                                              FlatpakImageSource            *opt_image_source,
                                                                              GBytes                        *require_metadata,
-                                                                             const char                    *token,
+                                                                             FlatpakTokenProvider          *token_provider,
                                                                              FlatpakProgress               *progress,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -114,10 +114,10 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitDetails, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitSubject, g_object_unref)
 #endif
 
-static FlatpakOciRegistry *flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
-                                                                         GLnxLockFile *file_lock,
-                                                                         const char   *token,
-                                                                         GError      **error);
+static FlatpakOciRegistry *flatpak_dir_create_system_child_oci_registry (FlatpakDir           *self,
+                                                                         GLnxLockFile         *file_lock,
+                                                                         FlatpakTokenProvider *token_provider,
+                                                                         GError              **error);
 
 static OstreeRepo * flatpak_dir_create_child_repo (FlatpakDir   *self,
                                                    GFile        *cache_dir,
@@ -129,16 +129,16 @@ static OstreeRepo * flatpak_dir_create_system_child_repo (FlatpakDir   *self,
                                                           const char   *optional_commit,
                                                           GError      **error);
 
-static gboolean flatpak_dir_mirror_oci (FlatpakDir          *self,
-                                        FlatpakOciRegistry  *dst_registry,
-                                        FlatpakRemoteState  *state,
-                                        const char          *ref,
-                                        const char          *opt_rev,
-                                        FlatpakImageSource  *opt_image_source,
-                                        const char          *token,
-                                        FlatpakProgress     *progress,
-                                        GCancellable        *cancellable,
-                                        GError             **error);
+static gboolean flatpak_dir_mirror_oci (FlatpakDir           *self,
+                                        FlatpakOciRegistry   *dst_registry,
+                                        FlatpakRemoteState   *state,
+                                        const char           *ref,
+                                        const char           *opt_rev,
+                                        FlatpakImageSource   *opt_image_source,
+                                        FlatpakTokenProvider *token_provider,
+                                        FlatpakProgress      *progress,
+                                        GCancellable         *cancellable,
+                                        GError              **error);
 
 static gboolean flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
                                                   const char   *name,
@@ -1252,13 +1252,13 @@ lookup_oci_registry_uri_from_summary (GVariant *summary,
 }
 
 static FlatpakImageSource *
-flatpak_remote_state_new_image_source (FlatpakRemoteState  *self,
-                                       FlatpakDir          *dir,
-                                       const char          *oci_repository,
-                                       const char          *digest,
-                                       const char          *token,
-                                       GCancellable        *cancellable,
-                                       GError             **error)
+flatpak_remote_state_new_image_source (FlatpakRemoteState   *self,
+                                       FlatpakDir           *dir,
+                                       const char           *oci_repository,
+                                       const char           *digest,
+                                       FlatpakTokenProvider *token_provider,
+                                       GCancellable         *cancellable,
+                                       GError              **error)
 {
   g_autofree char *registry_uri = NULL;
   g_autoptr(FlatpakImageSource) image_source = NULL;
@@ -1276,7 +1276,7 @@ flatpak_remote_state_new_image_source (FlatpakRemoteState  *self,
   image_source = flatpak_image_source_new_remote (registry_uri,
                                                   oci_repository,
                                                   digest,
-                                                  token,
+                                                  token_provider,
                                                   signature_lookaside,
                                                   NULL, error);
   if (image_source == NULL)
@@ -1286,13 +1286,13 @@ flatpak_remote_state_new_image_source (FlatpakRemoteState  *self,
 }
 
 FlatpakImageSource *
-flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
-                                         FlatpakDir         *dir,
-                                         const char         *ref,
-                                         const char         *opt_rev,
-                                         const char         *token,
-                                         GCancellable       *cancellable,
-                                         GError            **error)
+flatpak_remote_state_fetch_image_source (FlatpakRemoteState   *self,
+                                         FlatpakDir           *dir,
+                                         const char           *ref,
+                                         const char           *opt_rev,
+                                         FlatpakTokenProvider *token_provider,
+                                         GCancellable         *cancellable,
+                                         GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
   g_autofree char *latest_rev = NULL;
@@ -1324,7 +1324,7 @@ flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
 
       oci_digest = g_strconcat ("sha256:", opt_rev ? opt_rev : latest_rev, NULL);
 
-      image_source = flatpak_remote_state_new_image_source (self, dir, oci_repository, oci_digest, token, cancellable, error);
+      image_source = flatpak_remote_state_new_image_source (self, dir, oci_repository, oci_digest, token_provider, cancellable, error);
       if (image_source == NULL)
         return NULL;
 
@@ -1345,17 +1345,17 @@ flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
 
 
 static GVariant *
-flatpak_remote_state_fetch_commit_object_oci (FlatpakRemoteState *self,
-                                              FlatpakDir   *dir,
-                                              const char   *ref,
-                                              const char   *checksum,
-                                              const char   *token,
-                                              GCancellable *cancellable,
-                                              GError      **error)
+flatpak_remote_state_fetch_commit_object_oci (FlatpakRemoteState   *self,
+                                              FlatpakDir           *dir,
+                                              const char           *ref,
+                                              const char           *checksum,
+                                              FlatpakTokenProvider *token_provider,
+                                              GCancellable         *cancellable,
+                                              GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
 
-  image_source = flatpak_remote_state_fetch_image_source (self, dir, ref, checksum, token, cancellable, error);
+  image_source = flatpak_remote_state_fetch_image_source (self, dir, ref, checksum, token_provider, cancellable, error);
   if (image_source == NULL)
     return NULL;
 
@@ -1473,14 +1473,14 @@ flatpak_remote_state_fetch_commit_object (FlatpakRemoteState *self,
    repo, or from one of the sideloading repos, and if not available we
    download it from the actual remote. */
 GVariant *
-flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
-                                      FlatpakDir         *dir,
-                                      const char         *ref,
-                                      const char         *opt_commit,
-                                      const char         *token,
-                                      char              **out_commit,
-                                      GCancellable       *cancellable,
-                                      GError            **error)
+flatpak_remote_state_load_ref_commit (FlatpakRemoteState   *self,
+                                      FlatpakDir           *dir,
+                                      const char           *ref,
+                                      const char           *opt_commit,
+                                      FlatpakTokenProvider *token_provider,
+                                      char                **out_commit,
+                                      GCancellable         *cancellable,
+                                      GError              **error)
 {
   g_autoptr(GVariant) commit_data = NULL;
   g_autofree char *commit = NULL;
@@ -1528,11 +1528,16 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
     }
 
   if (flatpak_dir_get_remote_oci (dir, self->remote_name))
-    commit_data = flatpak_remote_state_fetch_commit_object_oci (self, dir, ref, commit, token,
-                                                                cancellable, error);
+    {
+      commit_data = flatpak_remote_state_fetch_commit_object_oci (self, dir, ref, commit, token_provider,
+                                                                  cancellable, error);
+    }
   else
-    commit_data = flatpak_remote_state_fetch_commit_object (self, dir, ref, commit, token,
-                                                            cancellable, error);
+    {
+      const char *token = token_provider ? flatpak_token_provider_get_token (token_provider) : NULL;
+      commit_data = flatpak_remote_state_fetch_commit_object (self, dir, ref, commit, token,
+                                                              cancellable, error);
+    }
 
 out:
   if (out_commit)
@@ -6369,7 +6374,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
                               OstreeRepo                           *repo,
                               const char                           *ref,
                               const char                           *rev,
-                              const char                           *token,
+                              FlatpakTokenProvider                 *token_provider,
                               FlatpakPullFlags                      flatpak_flags,
                               FlatpakProgress                      *progress,
                               GCancellable                         *cancellable,
@@ -6414,7 +6419,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
           g_autoptr(GVariant) extra_data_sources = NULL;
 
           commitv = flatpak_remote_state_load_ref_commit (state, self, ref, rev,
-                                                          token, NULL, cancellable, error);
+                                                          token_provider, NULL, cancellable, error);
           if (commitv == NULL)
             return FALSE;
 
@@ -6887,16 +6892,16 @@ oci_pull_progress_cb (guint64 total_size, guint64 pulled_size,
 }
 
 static gboolean
-flatpak_dir_mirror_oci (FlatpakDir          *self,
-                        FlatpakOciRegistry  *dst_registry,
-                        FlatpakRemoteState  *state,
-                        const char          *ref,
-                        const char          *opt_rev,
-                        FlatpakImageSource  *opt_image_source,
-                        const char          *token,
-                        FlatpakProgress     *progress,
-                        GCancellable        *cancellable,
-                        GError             **error)
+flatpak_dir_mirror_oci (FlatpakDir           *self,
+                        FlatpakOciRegistry   *dst_registry,
+                        FlatpakRemoteState   *state,
+                        const char           *ref,
+                        const char           *opt_rev,
+                        FlatpakImageSource   *opt_image_source,
+                        FlatpakTokenProvider *token_provider,
+                        FlatpakProgress      *progress,
+                        GCancellable         *cancellable,
+                        GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
   gboolean res;
@@ -6907,7 +6912,7 @@ flatpak_dir_mirror_oci (FlatpakDir          *self,
   if (!image_source)
     {
       image_source = flatpak_remote_state_fetch_image_source (state, self,
-                                                              ref, opt_rev, token,
+                                                              ref, opt_rev, token_provider,
                                                               cancellable, error);
       if (image_source == NULL)
         return FALSE;
@@ -6934,18 +6939,18 @@ flatpak_dir_mirror_oci (FlatpakDir          *self,
 }
 
 static gboolean
-flatpak_dir_pull_oci (FlatpakDir          *self,
-                      FlatpakRemoteState  *state,
-                      const char          *ref,
-                      const char          *opt_rev,
-                      FlatpakImageSource  *opt_image_source,
-                      OstreeRepo          *repo,
-                      FlatpakPullFlags     flatpak_flags,
-                      OstreeRepoPullFlags  flags,
-                      const char          *token,
-                      FlatpakProgress     *progress,
-                      GCancellable        *cancellable,
-                      GError             **error)
+flatpak_dir_pull_oci (FlatpakDir           *self,
+                      FlatpakRemoteState   *state,
+                      const char           *ref,
+                      const char           *opt_rev,
+                      FlatpakImageSource   *opt_image_source,
+                      OstreeRepo           *repo,
+                      FlatpakPullFlags      flatpak_flags,
+                      OstreeRepoPullFlags   flags,
+                      FlatpakTokenProvider *token_provider,
+                      FlatpakProgress      *progress,
+                      GCancellable         *cancellable,
+                      GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
   FlatpakOciRegistry *registry = NULL;
@@ -6962,7 +6967,7 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
   if (!image_source)
     {
       image_source = flatpak_remote_state_fetch_image_source (state, self,
-                                                              ref, opt_rev, token,
+                                                              ref, opt_rev, token_provider,
                                                               cancellable, error);
       if (image_source == NULL)
         return FALSE;
@@ -6990,7 +6995,7 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
   g_info ("Imported OCI image as checksum %s", checksum);
 
   if (!flatpak_dir_setup_extra_data (self, state, repo,
-                                     ref, checksum, token,
+                                     ref, checksum, token_provider,
                                      flatpak_flags,
                                      progress,
                                      cancellable,
@@ -7031,7 +7036,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
                   GFile                                *sideload_repo,
                   FlatpakImageSource                   *opt_image_source,
                   GBytes                               *require_metadata,
-                  const char                           *token,
+                  FlatpakTokenProvider                 *token_provider,
                   OstreeRepo                           *repo,
                   FlatpakPullFlags                      flatpak_flags,
                   OstreeRepoPullFlags                   flags,
@@ -7046,6 +7051,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
   g_autoptr(GPtrArray) subdirs_arg = NULL;
   g_auto(GLnxLockFile) lock = { 0, };
   g_autofree char *current_checksum = NULL;
+  const char *token = token_provider ? flatpak_token_provider_get_token (token_provider) : NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -7061,7 +7067,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
 
   if (opt_image_source || flatpak_dir_get_remote_oci (self, state->remote_name))
     return flatpak_dir_pull_oci (self, state, ref, opt_rev, opt_image_source, repo, flatpak_flags,
-                                 flags, token, progress, cancellable, error);
+                                 flags, token_provider, progress, cancellable, error);
 
   if (!ostree_repo_remote_get_url (self->repo,
                                    state->remote_name,
@@ -7111,7 +7117,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
   /* Setup extra data information before starting to pull, so we can have precise
    * progress reports */
   if (!flatpak_dir_setup_extra_data (self, state, repo,
-                                     ref, rev, token,
+                                     ref, rev, token_provider,
                                      flatpak_flags,
                                      progress,
                                      cancellable,
@@ -10614,10 +10620,10 @@ rewrite_dynamic_launchers (FlatpakDecomposed   *ref,
 }
 
 static FlatpakOciRegistry *
-flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
-                                              GLnxLockFile *file_lock,
-                                              const char   *token,
-                                              GError      **error)
+flatpak_dir_create_system_child_oci_registry (FlatpakDir           *self,
+                                              GLnxLockFile         *file_lock,
+                                              FlatpakTokenProvider *token_provider,
+                                              GError              **error)
 {
   g_autoptr(GFile) cache_dir = NULL;
   g_autoptr(GFile) repo_dir = NULL;
@@ -10651,7 +10657,7 @@ flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
   if (new_registry == NULL)
     return NULL;
 
-  flatpak_oci_registry_set_token (new_registry, token);
+  flatpak_oci_registry_set_token_provider (new_registry, token_provider);
 
   return g_steal_pointer (&new_registry);
 }
@@ -10917,26 +10923,26 @@ flatpak_dir_unmount_and_cancel_pull (FlatpakDir    *self,
 }
 
 gboolean
-flatpak_dir_install (FlatpakDir          *self,
-                     gboolean             no_pull,
-                     gboolean             no_deploy,
-                     gboolean             no_static_deltas,
-                     gboolean             reinstall,
-                     gboolean             app_hint,
-                     gboolean             pin_on_deploy,
-                     gboolean             update_preinstalled_on_deploy,
-                     FlatpakRemoteState  *state,
-                     FlatpakDecomposed   *ref,
-                     const char          *opt_commit,
-                     const char         **opt_subpaths,
-                     const char         **opt_previous_ids,
-                     GFile               *sideload_repo,
-                     FlatpakImageSource  *opt_image_source,
-                     GBytes              *require_metadata,
-                     const char          *token,
-                     FlatpakProgress     *progress,
-                     GCancellable        *cancellable,
-                     GError             **error)
+flatpak_dir_install (FlatpakDir           *self,
+                     gboolean              no_pull,
+                     gboolean              no_deploy,
+                     gboolean              no_static_deltas,
+                     gboolean              reinstall,
+                     gboolean              app_hint,
+                     gboolean              pin_on_deploy,
+                     gboolean              update_preinstalled_on_deploy,
+                     FlatpakRemoteState   *state,
+                     FlatpakDecomposed    *ref,
+                     const char           *opt_commit,
+                     const char          **opt_subpaths,
+                     const char          **opt_previous_ids,
+                     GFile                *sideload_repo,
+                     FlatpakImageSource   *opt_image_source,
+                     GBytes               *require_metadata,
+                     FlatpakTokenProvider *token_provider,
+                     FlatpakProgress      *progress,
+                     GCancellable         *cancellable,
+                     GError              **error)
 {
   FlatpakPullFlags flatpak_flags;
 
@@ -10988,7 +10994,7 @@ flatpak_dir_install (FlatpakDir          *self,
           g_autoptr(FlatpakOciRegistry) registry = NULL;
           g_autoptr(GFile) registry_file = NULL;
 
-          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token, error);
+          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token_provider, error);
           if (registry == NULL)
             return FALSE;
 
@@ -10997,7 +11003,7 @@ flatpak_dir_install (FlatpakDir          *self,
           child_repo_path = g_file_get_path (registry_file);
 
           if (!flatpak_dir_mirror_oci (self, registry, state, flatpak_decomposed_get_ref (ref),
-                                       opt_commit, opt_image_source, token, progress, cancellable, error))
+                                       opt_commit, opt_image_source, token_provider, progress, cancellable, error))
             return FALSE;
         }
       else if (!gpg_verify_summary || !gpg_verify)
@@ -11091,7 +11097,7 @@ flatpak_dir_install (FlatpakDir          *self,
 
           flatpak_flags |= FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA;
 
-          if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref), opt_commit, subpaths, sideload_repo, NULL, require_metadata, token,
+          if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref), opt_commit, subpaths, sideload_repo, NULL, require_metadata, token_provider,
                                  child_repo,
                                  flatpak_flags,
                                  0,
@@ -11170,7 +11176,7 @@ flatpak_dir_install (FlatpakDir          *self,
   if (!no_pull)
     {
       if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref), opt_commit, opt_subpaths,
-                             sideload_repo, opt_image_source, require_metadata, token, NULL,
+                             sideload_repo, opt_image_source, require_metadata, token_provider, NULL,
                              flatpak_flags, OSTREE_REPO_PULL_FLAGS_NONE,
                              progress, cancellable, error))
         return FALSE;
@@ -11645,7 +11651,7 @@ flatpak_dir_update (FlatpakDir                           *self,
                     GFile                                *sideload_repo,
                     FlatpakImageSource                   *opt_image_source,
                     GBytes                               *require_metadata,
-                    const char                           *token,
+                    FlatpakTokenProvider                 *token_provider,
                     FlatpakProgress                      *progress,
                     GCancellable                         *cancellable,
                     GError                              **error)
@@ -11721,7 +11727,7 @@ flatpak_dir_update (FlatpakDir                           *self,
           g_autoptr(FlatpakOciRegistry) registry = NULL;
           g_autoptr(GFile) registry_file = NULL;
 
-          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token, error);
+          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token_provider, error);
           if (registry == NULL)
             return FALSE;
 
@@ -11730,7 +11736,7 @@ flatpak_dir_update (FlatpakDir                           *self,
           child_repo_path = g_file_get_path (registry_file);
 
           if (!flatpak_dir_mirror_oci (self, registry, state, flatpak_decomposed_get_ref (ref),
-                                       commit, opt_image_source, token, progress, cancellable, error))
+                                       commit, opt_image_source, token_provider, progress, cancellable, error))
             return FALSE;
         }
       else if (!gpg_verify_summary || !gpg_verify)
@@ -11810,7 +11816,7 @@ flatpak_dir_update (FlatpakDir                           *self,
 
           flatpak_flags |= FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA;
           if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref),
-                                 commit, subpaths, sideload_repo, NULL, require_metadata, token,
+                                 commit, subpaths, sideload_repo, NULL, require_metadata, token_provider,
                                  child_repo,
                                  flatpak_flags, 0,
                                  progress, cancellable, error))
@@ -11876,7 +11882,7 @@ flatpak_dir_update (FlatpakDir                           *self,
   if (!no_pull)
     {
       if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref),
-                             commit, subpaths, sideload_repo, opt_image_source, require_metadata, token,
+                             commit, subpaths, sideload_repo, opt_image_source, require_metadata, token_provider,
                              NULL, flatpak_flags, OSTREE_REPO_PULL_FLAGS_NONE,
                              progress, cancellable, error))
         return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -114,10 +114,10 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitDetails, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (AutoPolkitSubject, g_object_unref)
 #endif
 
-static FlatpakOciRegistry *flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
-                                                                         GLnxLockFile *file_lock,
-                                                                         const char   *token,
-                                                                         GError      **error);
+static FlatpakOciRegistry *flatpak_dir_create_system_child_oci_registry (FlatpakDir           *self,
+                                                                         GLnxLockFile         *file_lock,
+                                                                         FlatpakTokenProvider *token_provider,
+                                                                         GError              **error);
 
 static OstreeRepo * flatpak_dir_create_child_repo (FlatpakDir   *self,
                                                    GFile        *cache_dir,
@@ -129,16 +129,16 @@ static OstreeRepo * flatpak_dir_create_system_child_repo (FlatpakDir   *self,
                                                           const char   *optional_commit,
                                                           GError      **error);
 
-static gboolean flatpak_dir_mirror_oci (FlatpakDir          *self,
-                                        FlatpakOciRegistry  *dst_registry,
-                                        FlatpakRemoteState  *state,
-                                        const char          *ref,
-                                        const char          *opt_rev,
-                                        FlatpakImageSource  *opt_image_source,
-                                        const char          *token,
-                                        FlatpakProgress     *progress,
-                                        GCancellable        *cancellable,
-                                        GError             **error);
+static gboolean flatpak_dir_mirror_oci (FlatpakDir           *self,
+                                        FlatpakOciRegistry   *dst_registry,
+                                        FlatpakRemoteState   *state,
+                                        const char           *ref,
+                                        const char           *opt_rev,
+                                        FlatpakImageSource   *opt_image_source,
+                                        FlatpakTokenProvider *token_provider,
+                                        FlatpakProgress      *progress,
+                                        GCancellable         *cancellable,
+                                        GError              **error);
 
 static gboolean flatpak_dir_remote_fetch_summary (FlatpakDir   *self,
                                                   const char   *name,
@@ -1205,13 +1205,13 @@ lookup_oci_registry_uri_from_summary (GVariant *summary,
 }
 
 static FlatpakImageSource *
-flatpak_remote_state_new_image_source (FlatpakRemoteState  *self,
-                                       FlatpakDir          *dir,
-                                       const char          *oci_repository,
-                                       const char          *digest,
-                                       const char          *token,
-                                       GCancellable        *cancellable,
-                                       GError             **error)
+flatpak_remote_state_new_image_source (FlatpakRemoteState   *self,
+                                       FlatpakDir           *dir,
+                                       const char           *oci_repository,
+                                       const char           *digest,
+                                       FlatpakTokenProvider *token_provider,
+                                       GCancellable         *cancellable,
+                                       GError              **error)
 {
   g_autofree char *registry_uri = NULL;
   g_autoptr(FlatpakImageSource) image_source = NULL;
@@ -1229,7 +1229,7 @@ flatpak_remote_state_new_image_source (FlatpakRemoteState  *self,
   image_source = flatpak_image_source_new_remote (registry_uri,
                                                   oci_repository,
                                                   digest,
-                                                  token,
+                                                  token_provider,
                                                   signature_lookaside,
                                                   NULL, error);
   if (image_source == NULL)
@@ -1239,13 +1239,13 @@ flatpak_remote_state_new_image_source (FlatpakRemoteState  *self,
 }
 
 FlatpakImageSource *
-flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
-                                         FlatpakDir         *dir,
-                                         const char         *ref,
-                                         const char         *opt_rev,
-                                         const char         *token,
-                                         GCancellable       *cancellable,
-                                         GError            **error)
+flatpak_remote_state_fetch_image_source (FlatpakRemoteState   *self,
+                                         FlatpakDir           *dir,
+                                         const char           *ref,
+                                         const char           *opt_rev,
+                                         FlatpakTokenProvider *token_provider,
+                                         GCancellable         *cancellable,
+                                         GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
   g_autofree char *latest_rev = NULL;
@@ -1277,7 +1277,7 @@ flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
 
       oci_digest = g_strconcat ("sha256:", opt_rev ? opt_rev : latest_rev, NULL);
 
-      image_source = flatpak_remote_state_new_image_source (self, dir, oci_repository, oci_digest, token, cancellable, error);
+      image_source = flatpak_remote_state_new_image_source (self, dir, oci_repository, oci_digest, token_provider, cancellable, error);
       if (image_source == NULL)
         return NULL;
 
@@ -1298,17 +1298,17 @@ flatpak_remote_state_fetch_image_source (FlatpakRemoteState *self,
 
 
 static GVariant *
-flatpak_remote_state_fetch_commit_object_oci (FlatpakRemoteState *self,
-                                              FlatpakDir   *dir,
-                                              const char   *ref,
-                                              const char   *checksum,
-                                              const char   *token,
-                                              GCancellable *cancellable,
-                                              GError      **error)
+flatpak_remote_state_fetch_commit_object_oci (FlatpakRemoteState   *self,
+                                              FlatpakDir           *dir,
+                                              const char           *ref,
+                                              const char           *checksum,
+                                              FlatpakTokenProvider *token_provider,
+                                              GCancellable         *cancellable,
+                                              GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
 
-  image_source = flatpak_remote_state_fetch_image_source (self, dir, ref, checksum, token, cancellable, error);
+  image_source = flatpak_remote_state_fetch_image_source (self, dir, ref, checksum, token_provider, cancellable, error);
   if (image_source == NULL)
     return NULL;
 
@@ -1426,14 +1426,14 @@ flatpak_remote_state_fetch_commit_object (FlatpakRemoteState *self,
    repo, or from one of the sideloading repos, and if not available we
    download it from the actual remote. */
 GVariant *
-flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
-                                      FlatpakDir         *dir,
-                                      const char         *ref,
-                                      const char         *opt_commit,
-                                      const char         *token,
-                                      char              **out_commit,
-                                      GCancellable       *cancellable,
-                                      GError            **error)
+flatpak_remote_state_load_ref_commit (FlatpakRemoteState   *self,
+                                      FlatpakDir           *dir,
+                                      const char           *ref,
+                                      const char           *opt_commit,
+                                      FlatpakTokenProvider *token_provider,
+                                      char                **out_commit,
+                                      GCancellable         *cancellable,
+                                      GError              **error)
 {
   g_autoptr(GVariant) commit_data = NULL;
   g_autofree char *commit = NULL;
@@ -1481,11 +1481,16 @@ flatpak_remote_state_load_ref_commit (FlatpakRemoteState *self,
     }
 
   if (flatpak_dir_get_remote_oci (dir, self->remote_name))
-    commit_data = flatpak_remote_state_fetch_commit_object_oci (self, dir, ref, commit, token,
-                                                                cancellable, error);
+    {
+      commit_data = flatpak_remote_state_fetch_commit_object_oci (self, dir, ref, commit, token_provider,
+                                                                  cancellable, error);
+    }
   else
-    commit_data = flatpak_remote_state_fetch_commit_object (self, dir, ref, commit, token,
-                                                            cancellable, error);
+    {
+      const char *token = token_provider ? flatpak_token_provider_get_token (token_provider) : NULL;
+      commit_data = flatpak_remote_state_fetch_commit_object (self, dir, ref, commit, token,
+                                                              cancellable, error);
+    }
 
 out:
   if (out_commit)
@@ -6317,7 +6322,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
                               OstreeRepo                           *repo,
                               const char                           *ref,
                               const char                           *rev,
-                              const char                           *token,
+                              FlatpakTokenProvider                 *token_provider,
                               FlatpakPullFlags                      flatpak_flags,
                               FlatpakProgress                      *progress,
                               GCancellable                         *cancellable,
@@ -6362,7 +6367,7 @@ flatpak_dir_setup_extra_data (FlatpakDir                           *self,
           g_autoptr(GVariant) extra_data_sources = NULL;
 
           commitv = flatpak_remote_state_load_ref_commit (state, self, ref, rev,
-                                                          token, NULL, cancellable, error);
+                                                          token_provider, NULL, cancellable, error);
           if (commitv == NULL)
             return FALSE;
 
@@ -6832,16 +6837,16 @@ oci_pull_progress_cb (guint64 total_size, guint64 pulled_size,
 }
 
 static gboolean
-flatpak_dir_mirror_oci (FlatpakDir          *self,
-                        FlatpakOciRegistry  *dst_registry,
-                        FlatpakRemoteState  *state,
-                        const char          *ref,
-                        const char          *opt_rev,
-                        FlatpakImageSource  *opt_image_source,
-                        const char          *token,
-                        FlatpakProgress     *progress,
-                        GCancellable        *cancellable,
-                        GError             **error)
+flatpak_dir_mirror_oci (FlatpakDir           *self,
+                        FlatpakOciRegistry   *dst_registry,
+                        FlatpakRemoteState   *state,
+                        const char           *ref,
+                        const char           *opt_rev,
+                        FlatpakImageSource   *opt_image_source,
+                        FlatpakTokenProvider *token_provider,
+                        FlatpakProgress      *progress,
+                        GCancellable         *cancellable,
+                        GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
   gboolean res;
@@ -6852,7 +6857,7 @@ flatpak_dir_mirror_oci (FlatpakDir          *self,
   if (!image_source)
     {
       image_source = flatpak_remote_state_fetch_image_source (state, self,
-                                                              ref, opt_rev, token,
+                                                              ref, opt_rev, token_provider,
                                                               cancellable, error);
       if (image_source == NULL)
         return FALSE;
@@ -6879,18 +6884,18 @@ flatpak_dir_mirror_oci (FlatpakDir          *self,
 }
 
 static gboolean
-flatpak_dir_pull_oci (FlatpakDir          *self,
-                      FlatpakRemoteState  *state,
-                      const char          *ref,
-                      const char          *opt_rev,
-                      FlatpakImageSource  *opt_image_source,
-                      OstreeRepo          *repo,
-                      FlatpakPullFlags     flatpak_flags,
-                      OstreeRepoPullFlags  flags,
-                      const char          *token,
-                      FlatpakProgress     *progress,
-                      GCancellable        *cancellable,
-                      GError             **error)
+flatpak_dir_pull_oci (FlatpakDir           *self,
+                      FlatpakRemoteState   *state,
+                      const char           *ref,
+                      const char           *opt_rev,
+                      FlatpakImageSource   *opt_image_source,
+                      OstreeRepo           *repo,
+                      FlatpakPullFlags      flatpak_flags,
+                      OstreeRepoPullFlags   flags,
+                      FlatpakTokenProvider *token_provider,
+                      FlatpakProgress      *progress,
+                      GCancellable         *cancellable,
+                      GError              **error)
 {
   g_autoptr(FlatpakImageSource) image_source = NULL;
   FlatpakOciRegistry *registry = NULL;
@@ -6907,7 +6912,7 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
   if (!image_source)
     {
       image_source = flatpak_remote_state_fetch_image_source (state, self,
-                                                              ref, opt_rev, token,
+                                                              ref, opt_rev, token_provider,
                                                               cancellable, error);
       if (image_source == NULL)
         return FALSE;
@@ -6935,7 +6940,7 @@ flatpak_dir_pull_oci (FlatpakDir          *self,
   g_info ("Imported OCI image as checksum %s", checksum);
 
   if (!flatpak_dir_setup_extra_data (self, state, repo,
-                                     ref, checksum, token,
+                                     ref, checksum, token_provider,
                                      flatpak_flags,
                                      progress,
                                      cancellable,
@@ -6976,7 +6981,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
                   GFile                                *sideload_repo,
                   FlatpakImageSource                   *opt_image_source,
                   GBytes                               *require_metadata,
-                  const char                           *token,
+                  FlatpakTokenProvider                 *token_provider,
                   OstreeRepo                           *repo,
                   FlatpakPullFlags                      flatpak_flags,
                   OstreeRepoPullFlags                   flags,
@@ -6991,6 +6996,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
   g_autoptr(GPtrArray) subdirs_arg = NULL;
   g_auto(GLnxLockFile) lock = { 0, };
   g_autofree char *current_checksum = NULL;
+  const char *token = token_provider ? flatpak_token_provider_get_token (token_provider) : NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
     return FALSE;
@@ -7006,7 +7012,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
 
   if (opt_image_source || flatpak_dir_get_remote_oci (self, state->remote_name))
     return flatpak_dir_pull_oci (self, state, ref, opt_rev, opt_image_source, repo, flatpak_flags,
-                                 flags, token, progress, cancellable, error);
+                                 flags, token_provider, progress, cancellable, error);
 
   if (!ostree_repo_remote_get_url (self->repo,
                                    state->remote_name,
@@ -7056,7 +7062,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
   /* Setup extra data information before starting to pull, so we can have precise
    * progress reports */
   if (!flatpak_dir_setup_extra_data (self, state, repo,
-                                     ref, rev, token,
+                                     ref, rev, token_provider,
                                      flatpak_flags,
                                      progress,
                                      cancellable,
@@ -10471,10 +10477,10 @@ rewrite_dynamic_launchers (FlatpakDecomposed   *ref,
 }
 
 static FlatpakOciRegistry *
-flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
-                                              GLnxLockFile *file_lock,
-                                              const char   *token,
-                                              GError      **error)
+flatpak_dir_create_system_child_oci_registry (FlatpakDir           *self,
+                                              GLnxLockFile         *file_lock,
+                                              FlatpakTokenProvider *token_provider,
+                                              GError              **error)
 {
   g_autoptr(GFile) cache_dir = NULL;
   g_autoptr(GFile) repo_dir = NULL;
@@ -10508,7 +10514,8 @@ flatpak_dir_create_system_child_oci_registry (FlatpakDir   *self,
   if (new_registry == NULL)
     return NULL;
 
-  flatpak_oci_registry_set_token (new_registry, token);
+  if (token_provider)
+    flatpak_oci_registry_set_token_provider (new_registry, token_provider);
 
   return g_steal_pointer (&new_registry);
 }
@@ -10774,26 +10781,26 @@ flatpak_dir_unmount_and_cancel_pull (FlatpakDir    *self,
 }
 
 gboolean
-flatpak_dir_install (FlatpakDir          *self,
-                     gboolean             no_pull,
-                     gboolean             no_deploy,
-                     gboolean             no_static_deltas,
-                     gboolean             reinstall,
-                     gboolean             app_hint,
-                     gboolean             pin_on_deploy,
-                     gboolean             update_preinstalled_on_deploy,
-                     FlatpakRemoteState  *state,
-                     FlatpakDecomposed   *ref,
-                     const char          *opt_commit,
-                     const char         **opt_subpaths,
-                     const char         **opt_previous_ids,
-                     GFile               *sideload_repo,
-                     FlatpakImageSource  *opt_image_source,
-                     GBytes              *require_metadata,
-                     const char          *token,
-                     FlatpakProgress     *progress,
-                     GCancellable        *cancellable,
-                     GError             **error)
+flatpak_dir_install (FlatpakDir           *self,
+                     gboolean              no_pull,
+                     gboolean              no_deploy,
+                     gboolean              no_static_deltas,
+                     gboolean              reinstall,
+                     gboolean              app_hint,
+                     gboolean              pin_on_deploy,
+                     gboolean              update_preinstalled_on_deploy,
+                     FlatpakRemoteState   *state,
+                     FlatpakDecomposed    *ref,
+                     const char           *opt_commit,
+                     const char          **opt_subpaths,
+                     const char          **opt_previous_ids,
+                     GFile                *sideload_repo,
+                     FlatpakImageSource   *opt_image_source,
+                     GBytes               *require_metadata,
+                     FlatpakTokenProvider *token_provider,
+                     FlatpakProgress      *progress,
+                     GCancellable         *cancellable,
+                     GError              **error)
 {
   FlatpakPullFlags flatpak_flags;
 
@@ -10845,7 +10852,7 @@ flatpak_dir_install (FlatpakDir          *self,
           g_autoptr(FlatpakOciRegistry) registry = NULL;
           g_autoptr(GFile) registry_file = NULL;
 
-          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token, error);
+          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token_provider, error);
           if (registry == NULL)
             return FALSE;
 
@@ -10854,7 +10861,7 @@ flatpak_dir_install (FlatpakDir          *self,
           child_repo_path = g_file_get_path (registry_file);
 
           if (!flatpak_dir_mirror_oci (self, registry, state, flatpak_decomposed_get_ref (ref),
-                                       opt_commit, opt_image_source, token, progress, cancellable, error))
+                                       opt_commit, opt_image_source, token_provider, progress, cancellable, error))
             return FALSE;
         }
       else if (!gpg_verify_summary || !gpg_verify)
@@ -10948,7 +10955,7 @@ flatpak_dir_install (FlatpakDir          *self,
 
           flatpak_flags |= FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA;
 
-          if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref), opt_commit, subpaths, sideload_repo, NULL, require_metadata, token,
+          if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref), opt_commit, subpaths, sideload_repo, NULL, require_metadata, token_provider,
                                  child_repo,
                                  flatpak_flags,
                                  0,
@@ -11027,7 +11034,7 @@ flatpak_dir_install (FlatpakDir          *self,
   if (!no_pull)
     {
       if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref), opt_commit, opt_subpaths,
-                             sideload_repo, opt_image_source, require_metadata, token, NULL,
+                             sideload_repo, opt_image_source, require_metadata, token_provider, NULL,
                              flatpak_flags, OSTREE_REPO_PULL_FLAGS_NONE,
                              progress, cancellable, error))
         return FALSE;
@@ -11502,7 +11509,7 @@ flatpak_dir_update (FlatpakDir                           *self,
                     GFile                                *sideload_repo,
                     FlatpakImageSource                   *opt_image_source,
                     GBytes                               *require_metadata,
-                    const char                           *token,
+                    FlatpakTokenProvider                 *token_provider,
                     FlatpakProgress                      *progress,
                     GCancellable                         *cancellable,
                     GError                              **error)
@@ -11579,7 +11586,7 @@ flatpak_dir_update (FlatpakDir                           *self,
           g_autoptr(FlatpakOciRegistry) registry = NULL;
           g_autoptr(GFile) registry_file = NULL;
 
-          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token, error);
+          registry = flatpak_dir_create_system_child_oci_registry (self, &child_repo_lock, token_provider, error);
           if (registry == NULL)
             return FALSE;
 
@@ -11588,7 +11595,7 @@ flatpak_dir_update (FlatpakDir                           *self,
           child_repo_path = g_file_get_path (registry_file);
 
           if (!flatpak_dir_mirror_oci (self, registry, state, flatpak_decomposed_get_ref (ref),
-                                       commit, opt_image_source, token, progress, cancellable, error))
+                                       commit, opt_image_source, token_provider, progress, cancellable, error))
             return FALSE;
         }
       else if (!gpg_verify_summary || !gpg_verify)
@@ -11668,7 +11675,7 @@ flatpak_dir_update (FlatpakDir                           *self,
 
           flatpak_flags |= FLATPAK_PULL_FLAGS_SIDELOAD_EXTRA_DATA;
           if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref),
-                                 commit, subpaths, sideload_repo, NULL, require_metadata, token,
+                                 commit, subpaths, sideload_repo, NULL, require_metadata, token_provider,
                                  child_repo,
                                  flatpak_flags, 0,
                                  progress, cancellable, error))
@@ -11734,7 +11741,7 @@ flatpak_dir_update (FlatpakDir                           *self,
   if (!no_pull)
     {
       if (!flatpak_dir_pull (self, state, flatpak_decomposed_get_ref (ref),
-                             commit, subpaths, sideload_repo, opt_image_source, require_metadata, token,
+                             commit, subpaths, sideload_repo, opt_image_source, require_metadata, token_provider,
                              NULL, flatpak_flags, OSTREE_REPO_PULL_FLAGS_NONE,
                              progress, cancellable, error))
         return FALSE;

--- a/common/flatpak-image-source-private.h
+++ b/common/flatpak-image-source-private.h
@@ -42,13 +42,13 @@ FlatpakImageSource *flatpak_image_source_new_local (GFile        *file,
                                                     const char   *reference,
                                                     GCancellable *cancellable,
                                                     GError      **error);
-FlatpakImageSource *flatpak_image_source_new_remote (const char   *uri,
-                                                     const char   *oci_repository,
-                                                     const char   *digest,
-                                                     const char   *token,
-                                                     const char   *signature_lookaside,
-                                                     GCancellable *cancellable,
-                                                     GError      **error);
+FlatpakImageSource *flatpak_image_source_new_remote (const char           *uri,
+                                                     const char           *oci_repository,
+                                                     const char           *digest,
+                                                     FlatpakTokenProvider *token_provider,
+                                                     const char           *signature_lookaside,
+                                                     GCancellable         *cancellable,
+                                                     GError              **error);
 FlatpakImageSource *flatpak_image_source_new_for_location (const char   *location,
                                                            GCancellable *cancellable,
                                                            GError      **error);

--- a/common/flatpak-image-source.c
+++ b/common/flatpak-image-source.c
@@ -180,13 +180,13 @@ flatpak_image_source_new_local (GFile        *file,
 }
 
 FlatpakImageSource *
-flatpak_image_source_new_remote (const char   *uri,
-                                 const char   *oci_repository,
-                                 const char   *digest,
-                                 const char   *token,
-                                 const char   *signature_lookaside,
-                                 GCancellable *cancellable,
-                                 GError      **error)
+flatpak_image_source_new_remote (const char           *uri,
+                                 const char           *oci_repository,
+                                 const char           *digest,
+                                 FlatpakTokenProvider *token_provider,
+                                 const char           *signature_lookaside,
+                                 GCancellable         *cancellable,
+                                 GError              **error)
 {
   g_autoptr(FlatpakOciRegistry) registry = NULL;
 
@@ -194,7 +194,8 @@ flatpak_image_source_new_remote (const char   *uri,
   if (!registry)
     return NULL;
 
-  flatpak_oci_registry_set_token (registry, token);
+  if (token_provider)
+    flatpak_oci_registry_set_token_provider (registry, token_provider);
   flatpak_oci_registry_set_signature_lookaside (registry, signature_lookaside);
 
   return flatpak_image_source_new (registry, oci_repository, digest, cancellable, error);

--- a/common/flatpak-image-source.c
+++ b/common/flatpak-image-source.c
@@ -180,13 +180,13 @@ flatpak_image_source_new_local (GFile        *file,
 }
 
 FlatpakImageSource *
-flatpak_image_source_new_remote (const char   *uri,
-                                 const char   *oci_repository,
-                                 const char   *digest,
-                                 const char   *token,
-                                 const char   *signature_lookaside,
-                                 GCancellable *cancellable,
-                                 GError      **error)
+flatpak_image_source_new_remote (const char           *uri,
+                                 const char           *oci_repository,
+                                 const char           *digest,
+                                 FlatpakTokenProvider *token_provider,
+                                 const char           *signature_lookaside,
+                                 GCancellable         *cancellable,
+                                 GError              **error)
 {
   g_autoptr(FlatpakOciRegistry) registry = NULL;
 
@@ -194,7 +194,7 @@ flatpak_image_source_new_remote (const char   *uri,
   if (!registry)
     return NULL;
 
-  flatpak_oci_registry_set_token (registry, token);
+  flatpak_oci_registry_set_token_provider (registry, token_provider);
   flatpak_oci_registry_set_signature_lookaside (registry, signature_lookaside);
 
   return flatpak_image_source_new (registry, oci_repository, digest, cancellable, error);

--- a/common/flatpak-oci-registry-private.h
+++ b/common/flatpak-oci-registry-private.h
@@ -61,6 +61,8 @@ FlatpakOciRegistry *   flatpak_oci_registry_new_for_archive (GFile        *archi
                                                              GError      **error);
 void                   flatpak_oci_registry_set_token (FlatpakOciRegistry *self,
                                                        const char *token);
+void                   flatpak_oci_registry_set_token_provider (FlatpakOciRegistry  *self,
+                                                               FlatpakTokenProvider *provider);
 void                   flatpak_oci_registry_set_signature_lookaside (FlatpakOciRegistry *self,
                                                                      const char         *signature_lookaside);
 gboolean               flatpak_oci_registry_is_local (FlatpakOciRegistry *self);

--- a/common/flatpak-oci-registry-private.h
+++ b/common/flatpak-oci-registry-private.h
@@ -59,8 +59,9 @@ FlatpakOciRegistry  *  flatpak_oci_registry_new (const char    *uri,
 FlatpakOciRegistry *   flatpak_oci_registry_new_for_archive (GFile        *archive,
                                                              GCancellable *cancellable,
                                                              GError      **error);
-void                   flatpak_oci_registry_set_token (FlatpakOciRegistry *self,
-                                                       const char *token);
+void                   flatpak_oci_registry_set_token_provider (FlatpakOciRegistry  *self,
+                                                               FlatpakTokenProvider *provider);
+const char          *  flatpak_oci_registry_get_token (FlatpakOciRegistry *self);
 void                   flatpak_oci_registry_set_signature_lookaside (FlatpakOciRegistry *self,
                                                                      const char         *signature_lookaside);
 gboolean               flatpak_oci_registry_is_local (FlatpakOciRegistry *self);
@@ -81,12 +82,12 @@ int                    flatpak_oci_registry_download_blob (FlatpakOciRegistry   
                                                            gpointer               user_data,
                                                            GCancellable          *cancellable,
                                                            GError               **error);
-char *                 flatpak_oci_registry_get_token (FlatpakOciRegistry *self,
-                                                       const char         *repository,
-                                                       const char         *digest,
-                                                       const char         *basic_auth,
-                                                       GCancellable       *cancellable,
-                                                       GError            **error);
+char *                 flatpak_oci_registry_fetch_token (FlatpakOciRegistry *self,
+                                                         const char         *repository,
+                                                         const char         *digest,
+                                                         const char         *basic_auth,
+                                                         GCancellable       *cancellable,
+                                                         GError            **error);
 GBytes             *   flatpak_oci_registry_load_blob (FlatpakOciRegistry *self,
                                                        const char         *repository,
                                                        gboolean            manifest,

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -74,6 +74,7 @@ struct FlatpakOciRegistry
   GFile   *archive;
   int      tmp_dfd;
   char    *token;
+  FlatpakTokenProvider *token_provider;
   char    *signature_lookaside;
 
   /* Local repos */
@@ -138,6 +139,7 @@ flatpak_oci_registry_finalize (GObject *object)
   g_clear_pointer (&self->base_uri, g_uri_unref);
   g_clear_pointer (&self->uri, g_free);
   g_clear_pointer (&self->token, g_free);
+  g_clear_object (&self->token_provider);
   g_clear_object (&self->archive);
   g_clear_pointer (&self->tmp_dir, glnx_tmpdir_free);
   g_clear_pointer (&self->certificates, flatpak_certificates_free);
@@ -292,6 +294,68 @@ flatpak_oci_registry_set_token (FlatpakOciRegistry *self,
 }
 
 void
+flatpak_oci_registry_set_token_provider (FlatpakOciRegistry   *self,
+                                         FlatpakTokenProvider *provider)
+{
+  g_set_object (&self->token_provider, provider);
+  if (provider)
+    flatpak_oci_registry_set_token (self, flatpak_token_provider_get_token (provider));
+}
+
+static gboolean
+flatpak_oci_registry_try_refresh_token (FlatpakOciRegistry *self,
+                                        GCancellable       *cancellable)
+{
+  if (self->token_provider == NULL)
+    return FALSE;
+
+  g_info ("Refreshing token for registry %s", self->uri);
+
+  if (!flatpak_token_provider_refresh_token (self->token_provider, cancellable))
+    return FALSE;
+
+  flatpak_oci_registry_set_token (self, flatpak_token_provider_get_token (self->token_provider));
+  return TRUE;
+}
+
+static gboolean
+flatpak_oci_registry_download_with_retry (FlatpakOciRegistry     *self,
+                                          FlatpakHttpSession     *http_session,
+                                          const char             *uri,
+                                          FlatpakCertificates    *certificates,
+                                          GOutputStream          *out_stream,
+                                          FlatpakLoadUriProgress  progress_cb,
+                                          gpointer                user_data,
+                                          GCancellable           *cancellable,
+                                          GError                **error)
+{
+  gboolean ok = flatpak_download_http_uri (http_session, uri, certificates,
+                                           FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
+                                           out_stream, self->token,
+                                           progress_cb, user_data,
+                                           cancellable, error);
+  if (!ok
+      && error != NULL
+      && g_error_matches (*error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_UNAUTHORIZED)
+      && flatpak_oci_registry_try_refresh_token (self, cancellable))
+    {
+      int fd = g_unix_output_stream_get_fd (G_UNIX_OUTPUT_STREAM (out_stream));
+
+      g_clear_error (error);
+      ftruncate (fd, 0);
+      lseek (fd, 0, SEEK_SET);
+
+      ok = flatpak_download_http_uri (http_session, uri, certificates,
+                                      FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
+                                      out_stream, self->token,
+                                      progress_cb, user_data,
+                                      cancellable, error);
+    }
+
+  return ok;
+}
+
+void
 flatpak_oci_registry_set_signature_lookaside (FlatpakOciRegistry *self,
                                               const char         *signature_lookaside)
 {
@@ -384,6 +448,19 @@ remote_load_file (FlatpakOciRegistry *self,
                                  NULL, self->token,
                                  NULL, NULL, NULL, out_content_type, NULL,
                                  cancellable, error);
+  if (bytes == NULL
+      && error != NULL
+      && g_error_matches (*error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_UNAUTHORIZED)
+      && flatpak_oci_registry_try_refresh_token (self, cancellable))
+    {
+      g_clear_error (error);
+      bytes = flatpak_load_uri_full (self->http_session,
+                                     uri_s, self->certificates, FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
+                                     NULL, self->token,
+                                     NULL, NULL, NULL, out_content_type, NULL,
+                                     cancellable, error);
+    }
+
   if (bytes == NULL)
     return NULL;
 
@@ -1016,13 +1093,11 @@ flatpak_oci_registry_download_blob (FlatpakOciRegistry    *self,
       if (fd == -1)
         return -1;
 
-      if (!flatpak_download_http_uri (self->http_session, uri_s,
-                                      self->certificates,
-                                      FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
-                                      out_stream,
-                                      self->token,
-                                      progress_cb, user_data,
-                                      cancellable, error))
+      if (!flatpak_oci_registry_download_with_retry (self,
+                                                     self->http_session, uri_s,
+                                                     self->certificates, out_stream,
+                                                     progress_cb, user_data,
+                                                     cancellable, error))
         return -1;
 
       if (!g_output_stream_close (out_stream, cancellable, error))
@@ -1109,12 +1184,11 @@ flatpak_oci_registry_mirror_blob (FlatpakOciRegistry    *self,
 
       out_stream = g_unix_output_stream_new (tmpf.fd, FALSE);
 
-      if (!flatpak_download_http_uri (source_registry->http_session,
-                                      uri_s, source_registry->certificates,
-                                      FLATPAK_HTTP_FLAGS_ACCEPT_OCI, out_stream,
-                                      self->token,
-                                      progress_cb, user_data,
-                                      cancellable, error))
+      if (!flatpak_oci_registry_download_with_retry (self,
+                                                     source_registry->http_session, uri_s,
+                                                     source_registry->certificates, out_stream,
+                                                     progress_cb, user_data,
+                                                     cancellable, error))
         return FALSE;
 
       if (!g_output_stream_close (out_stream, cancellable, error))

--- a/common/flatpak-oci-registry.c
+++ b/common/flatpak-oci-registry.c
@@ -71,7 +71,6 @@ struct FlatpakOciRegistry
   char    *uri;
   GFile   *archive;
   int      tmp_dfd;
-  char    *token;
   char    *signature_lookaside;
 
   /* Local repos */
@@ -82,6 +81,7 @@ struct FlatpakOciRegistry
   FlatpakHttpSession *http_session;
   GUri *base_uri;
   FlatpakCertificates *certificates;
+  FlatpakTokenProvider *token_provider;
 };
 
 typedef struct
@@ -135,7 +135,7 @@ flatpak_oci_registry_finalize (GObject *object)
   g_clear_pointer (&self->http_session, flatpak_http_session_free);
   g_clear_pointer (&self->base_uri, g_uri_unref);
   g_clear_pointer (&self->uri, g_free);
-  g_clear_pointer (&self->token, g_free);
+  g_clear_object (&self->token_provider);
   g_clear_object (&self->archive);
   g_clear_pointer (&self->tmp_dir, glnx_tmpdir_free);
   g_clear_pointer (&self->certificates, flatpak_certificates_free);
@@ -276,17 +276,77 @@ flatpak_oci_registry_get_uri (FlatpakOciRegistry *self)
 }
 
 void
-flatpak_oci_registry_set_token (FlatpakOciRegistry *self,
-                                const char *token)
+flatpak_oci_registry_set_token_provider (FlatpakOciRegistry   *self,
+                                         FlatpakTokenProvider *provider)
 {
-  g_free (self->token);
-  self->token = g_strdup (token);
+  g_set_object (&self->token_provider, provider);
+}
 
-  if (self->token)
-    (void)glnx_file_replace_contents_at (self->dfd, ".token",
-                                         (guchar *)self->token,
-                                         strlen (self->token),
-                                         0, NULL, NULL);
+static gboolean
+flatpak_oci_registry_try_refresh_token (FlatpakOciRegistry *self,
+                                        GCancellable       *cancellable)
+{
+  if (self->token_provider == NULL)
+    return FALSE;
+
+  g_info ("Refreshing token for registry %s", self->uri);
+
+  if (!flatpak_token_provider_refresh_token (self->token_provider, cancellable))
+    return FALSE;
+
+  return TRUE;
+}
+
+const char *
+flatpak_oci_registry_get_token (FlatpakOciRegistry *self)
+{
+  if (self->token_provider)
+    return flatpak_token_provider_get_token (self->token_provider);
+
+  return NULL;
+}
+
+static gboolean
+flatpak_oci_registry_download_with_retry (FlatpakOciRegistry     *self,
+                                          const char             *uri,
+                                          GOutputStream          *out_stream,
+                                          FlatpakLoadUriProgress  progress_cb,
+                                          gpointer                user_data,
+                                          GCancellable           *cancellable,
+                                          GError                **error)
+{
+  g_autoptr(GError) local_error = NULL;
+
+  gboolean ok = flatpak_download_http_uri (self->http_session, uri,
+                                           self->certificates,
+                                           FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
+                                           out_stream,
+                                           flatpak_oci_registry_get_token(self),
+                                           progress_cb, user_data,
+                                           cancellable, &local_error);
+  if (!ok
+      && g_error_matches (local_error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_UNAUTHORIZED)
+      && flatpak_oci_registry_try_refresh_token (self, cancellable))
+    {
+      int fd = g_unix_output_stream_get_fd (G_UNIX_OUTPUT_STREAM (out_stream));
+
+      g_clear_error (&local_error);
+      ftruncate (fd, 0);
+      lseek (fd, 0, SEEK_SET);
+
+      ok = flatpak_download_http_uri (self->http_session, uri,
+                                      self->certificates,
+                                      FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
+                                      out_stream,
+                                      flatpak_oci_registry_get_token(self),
+                                      progress_cb, user_data,
+                                      cancellable, &local_error);
+    }
+
+  if (local_error)
+    g_propagate_error (error, g_steal_pointer (&local_error));
+
+  return ok;
 }
 
 void
@@ -367,6 +427,7 @@ remote_load_file (FlatpakOciRegistry *self,
                   GError            **error)
 {
   g_autoptr(GBytes) bytes = NULL;
+  g_autoptr(GError) local_error = NULL;
   g_autofree char *uri_s = NULL;
 
   uri_s = choose_alt_uri (self->base_uri, alt_uris);
@@ -378,10 +439,27 @@ remote_load_file (FlatpakOciRegistry *self,
     }
 
   bytes = flatpak_load_uri_full (self->http_session,
-                                 uri_s, self->certificates, FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
-                                 NULL, self->token,
+                                 uri_s, self->certificates,
+                                 FLATPAK_HTTP_FLAGS_ACCEPT_OCI, NULL,
+                                 flatpak_oci_registry_get_token(self),
                                  NULL, NULL, NULL, out_content_type, NULL,
-                                 cancellable, error);
+                                 cancellable, &local_error);
+  if (bytes == NULL
+      && g_error_matches (local_error, FLATPAK_HTTP_ERROR, FLATPAK_HTTP_ERROR_UNAUTHORIZED)
+      && flatpak_oci_registry_try_refresh_token (self, cancellable))
+    {
+      g_clear_error (&local_error);
+      bytes = flatpak_load_uri_full (self->http_session,
+                                     uri_s, self->certificates,
+                                     FLATPAK_HTTP_FLAGS_ACCEPT_OCI, NULL,
+                                     flatpak_oci_registry_get_token(self),
+                                     NULL, NULL, NULL, out_content_type, NULL,
+                                     cancellable, &local_error);
+    }
+
+  if (local_error)
+    g_propagate_error (error, g_steal_pointer (&local_error));
+
   if (bytes == NULL)
     return NULL;
 
@@ -727,13 +805,6 @@ flatpak_oci_registry_ensure_local (FlatpakOciRegistry *self,
   else if (!verify_oci_version (oci_layout_bytes, &not_json, cancellable, error))
     return FALSE;
 
-  if (self->dfd != -1)
-    {
-      token_bytes = flatpak_load_file_at (self->dfd, ".token", cancellable, NULL);
-      if (token_bytes != NULL)
-        self->token = g_strndup (g_bytes_get_data (token_bytes, NULL), g_bytes_get_size (token_bytes));
-    }
-
   if (self->dfd == -1)
     {
       self->dfd = g_steal_fd (&local_dfd);
@@ -1037,13 +1108,10 @@ flatpak_oci_registry_download_blob (FlatpakOciRegistry    *self,
       if (fd == -1)
         return -1;
 
-      if (!flatpak_download_http_uri (self->http_session, uri_s,
-                                      self->certificates,
-                                      FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
-                                      out_stream,
-                                      self->token,
-                                      progress_cb, user_data,
-                                      cancellable, error))
+      if (!flatpak_oci_registry_download_with_retry (self,
+                                                     uri_s, out_stream,
+                                                     progress_cb, user_data,
+                                                     cancellable, error))
         return -1;
 
       if (!g_output_stream_close (out_stream, cancellable, error))
@@ -1130,12 +1198,11 @@ flatpak_oci_registry_mirror_blob (FlatpakOciRegistry    *self,
 
       out_stream = g_unix_output_stream_new (tmpf.fd, FALSE);
 
-      if (!flatpak_download_http_uri (source_registry->http_session,
-                                      uri_s, source_registry->certificates,
-                                      FLATPAK_HTTP_FLAGS_ACCEPT_OCI, out_stream,
-                                      source_registry->token,
-                                      progress_cb, user_data,
-                                      cancellable, error))
+
+      if (!flatpak_oci_registry_download_with_retry (source_registry,
+                                                     uri_s, out_stream,
+                                                     progress_cb, user_data,
+                                                     cancellable, error))
         return FALSE;
 
       if (!g_output_stream_close (out_stream, cancellable, error))
@@ -1326,12 +1393,12 @@ get_token_for_www_auth (FlatpakOciRegistry *self,
 }
 
 char *
-flatpak_oci_registry_get_token (FlatpakOciRegistry *self,
-                                const char         *repository,
-                                const char         *digest,
-                                const char         *basic_auth,
-                                GCancellable       *cancellable,
-                                GError            **error)
+flatpak_oci_registry_fetch_token (FlatpakOciRegistry *self,
+                                  const char         *repository,
+                                  const char         *digest,
+                                  const char         *basic_auth,
+                                  GCancellable       *cancellable,
+                                  GError            **error)
 {
   g_autofree char *subpath = NULL;
   g_autofree char *uri_s = NULL;
@@ -2326,8 +2393,9 @@ flatpak_oci_registry_find_delta_manifest (FlatpakOciRegistry    *registry,
 
       if (uri_s != NULL)
         bytes = flatpak_load_uri_full (registry->http_session,
-                                       uri_s, registry->certificates, FLATPAK_HTTP_FLAGS_ACCEPT_OCI,
-                                       NULL, registry->token,
+                                       uri_s, registry->certificates,
+                                       FLATPAK_HTTP_FLAGS_ACCEPT_OCI, NULL,
+                                       flatpak_oci_registry_get_token(registry),
                                        NULL, NULL, NULL, NULL, NULL,
                                        cancellable, NULL);
       if (bytes != NULL)

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -164,6 +164,25 @@ typedef struct {
   GVariant *results;
 } RequestData;
 
+/* Pointers are not ref'd; the provider never outlives the transaction or op. */
+struct _FlatpakTokenProvider {
+  GObject                      parent;
+  FlatpakTransaction          *transaction;
+  FlatpakTransactionOperation *op;
+};
+
+G_DEFINE_TYPE (FlatpakTokenProvider, flatpak_token_provider, G_TYPE_OBJECT)
+
+static void
+flatpak_token_provider_class_init (FlatpakTokenProviderClass *klass)
+{
+}
+
+static void
+flatpak_token_provider_init (FlatpakTokenProvider *self)
+{
+}
+
 typedef struct _FlatpakTransactionPrivate
 {
   GObject                      parent;
@@ -244,6 +263,8 @@ enum {
 };
 
 static gboolean op_may_need_token (FlatpakTransactionOperation *op);
+static FlatpakTokenProvider *flatpak_token_provider_new_for_op (FlatpakTransaction          *transaction,
+                                                                FlatpakTransactionOperation *op);
 
 static void flatpak_transaction_normalize_ops (FlatpakTransaction *self);
 static gboolean request_required_tokens (FlatpakTransaction *self,
@@ -3926,9 +3947,12 @@ resolve_ops (FlatpakTransaction *self,
                 flatpak_remote_state_lookup_ref (state, flatpak_decomposed_get_ref (op->ref),
                                                   NULL, NULL, &op->summary_metadata, NULL, NULL, NULL);
 
+              g_autoptr(FlatpakTokenProvider) token_provider =
+                  flatpak_token_provider_new_for_op (self, op);
+
               commit_data = flatpak_remote_state_load_ref_commit (state, priv->dir,
                                                                   flatpak_decomposed_get_ref (op->ref),
-                                                                  checksum, /* initially NULL */ op->resolved_token,
+                                                                  checksum, token_provider,
                                                                   NULL, NULL, &local_error);
               if (commit_data == NULL)
                 {
@@ -4367,8 +4391,44 @@ request_tokens_for_remote (FlatpakTransaction *self,
 
       /* Allow sending empty tokens to mean no token needed */
 
+      g_free (op->resolved_token);
       op->resolved_token = *token == 0 ? NULL : g_strdup (token);
       op->requested_token = TRUE;
+    }
+
+  return TRUE;
+}
+
+static FlatpakTokenProvider *
+flatpak_token_provider_new_for_op (FlatpakTransaction          *transaction,
+                                   FlatpakTransactionOperation *op)
+{
+  FlatpakTokenProvider *self = g_object_new (FLATPAK_TYPE_TOKEN_PROVIDER, NULL);
+
+  self->transaction = transaction;
+  self->op = op;
+
+  return self;
+}
+
+const char *
+flatpak_token_provider_get_token (FlatpakTokenProvider *self)
+{
+  return self->op->resolved_token;
+}
+
+gboolean
+flatpak_token_provider_refresh_token (FlatpakTokenProvider *self,
+                                      GCancellable         *cancellable)
+{
+  GList op_list = { .data = self->op, .next = NULL, .prev = NULL };
+  g_autoptr(GError) local_error = NULL;
+
+  if (!request_tokens_for_remote (self->transaction, self->op->remote,
+                                  &op_list, cancellable, &local_error))
+    {
+      g_info ("Token refresh failed: %s", local_error->message);
+      return FALSE;
     }
 
   return TRUE;
@@ -5109,24 +5169,29 @@ _run_op_kind (FlatpakTransaction           *self,
                                                                    op->resolved_metakey, &local_error))
         res = FALSE;
       else
-        res = flatpak_dir_install (priv->dir,
-                                   priv->no_pull,
-                                   priv->no_deploy,
-                                   priv->disable_static_deltas,
-                                   priv->reinstall,
-                                   priv->max_op >= APP_UPDATE,
-                                   op->pin_on_deploy,
-                                   op->update_preinstalled_on_deploy,
-                                   remote_state, op->ref,
-                                   op->resolved_commit,
-                                   (const char **) op->subpaths,
-                                   (const char **) op->previous_ids,
-                                   op->resolved_sideload_path,
-                                   op->resolved_image_source,
-                                   op->resolved_metadata,
-                                   op->resolved_token,
-                                   progress->progress_obj,
-                                   cancellable, &local_error);
+        {
+          g_autoptr(FlatpakTokenProvider) token_provider =
+              flatpak_token_provider_new_for_op (self, op);
+
+          res = flatpak_dir_install (priv->dir,
+                                     priv->no_pull,
+                                     priv->no_deploy,
+                                     priv->disable_static_deltas,
+                                     priv->reinstall,
+                                     priv->max_op >= APP_UPDATE,
+                                     op->pin_on_deploy,
+                                     op->update_preinstalled_on_deploy,
+                                     remote_state, op->ref,
+                                     op->resolved_commit,
+                                     (const char **) op->subpaths,
+                                     (const char **) op->previous_ids,
+                                     op->resolved_sideload_path,
+                                     op->resolved_image_source,
+                                     op->resolved_metadata,
+                                     token_provider,
+                                     progress->progress_obj,
+                                     cancellable, &local_error);
+        }
 
       flatpak_transaction_progress_done (progress);
 
@@ -5183,24 +5248,29 @@ _run_op_kind (FlatpakTransaction           *self,
                                              (const char **) op->previous_ids,
                                              cancellable, &local_error);
           else
-            res = flatpak_dir_update (priv->dir,
-                                      priv->no_pull,
-                                      priv->no_deploy,
-                                      priv->disable_static_deltas,
-                                      op->commit != NULL, /* Allow downgrade if we specify commit */
-                                      priv->max_op >= APP_UPDATE,
-                                      priv->max_op == APP_INSTALL || priv->max_op == RUNTIME_INSTALL,
-                                      remote_state,
-                                      op->ref,
-                                      op->resolved_commit,
-                                      (const char **) op->subpaths,
-                                      (const char **) op->previous_ids,
-                                      op->resolved_sideload_path,
-                                      op->resolved_image_source,
-                                      op->resolved_metadata,
-                                      op->resolved_token,
-                                      progress->progress_obj,
-                                      cancellable, &local_error);
+            {
+              g_autoptr(FlatpakTokenProvider) token_provider =
+                  flatpak_token_provider_new_for_op (self, op);
+
+              res = flatpak_dir_update (priv->dir,
+                                        priv->no_pull,
+                                        priv->no_deploy,
+                                        priv->disable_static_deltas,
+                                        op->commit != NULL, /* Allow downgrade if we specify commit */
+                                        priv->max_op >= APP_UPDATE,
+                                        priv->max_op == APP_INSTALL || priv->max_op == RUNTIME_INSTALL,
+                                        remote_state,
+                                        op->ref,
+                                        op->resolved_commit,
+                                        (const char **) op->subpaths,
+                                        (const char **) op->previous_ids,
+                                        op->resolved_sideload_path,
+                                        op->resolved_image_source,
+                                        op->resolved_metadata,
+                                        token_provider,
+                                        progress->progress_obj,
+                                        cancellable, &local_error);
+            }
           flatpak_transaction_progress_done (progress);
 
           /* Handle noop-updates */

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -225,6 +225,8 @@ typedef struct _FlatpakTransactionPrivate
 
   gboolean                     needs_resolve;
   gboolean                     needs_tokens;
+
+  GDBusConnection             *auth_connection;
 } FlatpakTransactionPrivate;
 
 enum {
@@ -270,7 +272,6 @@ static gboolean request_required_tokens (FlatpakTransaction *self,
                                          const char         *optional_remote,
                                          GCancellable       *cancellable,
                                          GError            **error);
-
 
 static BundleData *
 bundle_data_new (GFile  *file,
@@ -1107,6 +1108,8 @@ flatpak_transaction_finalize (GObject *object)
   g_ptr_array_free (priv->extra_dependency_dirs, TRUE);
   g_ptr_array_free (priv->extra_sideload_repos, TRUE);
   g_ptr_array_free (priv->sideload_image_collections, TRUE);
+
+  g_clear_pointer (&priv->auth_connection, flatpak_auth_connection_close);
 
   G_OBJECT_CLASS (flatpak_transaction_parent_class)->finalize (object);
 }
@@ -4207,7 +4210,6 @@ copy_summary_data (GVariantBuilder *builder, GVariant *summary, const char *key)
     g_variant_builder_add (builder, "{s@v}", key, g_variant_new_variant (value));
 }
 
-
 static gboolean
 request_tokens_for_remote (FlatpakTransaction *self,
                            const char         *remote,
@@ -4294,9 +4296,16 @@ request_tokens_for_remote (FlatpakTransaction *self,
   if (flatpak_dir_get_no_interaction (priv->dir))
     g_variant_builder_add (extra_builder, "{sv}", "no-interaction", g_variant_new_boolean (TRUE));
 
+  if (priv->auth_connection == NULL)
+    {
+      priv->auth_connection = flatpak_auth_connection_new (cancellable, error);
+      if (priv->auth_connection == NULL)
+        return FALSE;
+    }
+
   context = flatpak_main_context_new_default ();
 
-  authenticator = flatpak_auth_new_for_remote (priv->dir, remote, cancellable, error);
+  authenticator = flatpak_auth_new_for_remote (priv->dir, remote, priv->auth_connection, cancellable, error);
   if (authenticator == NULL)
     return FALSE;
 

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -164,6 +164,24 @@ typedef struct {
   GVariant *results;
 } RequestData;
 
+struct _FlatpakTokenProvider {
+  GObject                      parent;
+  FlatpakTransaction          *transaction;
+  FlatpakTransactionOperation *op;
+};
+
+G_DEFINE_TYPE (FlatpakTokenProvider, flatpak_token_provider, G_TYPE_OBJECT)
+
+static void
+flatpak_token_provider_class_init (FlatpakTokenProviderClass *klass)
+{
+}
+
+static void
+flatpak_token_provider_init (FlatpakTokenProvider *self)
+{
+}
+
 typedef struct _FlatpakTransactionPrivate
 {
   GObject                      parent;
@@ -244,6 +262,8 @@ enum {
 };
 
 static gboolean op_may_need_token (FlatpakTransactionOperation *op);
+static FlatpakTokenProvider *flatpak_token_provider_new_for_op (FlatpakTransaction          *transaction,
+                                                                FlatpakTransactionOperation *op);
 
 static void flatpak_transaction_normalize_ops (FlatpakTransaction *self);
 static gboolean request_required_tokens (FlatpakTransaction *self,
@@ -3926,9 +3946,10 @@ resolve_ops (FlatpakTransaction *self,
                 flatpak_remote_state_lookup_ref (state, flatpak_decomposed_get_ref (op->ref),
                                                   NULL, NULL, &op->summary_metadata, NULL, NULL, NULL);
 
+              g_autoptr(FlatpakTokenProvider) token_provider = flatpak_token_provider_new_for_op (self, op);
               commit_data = flatpak_remote_state_load_ref_commit (state, priv->dir,
                                                                   flatpak_decomposed_get_ref (op->ref),
-                                                                  checksum, /* initially NULL */ op->resolved_token,
+                                                                  checksum, token_provider,
                                                                   NULL, NULL, &local_error);
               if (commit_data == NULL)
                 {
@@ -4367,8 +4388,44 @@ request_tokens_for_remote (FlatpakTransaction *self,
 
       /* Allow sending empty tokens to mean no token needed */
 
+      g_free (op->resolved_token);
       op->resolved_token = *token == 0 ? NULL : g_strdup (token);
       op->requested_token = TRUE;
+    }
+
+  return TRUE;
+}
+
+static FlatpakTokenProvider *
+flatpak_token_provider_new_for_op (FlatpakTransaction          *transaction,
+                                   FlatpakTransactionOperation *op)
+{
+  FlatpakTokenProvider *self = g_object_new (FLATPAK_TYPE_TOKEN_PROVIDER, NULL);
+
+  self->transaction = transaction;
+  self->op = op;
+
+  return self;
+}
+
+const char *
+flatpak_token_provider_get_token (FlatpakTokenProvider *self)
+{
+  return self->op->resolved_token;
+}
+
+gboolean
+flatpak_token_provider_refresh_token (FlatpakTokenProvider *self,
+                                      GCancellable         *cancellable)
+{
+  GList op_list = { .data = self->op, .next = NULL, .prev = NULL };
+  g_autoptr(GError) local_error = NULL;
+
+  if (!request_tokens_for_remote (self->transaction, self->op->remote,
+                                  &op_list, cancellable, &local_error))
+    {
+      g_info ("Token refresh failed: %s", local_error->message);
+      return FALSE;
     }
 
   return TRUE;
@@ -5109,24 +5166,28 @@ _run_op_kind (FlatpakTransaction           *self,
                                                                    op->resolved_metakey, &local_error))
         res = FALSE;
       else
-        res = flatpak_dir_install (priv->dir,
-                                   priv->no_pull,
-                                   priv->no_deploy,
-                                   priv->disable_static_deltas,
-                                   priv->reinstall,
-                                   priv->max_op >= APP_UPDATE,
-                                   op->pin_on_deploy,
-                                   op->update_preinstalled_on_deploy,
-                                   remote_state, op->ref,
-                                   op->resolved_commit,
-                                   (const char **) op->subpaths,
-                                   (const char **) op->previous_ids,
-                                   op->resolved_sideload_path,
-                                   op->resolved_image_source,
-                                   op->resolved_metadata,
-                                   op->resolved_token,
-                                   progress->progress_obj,
-                                   cancellable, &local_error);
+        {
+          g_autoptr(FlatpakTokenProvider) token_provider = flatpak_token_provider_new_for_op (self, op);
+
+          res = flatpak_dir_install (priv->dir,
+                                     priv->no_pull,
+                                     priv->no_deploy,
+                                     priv->disable_static_deltas,
+                                     priv->reinstall,
+                                     priv->max_op >= APP_UPDATE,
+                                     op->pin_on_deploy,
+                                     op->update_preinstalled_on_deploy,
+                                     remote_state, op->ref,
+                                     op->resolved_commit,
+                                     (const char **) op->subpaths,
+                                     (const char **) op->previous_ids,
+                                     op->resolved_sideload_path,
+                                     op->resolved_image_source,
+                                     op->resolved_metadata,
+                                     token_provider,
+                                     progress->progress_obj,
+                                     cancellable, &local_error);
+        }
 
       flatpak_transaction_progress_done (progress);
 
@@ -5183,24 +5244,28 @@ _run_op_kind (FlatpakTransaction           *self,
                                              (const char **) op->previous_ids,
                                              cancellable, &local_error);
           else
-            res = flatpak_dir_update (priv->dir,
-                                      priv->no_pull,
-                                      priv->no_deploy,
-                                      priv->disable_static_deltas,
-                                      op->commit != NULL, /* Allow downgrade if we specify commit */
-                                      priv->max_op >= APP_UPDATE,
-                                      priv->max_op == APP_INSTALL || priv->max_op == RUNTIME_INSTALL,
-                                      remote_state,
-                                      op->ref,
-                                      op->resolved_commit,
-                                      (const char **) op->subpaths,
-                                      (const char **) op->previous_ids,
-                                      op->resolved_sideload_path,
-                                      op->resolved_image_source,
-                                      op->resolved_metadata,
-                                      op->resolved_token,
-                                      progress->progress_obj,
-                                      cancellable, &local_error);
+            {
+              g_autoptr(FlatpakTokenProvider) token_provider = flatpak_token_provider_new_for_op (self, op);
+
+              res = flatpak_dir_update (priv->dir,
+                                        priv->no_pull,
+                                        priv->no_deploy,
+                                        priv->disable_static_deltas,
+                                        op->commit != NULL, /* Allow downgrade if we specify commit */
+                                        priv->max_op >= APP_UPDATE,
+                                        priv->max_op == APP_INSTALL || priv->max_op == RUNTIME_INSTALL,
+                                        remote_state,
+                                        op->ref,
+                                        op->resolved_commit,
+                                        (const char **) op->subpaths,
+                                        (const char **) op->previous_ids,
+                                        op->resolved_sideload_path,
+                                        op->resolved_image_source,
+                                        op->resolved_metadata,
+                                        token_provider,
+                                        progress->progress_obj,
+                                        cancellable, &local_error);
+            }
           flatpak_transaction_progress_done (progress);
 
           /* Handle noop-updates */

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -35,6 +35,9 @@ static guint name_owner_id = 0;
 static gboolean no_idle_exit = FALSE;
 static FlatpakHttpSession *http_session = NULL;
 
+G_LOCK_DEFINE (cached_auth);
+static GHashTable *cached_auth; /* "peer_name\nregistry_uri" -> auth_string */
+
 #define IDLE_TIMEOUT_SECS 10 * 60
 
 static void
@@ -74,13 +77,30 @@ unref_skeleton_in_timeout (void)
   g_timeout_add (500, unref_skeleton_in_timeout_cb, NULL);
 }
 
+static void schedule_idle_callback (void);
+
 static gboolean
 idle_timeout_cb (gpointer user_data)
 {
+  gboolean have_cached_auth = FALSE;
+
   if (name_owner_id)
     {
-      g_info ("Idle - unowning name");
-      unref_skeleton_in_timeout ();
+      G_LOCK (cached_auth);
+      if (cached_auth != NULL)
+        have_cached_auth = g_hash_table_size (cached_auth) > 0;
+      G_UNLOCK (cached_auth);
+
+      if (have_cached_auth)
+        {
+          g_info ("Idle but have cached credentials - rescheduling");
+          schedule_idle_callback ();
+        }
+      else
+        {
+          g_info ("Idle - unowning name");
+          unref_skeleton_in_timeout ();
+        }
     }
   return G_SOURCE_REMOVE;
 }
@@ -170,6 +190,78 @@ remove_auth_for_peer (const char *sender,
   G_UNLOCK (active_auth);
 }
 
+static char *
+make_cached_auth_key (const char *sender,
+                      const char *registry_uri)
+{
+  return g_strconcat (sender, "\n", registry_uri, NULL);
+}
+
+static gboolean
+cached_auth_key_has_peer (gpointer key,
+                          gpointer value,
+                          gpointer user_data)
+{
+  const char *k = key;
+  const char *peer = user_data;
+  gsize peer_len = strlen (peer);
+
+  return strncmp (k, peer, peer_len) == 0 && k[peer_len] == '\n';
+}
+
+static void
+add_cached_auth_for_peer (const char *sender,
+                          const char *registry_uri,
+                          const char *auth)
+{
+  G_LOCK (cached_auth);
+
+  if (cached_auth == NULL)
+    cached_auth = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                         g_free, g_free);
+
+  g_hash_table_insert (cached_auth,
+                       make_cached_auth_key (sender, registry_uri),
+                       g_strdup (auth));
+
+  G_UNLOCK (cached_auth);
+}
+
+static char *
+get_cached_auth_for_peer (const char *sender,
+                          const char *registry_uri)
+{
+  char *auth = NULL;
+
+  G_LOCK (cached_auth);
+
+  if (cached_auth != NULL)
+    {
+      g_autofree char *key = make_cached_auth_key (sender, registry_uri);
+      const char *cached = g_hash_table_lookup (cached_auth, key);
+      if (cached != NULL)
+        auth = g_strdup (cached);
+    }
+
+  G_UNLOCK (cached_auth);
+  return auth;
+}
+
+static void
+remove_cached_auth_for_peer (const char *sender,
+                             const char *registry_uri)
+{
+  G_LOCK (cached_auth);
+
+  if (cached_auth != NULL)
+    {
+      g_autofree char *key = make_cached_auth_key (sender, registry_uri);
+      g_hash_table_remove (cached_auth, key);
+    }
+
+  G_UNLOCK (cached_auth);
+}
+
 static gpointer
 peer_died (const char *name)
 {
@@ -189,6 +281,12 @@ peer_died (const char *name)
         }
     }
   G_UNLOCK (active_auth);
+
+  G_LOCK (cached_auth);
+  if (cached_auth != NULL)
+    g_hash_table_foreach_remove (cached_auth, cached_auth_key_has_peer, (gpointer) name);
+  G_UNLOCK (cached_auth);
+
   return NULL;
 }
 
@@ -514,8 +612,38 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
       have_auth = auth != NULL;
     }
 
-  /* Try to see if we can get a token without presenting credentials */
+  /* Try previously cached credentials from interactive auth */
   n_refs = g_variant_n_children (arg_refs);
+  if (!have_auth && n_refs > 0)
+    {
+      g_autofree char *cached = get_cached_auth_for_peer (sender, oci_registry_uri);
+
+      if (cached != NULL)
+        {
+          g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
+
+          g_info ("Trying cached credentials for %s", oci_registry_uri);
+
+          first_token = get_token_for_ref (registry, ref_data, cached, &error);
+          if (first_token != NULL)
+            {
+              auth = g_steal_pointer (&cached);
+              have_auth = TRUE;
+            }
+          else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_AUTHORIZED))
+            {
+              g_info ("Cached credentials failed: %s", error->message);
+              remove_cached_auth_for_peer (sender, oci_registry_uri);
+              g_clear_error (&error);
+            }
+          else
+            {
+              return error_request (request, sender, error);
+            }
+        }
+    }
+
+  /* Try to see if we can get a token without presenting credentials */
   if (!have_auth && n_refs > 0)
     {
       g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
@@ -569,6 +697,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
             {
               auth = g_steal_pointer (&test_auth);
               have_auth = TRUE;
+              add_cached_auth_for_peer (sender, oci_registry_uri, auth);
             }
           else
             {

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -294,7 +294,7 @@ get_token_for_ref (FlatpakOciRegistry *registry,
 
   oci_digest = g_strconcat ("sha256:", commit, NULL);
 
-  return flatpak_oci_registry_get_token (registry, oci_repository, oci_digest, basic_auth, NULL, error);
+  return flatpak_oci_registry_fetch_token (registry, oci_repository, oci_digest, basic_auth, NULL, error);
 }
 
 static gboolean

--- a/oci-authenticator/flatpak-oci-authenticator.c
+++ b/oci-authenticator/flatpak-oci-authenticator.c
@@ -35,7 +35,7 @@ static guint name_owner_id = 0;
 static gboolean no_idle_exit = FALSE;
 static FlatpakHttpSession *http_session = NULL;
 
-#define IDLE_TIMEOUT_SECS 10 * 60
+#define IDLE_TIMEOUT_SECS 60 * 60
 
 static void
 skeleton_died_cb (gpointer data)
@@ -111,6 +111,10 @@ typedef struct {
 G_LOCK_DEFINE (active_auth);
 static GHashTable *active_auth;
 
+G_LOCK_DEFINE (cached_auth);
+/* peer_name -> GHashTable(registry_uri -> auth_string) */
+static GHashTable *cached_auth;
+
 static void
 cancel_basic_auth (BasicAuthData *auth)
 {
@@ -170,6 +174,73 @@ remove_auth_for_peer (const char *sender,
   G_UNLOCK (active_auth);
 }
 
+static void
+add_cached_auth_for_peer (const char *sender,
+                          const char *registry_uri,
+                          const char *auth)
+{
+  GHashTable *peer_table;
+
+  G_LOCK (cached_auth);
+
+  if (cached_auth == NULL)
+    cached_auth = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                         g_free, (GDestroyNotify) g_hash_table_destroy);
+
+  peer_table = g_hash_table_lookup (cached_auth, sender);
+  if (peer_table == NULL)
+    {
+      peer_table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+      g_hash_table_insert (cached_auth, g_strdup (sender), peer_table);
+    }
+
+  g_hash_table_insert (peer_table, g_strdup (registry_uri), g_strdup (auth));
+
+  G_UNLOCK (cached_auth);
+}
+
+static char *
+get_cached_auth_for_peer (const char *sender,
+                          const char *registry_uri)
+{
+  GHashTable *peer_table;
+  char *auth = NULL;
+
+  G_LOCK (cached_auth);
+
+  if (cached_auth != NULL)
+    {
+      peer_table = g_hash_table_lookup (cached_auth, sender);
+      if (peer_table != NULL)
+        {
+          const char *cached = g_hash_table_lookup (peer_table, registry_uri);
+          if (cached != NULL)
+            auth = g_strdup (cached);
+        }
+    }
+
+  G_UNLOCK (cached_auth);
+  return auth;
+}
+
+static void
+remove_cached_auth_for_peer (const char *sender,
+                             const char *registry_uri)
+{
+  GHashTable *peer_table;
+
+  G_LOCK (cached_auth);
+
+  if (cached_auth != NULL)
+    {
+      peer_table = g_hash_table_lookup (cached_auth, sender);
+      if (peer_table != NULL)
+        g_hash_table_remove (peer_table, registry_uri);
+    }
+
+  G_UNLOCK (cached_auth);
+}
+
 static gpointer
 peer_died (const char *name)
 {
@@ -189,6 +260,12 @@ peer_died (const char *name)
         }
     }
   G_UNLOCK (active_auth);
+
+  G_LOCK (cached_auth);
+  if (cached_auth != NULL)
+    g_hash_table_remove (cached_auth, name);
+  G_UNLOCK (cached_auth);
+
   return NULL;
 }
 
@@ -514,8 +591,38 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
       have_auth = auth != NULL;
     }
 
-  /* Try to see if we can get a token without presenting credentials */
+  /* Try previously cached credentials from interactive auth */
   n_refs = g_variant_n_children (arg_refs);
+  if (!have_auth && n_refs > 0)
+    {
+      g_autofree char *cached = get_cached_auth_for_peer (sender, oci_registry_uri);
+
+      if (cached != NULL)
+        {
+          g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
+
+          g_info ("Trying cached credentials for %s", oci_registry_uri);
+
+          first_token = get_token_for_ref (registry, ref_data, cached, &error);
+          if (first_token != NULL)
+            {
+              auth = g_steal_pointer (&cached);
+              have_auth = TRUE;
+            }
+          else if (g_error_matches (error, FLATPAK_ERROR, FLATPAK_ERROR_NOT_AUTHORIZED))
+            {
+              g_info ("Cached credentials failed: %s", error->message);
+              remove_cached_auth_for_peer (sender, oci_registry_uri);
+              g_clear_error (&error);
+            }
+          else
+            {
+              return error_request (request, sender, error);
+            }
+        }
+    }
+
+  /* Try to see if we can get a token without presenting credentials */
   if (!have_auth && n_refs > 0)
     {
       g_autoptr(GVariant) ref_data = g_variant_get_child_value (arg_refs, 0);
@@ -569,6 +676,7 @@ handle_request_ref_tokens (FlatpakAuthenticator *f_authenticator,
             {
               auth = g_steal_pointer (&test_auth);
               have_auth = TRUE;
+              add_cached_auth_for_peer (sender, oci_registry_uri, auth);
             }
           else
             {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -268,6 +268,19 @@ executable(
 )
 
 executable(
+  'test-oci-auth-cache',
+  'test-oci-auth-cache.c',
+  dependencies : [
+    base_deps,
+    libflatpak_common_dep,
+    libflatpak_common_base_dep,
+    libglnx_dep,
+  ],
+  install : get_option('installed_tests'),
+  install_dir : installed_testdir,
+)
+
+executable(
   'try-syscall',
   'try-syscall.c',
   include_directories : [common_include_directories],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -269,6 +269,19 @@ executable(
 )
 
 executable(
+  'test-oci-auth-cache',
+  'test-oci-auth-cache.c',
+  dependencies : [
+    base_deps,
+    libflatpak_common_dep,
+    libflatpak_common_base_dep,
+    libglnx_dep,
+  ],
+  install : get_option('installed_tests'),
+  install_dir : installed_testdir,
+)
+
+executable(
   'try-syscall',
   'try-syscall.c',
   include_directories : [common_include_directories],

--- a/tests/oci-registry-client.py
+++ b/tests/oci-registry-client.py
@@ -82,12 +82,28 @@ def run_delete_sig(args):
         sys.exit(1)
 
 
-def run_configure_auth(args):
+def run_set_auth(args):
     params = {"token": args.token}
+    if args.expire_on_path is not None:
+        params["expire-on-path"] = args.expire_on_path
+    if args.next_token is not None:
+        params["next-token"] = args.next_token
+    if args.token_update_file is not None:
+        params["token-update-file"] = args.token_update_file
     query = urllib.parse.urlencode(params)
     conn = get_conn(args)
-    path = "/testing-auth/configure?{query}".format(query=query)
+    path = "/testing-auth?{query}".format(query=query)
     conn.request("POST", path)
+    response = conn.getresponse()
+    if response.status != 200:
+        print(response.read(), file=sys.stderr)
+        print("Failed: status={}".format(response.status), file=sys.stderr)
+        sys.exit(1)
+
+
+def run_reset_auth(args):
+    conn = get_conn(args)
+    conn.request("DELETE", "/testing-auth")
     response = conn.getresponse()
     if response.status != 200:
         print(response.read(), file=sys.stderr)
@@ -127,9 +143,15 @@ delete_sig_parser.add_argument("repo")
 delete_sig_parser.add_argument("digest")
 delete_sig_parser.set_defaults(func=run_delete_sig)
 
-configure_auth_parser = subparsers.add_parser("configure-auth")
-configure_auth_parser.add_argument("--token", required=True)
-configure_auth_parser.set_defaults(func=run_configure_auth)
+set_auth_parser = subparsers.add_parser("set-auth")
+set_auth_parser.add_argument("--token", required=True)
+set_auth_parser.add_argument("--expire-on-path", default=None)
+set_auth_parser.add_argument("--next-token", default=None)
+set_auth_parser.add_argument("--token-update-file", default=None)
+set_auth_parser.set_defaults(func=run_set_auth)
+
+reset_auth_parser = subparsers.add_parser("reset-auth")
+reset_auth_parser.set_defaults(func=run_reset_auth)
 
 args = parser.parse_args()
 args.func(args)

--- a/tests/oci-registry-client.py
+++ b/tests/oci-registry-client.py
@@ -90,6 +90,8 @@ def run_set_auth(args):
         params["next-token"] = args.next_token
     if args.token_update_file is not None:
         params["token-update-file"] = args.token_update_file
+    if args.basic_auth is not None:
+        params["basic-auth"] = args.basic_auth
     query = urllib.parse.urlencode(params)
     conn = get_conn(args)
     path = "/testing-auth?{query}".format(query=query)
@@ -148,6 +150,7 @@ set_auth_parser.add_argument("--token", required=True)
 set_auth_parser.add_argument("--expire-on-path", default=None)
 set_auth_parser.add_argument("--next-token", default=None)
 set_auth_parser.add_argument("--token-update-file", default=None)
+set_auth_parser.add_argument("--basic-auth", default=None)
 set_auth_parser.set_defaults(func=run_set_auth)
 
 reset_auth_parser = subparsers.add_parser("reset-auth")

--- a/tests/oci-registry-server.py
+++ b/tests/oci-registry-server.py
@@ -2,6 +2,7 @@
 
 import argparse
 import base64
+import fnmatch
 import hashlib
 import json
 import os
@@ -15,7 +16,12 @@ repositories = {}
 icons = {}
 signatures = {}
 
-required_token = None
+token_config = {
+    "token": None,
+    "expire_on_path": None,
+    "next_token": None,
+    "update_file": None,
+}
 
 
 def get_index():
@@ -85,12 +91,27 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
 
     def check_auth(self):
         """Return True if auth is not required or the Authorization: Bearer header matches the required token."""
-        if required_token is None:
+        cfg = token_config
+        if cfg["token"] is None:
             return True
+
+        if cfg["expire_on_path"] is not None:
+            path = self.path.split("?", 1)[0]
+            if fnmatch.fnmatch(path, cfg["expire_on_path"]):
+                cfg["token"] = cfg["next_token"]
+                cfg["expire_on_path"] = None
+                if cfg["update_file"]:
+                    with open(cfg["update_file"], "w") as f:
+                        f.write(cfg["next_token"])
+                return False
+
         auth_header = self.headers.get("Authorization", "")
         if not auth_header.startswith("Bearer "):
             return False
-        return auth_header[len("Bearer "):] == required_token
+        if auth_header[len("Bearer "):] != cfg["token"]:
+            return False
+
+        return True
 
     def do_GET(self):
         response = 404
@@ -255,9 +276,11 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             sigs.append(signature_bytes)
             self.send_response(200)
             self.end_headers()
-        elif self.check_route("/testing-auth/configure"):
-            global required_token
-            required_token = self.query.get("token", [None])[0]
+        elif self.check_route("/testing-auth"):
+            token_config["token"] = self.query.get("token", [None])[0]
+            token_config["expire_on_path"] = self.query.get("expire-on-path", [None])[0]
+            token_config["next_token"] = self.query.get("next-token", [None])[0]
+            token_config["update_file"] = self.query.get("token-update-file", [None])[0]
 
             self.send_response(200)
             self.end_headers()
@@ -300,6 +323,14 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             digest = digest.replace(":", "=")
             ref = f"{repo_name}@{digest}"
             signatures[ref] = list()
+            self.send_response(200)
+            self.end_headers()
+            return
+        elif self.check_route("/testing-auth"):
+            token_config["token"] = None
+            token_config["expire_on_path"] = None
+            token_config["next_token"] = None
+            token_config["update_file"] = None
             self.send_response(200)
             self.end_headers()
             return

--- a/tests/oci-registry-server.py
+++ b/tests/oci-registry-server.py
@@ -21,6 +21,7 @@ token_config = {
     "expire_on_path": None,
     "next_token": None,
     "update_file": None,
+    "basic_auth": None,
 }
 
 
@@ -113,6 +114,17 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
 
         return True
 
+    def send_auth_required(self):
+        """Send a 401 with WWW-Authenticate header pointing to the /token endpoint."""
+        host, port = self.server.server_address[:2]
+        realm = "http://{}:{}/token".format(host, port)
+        self.send_response(401)
+        self.send_header(
+            "WWW-Authenticate",
+            'Bearer realm="{}",service="test-registry"'.format(realm),
+        )
+        self.end_headers()
+
     def do_GET(self):
         response = 404
         response_string = b""
@@ -130,20 +142,33 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
 
         if self.check_route("/v2/@repo_name/blobs/@digest"):
             if not self.check_auth():
-                self.send_response(401)
-                self.end_headers()
+                self.send_auth_required()
                 return
             repo_name = self.matches["repo_name"]
             digest = self.matches["digest"]
             response, response_string = get_file_contents(repo_name, "blobs", digest)
         elif self.check_route("/v2/@repo_name/manifests/@ref"):
             if not self.check_auth():
-                self.send_response(401)
-                self.end_headers()
+                self.send_auth_required()
                 return
             repo_name = self.matches["repo_name"]
             ref = self.matches["ref"]
             response, response_string = get_file_contents(repo_name, "manifests", ref)
+        elif self.check_route("/token"):
+            cfg = token_config
+            auth_header = self.headers.get("Authorization", "")
+            expected_auth = "Basic " + cfg["basic_auth"] if cfg["basic_auth"] else None
+            if expected_auth is not None and auth_header != expected_auth:
+                response = 401
+                response_string = json.dumps(
+                    {"errors": [{"message": "unauthorized"}]}
+                ).encode("UTF-8")
+            else:
+                response = 200
+                response_string = json.dumps(
+                    {"token": cfg["token"]}
+                ).encode("UTF-8")
+            response_content_type = "application/json"
         elif self.check_route("/index/static") or self.check_route("/index/dynamic"):
             etag = get_etag()
             add_headers["Etag"] = etag
@@ -281,6 +306,7 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             token_config["expire_on_path"] = self.query.get("expire-on-path", [None])[0]
             token_config["next_token"] = self.query.get("next-token", [None])[0]
             token_config["update_file"] = self.query.get("token-update-file", [None])[0]
+            token_config["basic_auth"] = self.query.get("basic-auth", [None])[0]
 
             self.send_response(200)
             self.end_headers()
@@ -331,6 +357,7 @@ class RequestHandler(http_server.BaseHTTPRequestHandler):
             token_config["expire_on_path"] = None
             token_config["next_token"] = None
             token_config["update_file"] = None
+            token_config["basic_auth"] = None
             self.send_response(200)
             self.end_headers()
             return

--- a/tests/test-oci-auth-cache.c
+++ b/tests/test-oci-auth-cache.c
@@ -1,0 +1,173 @@
+/* vi:set et sw=2 sts=2 cin cino=t0,f0,(0,{s,>2s,n-s,^-s,e-s:
+ * Copyright (C) 2026 Red Hat, Inc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "flatpak-auth-private.h"
+#include "flatpak-dbus-generated.h"
+
+typedef struct {
+  int basic_auth_count;
+  guint response_code;
+  gboolean done;
+} TestData;
+
+static void
+on_basic_auth (FlatpakAuthenticatorRequest *request,
+               const gchar *realm,
+               GVariant *options,
+               TestData *data)
+{
+  g_autoptr(GVariant) reply_options = NULL;
+  g_autoptr(GError) error = NULL;
+
+  data->basic_auth_count++;
+  g_info ("BasicAuth signal received (count=%d), realm=%s", data->basic_auth_count, realm);
+
+  reply_options = g_variant_ref_sink (g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0));
+  flatpak_authenticator_request_call_basic_auth_reply_sync (request,
+                                                            "user", "pass",
+                                                            reply_options,
+                                                            NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+on_response (FlatpakAuthenticatorRequest *request,
+             guint response,
+             GVariant *results,
+             TestData *data)
+{
+  data->response_code = response;
+  data->done = TRUE;
+}
+
+static GVariant *
+build_test_refs (const char *registry_uri)
+{
+  GVariantBuilder refs_builder;
+  GVariantBuilder metadata_builder;
+
+  g_variant_builder_init (&refs_builder, G_VARIANT_TYPE ("a(ssia{sv})"));
+  g_variant_builder_init (&metadata_builder, G_VARIANT_TYPE ("a{sv}"));
+
+  g_variant_builder_add (&metadata_builder, "{sv}",
+                         "summary.xa.oci-repository",
+                         g_variant_new_string ("testrepo"));
+
+  g_variant_builder_add (&refs_builder, "(ssi@a{sv})",
+                         "app/org.test.App/x86_64/stable",
+                         "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                         1,
+                         g_variant_builder_end (&metadata_builder));
+
+  return g_variant_ref_sink (g_variant_builder_end (&refs_builder));
+}
+
+static GVariant *
+build_test_options (const char *registry_uri)
+{
+  GVariantBuilder options_builder;
+
+  g_variant_builder_init (&options_builder, G_VARIANT_TYPE ("a{sv}"));
+  g_variant_builder_add (&options_builder, "{sv}",
+                         "xa.oci-registry-uri",
+                         g_variant_new_string (registry_uri));
+
+  return g_variant_ref_sink (g_variant_builder_end (&options_builder));
+}
+
+static void
+do_request_ref_tokens (FlatpakAuthenticator *authenticator,
+                       const char *registry_uri,
+                       TestData *data)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(AutoFlatpakAuthenticatorRequest) request = NULL;
+  g_autoptr(GVariant) refs = NULL;
+  g_autoptr(GVariant) options = NULL;
+  g_autoptr(GVariant) auth_options = NULL;
+
+  data->done = FALSE;
+  data->response_code = -1;
+
+  request = flatpak_auth_create_request (authenticator, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (request);
+
+  g_signal_connect (request, "basic-auth", G_CALLBACK (on_basic_auth), data);
+  g_signal_connect (request, "response", G_CALLBACK (on_response), data);
+
+  refs = build_test_refs (registry_uri);
+  options = build_test_options (registry_uri);
+  auth_options = g_variant_ref_sink (g_variant_new_array (G_VARIANT_TYPE ("{sv}"), NULL, 0));
+
+  g_object_set_data_full (G_OBJECT (authenticator), "authenticator-options",
+                          g_variant_ref (auth_options), (GDestroyNotify) g_variant_unref);
+
+  if (!flatpak_auth_request_ref_tokens (authenticator, request,
+                                        "test-remote", registry_uri,
+                                        refs, options, "",
+                                        NULL, &error))
+    {
+      g_error ("RequestRefTokens failed: %s", error->message);
+    }
+
+  while (!data->done)
+    g_main_context_iteration (NULL, TRUE);
+}
+
+static void
+test_credential_cache (void)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(AutoFlatpakAuthenticator) authenticator = NULL;
+  g_autofree char *registry_uri = NULL;
+  g_autofree char *port_str = NULL;
+  TestData data = { 0 };
+
+  g_file_get_contents ("httpd-port", &port_str, NULL, &error);
+  g_assert_no_error (error);
+  g_strstrip (port_str);
+  registry_uri = g_strdup_printf ("http://127.0.0.1:%s", port_str);
+
+  authenticator = flatpak_authenticator_proxy_new_for_bus_sync (
+    G_BUS_TYPE_SESSION,
+    G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
+    "org.flatpak.Authenticator.Oci",
+    FLATPAK_AUTHENTICATOR_OBJECT_PATH,
+    NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (authenticator);
+
+  /* First request: should trigger BasicAuth */
+  do_request_ref_tokens (authenticator, registry_uri, &data);
+  g_assert_cmpuint (data.response_code, ==, FLATPAK_AUTH_RESPONSE_OK);
+  g_assert_cmpint (data.basic_auth_count, ==, 1);
+
+  /* Second request: should use cached credentials, no BasicAuth */
+  do_request_ref_tokens (authenticator, registry_uri, &data);
+  g_assert_cmpuint (data.response_code, ==, FLATPAK_AUTH_RESPONSE_OK);
+  g_assert_cmpint (data.basic_auth_count, ==, 1);
+}
+
+int
+main (int argc, char **argv)
+{
+  test_credential_cache ();
+  return 0;
+}

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..1"
+echo "1..6"
 
 # Start the fake OCI registry server
 
@@ -52,18 +52,110 @@ $client add hello latest "$(pwd)/oci/app-image"
 ${FLATPAK} remote-add ${U} oci-auth-registry "oci+http://127.0.0.1:${port}" \
     --authenticator-name org.flatpak.Authenticator.test >&2
 
-# Test: install from an auth-protected OCI registry
-#
-# The registry requires a bearer token for all /v2/ requests.  The client
-# authenticates via the mock authenticator and completes the installation
-# successfully.
+# Test: install from an auth-protected registry
 
 echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
-$client configure-auth --token token-1
+$client set-auth --token token-1
 
 ${FLATPAK} ${U} install -y oci-auth-registry org.test.Hello >&2
 
 run org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
-ok "install from auth-protected OCI registry"
+ok "install"
+
+# Test: token expires during install on manifest fetch
+
+$client reset-auth
+${FLATPAK} ${U} uninstall -y org.test.Hello >&2
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/manifests/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} install -y oci-auth-registry org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandbox$'
+
+ok "install with token expiry on manifest fetch"
+
+# Test: token expires during install on blob fetch
+
+$client reset-auth
+${FLATPAK} ${U} uninstall -y org.test.Hello >&2
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/blobs/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} install -y oci-auth-registry org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandbox$'
+
+ok "install with token expiry on blob fetch"
+
+# Test: update from an auth-protected registry
+
+$client reset-auth
+make_updated_app oci "" "" UPDATE
+
+${FLATPAK} build-bundle --oci $FL_GPGARGS repos/oci oci/app-image org.test.Hello >&2
+$client add hello latest "$(pwd)/oci/app-image"
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE$'
+
+ok "update"
+
+# Test: token expires during update on manifest fetch
+
+$client reset-auth
+make_updated_app oci "" "" UPDATE1
+
+${FLATPAK} build-bundle --oci $FL_GPGARGS repos/oci oci/app-image org.test.Hello >&2
+$client add hello latest "$(pwd)/oci/app-image"
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/manifests/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE1$'
+
+ok "update with token expiry on manifest fetch"
+
+# Test: token expires during update on blob fetch
+
+$client reset-auth
+make_updated_app oci "" "" UPDATE2
+
+${FLATPAK} build-bundle --oci $FL_GPGARGS repos/oci oci/app-image org.test.Hello >&2
+$client add hello latest "$(pwd)/oci/app-image"
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/blobs/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE2$'
+
+ok "update with token expiry on blob fetch"

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..6"
+echo "1..7"
 
 # Start the fake OCI registry server
 
@@ -159,3 +159,15 @@ run org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE2$'
 
 ok "update with token expiry on blob fetch"
+
+# Test: credential cache avoids repeated BasicAuth prompts.
+# Uses the real org.flatpak.Authenticator.Oci (not the mock test authenticator).
+# dXNlcjpwYXNz = base64("user:pass"), must match the C binary's BasicAuthReply args.
+
+$client reset-auth
+$client set-auth --token token-1 --basic-auth dXNlcjpwYXNz
+
+# shellcheck disable=SC2154
+${test_builddir}/test-oci-auth-cache
+
+ok "credential cache reuses basic auth"

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -158,4 +158,16 @@ assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE2$'
 
 ok "update with token expiry on blob fetch"
 
+# Test: credential cache avoids repeated BasicAuth prompts.
+# Uses the real org.flatpak.Authenticator.Oci (not the mock test authenticator).
+# dXNlcjpwYXNz = base64("user:pass"), must match the C binary's BasicAuthReply args.
+
+$client reset-auth
+$client set-auth --token token-1 --basic-auth dXNlcjpwYXNz
+
+# shellcheck disable=SC2154
+${test_builddir}/test-oci-auth-cache
+
+ok "credential cache reuses basic auth"
+
 done_testing

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -50,20 +50,112 @@ $client add hello latest "$(pwd)/oci/app-image"
 ${FLATPAK} remote-add ${U} oci-auth-registry "oci+http://127.0.0.1:${port}" \
     --authenticator-name org.flatpak.Authenticator.test >&2
 
-# Test: install from an auth-protected OCI registry
-#
-# The registry requires a bearer token for all /v2/ requests.  The client
-# authenticates via the mock authenticator and completes the installation
-# successfully.
+# Test: install from an auth-protected registry
 
 echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
-$client configure-auth --token token-1
+$client set-auth --token token-1
 
 ${FLATPAK} ${U} install -y oci-auth-registry org.test.Hello >&2
 
 run org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
-ok "install from auth-protected OCI registry"
+ok "install"
+
+# Test: token expires during install on manifest fetch
+
+$client reset-auth
+${FLATPAK} ${U} uninstall -y org.test.Hello >&2
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/manifests/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} install -y oci-auth-registry org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandbox$'
+
+ok "install with token expiry on manifest fetch"
+
+# Test: token expires during install on blob fetch
+
+$client reset-auth
+${FLATPAK} ${U} uninstall -y org.test.Hello >&2
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/blobs/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} install -y oci-auth-registry org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandbox$'
+
+ok "install with token expiry on blob fetch"
+
+# Test: update from an auth-protected registry
+
+$client reset-auth
+make_updated_app oci "" "" UPDATE
+
+${FLATPAK} build-bundle --oci $FL_GPGARGS repos/oci oci/app-image org.test.Hello >&2
+$client add hello latest "$(pwd)/oci/app-image"
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE$'
+
+ok "update"
+
+# Test: token expires during update on manifest fetch
+
+$client reset-auth
+make_updated_app oci "" "" UPDATE1
+
+${FLATPAK} build-bundle --oci $FL_GPGARGS repos/oci oci/app-image org.test.Hello >&2
+$client add hello latest "$(pwd)/oci/app-image"
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/manifests/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE1$'
+
+ok "update with token expiry on manifest fetch"
+
+# Test: token expires during update on blob fetch
+
+$client reset-auth
+make_updated_app oci "" "" UPDATE2
+
+${FLATPAK} build-bundle --oci $FL_GPGARGS repos/oci oci/app-image org.test.Hello >&2
+$client add hello latest "$(pwd)/oci/app-image"
+
+echo -n "token-1" > "${XDG_RUNTIME_DIR}/required-token"
+$client set-auth --token token-1 \
+    --expire-on-path '/v2/*/blobs/*' \
+    --next-token token-2 \
+    --token-update-file "${XDG_RUNTIME_DIR}/required-token"
+
+${FLATPAK} ${U} update -y org.test.Hello >&2
+
+run org.test.Hello > hello_out
+assert_file_has_content hello_out '^Hello world, from a sandboxUPDATE2$'
+
+ok "update with token expiry on blob fetch"
 
 done_testing


### PR DESCRIPTION
(This is a revised implementation of https://github.com/flatpak/flatpak/pull/6639)

Bearer tokens can expire mid-transaction when downloads take longer than
the token lifetime. Add a token refresh mechanism so the OCI registry
layer can transparently retry a failed HTTP request after obtaining a
fresh token.

Introduce FlatpakTokenProvider, a GObject that holds references to the
transaction and current operation. Its refresh_token method re-invokes
request_tokens_for_remote() to get a fresh token from the authenticator;
get_token returns the current token from the operation. Replace the plain
const char *token parameter on OCI code path functions with this object,
storing it on FlatpakOciRegistry so the three HTTP call sites
(remote_load_file, download_blob, mirror_blob) can attempt one refresh
and retry on 401.

Related to https://github.com/flatpak/flatpak/issues/4862

Assisted-by: Cursor