### PR TITLE
run: Add support for fuzzy autocompleting app names

### DIFF
--- a/app/flatpak-builtins-build-init.c
+++ b/app/flatpak-builtins-build-init.c
@@ -588,6 +588,8 @@ flatpak_complete_build_init (FlatpakCompletion *completion)
         flatpak_complete_ref_id (completion, refs);
       }
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
 
     case 5: /* BRANCH */

--- a/app/flatpak-builtins-create-usb.c
+++ b/app/flatpak-builtins-create-usb.c
@@ -859,6 +859,7 @@ flatpak_complete_create_usb (FlatpakCompletion *completion)
           FlatpakDir *dir = g_ptr_array_index (dirs, i);
           flatpak_complete_partial_ref (completion, kinds, opt_arch, dir, NULL);
         }
+      flatpak_complete_ref_id_flush (completion);
       break;
     }
 

--- a/app/flatpak-builtins-document-list.c
+++ b/app/flatpak-builtins-document-list.c
@@ -246,6 +246,8 @@ flatpak_complete_document_list (FlatpakCompletion *completion)
         flatpak_complete_ref_id (completion, refs);
       }
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
     }
 

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -564,6 +564,7 @@ flatpak_complete_info (FlatpakCompletion *completion)
 
           flatpak_complete_ref_id (completion, refs);
         }
+      flatpak_complete_ref_id_flush (completion);
       break;
 
     case 2: /* BRANCH */

--- a/app/flatpak-builtins-info.c
+++ b/app/flatpak-builtins-info.c
@@ -555,8 +555,10 @@ flatpak_complete_info (FlatpakCompletion *completion)
       for (i = 0; i < dirs->len; i++)
         {
           FlatpakDir *dir = g_ptr_array_index (dirs, i);
-          g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (dir, NULL, NULL, opt_arch,
-                                                                       kinds, FIND_MATCHING_REFS_FLAGS_NONE, &error);
+          g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (dir, completion->cur, NULL, opt_arch,
+                                                                       kinds,
+                                                                       FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ | FIND_MATCHING_REFS_FLAGS_FUZZY_WITH_SUBREFS,
+                                                                       &error);
           if (refs == NULL)
             flatpak_completion_debug ("find local refs error: %s", error->message);
 

--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -683,6 +683,7 @@ flatpak_complete_install (FlatpakCompletion *completion)
 
     default: /* REF */
       flatpak_complete_partial_ref (completion, kinds, opt_arch, dir, completion->argv[1]);
+      flatpak_complete_ref_id_flush (completion);
       break;
     }
 

--- a/app/flatpak-builtins-make-current.c
+++ b/app/flatpak-builtins-make-current.c
@@ -135,9 +135,9 @@ flatpak_complete_make_current_app (FlatpakCompletion *completion)
       flatpak_complete_options (completion, options);
       flatpak_complete_options (completion, user_entries);
 
-      refs = flatpak_dir_find_installed_refs (dir, NULL, NULL, opt_arch,
+      refs = flatpak_dir_find_installed_refs (dir, completion->cur, NULL, opt_arch,
                                               FLATPAK_KINDS_APP,
-                                              FIND_MATCHING_REFS_FLAGS_NONE,
+                                              FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ,
                                               &error);
       if (refs == NULL)
         flatpak_completion_debug ("find installed refs error: %s", error->message);

--- a/app/flatpak-builtins-make-current.c
+++ b/app/flatpak-builtins-make-current.c
@@ -142,6 +142,7 @@ flatpak_complete_make_current_app (FlatpakCompletion *completion)
       if (refs == NULL)
         flatpak_completion_debug ("find installed refs error: %s", error->message);
       flatpak_complete_ref_id (completion, refs);
+      flatpak_complete_ref_id_flush (completion);
       break;
 
     case 2: /* Branch */

--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -152,9 +152,9 @@ flatpak_complete_override (FlatpakCompletion *completion)
       for (i = 0; i < dirs->len; i++)
         {
           FlatpakDir *dir = g_ptr_array_index (dirs, i);
-          g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (dir, NULL, NULL, NULL,
+          g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (dir, completion->cur, NULL, NULL,
                                                                        FLATPAK_KINDS_APP,
-                                                                       FIND_MATCHING_REFS_FLAGS_NONE,
+                                                                       FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ,
                                                                        &error);
           if (refs == NULL)
             flatpak_completion_debug ("find local refs error: %s", error->message);

--- a/app/flatpak-builtins-override.c
+++ b/app/flatpak-builtins-override.c
@@ -162,6 +162,8 @@ flatpak_complete_override (FlatpakCompletion *completion)
           flatpak_complete_ref_id (completion, refs);
         }
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
     }
 

--- a/app/flatpak-builtins-permission-remove.c
+++ b/app/flatpak-builtins-permission-remove.c
@@ -209,6 +209,7 @@ flatpak_complete_permission_remove (FlatpakCompletion *completion)
     case 3:
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, flatpak_dir_get_user (), NULL);
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, flatpak_dir_get_system_default (), NULL);
+      flatpak_complete_ref_id_flush (completion);
       break;
 
     default:

--- a/app/flatpak-builtins-permission-reset.c
+++ b/app/flatpak-builtins-permission-reset.c
@@ -200,6 +200,8 @@ flatpak_complete_permission_reset (FlatpakCompletion *completion)
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, user_dir, NULL);
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, system_dir, NULL);
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
 
     default:

--- a/app/flatpak-builtins-permission-set.c
+++ b/app/flatpak-builtins-permission-set.c
@@ -217,6 +217,7 @@ flatpak_complete_permission_set (FlatpakCompletion *completion)
     case 3:
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, flatpak_dir_get_user (), NULL);
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, flatpak_dir_get_system_default (), NULL);
+      flatpak_complete_ref_id_flush (completion);
       break;
 
     default:

--- a/app/flatpak-builtins-permission-show.c
+++ b/app/flatpak-builtins-permission-show.c
@@ -196,6 +196,8 @@ flatpak_complete_permission_show (FlatpakCompletion *completion)
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, user_dir, NULL);
       flatpak_complete_partial_ref (completion, FLATPAK_KINDS_APP, FALSE, system_dir, NULL);
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
 
     default:

--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -502,6 +502,8 @@ flatpak_complete_remote_info (FlatpakCompletion *completion)
           flatpak_complete_partial_ref (completion, kinds, opt_arch, dir, completion->argv[1]);
         }
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
     }
 

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -524,9 +524,9 @@ flatpak_complete_run (FlatpakCompletion *completion)
 
       user_dir = flatpak_dir_get_user ();
       {
-        g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (user_dir, NULL, NULL, opt_arch,
+        g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (user_dir, completion->cur, NULL, opt_arch,
                                                                      FLATPAK_KINDS_APP,
-                                                                     FIND_MATCHING_REFS_FLAGS_NONE,
+                                                                     FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ,
                                                                      &error);
         if (refs == NULL)
           flatpak_completion_debug ("find local refs error: %s", error->message);
@@ -544,9 +544,9 @@ flatpak_complete_run (FlatpakCompletion *completion)
       for (i = 0; i < system_dirs->len; i++)
         {
           FlatpakDir *dir = g_ptr_array_index (system_dirs, i);
-          g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (dir, NULL, NULL, opt_arch,
+          g_autoptr(GPtrArray) refs = flatpak_dir_find_installed_refs (dir, completion->cur, NULL, opt_arch,
                                                                        FLATPAK_KINDS_APP,
-                                                                       FIND_MATCHING_REFS_FLAGS_NONE,
+                                                                       FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ,
                                                                        &error);
           if (refs == NULL)
             flatpak_completion_debug ("find local refs error: %s", error->message);

--- a/app/flatpak-builtins-run.c
+++ b/app/flatpak-builtins-run.c
@@ -554,6 +554,8 @@ flatpak_complete_run (FlatpakCompletion *completion)
           flatpak_complete_ref_id (completion, refs);
         }
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
     }
 

--- a/app/flatpak-builtins-uninstall.c
+++ b/app/flatpak-builtins-uninstall.c
@@ -632,6 +632,8 @@ flatpak_complete_uninstall (FlatpakCompletion *completion)
           flatpak_complete_partial_ref (completion, kinds, opt_arch, dir, NULL);
         }
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
     }
 

--- a/app/flatpak-builtins-update.c
+++ b/app/flatpak-builtins-update.c
@@ -313,6 +313,8 @@ flatpak_complete_update (FlatpakCompletion *completion)
           flatpak_complete_partial_ref (completion, kinds, opt_arch, dir, NULL);
         }
 
+      flatpak_complete_ref_id_flush (completion);
+
       break;
     }
 

--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -26,6 +26,8 @@
 
 /* Uncomment to get debug traces in /tmp/flatpak-completion-debug.txt (nice
  * to not have it interfere with stdout/stderr)
+ *
+ *    tail -f /tmp/flatpak-completion-debug.txt
  */
 #if 0
 void
@@ -115,18 +117,112 @@ flatpak_complete_word (FlatpakCompletion *completion,
 }
 
 void
+flatpak_complete_raw (FlatpakCompletion *completion,
+                      const char *format,
+                      ...)
+{
+  va_list args;
+  g_autofree char *string = NULL;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+  va_start (args, format);
+  string = g_strdup_vprintf (format, args);
+  va_end (args);
+#pragma GCC diagnostic pop
+
+  flatpak_completion_debug ("completing: %s", string);
+
+  g_print ("%s\n", string);
+}
+
+void flatpak_complete_ref_id_flush (FlatpakCompletion *completion)
+{
+  GPtrArray *refs = completion->ref_scores;
+
+  int best = INT_MIN;
+  for (int i = 0; i < refs->len; ++i)
+    best = MAX (best, flatpak_decomposed_get_score (g_ptr_array_index (refs, i)));
+
+  for (int i = 0; i < refs->len; ++i)
+    {
+      FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
+      size_t len;
+      const char *ref_id = flatpak_decomposed_peek_id (ref, &len);
+      flatpak_completion_debug ("ref=%.*s pat=%s score=%i", (int)len, ref_id, completion->cur, flatpak_decomposed_get_score (ref));
+    }
+  flatpak_completion_debug ("best_score=%i", best);
+  flatpak_completion_debug ("----");
+
+  for (int i = refs->len; i > 0; --i)
+    if (flatpak_decomposed_get_score (g_ptr_array_index (refs, i - 1)) != best)
+      g_ptr_array_remove_index_fast(refs, i - 1);
+
+  g_ptr_array_sort (refs, (GCompareFunc)flatpak_decomposed_strcmp_p);
+
+  gboolean is_substr = TRUE;
+  const char* pref = NULL;
+  size_t pref_len = 0;
+  size_t completions = 0;
+  for (int i = 0; i < refs->len; ++i)
+    {
+      FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
+
+      size_t len;
+      const char *ref_id = flatpak_decomposed_peek_id (ref, &len);
+
+      // Skip duplicates
+      if (i > 0)
+        {
+          size_t next_len;
+          const char *next_ref_id = flatpak_decomposed_peek_id (g_ptr_array_index (refs, i - 1), &next_len);
+          if (next_len == len && !strncmp(next_ref_id, ref_id, len))
+            continue;
+        }
+
+      flatpak_complete_raw (completion, "%.*s ", (int)len, ref_id);
+      completions += 1;
+
+      if (!is_substr)
+        continue;
+
+      // Check if there's a common prefix that includes the user's pattern
+      const char* pos;
+      for (pos = ref_id; pos < ref_id + len; ++pos)
+        if (!g_ascii_strncasecmp (pos, completion->cur, strlen (completion->cur)))
+          break;
+
+      if (pos == ref_id + len)
+        {
+          is_substr = FALSE;
+          continue;
+        }
+
+      if (!pref)
+        {
+          pref = ref_id;
+          pref_len = pos - ref_id;
+          continue;
+        }
+
+      if (pref_len != pos - ref_id || strncmp (ref_id, pref, pref_len))
+        is_substr = FALSE;
+    }
+
+  if (!is_substr && completions > 1)
+    flatpak_complete_raw (completion, " "); // a junk variant for bash not to attempt to coalesce a prefix
+
+  g_ptr_array_set_size (refs, 0);
+}
+
+void
 flatpak_complete_ref_id (FlatpakCompletion *completion,
                          GPtrArray         *refs)
 {
   if (refs == NULL)
     return;
 
-  for (int i = 0; i < refs->len; i++)
-    {
-      FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
-      g_autofree char *id = flatpak_decomposed_dup_id (ref);
-      g_print ("%s \n", id);
-    }
+  g_ptr_array_extend (completion->ref_scores, refs, (GCopyFunc)flatpak_decomposed_ref, NULL);
 }
 
 void
@@ -263,9 +359,8 @@ flatpak_complete_partial_ref (FlatpakCompletion *completion,
 
       if (element <= 1)
         {
-          size_t len;
-          const char *ref_id = flatpak_decomposed_peek_id (ref, &len);
-          g_print ("%.*s \n", (int)len, ref_id);
+          flatpak_decomposed_ref (ref);
+          g_ptr_array_add (completion->ref_scores, ref);
           continue;
         }
 
@@ -652,6 +747,8 @@ flatpak_completion_new (const char *arg_line,
 
   flatpak_completion_debug ("----");
 
+  completion->ref_scores = g_ptr_array_new_with_free_func ((GDestroyNotify)flatpak_decomposed_unref);
+
   return completion;
 }
 
@@ -664,5 +761,6 @@ flatpak_completion_free (FlatpakCompletion *completion)
   g_free (completion->argv);
   g_free (completion->shell_cur);
   g_strfreev (completion->original_argv);
+  g_ptr_array_free (completion->ref_scores, TRUE);
   g_free (completion);
 }

--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -125,7 +125,7 @@ flatpak_complete_ref_id (FlatpakCompletion *completion,
     {
       FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
       g_autofree char *id = flatpak_decomposed_dup_id (ref);
-      flatpak_complete_word (completion, "%s ", id);
+      g_print ("%s \n", id);
     }
 }
 
@@ -222,6 +222,10 @@ flatpak_complete_partial_ref (FlatpakCompletion *completion,
   cur_parts[2] = arch ? arch : "";
   cur_parts[3] = branch ? branch : "";
 
+  FindMatchingRefsFlags flags = FIND_MATCHING_REFS_FLAGS_NONE;
+  if (element == 1)
+    flags |= FIND_MATCHING_REFS_FLAGS_FUZZY | FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ;
+
   if (remote)
     {
       g_autoptr(FlatpakRemoteState) state = get_remote_state (dir, remote, TRUE, FALSE,
@@ -229,23 +233,23 @@ flatpak_complete_partial_ref (FlatpakCompletion *completion,
                                                               NULL, &error);
       if (state != NULL)
         refs = flatpak_dir_find_remote_refs (dir, state,
-                                             (element > 1) ? id : NULL,
+                                             id,
                                              NULL, /* branch */
                                              NULL, /* default branch */
                                              (element > 2) ? arch : only_arch,
                                              NULL, /* default arch */
                                              matched_kinds,
-                                             FIND_MATCHING_REFS_FLAGS_NONE,
+                                             flags,
                                              NULL, &error);
     }
   else
     {
       refs = flatpak_dir_find_installed_refs (dir,
-                                              (element > 1) ? id : NULL,
+                                              id,
                                               NULL, /* branch */
                                               (element > 2) ? arch : only_arch,
                                               matched_kinds,
-                                              FIND_MATCHING_REFS_FLAGS_NONE,
+                                              flags,
                                               &error);
     }
   if (refs == NULL)
@@ -256,6 +260,15 @@ flatpak_complete_partial_ref (FlatpakCompletion *completion,
       FlatpakDecomposed *ref = g_ptr_array_index (refs, i);
       int j;
       g_autoptr(GString) comp = NULL;
+
+      if (element <= 1)
+        {
+          size_t len;
+          const char *ref_id = flatpak_decomposed_peek_id (ref, &len);
+          g_print ("%.*s \n", (int)len, ref_id);
+          continue;
+        }
+
       g_auto(GStrv) parts = g_strsplit (flatpak_decomposed_get_ref (ref), "/", 0);
 
       if (!g_str_has_prefix (parts[element], cur_parts[element]))

--- a/app/flatpak-complete.h
+++ b/app/flatpak-complete.h
@@ -38,6 +38,7 @@ struct FlatpakCompletion
   char **original_argv;
   int    argc;
   int    original_argc;
+  GPtrArray *ref_scores;
 };
 
 void flatpak_completion_debug (const gchar *format,
@@ -46,6 +47,9 @@ void flatpak_completion_debug (const gchar *format,
 FlatpakCompletion *flatpak_completion_new (const char *arg_line,
                                            const char *arg_point,
                                            const char *arg_cur);
+void               flatpak_complete_raw (FlatpakCompletion *completion,
+                                         const char        *format,
+                                         ...) G_GNUC_PRINTF (2, 3);
 void               flatpak_complete_word (FlatpakCompletion *completion,
                                           const char        *format,
                                           ...) G_GNUC_PRINTF (2, 3);
@@ -53,6 +57,7 @@ void               flatpak_complete_ref (FlatpakCompletion *completion,
                                          OstreeRepo        *repo);
 void               flatpak_complete_ref_id (FlatpakCompletion *completion,
                                             GPtrArray         *refs);
+void               flatpak_complete_ref_id_flush (FlatpakCompletion *completion);
 void               flatpak_complete_ref_branch (FlatpakCompletion *completion,
                                                 GPtrArray         *refs);
 void               flatpak_complete_partial_ref (FlatpakCompletion *completion,

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -353,7 +353,9 @@ typedef enum {
 
 typedef enum {
   FIND_MATCHING_REFS_FLAGS_NONE = 0,
-  FIND_MATCHING_REFS_FLAGS_FUZZY = (1 << 0),
+  FIND_MATCHING_REFS_FLAGS_FUZZY = 1 << 0,
+  FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ = 1 << 1,
+  FIND_MATCHING_REFS_FLAGS_FUZZY_WITH_SUBREFS = 1 << 2,
 } FindMatchingRefsFlags;
 
 GQuark       flatpak_dir_error_quark (void);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14518,6 +14518,8 @@ find_matching_refs (GHashTable           *refs,
 
               if (score < 0)
                 continue;
+
+              flatpak_decomposed_set_score (ref, score);
             }
           else
             {
@@ -14556,7 +14558,10 @@ find_matching_refs (GHashTable           *refs,
         {
           FlatpakDecomposed *matched_ref = g_ptr_array_index (matched_refs, i - 1);
 
-          if (found_exact_name_match && !flatpak_decomposed_is_id (matched_ref, opt_name))
+          if (found_exact_name_match &&
+              (flags & FIND_MATCHING_REFS_FLAGS_FUZZY_WITH_SUBREFS
+                ? !flatpak_decomposed_id_has_prefix (matched_ref, opt_name)
+                : !flatpak_decomposed_is_id (matched_ref, opt_name)))
             g_ptr_array_remove_index (matched_refs, i - 1);
           else if (found_default_arch_match && !flatpak_decomposed_is_arch (matched_ref, opt_default_arch))
             g_ptr_array_remove_index (matched_refs, i - 1);

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -14466,6 +14466,9 @@ find_matching_refs (GHashTable           *refs,
   gboolean found_default_branch_match = FALSE;
   gboolean found_default_arch_match = FALSE;
 
+  if (flags & FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ || flags & FIND_MATCHING_REFS_FLAGS_FUZZY_WITH_SUBREFS)
+    flags |= FIND_MATCHING_REFS_FLAGS_FUZZY;
+
   if (opt_name && !(flags & FIND_MATCHING_REFS_FLAGS_FUZZY) &&
       !flatpak_is_valid_name (opt_name, -1, &local_error))
     {
@@ -14488,9 +14491,32 @@ find_matching_refs (GHashTable           *refs,
 
       if (opt_name)
         {
-          if ((flags & FIND_MATCHING_REFS_FLAGS_FUZZY) && !flatpak_decomposed_id_is_subref (ref))
+          if (flags & FIND_MATCHING_REFS_FLAGS_FUZZY &&
+              (flags & FIND_MATCHING_REFS_FLAGS_FUZZY_WITH_SUBREFS || !flatpak_decomposed_id_is_subref (ref)))
             {
-              if (!flatpak_decomposed_is_id_fuzzy (ref, opt_name))
+              size_t opt_len = strlen (opt_name);
+              size_t ref_id_len;
+              const char *ref_id = flatpak_decomposed_peek_id (ref, &ref_id_len);
+
+              int score;
+              if (flatpak_decomposed_id_has_prefix (ref, opt_name))
+                score = INT_MAX;
+              else if (flatpak_decomposed_id_has_substr (ref, opt_name))
+                score = INT_MAX - 1;
+              else if (!(flags & FIND_MATCHING_REFS_FLAGS_FUZZY_SUBSEQ))
+                score = 2 - flatpak_levenshtein_distance (opt_name, opt_len, ref_id, ref_id_len);
+              else if (flatpak_decomposed_id_part_has_subseq (ref, opt_name))
+                score = INT_MAX - 2;
+              else if (flatpak_decomposed_id_has_subseq (ref, opt_name))
+                score = INT_MAX - 3;
+              else if ((score = flatpak_decomposed_id_part_fuzzy_dist (ref, opt_name)) <= 1)
+                score = INT_MAX - 4 - score;
+              else if (g_hash_table_size (refs) < 10000)
+                score = 1 + abs ((int)ref_id_len - (int)opt_len) - flatpak_levenshtein_distance (opt_name, opt_len, ref_id, ref_id_len);
+              else
+                score = INT_MIN;
+
+              if (score < 0)
                 continue;
             }
           else

--- a/common/flatpak-ref-utils-private.h
+++ b/common/flatpak-ref-utils-private.h
@@ -142,6 +142,9 @@ const char *       flatpak_decomposed_get_branch            (FlatpakDecomposed  
 char *             flatpak_decomposed_dup_branch            (FlatpakDecomposed  *ref);
 gboolean           flatpak_decomposed_is_branch             (FlatpakDecomposed  *ref,
                                                              const char         *branch);
+int                flatpak_decomposed_get_score             (FlatpakDecomposed *ref);
+void               flatpak_decomposed_set_score             (FlatpakDecomposed *ref,
+                                                             int                score);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakDecomposed, flatpak_decomposed_unref)
 

--- a/common/flatpak-ref-utils-private.h
+++ b/common/flatpak-ref-utils-private.h
@@ -115,8 +115,16 @@ gboolean           flatpak_decomposed_id_has_suffix         (FlatpakDecomposed  
                                                              const char         *suffix);
 gboolean           flatpak_decomposed_id_has_prefix         (FlatpakDecomposed  *ref,
                                                              const char         *prefix);
+gboolean           flatpak_decomposed_id_has_substr         (FlatpakDecomposed  *ref,
+                                                             const char         *substr);
 gboolean           flatpak_decomposed_is_id_fuzzy           (FlatpakDecomposed  *ref,
                                                              const char         *id);
+gboolean           flatpak_decomposed_id_part_fuzzy_dist    (FlatpakDecomposed  *ref,
+                                                             const char         *pat);
+gboolean           flatpak_decomposed_id_has_subseq         (FlatpakDecomposed  *ref,
+                                                             const char         *subseq);
+gboolean           flatpak_decomposed_id_part_has_subseq    (FlatpakDecomposed  *ref,
+                                                             const char         *subseq);
 gboolean           flatpak_decomposed_id_is_subref          (FlatpakDecomposed  *ref);
 gboolean           flatpak_decomposed_id_is_subref_of       (FlatpakDecomposed  *ref,
                                                              FlatpakDecomposed  *parent_ref);

--- a/common/flatpak-ref-utils.c
+++ b/common/flatpak-ref-utils.c
@@ -1381,6 +1381,15 @@ flatpak_decomposed_id_has_prefix (FlatpakDecomposed  *ref,
   return str_has_prefix (ref_id, id_len, prefix);
 }
 
+gboolean
+flatpak_decomposed_id_has_substr (FlatpakDecomposed  *ref,
+                                  const char         *substr)
+{
+  size_t ref_id_len;
+  const char *ref_id = flatpak_decomposed_peek_id (ref, &ref_id_len);
+  return slashed_str_strcasestr (ref_id, ref_id_len, substr);
+}
+
 
 /* See if the given id looks similar to this ref. The
  * Levenshtein distance constant was chosen pretty arbitrarily. */
@@ -1396,6 +1405,65 @@ flatpak_decomposed_is_id_fuzzy (FlatpakDecomposed  *ref,
 
   return flatpak_levenshtein_distance (id, -1, ref_id, ref_id_len) <= 2;
 }
+
+gboolean
+flatpak_decomposed_id_part_fuzzy_dist (FlatpakDecomposed  *ref,
+                                       const char         *pat)
+{
+  size_t pat_len = strlen (pat);
+  size_t ref_id_len;
+  const char *ref_id = flatpak_decomposed_peek_id (ref, &ref_id_len);
+  const char *end = ref_id + ref_id_len;
+
+  int res = INT_MAX;
+  const char *last = ref_id;
+  for (const char *next; (next = memchr (last, '.', end - last)); last = next + 1)
+    res = MIN (res, flatpak_levenshtein_distance (pat, pat_len, last, next - last));
+  res = MIN (res, flatpak_levenshtein_distance (pat, pat_len, last, end - last));
+
+  return res;
+}
+
+static gboolean
+_flatpak_has_subseq (const char *ref_id,
+                     size_t      ref_id_len,
+                     const char *subseq)
+{
+  while (*subseq != '\0' && ref_id_len > 0) {
+    if (g_ascii_tolower (*subseq) == g_ascii_tolower (*ref_id))
+      subseq += 1;
+    ref_id_len -= 1;
+    ref_id += 1;
+  }
+  return *subseq == '\0';
+}
+
+gboolean
+flatpak_decomposed_id_has_subseq (FlatpakDecomposed  *ref,
+                                  const char         *subseq)
+{
+  size_t ref_id_len;
+  const char *ref_id = flatpak_decomposed_peek_id (ref, &ref_id_len);
+
+  return _flatpak_has_subseq (ref_id, ref_id_len, subseq);
+}
+
+gboolean
+flatpak_decomposed_id_part_has_subseq (FlatpakDecomposed  *ref,
+                                       const char         *subseq)
+{
+  size_t ref_id_len;
+  const char *ref_id = flatpak_decomposed_peek_id (ref, &ref_id_len);
+  const char *end = ref_id + ref_id_len;
+
+  const char *last = ref_id;
+  for (const char *next; (next = memchr (last, '.', end - last)); last = next + 1)
+    if (_flatpak_has_subseq (last, next - last, subseq))
+      return TRUE;
+
+  return _flatpak_has_subseq (last, end - last, subseq);
+}
+
 
 gboolean
 flatpak_decomposed_id_is_subref (FlatpakDecomposed  *ref)

--- a/common/flatpak-ref-utils.c
+++ b/common/flatpak-ref-utils.c
@@ -558,6 +558,7 @@ struct _FlatpakDecomposed {
   guint16 id_offset;
   guint16 arch_offset;
   guint16 branch_offset;
+  int fuzzy_score;
   char *data;
 
   /* This is only used when we're directly manipulating sideload repos, by giving
@@ -753,6 +754,7 @@ _flatpak_decomposed_new (char            *ref,
   decomposed->id_offset = (guint16)id_offset;
   decomposed->arch_offset = (guint16)arch_offset;
   decomposed->branch_offset = (guint16)branch_offset;
+  decomposed->fuzzy_score = INT_MIN;
 
   return decomposed;
 }
@@ -1602,6 +1604,19 @@ flatpak_decomposed_is_branch (FlatpakDecomposed  *ref,
   const char *ref_branch = flatpak_decomposed_get_branch (ref);
 
   return strcmp (ref_branch, branch) == 0;
+}
+
+int
+flatpak_decomposed_get_score (FlatpakDecomposed  *ref)
+{
+  return ref->fuzzy_score;
+}
+
+void
+flatpak_decomposed_set_score (FlatpakDecomposed  *ref,
+                              int                 score)
+{
+  ref->fuzzy_score = score;
 }
 
 static const char *

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2136,6 +2136,13 @@ dist (const char *s, int ls, const char *t, int lt, int i, int j, int *d)
       y = dist (s, ls, t, lt, i + 1, j, d);
       if (y < x)
         x = y;
+      if (i + 1 != ls &&
+          j + 1 != lt &&
+          g_ascii_tolower (s[i]) == g_ascii_tolower (t[j + 1]) &&
+          g_ascii_tolower (s[i + 1]) == g_ascii_tolower (t[j]))
+        y = dist (s, ls, t, lt, i + 2, j + 2, d);
+      if (y < x)
+        x = y;
       x++;
     }
 

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2125,7 +2125,7 @@ dist (const char *s, int ls, const char *t, int lt, int i, int j, int *d)
     x = lt - j;
   else if (j == lt)
     x = ls - i;
-  else if (s[i] == t[j])
+  else if (g_ascii_tolower (s[i]) == g_ascii_tolower (t[j]))
     x = dist (s, ls, t, lt, i + 1, j + 1, d);
   else
     {

--- a/completion/flatpak
+++ b/completion/flatpak
@@ -44,4 +44,4 @@ __flatpak() {
 
 ####################################################################################################
 
-complete -o nospace -F __flatpak flatpak
+complete -o nospace -o nosort -F __flatpak flatpak

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -149,6 +149,19 @@ EOF
 
 ok "complete partial ref"
 
+${FLATPAK} complete "flatpak info pl" 100 "" > complete_out
+(diff -u complete_out - || exit 1) <<EOF
+org.test.Platform 
+EOF
+
+${FLATPAK} complete "flatpak info hello" 100 "" > complete_out
+(diff -u complete_out - || exit 1) <<EOF
+org.test.Hello 
+org.test.Hello.Locale 
+EOF
+
+ok "complete ref order"
+
 # flatpak CMD ... APP
 for cmd in \
     "run" \

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -149,6 +149,59 @@ EOF
 
 ok "complete partial ref"
 
+# flatpak CMD ... APP
+for cmd in \
+    "run" \
+    "update --app" \
+    "uninstall --app" \
+    "make-current --user" \
+    "override --user" \
+    "permission-show" \
+    "permission-reset" \
+    "permission-remove background background" \
+    "permission-set background background"
+do
+  ${FLATPAK} complete "flatpak $cmd " 100 "" | sort > complete_out
+  (diff -u complete_out - || exit 1) <<EOF
+org.test.Hello 
+EOF
+
+  ${FLATPAK} complete "flatpak $cmd helo" 100 "helo" | sort > complete_out
+  (diff -u complete_out - || exit 1) <<EOF
+org.test.Hello 
+EOF
+
+  ${FLATPAK} complete "flatpak $cmd non.existent" 100 "non.existent" | sort > complete_out
+  (diff -u complete_out - || exit 1) <<EOF
+EOF
+
+  ok "complete $cmd"
+done
+
+# flatpak CMD REMOTE REF
+for cmd in install remote-info; do
+  cmd="$cmd --user test-repo"
+
+  ${FLATPAK} complete "flatpak $cmd " 100 "" | sort > complete_out
+  (diff -u complete_out - || exit 1) <<EOF
+org.test.Hello 
+org.test.Hello.Plugin.fun 
+org.test.Platform 
+EOF
+
+  ${FLATPAK} complete "flatpak $cmd hello" 100 "hello" | sort > complete_out
+  (diff -u complete_out - || exit 1) <<EOF
+org.test.Hello 
+org.test.Hello.Plugin.fun 
+EOF
+
+  ${FLATPAK} complete "flatpak $cmd non.existent" 100 "non.existent" | sort > complete_out
+  (diff -u complete_out - || exit 1) <<EOF
+EOF
+
+  ok "complete $cmd"
+done
+
 for cmd in build-bundle build-commit-from build-export build-finish \
            build-import-bundle build-init build-sign build-update-repo \
            build document-export document-info document-list document-unexport \

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -144,7 +144,7 @@ ok "complete ref"
 
 ${FLATPAK} complete "flatpak permission-reset o" 26 "o" | sort > complete_out
 (diff -u complete_out - || exit 1) <<EOF
-org.test.Hello
+org.test.Hello 
 EOF
 
 ok "complete partial ref"


### PR DESCRIPTION
Currently, shell completions return only apps that have with a given prefix, which is most often utterly useless when you want to lookup an app by its name, considering that this prefix is lengthy and often irrelevant domain name, i.e. `flatpak run <tab>` shows every single installed app, while `flatpak run firef<tab>` shows nothing.

Conversely, when running the same apps from shell, it seems that the fish doesn't have any problems finding the correct executable with the same lengthy name by its short fragment. I've checked what it's doing, the callchain looks like below, with string_fuzzy_match_string() checking in order: prefix, substring, subsequence.

[complete_cmd()](https://github.com/fish-shell/fish-shell/blob/b2576d0b45bfcb0ebad5c2b719f7e10f8bea65af/src/complete.rs#L1107) -> [stage_wildcards](https://github.com/fish-shell/fish-shell/blob/b2576d0b45bfcb0ebad5c2b719f7e10f8bea65af/src/expand.rs#L1438) -> [wildcard_complete_internal()](https://github.com/fish-shell/fish-shell/blob/b2576d0b45bfcb0ebad5c2b719f7e10f8bea65af/src/wildcard.rs#L116) -> [string_fuzzy_match_string()](https://github.com/fish-shell/fish-shell/blob/b2576d0b45bfcb0ebad5c2b719f7e10f8bea65af/crates/wcstringutil/src/lib.rs#L261).

Notably, flatpak already has a fuzzy-finding utilities, but looking closely at flatpak_decomposed_is_id_fuzzy(), it only checks for a substring. And while it does compute edit distance, if the substring is misspelled, for example, for some reason, it only accepts matches with a distance of less then 2, which is weird, because this only would work if user entered the full app name inluding the domain prefix, so typing "geditt" against "org.gnome.gedit" gives no result, since "org.gnome." prefix is also counted towards the edit distance.

This PR adds a flag to enable prefix-ignoring fuzzy matching for commands like `flatpak run`, so the minimal edit distance is computed as 1 + abs(prompt_len, app_name_len), essentially matching a subsequence plus a possible typo. Comparing this to the uninstall command, this approach has more false-positives when matching short subsequences, but this is probably fine, since it's much easier to narrow down the list by typing a couple characters more, than eyeballing a correct item in a list.

P.S. ~~I think the same completion code can be called from the other subcommands accepting refs, but this PR would touch a more code then. Also matches are probably better printed in order of relevance, so false-positives are more acceptable when the correct item is one \<tab\> press away regardless.~~ Done.

Closes: #5437