### PR TITLE
completion: Cleanup of Bash completion

### DIFF
--- a/completion/flatpak
+++ b/completion/flatpak
@@ -6,9 +6,11 @@
 __flatpak() {
     local IFS=$'\n'
     local cur=`_get_cword :`
+    local -a RES
     RES=($(flatpak complete "${COMP_LINE}" "${COMP_POINT}" "${cur}"))
 
     COMPREPLY=()
+    local i
     for i in "${!RES[@]}"; do
         if [[ "${RES[$i]}" = "__FLATPAK_FILE" ]]; then
             declare -a COMPGEN_OPTS=('-f')
@@ -23,6 +25,7 @@ __flatpak() {
         fi
 
         if [[ ${#COMPGEN_OPTS[@]} -ne 0 ]]; then
+            local CUR
             if [[ "${cur}" = "=" ]]; then
                 CUR=""
             else

--- a/completion/flatpak
+++ b/completion/flatpak
@@ -11,32 +11,33 @@ __flatpak() {
     readarray -t RES < <(flatpak complete "${COMP_LINE}" "${COMP_POINT}" "${cur}")
 
     COMPREPLY=()
-    local i
+    local res
+    local -a COMPGEN_OPTS
     local -a REPLIES
-    for i in "${!RES[@]}"; do
-        if [[ "${RES[$i]}" = "__FLATPAK_FILE" ]]; then
-            declare -a COMPGEN_OPTS=('-f')
-        elif [[ "${RES[$i]}" = "__FLATPAK_BUNDLE_FILE" ]]; then
-            declare -a COMPGEN_OPTS=('-f' '-X' '!*.flatpak')
-        elif [[ "${RES[$i]}" = "__FLATPAK_BUNDLE_OR_REF_FILE" ]]; then
-            declare -a COMPGEN_OPTS=('-f' '-X' '!*.flatpak@(|ref)')
-        elif [[ "${RES[$i]}" = "__FLATPAK_DIR" ]]; then
-            declare -a COMPGEN_OPTS=('-d')
+    for res in "${RES[@]}"; do
+        if [[ $res == "__FLATPAK_FILE" ]]; then
+            COMPGEN_OPTS=('-f')
+        elif [[ $res == "__FLATPAK_BUNDLE_FILE" ]]; then
+            COMPGEN_OPTS=('-f' '-X' '!*.flatpak')
+        elif [[ $res == "__FLATPAK_BUNDLE_OR_REF_FILE" ]]; then
+            COMPGEN_OPTS=('-f' '-X' '!*.flatpak@(|ref)')
+        elif [[ $res == "__FLATPAK_DIR" ]]; then
+            COMPGEN_OPTS=('-d')
         else
-            declare -a COMPGEN_OPTS=()
+            COMPGEN_OPTS=()
         fi
 
         if [[ ${#COMPGEN_OPTS[@]} -ne 0 ]]; then
             local CUR
-            if [[ "${cur}" = "=" ]]; then
+            if [[ $cur == "=" ]]; then
                 CUR=""
             else
-                CUR="${cur}"
+                CUR="$cur"
             fi
             readarray -t REPLIES < <(compgen "${COMPGEN_OPTS[@]}" -- "${CUR}")
             COMPREPLY+=("${REPLIES[@]}")
         else
-            COMPREPLY=("${COMPREPLY[@]}" "${RES[$i]}")
+            COMPREPLY=("${COMPREPLY[@]}" "$res")
         fi
     done
 }

--- a/completion/flatpak
+++ b/completion/flatpak
@@ -5,12 +5,14 @@
 
 __flatpak() {
     local IFS=$'\n'
-    local cur=`_get_cword :`
+    local cur
     local -a RES
-    RES=($(flatpak complete "${COMP_LINE}" "${COMP_POINT}" "${cur}"))
+    cur=$(_get_cword :)
+    readarray -t RES < <(flatpak complete "${COMP_LINE}" "${COMP_POINT}" "${cur}")
 
     COMPREPLY=()
     local i
+    local -a REPLIES
     for i in "${!RES[@]}"; do
         if [[ "${RES[$i]}" = "__FLATPAK_FILE" ]]; then
             declare -a COMPGEN_OPTS=('-f')
@@ -31,7 +33,8 @@ __flatpak() {
             else
                 CUR="${cur}"
             fi
-            COMPREPLY=("${COMPREPLY[@]}" $(compgen ${COMPGEN_OPTS[@]} -- "${CUR}") )
+            readarray -t REPLIES < <(compgen "${COMPGEN_OPTS[@]}" -- "${CUR}")
+            COMPREPLY+=("${REPLIES[@]}")
         else
             COMPREPLY=("${COMPREPLY[@]}" "${RES[$i]}")
         fi


### PR DESCRIPTION
This is the cleanup and bugfix parts only of #6678. I've split them off into a separate PR so that the fixes don't have to wait on my other PRs that don't actually matter to them.

All shellcheck warnings have been addressed, and 2 fixes have been made:
1. `i`, `RES` and `CUR` are now local instead of global to prevent modifying user's shell session's state
2. `COMPGEN_OPTS` is properly quoted, which is needed for the filters passed to `compgen -X` to be interpreted by `compgen` instead of directly by Bash when expanding `COMPGEN_OPTS`. This makes completion for `flatpak install` not just error out when `failglob` is enabled, and has the filter actually correctly match `.flatpak` and `.flatpakref` files in all cases.

https://github.com/user-attachments/assets/a6b01851-a27c-4379-a98d-c27b08a3acf2