### PR TITLE
Fix typo in summary-history-length config key

### DIFF
--- a/common/flatpak-repo-utils.c
+++ b/common/flatpak-repo-utils.c
@@ -318,7 +318,7 @@ flatpak_repo_get_summary_history_length (OstreeRepo *repo)
   GKeyFile *config = ostree_repo_get_config (repo);
   int length;
 
-  length = g_key_file_get_integer (config, "flatpak", "sumary-history-length", NULL);
+  length = g_key_file_get_integer (config, "flatpak", "summary-history-length", NULL);
 
   if (length <= 0)
     return FLATPAK_SUMMARY_HISTORY_LENGTH_DEFAULT;


### PR DESCRIPTION
## Summary
- Corrects a misspelled config key in `flatpak_repo_get_summary_history_length`.
- The setter and docs already use `summary-history-length`; the getter had `sumary-history-length`, so configured values were ignored and the default was always used.

Fixes #5927

## Test plan
- [x] Confirmed setter/docs use `summary-history-length` and only the getter had the typo
- [ ] Maintainer CI / review