### PR TITLE
[1.18] instance: Annotate flatpak_instance_get_all as (transfer container)

### DIFF
--- a/common/flatpak-instance.c
+++ b/common/flatpak-instance.c
@@ -1168,7 +1168,7 @@ flatpak_instance_iterate_all_and_gc (GPtrArray *out_instances)
  *
  * Gets FlatpakInstance objects for all running sandboxes in the current session.
  *
- * Returns: (transfer full) (element-type FlatpakInstance): a #GPtrArray of
+ * Returns: (transfer container) (element-type FlatpakInstance): a #GPtrArray of
  *   #FlatpakInstance objects
  *
  * Since: 1.1


### PR DESCRIPTION
Backport of #6696

Annotating the return as (transfer full) causes bindings to additionally unref each element on array free, resulting in a use-after-free.

Change the annotation to (transfer container) so bindings know to unref the array only.

Fixes: https://github.com/flatpak/flatpak/issues/6666