### PR TITLE
dir: Ignore system bus failures in parental controls check

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9448,8 +9448,17 @@ flatpak_dir_check_parental_controls (FlatpakDir    *self,
   dbus_connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, cancellable, &local_error);
   if (dbus_connection == NULL)
     {
-      g_propagate_error (error, g_steal_pointer (&local_error));
-      return FALSE;
+      /* Since the checks below allow access when malcontent or
+       * accounts-service aren't available on the bus, this whole routine can
+       * be trivially bypassed by setting DBUS_SYSTEM_BUS_ADDRESS to a
+       * temporary dbus-daemon. Not being able to connect to the system bus is
+       * basically equivalent.
+       */
+      g_debug ("Skipping parental controls check for %s since D-Bus system "
+               "bus connection failed: %s",
+               ref,
+               local_error ? local_error->message : "unknown reason");
+      return TRUE;
     }
 
   if (self->subject)


### PR DESCRIPTION
Being unable to access the system-bus is nto a security boundry since,
in that case it's trivial to start your own session and set
DBUS_SYSTEM_BUS_ADDRESS. This is the same fix as 3afdfd2 but for handling
installation instead. See said commit for more details.

Adapted from #5609
Fixes #5076

Co-authored-by: Dan Nicholson <dbn@endlessaccess.org>
