### PR TITLE
[1.18] context: Fixed negated permission string for allow and share options

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -293,7 +293,7 @@ flatpak_permission_to_args (FlatpakPermission *permission,
     {
       /* Completely disallowed */
 
-      g_ptr_array_add (args, g_strdup_printf ("--no%s=%s", argname, name));
+      g_ptr_array_add (args, g_strdup_printf ("--%s=%s", noargname, name));
     }
 }
 


### PR DESCRIPTION
Backport of #6684

It was solved partially in e0e1b20, but not for completely disallowed code path. Steps to reproduce:
1. Run any flatpak with explicit --unshare option, e.g: [user@user-standardpc ~]$ flatpak run --unshare=network --command=bash io.gitlab.librewolf-community
2. Inside flatpak shell spawn any executable: [io.gitlab.librewolf-community ~]$ flatpak-spawn ls / Result is:
error: Unknown option --noshare=network