### PR TITLE
ci: Bump actions to latest versions

### DIFF
--- a/.github/workflows/block-autosquash-commits.yml
+++ b/.github/workflows/block-autosquash-commits.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine PR number
         run: |

--- a/.github/workflows/check-potfiles.yml
+++ b/.github/workflows/check-potfiles.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Create logs dir
@@ -73,7 +73,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/meson-logs/* test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() || cancelled()
       with:
         name: test logs
@@ -100,7 +100,7 @@ jobs:
         # One of the tests wants this
         sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
     - name: Check out flatpak
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Create logs dir
@@ -132,7 +132,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/meson-logs/* test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() || cancelled()
       with:
         name: test logs
@@ -171,7 +171,7 @@ jobs:
         libgirepository1.0-dev libappstream-dev libdconf-dev clang e2fslibs-dev meson socat libxau-dev libgdk-pixbuf2.0-dev \
         xmlto libc6-dev
     - name: Check out flatpak
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Configure
@@ -189,7 +189,7 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
     - name: Upload docs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         if-no-files-found: error
         overwrite: true
@@ -214,7 +214,7 @@ jobs:
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat meson libdbus-1-dev \
         valgrind e2fslibs-dev meson libxau-dev libgdk-pixbuf2.0-dev libc6-dev
     - name: Check out flatpak
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Create logs dir
@@ -240,7 +240,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/tests/*.log test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() || cancelled()
       with:
         name: test logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -153,7 +153,7 @@ jobs:
     steps:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -187,7 +187,7 @@ jobs:
       # Can't use `meson compile` here because Ubuntu 20.04 is too old
       run: ninja -C _build
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
     - name: Upload docs
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v4
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           sudo mkdir /tmp/flatpak-com.example.App-OwnedByRoot
 
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build flatpak
         run: |


### PR DESCRIPTION
Node 20 actions are deprecated and CodeQL Action v3 will be deprecated in a few months. I also updated Differential ShellCheck to v5 just to keep it up to date.