### PR TITLE
Improve handling of null and missing elements in OCI JSON files

### DIFF
--- a/common/flatpak-json-oci.c
+++ b/common/flatpak-json-oci.c
@@ -88,9 +88,9 @@ flatpak_oci_descriptor_free (FlatpakOciDescriptor *self)
 }
 
 static FlatpakJsonProp flatpak_oci_descriptor_props[] = {
-  FLATPAK_JSON_STRING_PROP (FlatpakOciDescriptor, mediatype, "mediaType"),
-  FLATPAK_JSON_STRING_PROP (FlatpakOciDescriptor, digest, "digest"),
-  FLATPAK_JSON_INT64_PROP (FlatpakOciDescriptor, size, "size"),
+  FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciDescriptor, mediatype, "mediaType"),
+  FLATPAK_JSON_MANDATORY_STRING_PROP (FlatpakOciDescriptor, digest, "digest"),
+  FLATPAK_JSON_MANDATORY_INT64_PROP (FlatpakOciDescriptor, size, "size"),
   FLATPAK_JSON_STRV_PROP (FlatpakOciDescriptor, urls, "urls"),
   FLATPAK_JSON_STRMAP_PROP (FlatpakOciDescriptor, annotations, "annotations"),
   FLATPAK_JSON_LAST_PROP
@@ -127,6 +127,10 @@ flatpak_oci_manifest_descriptor_free (FlatpakOciManifestDescriptor *self)
   g_free (self);
 }
 
+/* Note that according to the OCI image spec, architecture and os are mandatory
+ * elements of the `platform` object - but the platform object is itself optional,
+ * so we leave them marked optional here to avoid confusion.
+ */
 static FlatpakJsonProp flatpak_oci_manifest_platform_props[] = {
   FLATPAK_JSON_STRING_PROP (FlatpakOciManifestPlatform, architecture, "architecture"),
   FLATPAK_JSON_STRING_PROP (FlatpakOciManifestPlatform, os, "os"),
@@ -276,8 +280,11 @@ flatpak_oci_manifest_class_init (FlatpakOciManifestClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   FlatpakJsonClass *json_class = FLATPAK_JSON_CLASS (klass);
   static FlatpakJsonProp props[] = {
-    FLATPAK_JSON_STRUCT_PROP (FlatpakOciManifest, config, "config", flatpak_oci_descriptor_props),
-    FLATPAK_JSON_STRUCTV_PROP (FlatpakOciManifest, layers, "layers", flatpak_oci_descriptor_props),
+    FLATPAK_JSON_MANDATORY_STRUCT_PROP (FlatpakOciManifest, config, "config", flatpak_oci_descriptor_props),
+    /* Not marked as REQUIRED in the OCI spec, but also not marked OPTIONAL. A manifest
+     * without layers, is in any case, useless to us.
+     */
+    FLATPAK_JSON_MANDATORY_STRUCTV_PROP (FlatpakOciManifest, layers, "layers", flatpak_oci_descriptor_props),
     FLATPAK_JSON_STRMAP_PROP (FlatpakOciManifest, annotations, "annotations"),
     FLATPAK_JSON_LAST_PROP
   };
@@ -433,7 +440,7 @@ flatpak_oci_index_class_init (FlatpakOciIndexClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   FlatpakJsonClass *json_class = FLATPAK_JSON_CLASS (klass);
   static FlatpakJsonProp props[] = {
-    FLATPAK_JSON_STRUCTV_PROP (FlatpakOciIndex, manifests, "manifests", flatpak_oci_manifest_descriptor_props),
+    FLATPAK_JSON_MANDATORY_STRUCTV_PROP (FlatpakOciIndex, manifests, "manifests", flatpak_oci_manifest_descriptor_props),
     FLATPAK_JSON_STRMAP_PROP (FlatpakOciIndex, annotations, "annotations"),
     FLATPAK_JSON_LAST_PROP
   };

--- a/common/flatpak-json-oci.c
+++ b/common/flatpak-json-oci.c
@@ -595,7 +595,7 @@ flatpak_oci_index_get_manifest_for_arch (FlatpakOciIndex *self,
 
   for (i = 0; self->manifests[i] != NULL; i++)
     {
-      if (strcmp (self->manifests[i]->platform.architecture, oci_arch) == 0)
+      if (g_strcmp0 (self->manifests[i]->platform.architecture, oci_arch) == 0)
         return self->manifests[i];
     }
 

--- a/common/flatpak-json-private.h
+++ b/common/flatpak-json-private.h
@@ -65,6 +65,8 @@ struct _FlatpakJsonProp
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRING, 0, 0, FLATPAK_JSON_PROP_FLAGS_MANDATORY }
 #define FLATPAK_JSON_INT64_PROP(_struct, _field, _name) \
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_INT64 }
+#define FLATPAK_JSON_MANDATORY_INT64_PROP(_struct, _field, _name) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_INT64, 0, 0, FLATPAK_JSON_PROP_FLAGS_MANDATORY }
 #define FLATPAK_JSON_BOOL_PROP(_struct, _field, _name) \
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_BOOL }
 #define FLATPAK_JSON_STRV_PROP(_struct, _field, _name) \
@@ -77,6 +79,10 @@ struct _FlatpakJsonProp
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_BOOLMAP }
 #define FLATPAK_JSON_STRUCT_PROP(_struct, _field, _name, _props) \
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRUCT, (gpointer) _props}
+/* MANDATORY_STRUCT_PROP is one that must be present when demarshalling */
+#define FLATPAK_JSON_MANDATORY_STRUCT_PROP(_struct, _field, _name, _props) \
+  { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRUCT, (gpointer) _props, 0, FLATPAK_JSON_PROP_FLAGS_MANDATORY}
+/* OPT_STRUCT_PROP is one that is not emitted into the result when marshalling if it would be empty */
 #define FLATPAK_JSON_OPT_STRUCT_PROP(_struct, _field, _name, _props) \
   { _name, G_STRUCT_OFFSET (_struct, _field), FLATPAK_JSON_PROP_TYPE_STRUCT, (gpointer) _props, 0, FLATPAK_JSON_PROP_FLAGS_OPTIONAL}
 #define FLATPAK_JSON_STRICT_STRUCT_PROP(_struct, _field, _name, _props) \

--- a/common/flatpak-json.c
+++ b/common/flatpak-json.c
@@ -59,12 +59,18 @@ demarshal (JsonNode            *parent_node,
   JsonObject *parent_object;
   JsonNode *node;
 
+  /* We treat <property>: null the same as missing. While you could
+   * have JSON data structures where the distinction is significant, we
+   * don't need to handle any such.
+   */
+
   if (type != FLATPAK_JSON_PROP_TYPE_PARENT)
     {
       parent_object = json_node_get_object (parent_node);
       node = json_object_get_member (parent_object, name);
 
-      if (node == NULL && (flags & FLATPAK_JSON_PROP_FLAGS_MANDATORY) != 0)
+      if ((node == NULL || JSON_NODE_TYPE (node) == JSON_NODE_NULL)
+          && (flags & FLATPAK_JSON_PROP_FLAGS_MANDATORY) != 0)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                        "No value for mandatory property %s", name);

--- a/common/flatpak-oci-signatures.c
+++ b/common/flatpak-oci-signatures.c
@@ -415,6 +415,7 @@ flatpak_oci_signatures_verify (FlatpakOciSignatures *self,
     {
       g_autoptr(FlatpakOciSignature) signature = NULL;
       g_autoptr(GError) local_error = NULL;
+      g_autofree char *stripped_reference = NULL;
 
       signature = flatpak_oci_verify_signature (repo, remote_name,
                                                 g_ptr_array_index (self->signatures, i),
@@ -439,19 +440,17 @@ flatpak_oci_signatures_verify (FlatpakOciSignatures *self,
           continue;
         }
 
-      if (signature->critical.identity.reference != NULL)
+      /* checked during demarshaling via mandatory properties */
+      g_assert (signature->critical.identity.reference != NULL);
+
+      stripped_reference = reference_strip_tag_and_digest (signature->critical.identity.reference);
+
+      if (g_strcmp0 (expected_identity, stripped_reference) != 0)
         {
-          g_autofree char *stripped = NULL;
-
-          stripped = reference_strip_tag_and_digest (signature->critical.identity.reference);
-
-          if (g_strcmp0 (expected_identity, stripped) != 0)
-            {
-              g_info ("Identity in signature (%s) does not match %s",
-                      signature->critical.identity.reference,
-                      expected_identity);
-              continue;
-            }
+          g_info ("Identity in signature (%s) does not match %s",
+                  signature->critical.identity.reference,
+                  expected_identity);
+          continue;
         }
 
       g_info ("%s: found valid signature for %s@%s",


### PR DESCRIPTION
 * Consistently handle `<property>: null` in the input the same as a missing property.
 * Mark all properties required by the OCI specification as required; this eliminates a bunch of cases where we were assume that descriptor->digest was non-NULL, and potentially generating critical errors from g_return_if_fail()
 * Fix a case where strcmp() was called on a potentially NULL architecture value.