### PR TITLE
Don't attempt to export metainfo releases.xml files twice

### DIFF
--- a/app/flatpak-builtins-build-finish.c
+++ b/app/flatpak-builtins-build-finish.c
@@ -239,7 +239,6 @@ collect_exports (GFile          *base,
     "share/krunner/dbusplugins",          /* KDE krunner DBus plugins */
     "share/appdata",                      /* Copy appdata/metainfo files (legacy path) */
     "share/metainfo",                     /* Copy appdata/metainfo files */
-    "share/metainfo/releases",            /* Copy AppStream release files */
     NULL,
   };
 

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -8997,7 +8997,6 @@ flatpak_export_dir (GFile        *source,
     "share/krunner/dbusplugins",           "../../..",
     "share/mime/packages",                 "../../..",
     "share/metainfo",                      "../..",
-    "share/metainfo/releases",             "../../..",
     "bin",                                 "..",
   };
   int i;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -411,6 +411,7 @@ tests = {
   'preinstall': {},
   'run-custom': {'wrap': ['user', 'system']},
   'upgrade-from-header': {'wrap': ['user', 'system', 'system-norevokefs']},
+  'metainfo-export': {},
 }
 
 wrapped_tests = []

--- a/tests/test-metainfo-export.sh
+++ b/tests/test-metainfo-export.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Mia McMahill <electricbrass@proton.me>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+source "$(dirname "$0")/libtest.sh"
+
+echo "1..2"
+
+setup_repo
+install_repo
+
+APP_DIR="$(mktemp -d)"
+APP_ID="org.test.MetainfoReleases"
+
+$FLATPAK build-init "$APP_DIR" "$APP_ID" org.test.Platform org.test.Platform >&2
+
+mkdir -p "${APP_DIR}/files/share/metainfo/"
+mkdir -p "${APP_DIR}/files/share/metainfo/releases"
+
+cat <<EOF > "${APP_DIR}/files/share/metainfo/${APP_ID}.metainfo.xml"
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop-application">
+  <id>${APP_ID}</id>
+  <metadata_license></metadata_license>
+  <name>Metainfo Releases Export Test</name>
+  <summary>Test metainfo releases.xml export</summary>
+  <description><p>This is a test app.</p></description>
+  <releases type="external"/>
+</component>
+EOF
+
+cat <<EOF > "${APP_DIR}/files/share/metainfo/releases/${APP_ID}.releases.xml"
+<releases>
+  <release version="1.0.0" date="2026-06-14"/>
+</releases>
+EOF
+
+$FLATPAK build-finish "$APP_DIR" >&2
+
+assert_has_file "${APP_DIR}/export/share/metainfo/${APP_ID}.metainfo.xml"
+assert_file_has_content "${APP_DIR}/export/share/metainfo/${APP_ID}.metainfo.xml" \
+  '<name>Metainfo Releases Export Test</name>'
+assert_has_file "${APP_DIR}/export/share/metainfo/releases/${APP_ID}.releases.xml"
+assert_file_has_content "${APP_DIR}/export/share/metainfo/releases/${APP_ID}.releases.xml" \
+  '<release version="1.0.0" date="2026-06-14"/>'
+
+ok "build-finish exported metainfo and releases"
+
+REPO="$(mktemp -d)"
+
+$FLATPAK build-export "$REPO" "$APP_DIR" >&2
+
+$FLATPAK ${U} install -y "$REPO" "$APP_ID" >&2
+
+assert_has_file "${FL_DIR}/exports/share/metainfo/${APP_ID}.metainfo.xml"
+assert_file_has_content "${APP_DIR}/export/share/metainfo/${APP_ID}.metainfo.xml" \
+  '<name>Metainfo Releases Export Test</name>'
+assert_has_file "${FL_DIR}/exports/share/metainfo/releases/${APP_ID}.releases.xml"
+assert_file_has_content "${APP_DIR}/export/share/metainfo/releases/${APP_ID}.releases.xml" \
+  '<release version="1.0.0" date="2026-06-14"/>'
+
+ok "install exported metainfo and releases"


### PR DESCRIPTION
Fixes #6695

Removes unnecessary duplicate directories from export steps that would cause errors when trying to export the same file multiple times.

I'm not very familiar with how all the tests are set up, so hopefully I did it right. It seems to work at least.