### PR TITLE
system-helper: Authenticate via polkit for system wide downgrades

### DIFF
--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -197,6 +197,7 @@ typedef enum {
   FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT = 1 << 6,
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED = 1 << 7,
   FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PREINSTALLED = 1 << 8,
+  FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE     = 1 << 9,
 } FlatpakHelperDeployFlags;
 
 #define FLATPAK_HELPER_DEPLOY_FLAGS_ALL (FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE | \
@@ -207,7 +208,8 @@ typedef enum {
                                          FLATPAK_HELPER_DEPLOY_FLAGS_APP_HINT | \
                                          FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT | \
                                          FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED | \
-                                         FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PREINSTALLED)
+                                         FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PREINSTALLED | \
+                                         FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE)
 
 typedef enum {
   FLATPAK_HELPER_UNINSTALL_FLAGS_NONE = 0,
@@ -623,6 +625,7 @@ gboolean              flatpak_dir_pull_untrusted_local                      (Fla
                                                                              const char                    *remote_name,
                                                                              const char                    *ref,
                                                                              const char                   **subpaths,
+                                                                             FlatpakPullFlags               flags,
                                                                              FlatpakProgress               *progress,
                                                                              GCancellable                  *cancellable,
                                                                              GError                       **error);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -7211,6 +7211,7 @@ flatpak_dir_pull_untrusted_local (FlatpakDir          *self,
                                   const char          *remote_name,
                                   const char          *ref,
                                   const char         **subpaths,
+                                  FlatpakPullFlags     flags,
                                   FlatpakProgress     *progress,
                                   GCancellable        *cancellable,
                                   GError             **error)
@@ -7311,7 +7312,7 @@ flatpak_dir_pull_untrusted_local (FlatpakDir          *self,
       old_timestamp = ostree_commit_get_timestamp (old_commit);
       new_timestamp = ostree_commit_get_timestamp (new_commit);
 
-      if (new_timestamp < old_timestamp)
+      if (new_timestamp < old_timestamp && !(flags & FLATPAK_PULL_FLAGS_ALLOW_DOWNGRADE))
         return flatpak_fail_error (error, FLATPAK_ERROR_DOWNGRADE, "Not allowed to downgrade %s (old_commit: %s/%" G_GINT64_FORMAT " new_commit: %s/%" G_GINT64_FORMAT ")",
                                    ref, current_checksum, old_timestamp, checksum, new_timestamp);
     }
@@ -11556,11 +11557,10 @@ flatpak_dir_update (FlatpakDir                           *self,
       gboolean gpg_verify;
       gboolean is_revokefs_pull = FALSE;
 
-      if (allow_downgrade)
-        return flatpak_fail_error (error, FLATPAK_ERROR_DOWNGRADE,
-                                   _("Can't update to a specific commit without root permissions"));
-
       helper_flags = FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE;
+
+      if (allow_downgrade)
+        helper_flags |= FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE;
 
       if (!ostree_repo_remote_get_gpg_verify_summary (self->repo, state->remote_name,
                                                       &gpg_verify_summary, error))

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -368,6 +368,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   gboolean reinstall;
   gboolean update_pinned;
   gboolean update_preinstalled;
+  gboolean allow_downgrade;
   g_autofree char *url = NULL;
   g_autoptr(OngoingPull) ongoing_pull = NULL;
   g_autofree gchar *src_dir = NULL;
@@ -444,6 +445,7 @@ handle_deploy (FlatpakSystemHelper   *object,
   reinstall = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL) != 0;
   update_pinned = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PINNED) != 0;
   update_preinstalled = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_UPDATE_PREINSTALLED) != 0;
+  allow_downgrade = (arg_flags & FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE) != 0;
 
   deploy_dir = flatpak_dir_get_if_deployed (system, ref, NULL, NULL);
 
@@ -592,6 +594,7 @@ handle_deploy (FlatpakSystemHelper   *object,
                                              arg_origin,
                                              arg_ref,
                                              (const char **) arg_subpaths,
+                                             allow_downgrade ? FLATPAK_PULL_FLAGS_ALLOW_DOWNGRADE : FLATPAK_PULL_FLAGS_NONE,
                                              NULL, NULL, &error))
         {
           flatpak_invocation_return_error (invocation, error, "Error pulling from repo");
@@ -625,7 +628,8 @@ handle_deploy (FlatpakSystemHelper   *object,
         }
 
       if (!flatpak_dir_pull (system, state, arg_ref, NULL, (const char **) arg_subpaths, NULL, NULL, NULL, NULL, NULL,
-                             FLATPAK_PULL_FLAGS_NONE, OSTREE_REPO_PULL_FLAGS_UNTRUSTED, NULL,
+                             allow_downgrade ? FLATPAK_PULL_FLAGS_ALLOW_DOWNGRADE : FLATPAK_PULL_FLAGS_NONE,
+                             OSTREE_REPO_PULL_FLAGS_UNTRUSTED, NULL,
                              NULL, &error))
         {
           flatpak_invocation_return_error (invocation, error, "Error pulling from repo");
@@ -800,6 +804,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
                                              arg_origin,
                                              new_branch,
                                              NULL,
+                                             FLATPAK_PULL_FLAGS_NONE,
                                              NULL,
                                              NULL, &first_error))
         {
@@ -807,6 +812,7 @@ handle_deploy_appstream (FlatpakSystemHelper   *object,
                                                  arg_origin,
                                                  old_branch,
                                                  NULL,
+                                                 FLATPAK_PULL_FLAGS_NONE,
                                                  NULL,
                                                  NULL, &second_error))
             {
@@ -1945,9 +1951,19 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
           else
             {
               if (is_app)
-                action = "org.freedesktop.Flatpak.app-update";
+                {
+                  if ((flags & FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE) != 0)
+                    action = "org.freedesktop.Flatpak.app-downgrade";
+                  else
+                    action = "org.freedesktop.Flatpak.app-update";
+                }
               else
-                action = "org.freedesktop.Flatpak.runtime-update";
+                {
+                  if ((flags & FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE) != 0)
+                    action = "org.freedesktop.Flatpak.runtime-downgrade";
+                  else
+                    action = "org.freedesktop.Flatpak.runtime-update";
+                }
             }
         }
 

--- a/system-helper/org.freedesktop.Flatpak.policy.in
+++ b/system-helper/org.freedesktop.Flatpak.policy.in
@@ -86,6 +86,50 @@
     </defaults>
   </action>
 
+  <action id="org.freedesktop.Flatpak.app-downgrade">
+    <!-- SECURITY:
+          - Normal users need admin authentication to downgrade an
+            application system-wide, as downgrading may install an older
+            version with known vulnerabilities or unverified changes.
+          - Note that we install polkit rules that allow local users
+            in the wheel group to downgrade without authenticating.
+          - Note that authorizing this action also authorizes
+            org.freedesktop.Flatpak.app-update, as a downgrade implies
+            the ability to update.
+     -->
+    <description>Update application to older version</description>
+    <message>Authentication is required to downgrade an application</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.Flatpak.app-update</annotate>
+  </action>
+
+  <action id="org.freedesktop.Flatpak.runtime-downgrade">
+    <!-- SECURITY:
+          - Normal users need admin authentication to downgrade a
+            runtime system-wide, as downgrading may install an older
+            version with known vulnerabilities or unverified changes.
+          - Note that we install polkit rules that allow local users
+            in the wheel group to downgrade without authenticating.
+          - Note that authorizing this action also authorizes
+            org.freedesktop.Flatpak.runtime-update, as a downgrade implies
+            the ability to update.
+     -->
+    <description>Update runtime to older version</description>
+    <message>Authentication is required to downgrade a runtime</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.Flatpak.runtime-update</annotate>
+  </action>
+
   <action id="org.freedesktop.Flatpak.update-remote">
     <!-- SECURITY:
           - Normal users do not need authentication to update metadata


### PR DESCRIPTION
Downgrading an app or runtime previously failed outright for non root users calling through the system helper, with an error stating that updating to a specific commit requires root permissions.

Instead, allow downgrades through the system helper by introducing a new flag that is set when the caller requests a downgrade. New "org.freedesktop.Flatpak.app-downgrade" and "runtime-downgrade" polkit actions are added that require auth_admin_keep for active users.

Closes #3831 