### PR TITLE
flatpak_set_tty_echo: call tcsetattr() only if needed

### DIFF
--- a/app/flatpak-tty-utils.c
+++ b/app/flatpak-tty-utils.c
@@ -427,6 +427,9 @@ flatpak_set_tty_echo (gboolean echo)
   tcgetattr (STDIN_FILENO, &term);
   was = (term.c_lflag & ECHO) != 0;
 
+  if (was == echo)
+    return was;
+
   if (echo)
     term.c_lflag |= ECHO;
   else


### PR DESCRIPTION
Prevent SIGTTOU when running in background.
Consider adding test if in backgrount on a proper place
    if (getpgrp() != tcgetpgrp(STDIN_FILENO))