### PR TITLE
run: Add `--custom-slice` to `flatpak run`

### DIFF
--- a/app/flatpak-builtins-build.c
+++ b/app/flatpak-builtins-build.c
@@ -623,7 +623,8 @@ flatpak_builtin_build (int argc, char **argv, GCancellable *cancellable, GError 
                                          app_context,
                                          shares, devices, sockets, features,
                                          app_id_dir, NULL, -1,
-                                         instance_id, NULL, cancellable, error))
+                                         instance_id, NULL, NULL, cancellable,
+                                         error))
     return FALSE;
 
   for (i = 0; opt_bind_mounts != NULL && opt_bind_mounts[i] != NULL; i++)

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -66,6 +66,7 @@ static int opt_usr_fd = -1;
 static gboolean opt_clear_env;
 static GArray *opt_bind_fds = NULL;
 static GArray *opt_ro_bind_fds = NULL;
+static char *opt_custom_slice;
 
 static gboolean
 option_bind_fd_cb (const char  *option_name,
@@ -186,6 +187,7 @@ static GOptionEntry options[] = {
   { "clear-env", 0, 0, G_OPTION_ARG_NONE, &opt_clear_env, N_("Clear all outside environment variables"), NULL },
   { "bind-fd", 0, 0, G_OPTION_ARG_CALLBACK | G_OPTION_FLAG_HIDDEN, &option_bind_fd_cb, N_("Bind mount the file or directory referred to by FD to its canonicalized path"), N_("FD") },
   { "ro-bind-fd", 0, 0, G_OPTION_ARG_CALLBACK | G_OPTION_FLAG_HIDDEN, &option_ro_bind_fd_cb, N_("Bind mount the file or directory referred to by FD read-only to its canonicalized path"), N_("FD") },
+  { "custom-slice", 0, 0, G_OPTION_ARG_STRING, &opt_custom_slice, N_("The app will be put under the slice app-flatpak-SLICE.slice"), N_("SLICE") },
   { NULL }
 };
 
@@ -485,6 +487,7 @@ flatpak_builtin_run (int argc, char **argv, GCancellable *cancellable, GError **
                         NULL,
                         opt_bind_fds,
                         opt_ro_bind_fds,
+                        opt_custom_slice,
                         cancellable,
                         error))
     return FALSE;

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -9346,7 +9346,7 @@ apply_extra_data (FlatpakDir   *self,
   if (!flatpak_run_add_environment_args (bwrap, NULL, run_flags, id,
                                          app_context, 0, 0, 0, 0,
                                          NULL, NULL, -1,
-                                         NULL, NULL, cancellable, error))
+                                         NULL, NULL, NULL, cancellable, error))
     return FALSE;
 
   flatpak_bwrap_populate_runtime_dir (bwrap, NULL);

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -712,6 +712,7 @@ flatpak_installation_launch_full (FlatpakInstallation *self,
                         (const char * const *) run_environ,
                         &instance_dir,
                         NULL, NULL,
+                        NULL,
                         cancellable, error))
     return FALSE;
 

--- a/common/flatpak-run-private.h
+++ b/common/flatpak-run-private.h
@@ -37,6 +37,7 @@
 
 gboolean flatpak_run_in_transient_unit (const char *app_id,
                                         const char *instance_id,
+                                        const char *custom_slice,
                                         GError    **error);
 
 void     flatpak_run_extend_ld_path       (FlatpakBwrap       *bwrap,
@@ -65,6 +66,7 @@ gboolean flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
                                            int                     per_app_dir_lock_fd,
                                            const char             *instance_id,
                                            FlatpakExports        **exports_out,
+                                           const char             *custom_slice,
                                            GCancellable           *cancellable,
                                            GError                **error);
 char **  flatpak_run_get_minimal_env (gboolean devel,
@@ -131,6 +133,7 @@ gboolean flatpak_run_app (FlatpakDecomposed   *app_ref,
                           char               **instance_dir_out,
                           GArray              *bind_fds,
                           GArray              *ro_bind_fds,
+                          const char          *custom_slice,
                           GCancellable        *cancellable,
                           GError             **error);
 

--- a/common/flatpak-run.c
+++ b/common/flatpak-run.c
@@ -353,6 +353,7 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
                                   int                     per_app_dir_lock_fd,
                                   const char             *instance_id,
                                   FlatpakExports        **exports_out,
+                                  const char             *custom_slice,
                                   GCancellable           *cancellable,
                                   GError                **error)
 {
@@ -601,7 +602,7 @@ flatpak_run_add_environment_args (FlatpakBwrap           *bwrap,
      ends up in the app cgroup */
   if (instance_id)
     {
-      if (!flatpak_run_in_transient_unit (app_id, instance_id, &my_error))
+      if (!flatpak_run_in_transient_unit (app_id, instance_id, custom_slice, &my_error))
         {
           /* We still run along even if we don't get a cgroup, as nothing
              really depends on it. Its just nice to have */
@@ -922,6 +923,7 @@ systemd_unit_name_escape (const gchar *in)
 gboolean
 flatpak_run_in_transient_unit (const char  *app_id,
                                const char  *instance_id,
+                               const char  *custom_slice,
                                GError     **error)
 {
   g_autoptr(GDBusConnection) conn = NULL;
@@ -931,6 +933,7 @@ flatpak_run_in_transient_unit (const char  *app_id,
   g_autofree char *app_id_escaped = NULL;
   g_autofree char *instance_id_escaped = NULL;
   g_autofree char *job = NULL;
+  g_autofree char *slice = NULL;
   SystemdManager *manager = NULL;
   GVariantBuilder builder;
   GVariant *properties = NULL;
@@ -983,6 +986,15 @@ flatpak_run_in_transient_unit (const char  *app_id,
                          "PIDs",
                          g_variant_new_fixed_array (G_VARIANT_TYPE ("u"),
                                                     &pid, 1, sizeof (guint32)));
+
+  if (custom_slice)
+    {
+      slice = g_strdup_printf ("app-flatpak-%s.slice",
+                              custom_slice);
+      g_variant_builder_add (&builder, "(sv)",
+                             "Slice",
+                             g_variant_new_string (slice));
+    }
 
   properties = g_variant_builder_end (&builder);
 
@@ -3119,6 +3131,7 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
                  char               **instance_dir_out,
                  GArray              *bind_fds,
                  GArray              *ro_bind_fds,
+                 const char          *custom_slice,
                  GCancellable        *cancellable,
                  GError             **error)
 {
@@ -3748,7 +3761,8 @@ flatpak_run_app (FlatpakDecomposed   *app_ref,
                                          shares, devices, sockets, features,
                                          app_id_dir, previous_app_id_dirs,
                                          per_app_dir_lock_fd, instance_id,
-                                         &exports, cancellable, error))
+                                         &exports, custom_slice, cancellable,
+                                         error))
     return FALSE;
 
   if (per_app_dir_lock_path != NULL)

--- a/doc/flatpak-run.xml
+++ b/doc/flatpak-run.xml
@@ -942,6 +942,12 @@ key=v1;v2;
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--custom-slice=<replaceable>SLICE</replaceable></option></term>
+                <listitem><para>
+                    The app will be put under the slice app-flatpak-<replaceable>SLICE</replaceable>.slice.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
 
     </refsect1>


### PR DESCRIPTION
Add an option to put an instance under a specific systemd slice. According to this [comment](https://github.com/flatpak/flatpak/issues/4869#issuecomment-1116046159), I can do this with a dropin file, but this will affect all instances. In my case, the flatpak app acutally is another launcher(Steam), I want to put different games under different slices.

To solve my problem, I created this PR #6554, but it is reverted. @swick @bbhtt Can you review this PR?