### PR TITLE
dir: Don't pass temp repo path to flatpak_dir_log during initial pull

### DIFF
--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -6990,7 +6990,6 @@ flatpak_dir_pull (FlatpakDir                           *self,
   g_autofree char *url = NULL;
   g_autoptr(GPtrArray) subdirs_arg = NULL;
   g_auto(GLnxLockFile) lock = { 0, };
-  g_autofree char *name = NULL;
   g_autofree char *current_checksum = NULL;
 
   if (!flatpak_dir_ensure_repo (self, cancellable, error))
@@ -7125,15 +7124,7 @@ flatpak_dir_pull (FlatpakDir                           *self,
 
   ret = TRUE;
 
-  if (repo == self->repo)
-    name = flatpak_dir_get_name (self);
-  else
-    {
-      GFile *file = ostree_repo_get_path (repo);
-      name = g_file_get_path (file);
-    }
-
-  (flatpak_dir_log) (self, __FILE__, __LINE__, __FUNCTION__, name,
+  (flatpak_dir_log) (self, __FILE__, __LINE__, __FUNCTION__, NULL,
                      "pull", state->remote_name, ref, rev, current_checksum, NULL,
                      "Pulled %s from %s", ref, state->remote_name);
 

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -57,10 +57,7 @@ if ! ${FLATPAK} --installation=history-installation history --since="${HISTORY_S
     exit 1
 fi
 
-# Pulls are logged when system helper is compiled out as they do
-# not go to the temp child repo anymore
-if [ "${HAVE_SYSTEM_HELPER:-1}" = "0" ]; then
-    cat > expected-log << 'EOF'
+cat > expected-log << 'EOF'
 add remote			system (history-installation)	test-repo
 pull	org.test.Hello.Locale	master	system (history-installation)	test-repo
 deploy install	org.test.Hello.Locale	master	system (history-installation)	test-repo
@@ -77,20 +74,6 @@ uninstall	org.test.Platform	master	system (history-installation)
 uninstall	org.test.Hello.Locale	master	system (history-installation)
 remove remote			system (history-installation)	test-repo
 EOF
-else
-    cat > expected-log << 'EOF'
-add remote			system (history-installation)	test-repo
-deploy install	org.test.Hello.Locale	master	system (history-installation)	test-repo
-deploy install	org.test.Platform	master	system (history-installation)	test-repo
-deploy install	org.test.Hello	master	system (history-installation)	test-repo
-deploy update	org.test.Hello.Locale	master	system (history-installation)	test-repo
-deploy update	org.test.Hello	master	system (history-installation)	test-repo
-uninstall	org.test.Hello	master	system (history-installation)
-uninstall	org.test.Platform	master	system (history-installation)
-uninstall	org.test.Hello.Locale	master	system (history-installation)
-remove remote			system (history-installation)	test-repo
-EOF
-fi
 
 diff history-log expected-log >&2
 
@@ -101,10 +84,7 @@ if ! ${FLATPAK} --installation=history-installation history --since="${HISTORY_S
     exit 1
 fi
 
-# Pulls are logged when system helper is compiled out as they do
-# not go to the temp child repo anymore
-if [ "${HAVE_SYSTEM_HELPER:-1}" = "0" ]; then
-    cat > expected-log << 'EOF'
+cat > expected-log << 'EOF'
 [
   {
     "change" : "add remote",
@@ -213,82 +193,6 @@ if [ "${HAVE_SYSTEM_HELPER:-1}" = "0" ]; then
   }
 ]
 EOF
-else
-    cat > expected-log << 'EOF'
-[
-  {
-    "change" : "add remote",
-    "application" : "",
-    "branch" : "",
-    "installation" : "system (history-installation)",
-    "remote" : "test-repo"
-  },
-  {
-    "change" : "deploy install",
-    "application" : "org.test.Hello.Locale",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : "test-repo"
-  },
-  {
-    "change" : "deploy install",
-    "application" : "org.test.Platform",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : "test-repo"
-  },
-  {
-    "change" : "deploy install",
-    "application" : "org.test.Hello",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : "test-repo"
-  },
-  {
-    "change" : "deploy update",
-    "application" : "org.test.Hello.Locale",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : "test-repo"
-  },
-  {
-    "change" : "deploy update",
-    "application" : "org.test.Hello",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : "test-repo"
-  },
-  {
-    "change" : "uninstall",
-    "application" : "org.test.Hello",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : ""
-  },
-  {
-    "change" : "uninstall",
-    "application" : "org.test.Platform",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : ""
-  },
-  {
-    "change" : "uninstall",
-    "application" : "org.test.Hello.Locale",
-    "branch" : "master",
-    "installation" : "system (history-installation)",
-    "remote" : ""
-  },
-  {
-    "change" : "remove remote",
-    "application" : "",
-    "branch" : "",
-    "installation" : "system (history-installation)",
-    "remote" : "test-repo"
-  }
-]
-EOF
-fi
 
 diff history-log expected-log >&2
 


### PR DESCRIPTION
During a system install with the system helper enabled, the initial network pull goes to a temporary repo and then via pull local from that repo to the final system repo while during user install there is only one pull from network to the final repo.

c672c55 set the logger to use the temporary repo path as installation but the history command afc87ad since the same day filters the initial pull out as the installation name will never match the temporary path.

This causes the initial pull operation to be never show up in flatpak history when using system installs while they work for user installs as `INSTALLATION=user`.

This is presumably also broken for custom installations as they will similarly not match the temp repo path.

So don't pass the path at all to flatpak_dir_log and we can later fall back via flatpak_dir_get_name_cached() which sets the correct `INSTALLATION` for system installs ie. `INSTALLATION=system`.

This also allows us to remove the workaround of adding two different expected history outputs from ad1ff6d as both branches log the pull.

Without system helper `flatpak install` needs to be executed as priviledged to operate on system install so the initial pull was always logged correctly for that branch.