### PR TITLE
transaction: Add flatpak_transaction_progress_get_bytes_per_second()

### DIFF
--- a/common/flatpak-progress-private.h
+++ b/common/flatpak-progress-private.h
@@ -74,6 +74,7 @@ void flatpak_progress_set_update_interval (FlatpakProgress *self,
 guint64 flatpak_progress_get_bytes_transferred (FlatpakProgress *self);
 guint64 flatpak_progress_get_transferred_extra_data_bytes (FlatpakProgress *self);
 guint64 flatpak_progress_get_start_time (FlatpakProgress *self);
+guint64 flatpak_progress_get_bytes_per_second (FlatpakProgress *self);
 const char *flatpak_progress_get_status (FlatpakProgress *self);
 int flatpak_progress_get_progress (FlatpakProgress *self);
 gboolean flatpak_progress_get_estimating (FlatpakProgress *self);

--- a/common/flatpak-progress.c
+++ b/common/flatpak-progress.c
@@ -113,6 +113,7 @@ struct _FlatpakProgress
   /* Self-progress-reporting fields, not from OSTree */
   guint   progress;
   guint   last_total;
+  guint64 bytes_per_second;
 
   guint32 update_interval;
 
@@ -190,6 +191,7 @@ update_status_progress_and_estimating (FlatpakProgress *self)
      extra data, so ignore those */
   if (self->requested == 0)
     {
+      self->bytes_per_second = 0;
       return;
     }
 
@@ -209,6 +211,7 @@ update_status_progress_and_estimating (FlatpakProgress *self)
     {
       g_string_append (buf, self->ostree_status);
       new_progress = 100;
+      self->bytes_per_second = 0;
       goto out;
     }
 
@@ -302,8 +305,14 @@ update_status_progress_and_estimating (FlatpakProgress *self)
 
   if (elapsed_time > 0) // Ignore first second
     {
-      g_autofree gchar *formatted_bytes_sec = g_format_size (total_transferred / elapsed_time);
+      g_autofree gchar *formatted_bytes_sec = NULL;
+      self->bytes_per_second = total_transferred / elapsed_time;
+      formatted_bytes_sec = g_format_size (self->bytes_per_second);
       g_string_append_printf (buf, " (%s/s)", formatted_bytes_sec);
+    }
+  else
+    {
+      self->bytes_per_second = 0;
     }
 
 out:
@@ -480,6 +489,12 @@ guint64
 flatpak_progress_get_start_time (FlatpakProgress *self)
 {
   return self->start_time;
+}
+
+guint64
+flatpak_progress_get_bytes_per_second (FlatpakProgress *self)
+{
+  return self->bytes_per_second;
 }
 
 const char *

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -395,6 +395,22 @@ flatpak_transaction_progress_get_start_time (FlatpakTransactionProgress *self)
   return flatpak_progress_get_start_time (self->progress_obj);
 }
 
+/**
+ * flatpak_transaction_progress_get_bytes_per_second:
+ * @self: a #FlatpakTransactionProgress
+ *
+ * Gets the current transfer speed in bytes per second. Returns 0 during
+ * the first second of a transfer while the rate is being established.
+ *
+ * Returns: the current transfer rate in bytes per second
+ * Since: 1.19.0
+ */
+guint64
+flatpak_transaction_progress_get_bytes_per_second (FlatpakTransactionProgress *self)
+{
+  return flatpak_progress_get_bytes_per_second (self->progress_obj);
+}
+
 static void
 flatpak_transaction_progress_finalize (GObject *object)
 {

--- a/common/flatpak-transaction.h
+++ b/common/flatpak-transaction.h
@@ -175,6 +175,8 @@ FLATPAK_EXTERN
 guint64     flatpak_transaction_progress_get_bytes_transferred (FlatpakTransactionProgress *self);
 FLATPAK_EXTERN
 guint64     flatpak_transaction_progress_get_start_time (FlatpakTransactionProgress *self);
+FLATPAK_EXTERN
+guint64     flatpak_transaction_progress_get_bytes_per_second (FlatpakTransactionProgress *self);
 
 
 FLATPAK_EXTERN


### PR DESCRIPTION
Right now this mirrors the cli formula for the connection speed.

We could go for a different formula, e.g. speed the last few seconds, but that might be confusing.