### PR TITLE
oci-signatures: Enforce gpg-verify config for OCI repos

### DIFF
--- a/app/flatpak-builtins-remote-add.c
+++ b/app/flatpak-builtins-remote-add.c
@@ -110,8 +110,10 @@ get_config_from_opts (GKeyFile *config,
 
   if (opt_do_gpg_verify)
     {
+      gboolean is_oci = opt_url && g_str_has_prefix (opt_url, "oci+");
+
       g_key_file_set_boolean (config, group, "gpg-verify", TRUE);
-      g_key_file_set_boolean (config, group, "gpg-verify-summary", TRUE);
+      g_key_file_set_boolean (config, group, "gpg-verify-summary", !is_oci);
     }
 
   if (opt_url)
@@ -342,8 +344,6 @@ flatpak_builtin_remote_add (int argc, char **argv,
     }
   else
     {
-      gboolean is_oci;
-
       config = g_key_file_new ();
       file = g_file_new_for_commandline_arg (location);
       if (g_file_is_native (file))
@@ -352,9 +352,7 @@ flatpak_builtin_remote_add (int argc, char **argv,
         remote_url = g_strdup (location);
       opt_url = remote_url;
 
-      /* Default to gpg verify, except for OCI registries */
-      is_oci = opt_url && g_str_has_prefix (opt_url, "oci+");
-      if (!opt_no_gpg_verify && !is_oci)
+      if (!opt_no_gpg_verify)
         opt_do_gpg_verify = TRUE;
     }
 

--- a/common/flatpak-oci-signatures.c
+++ b/common/flatpak-oci-signatures.c
@@ -391,11 +391,38 @@ flatpak_oci_signatures_verify (FlatpakOciSignatures *self,
   int port;
   g_autofree char *port_prefix = NULL;
   g_autofree char *expected_identity = NULL;
+  g_autofree char *group = NULL;
+  GKeyFile *config;
 
-  if (!flatpak_remote_has_gpg_key (repo, remote_name))
+  if (remote_name == NULL)
+    return TRUE;
+
+  group = g_strdup_printf ("remote \"%s\"", remote_name);
+  config = ostree_repo_get_config (repo);
+
+  if (!g_key_file_has_key (config, group, "gpg-verify", NULL))
     {
-      g_info ("%s: no GPG key, skipping verification", remote_name);
-      return TRUE;
+      /* Legacy path: we don't look at gpg-verify but only the gpg key file */
+      if (!flatpak_remote_has_gpg_key (repo, remote_name))
+        return TRUE;
+    }
+  else
+    {
+      gboolean gpg_verify;
+
+      if (!ostree_repo_remote_get_gpg_verify (repo, remote_name, &gpg_verify, error))
+        return FALSE;
+
+      if (!gpg_verify)
+        return TRUE;
+
+      if (!flatpak_remote_has_gpg_key (repo, remote_name))
+        {
+          return flatpak_fail_error (error, FLATPAK_ERROR_UNTRUSTED,
+                                     _("GPG verification is required for remote '%s', "
+                                       "but no GPG key is configured"),
+                                     remote_name);
+        }
     }
 
   uri = g_uri_parse (registry_url, FLATPAK_HTTP_URI_FLAGS | G_URI_FLAGS_PARSE_RELAXED, error);

--- a/common/flatpak-repo-utils.c
+++ b/common/flatpak-repo-utils.c
@@ -2909,8 +2909,8 @@ flatpak_parse_repofile (const char   *remote_name,
                                                           FLATPAK_REPO_COLLECTION_ID_KEY);
   if (collection_id != NULL)
     {
-      /* We don't support signatures for OCI remotes, but Collection ID's are
-       * still useful for preinstallation.
+      /* Collection ID's require GPG keys for non-OCI remotes. OCI remotes
+       * can use Collection ID's without GPG keys for preinstallation.
        */
       if (gpg_key == NULL && !g_str_has_prefix (uri, "oci+"))
         {
@@ -2922,7 +2922,7 @@ flatpak_parse_repofile (const char   *remote_name,
     }
 
   g_key_file_set_boolean (config, group, "gpg-verify-summary",
-                          (gpg_key != NULL));
+                          (gpg_key != NULL) && !g_str_has_prefix (uri, "oci+"));
 
   authenticator_name = g_key_file_get_string (keyfile, FLATPAK_REPO_GROUP,
                                               FLATPAK_REPO_AUTHENTICATOR_NAME_KEY, NULL);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -59,6 +59,7 @@ common/flatpak-image-source.c
 common/flatpak-installation.c
 common/flatpak-instance.c
 common/flatpak-oci-registry.c
+common/flatpak-oci-signatures.c
 common/flatpak-progress.c
 common/flatpak-ref-utils.c
 common/flatpak-remote.c

--- a/tests/test-extra-data.sh
+++ b/tests/test-extra-data.sh
@@ -80,7 +80,7 @@ $client add hello latest "$(pwd)/oci/app-image"
 
 # Add an OCI remote
 
-${FLATPAK} remote-add ${U} oci-registry "oci+${scheme}://127.0.0.1:${port}" >&2
+${FLATPAK} remote-add ${U} --no-gpg-verify oci-registry "oci+${scheme}://127.0.0.1:${port}" >&2
 
 # Check that the images we expect are listed
 

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -49,7 +49,7 @@ $client add hello latest "$(pwd)/oci/app-image"
 # we override it to use the mock authenticator that reads its token from
 # $XDG_RUNTIME_DIR/required-token on every call.
 
-${FLATPAK} remote-add ${U} oci-auth-registry "oci+http://127.0.0.1:${port}" \
+${FLATPAK} remote-add ${U} --no-gpg-verify oci-auth-registry "oci+http://127.0.0.1:${port}" \
     --authenticator-name org.flatpak.Authenticator.test >&2
 
 # Test: install from an auth-protected OCI registry

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -107,7 +107,7 @@ $client add hello latest $(pwd)/oci/app-image
 
 # Add an OCI remote
 
-${FLATPAK} remote-add ${U} oci-registry "oci+${scheme}://127.0.0.1:${port}" >&2
+${FLATPAK} remote-add ${U} --no-gpg-verify oci-registry "oci+${scheme}://127.0.0.1:${port}" >&2
 
 # Check that the images we expect are listed
 


### PR DESCRIPTION
The ostree code paths use the gpg-verify config to decide if GPG verification needs to happen or not. If the repo is OCI, this config is being ignored. Instead, the existence of the GPG key is used to decide.

This is confusing. The config should work the same with ostree and OCI.

The change here switches over to using the gpg-verify config as the only signal for deciding if GPG verification is enforced. It also changes the remote-add command and repo-utils to actually write the gpg-verify option in the OCI cases.

gpg-verify-summary is still ignored on OCI because it's simply not a concept that OCI has.

This change has implications for already existing OCI remotes. Depending on how they were added, they either don't have a gpg-verify config set, or explicitly set to false. OCI repos which were added without a GPG key and have the gpg-verify config unset must continue working, so we keep a code path in there to spot those cases and apply the legacy "GPG key exists" logic to enforce verification.

One backwards compatibility concern cannot be avoided though: adding an OCI repo without a GPG key and without --no-gpg-verify used to work just fine, but will now fail to pull, just like the ostree case.