### PR TITLE
Add flatpak-system-helper.service.in to POTFILES

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -71,4 +71,5 @@ common/flatpak-usb.c
 common/flatpak-utils.c
 oci-authenticator/flatpak-oci-authenticator.c
 portal/flatpak-portal.c
+system-helper/flatpak-system-helper.service.in
 system-helper/org.freedesktop.Flatpak.policy.in


### PR DESCRIPTION
This situation is reported by GNOME Damned Lies in [flatpak module](https://l10n.gnome.org/module/flatpak/) page:

```
There are some missing files from POTFILES.in:
    system-helper/flatpak-system-helper.service.in
```