### PR TITLE
Support for XDG Projects directory permissions

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1637,6 +1637,16 @@ get_xdg_user_dir_from_string (const char  *filesystem,
         *dir = g_strdup (g_get_user_special_dir (G_USER_DIRECTORY_PICTURES));
       return TRUE;
     }
+#if GLIB_CHECK_VERSION (2, 90, 0)
+  if (strcmp (prefix, "xdg-projects") == 0)
+    {
+      if (config_key)
+        *config_key = "XDG_PROJECTS_DIR";
+      if (dir)
+        *dir = g_strdup (g_get_user_special_dir (G_USER_DIRECTORY_PROJECTS));
+      return TRUE;
+    }
+#endif
   if (strcmp (prefix, "xdg-public-share") == 0)
     {
       if (config_key)

--- a/doc/flatpak-build-finish.xml
+++ b/doc/flatpak-build-finish.xml
@@ -322,7 +322,7 @@
                     Allow the application access to a subset of the filesystem.
                     This updates the [Context] group in the metadata.
                     FS can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-music, xdg-pictures, xdg-projects, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
                     The optional :ro suffix indicates that the location will be read-only.
@@ -342,7 +342,7 @@
                     the application. This overrides to the Context section from the
                     application metadata.
                     FILESYSTEM can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    xdg-music, xdg-pictures, xdg-projects, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
                 </para></listitem>

--- a/doc/flatpak-build.xml
+++ b/doc/flatpak-build.xml
@@ -224,7 +224,7 @@
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
                     <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-music, xdg-pictures, xdg-projects, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
                     path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
                     The optional :ro suffix indicates that the location will be read-only.
@@ -245,7 +245,7 @@
                     the application. This overrides to the Context section from the
                     application metadata.
                     <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    xdg-music, xdg-pictures, xdg-projects, xdg-public-share, xdg-templates, xdg-videos,
                     an absolute path, or a homedir-relative path like ~/dir.
                     This option can be used multiple times.
                 </para></listitem>

--- a/doc/flatpak-metadata.xml
+++ b/doc/flatpak-metadata.xml
@@ -521,6 +521,7 @@ sockets=!x11;x11;if:x11:!has-wayland;
                                 <option>xdg-download</option>,
                                 <option>xdg-music</option>,
                                 <option>xdg-pictures</option>,
+                                <option>xdg-projects</option>,
                                 <option>xdg-public-share</option>,
                                 <option>xdg-videos</option>,
                                 <option>xdg-templates</option>

--- a/doc/flatpak-override.xml
+++ b/doc/flatpak-override.xml
@@ -51,7 +51,7 @@
             <command>flatpak override</command>.
         </para>
         <para>
-            The application overrides are saved in text files residing in $XDG_DATA_HOME/flatpak/overrides in user mode. 
+            The application overrides are saved in text files residing in $XDG_DATA_HOME/flatpak/overrides in user mode.
         </para>
         <para>
             If the application ID <arg choice="plain">APP</arg> is not specified
@@ -301,7 +301,7 @@
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
                     <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-music, xdg-pictures, xdg-projects, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
                     xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths
                     relative to the xdg dirs, like xdg-download/subdir.

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -496,7 +496,7 @@
                     Allow the application access to a subset of the filesystem.
                     This overrides to the Context section from the application metadata.
                     <arg choice="plain">FILESYSTEM</arg> can be one of: home, host, host-os, host-etc, host-root, xdg-desktop, xdg-documents, xdg-download,
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    xdg-music, xdg-pictures, xdg-projects, xdg-public-share, xdg-templates, xdg-videos,
                     xdg-run, xdg-config, xdg-cache, xdg-data,
                     an absolute path, or a homedir-relative path like ~/dir or paths
                     relative to the xdg dirs, like xdg-download/subdir.

--- a/tests/test-exports.c
+++ b/tests/test-exports.c
@@ -562,6 +562,10 @@ static const Filesystem filesystems[] =
   { "xdg-music/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-pictures", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-pictures/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+#if GLIB_CHECK_VERSION(2, 90, 0)
+  { "xdg-projects", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+  { "xdg-projects/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
+#endif
   { "xdg-public-share", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-public-share/Stuff", FLATPAK_FILESYSTEM_MODE_READ_WRITE },
   { "xdg-templates", FLATPAK_FILESYSTEM_MODE_READ_WRITE },


### PR DESCRIPTION
Resolves #6719

Currently a draft because this requires the as-of-yet unreleased GLib 2.90, so the changes are not fully tested.