### PR TITLE
fix: prevent null pointer dereference by validating file object before caching check

### DIFF
--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -2725,7 +2725,7 @@ add_rest_args (FlatpakBwrap   *bwrap,
           else
             file = g_file_new_for_path (args[i]);
 
-          if (flatpak_file_get_path_cached (file) == NULL)
+          if (file && flatpak_file_get_path_cached (file) == NULL)
             return flatpak_fail (error, _("Invalid path ‘%s’"), args[i]);
         }
 

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..27"
+echo "1..30"
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
@@ -608,3 +608,23 @@ assert_file_has_content hello_out "not allowed to avoid sandbox escape"
 assert_not_file_has_content hello_out "secret-file"
 
 ok "--persist doesn't allow sandbox escape via a symlink (CVE-2024-42472)"
+
+run --file-forwarding --command=sh org.test.Hello -c 'echo "$@"' sh @@u https://google.com @@ > file_fwd_out
+assert_file_has_content file_fwd_out "^https://google.com$"
+ok "file-forwarding remote URI"
+
+if $FLATPAK documents &> /dev/null; then
+    echo "test" > local_file.txt
+    run --file-forwarding --command=sh org.test.Hello -c 'echo "$@"' sh @@ local_file.txt @@ > file_fwd_out2
+    assert_file_has_content file_fwd_out2 "/doc/"
+    ok "file-forwarding valid path"
+
+    if run --file-forwarding --command=sh org.test.Hello -c 'echo "$@"' sh @@ "" @@ &> file_fwd_err; then
+        assert_not_reached "Should not be able to forward empty path"
+    fi
+    assert_file_has_content file_fwd_err "Invalid path"
+    ok "file-forwarding empty path"
+else
+    ok "file-forwarding valid path # SKIP (no document portal)"
+    ok "file-forwarding empty path # SKIP (no document portal)"
+fi


### PR DESCRIPTION
Commit c4fce9e4 added a check to fail early when file-forwarding is attempted with empty paths (fixing a crash in #6689). However, the check flatpak_file_get_path_cached (file) == NULL is too broad:

- For empty paths, it returns NULL and correctly errors out.
- For remote web URIs (like https://google.com inside @@u ... @@), the file object is never initialized (NULL), meaning it also evaluates to NULL here and causes Flatpak to throw an Invalid path error.
- This regressed and broke all external link redirects from sandboxed applications (e.g., clicking login links or web links in Fractal or Element) to the host's default web browser.

This was fixed by ensuring we only fail on NULL caches paths if a local file object was created/recognized. URLs are now exempt from this check

Fixes: c4fce9e4 ("run: Error out if file forwarding of empty paths is attempted")