### PR TITLE
run: don't abort the launch when an optional dri device node is inaccessible

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -334,6 +334,26 @@ flatpak_run_evaluate_conditions (FlatpakContextConditions condition)
     }
 }
 
+/* Bind an optional device node into the sandbox if the host node exists
+ * and is accessible. bwrap aborts the whole launch when it cannot stat a
+ * bind source (e.g. an LSM denies the stat even though the node exists),
+ * so probe with lstat() — the same call bwrap performs — and skip the
+ * node with a notice instead of failing the launch. A missing node stays
+ * silently skipped, matching the previous G_FILE_TEST_EXISTS behavior;
+ * note that --dev-bind-try would not cover this, because bubblewrap only
+ * tolerates ENOENT there, not e.g. EACCES. */
+static void
+add_dev_node_args (FlatpakBwrap *bwrap,
+                   const char   *path)
+{
+  struct stat st;
+
+  if (lstat (path, &st) == 0)
+    flatpak_bwrap_add_args (bwrap, "--dev-bind", path, path, NULL);
+  else if (errno != ENOENT)
+    g_info ("Not sharing device %s with sandbox: %s", path, g_strerror (errno));
+}
+
 /*
  * @per_app_dir_lock_fd: If >= 0, make use of per-app directories in
  *  the host's XDG_RUNTIME_DIR to share /tmp between instances.
@@ -499,10 +519,7 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
           };
 
           for (i = 0; i < G_N_ELEMENTS (dri_devices); i++)
-            {
-              if (g_file_test (dri_devices[i], G_FILE_TEST_EXISTS))
-                flatpak_bwrap_add_args (bwrap, "--dev-bind", dri_devices[i], dri_devices[i], NULL);
-            }
+            add_dev_node_args (bwrap, dri_devices[i]);
 
           /* Each Nvidia card gets its own device.
              This is a fairly arbitrary limit but ASUS sells mining boards supporting 20 in theory. */
@@ -510,8 +527,7 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
           for (i = 0; i < 20; i++)
             {
               g_snprintf (nvidia_dev, sizeof (nvidia_dev), "/dev/nvidia%d", i);
-              if (g_file_test (nvidia_dev, G_FILE_TEST_EXISTS))
-                flatpak_bwrap_add_args (bwrap, "--dev-bind", nvidia_dev, nvidia_dev, NULL);
+              add_dev_node_args (bwrap, nvidia_dev);
             }
         }
 


### PR DESCRIPTION
## Problem

The dri device list is probed with `g_file_test (G_FILE_TEST_EXISTS)`, which resolves to `access(F_OK)` and only needs path resolution. bwrap then `lstat()`s every bind source in `setup_newroot()` and treats a failure as fatal. On hosts where an LSM denies the stat — e.g. an SELinux confined-user desktop (`staff_u`), where stock policy carries no allow for `staff_t` on `/dev/kfd`'s `hsa_device_t` and the denial is dontaudit-suppressed — the existence test passes, bwrap dies with `Can't get type of source /dev/kfd: Permission denied`, and every `--device=dri` application aborts at sandbox construction. First real-world reproducer: the Fedora Thunderbird flatpak on a Fedora 44 AMD host after updating to Flatpak 1.18.

## Fix

Probe optional device nodes with `lstat()` — the same call bwrap will make — and skip an inaccessible node with a notice in the existing "Not sharing ... with sandbox" style instead of failing the launch. A missing node stays silently skipped, matching previous behavior. Applied to the dri device list and the per-card nvidia loop (same pattern, same trap).

Note that switching to `--dev-bind-try` would not cover this case: bubblewrap's `ALLOW_NOTEXIST` tolerates only `ENOENT`, not `EACCES`.

The second suggestion from #6690 (a separate/conditional `kfd` device token, so compute access is opt-in rather than riding along with every `dri` declaration) is an API design question and deliberately not part of this PR.

## Testing

- `meson compile` clean, `testcommon` / `test-context` / `test-exports` / `test-instance` pass.
- The failure mode itself was reproduced and root-caused on a Fedora 44 `staff_u` desktop (AVC-silent EACCES on the bwrap bind-source stat).

Fixes #6690

🤖 Generated with [Claude Code](https://claude.com/claude-code)