### PR TITLE
Stop using G_GNUC_CONST in _get_type functions

### DIFF
--- a/app/flatpak-polkit-agent-text-listener.h
+++ b/app/flatpak-polkit-agent-text-listener.h
@@ -13,7 +13,7 @@ typedef struct _FlatpakPolkitAgentTextListener FlatpakPolkitAgentTextListener;
 #define FLATPAK_POLKIT_AGENT_TEXT_LISTENER(o)            (G_TYPE_CHECK_INSTANCE_CAST ((o), FLATPAK_POLKIT_AGENT_TYPE_TEXT_LISTENER, FlatpakPolkitAgentTextListener))
 #define FLATPAK_POLKIT_AGENT_IS_TEXT_LISTENER(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), FLATPAK_POLKIT_AGENT_TYPE_TEXT_LISTENER))
 
-GType                flatpak_polkit_agent_text_listener_get_type (void) G_GNUC_CONST;
+GType                flatpak_polkit_agent_text_listener_get_type (void);
 PolkitAgentListener *flatpak_polkit_agent_text_listener_new (GCancellable   *cancellable,
                                                              GError        **error);
 

--- a/common/flatpak-chain-input-stream-private.h
+++ b/common/flatpak-chain-input-stream-private.h
@@ -56,7 +56,7 @@ struct _FlatpakChainInputStreamClass
   void (*_g_reserved5) (void);
 };
 
-GType          flatpak_chain_input_stream_get_type (void) G_GNUC_CONST;
+GType          flatpak_chain_input_stream_get_type (void);
 
 FlatpakChainInputStream * flatpak_chain_input_stream_new (GPtrArray *streams);
 

--- a/common/flatpak-enum-types.h.template
+++ b/common/flatpak-enum-types.h.template
@@ -13,7 +13,7 @@ G_BEGIN_DECLS
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/
-FLATPAK_EXTERN GType @enum_name@_get_type (void) G_GNUC_CONST;
+FLATPAK_EXTERN GType @enum_name@_get_type (void);
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
 /*** END value-header ***/
 


### PR DESCRIPTION
As per g_type_ensure's documentation it is technically incorrect to mark _get_type fns with G_GNUC_CONST since they have side-effects on their first run.

See https://gitlab.gnome.org/GNOME/glib/-/merge_requests/5223 for more details.