### PR TITLE
run: Error out if file forwarding of empty paths is attempted

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2724,6 +2724,9 @@ add_rest_args (FlatpakBwrap   *bwrap,
             }
           else
             file = g_file_new_for_path (args[i]);
+
+          if (flatpak_file_get_path_cached (file) == NULL)
+            return flatpak_fail (error, _("Invalid path ‘%s’"), args[i]);
         }
 
       if (file && !flatpak_exports_path_is_visible (exports,


### PR DESCRIPTION
The file forwarding feature errors out when the path or URI does not lead to an actual file that can be forwarded. The empty path never describes an actual file, so we always have to error out.

Without the check, we would get a NULL path from
`flatpak_file_get_path_cached` and crash later.

Closes: #6689