### PR TITLE
Update Swedish translation

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: flatpak main\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2026-05-27 16:39+0200\n"
-"PO-Revision-Date: 2026-02-23 00:36+0100\n"
+"POT-Creation-Date: 2026-07-29 09:42+0000\n"
+"PO-Revision-Date: 2026-08-01 14:59+0200\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.8\n"
+"X-Generator: Poedit 3.9\n"
 
 #: app/flatpak-builtins-build-bundle.c:59
 msgid "Export runtime instead of app"
@@ -245,7 +245,7 @@ msgstr "Logga systembussanrop"
 msgid "DIRECTORY [COMMAND [ARGUMENT…]] - Build in directory"
 msgstr "KATALOG [KOMMANDO [ARGUMENT…]] - Bygg i katalog"
 
-#: app/flatpak-builtins-build.c:285 app/flatpak-builtins-build-finish.c:656
+#: app/flatpak-builtins-build.c:285 app/flatpak-builtins-build-finish.c:655
 msgid "DIRECTORY must be specified"
 msgstr "KATALOG måste anges"
 
@@ -269,8 +269,7 @@ msgstr "Ingen tilläggspunkt matchar %s i %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Saknar ”=” i bindningsmonteringsargument ”%s”"
 
-#: app/flatpak-builtins-build.c:679 common/flatpak-run.c:3961
-#, c-format
+#: app/flatpak-builtins-build.c:679 common/flatpak-run.c:3977
 msgid "Unable to start app"
 msgstr "Kunde inte starta program"
 
@@ -466,7 +465,7 @@ msgstr ""
 "angivet ID"
 
 #: app/flatpak-builtins-build-export.c:74
-#: app/flatpak-builtins-document-list.c:49 app/flatpak-cli-transaction.c:1427
+#: app/flatpak-builtins-document-list.c:49 app/flatpak-cli-transaction.c:1424
 msgid "ID"
 msgstr "ID"
 
@@ -528,7 +527,6 @@ msgid "Unable to find basename in %s, specify a name explicitly"
 msgstr "Kunde inte hitta basnamn i %s, ange ett namn explicit"
 
 #: app/flatpak-builtins-build-export.c:746
-#, c-format
 msgid "No slashes allowed in extra data name"
 msgstr "Inga snedstreck tillåtna i namn för extra data"
 
@@ -538,7 +536,6 @@ msgid "Invalid format for sha256 checksum: '%s'"
 msgstr "Ogiltigt format för sha256-kontrollsumman: ”%s”"
 
 #: app/flatpak-builtins-build-export.c:768
-#, c-format
 msgid "Extra data sizes of zero not supported"
 msgstr "Extra datastorlekar med noll i storlek stöds inte"
 
@@ -558,7 +555,7 @@ msgid "‘%s’ is not a valid collection ID: %s"
 msgstr "”%s” är inte ett giltigt samlings-ID: %s"
 
 #: app/flatpak-builtins-build-export.c:904
-#: app/flatpak-builtins-build-finish.c:684
+#: app/flatpak-builtins-build-finish.c:683
 msgid "No name specified in the metadata"
 msgstr "Inget namn angivet i metadata"
 
@@ -588,7 +585,6 @@ msgid "Content Written: %u\n"
 msgstr "Skrivet innehåll: %u\n"
 
 #: app/flatpak-builtins-build-export.c:1171
-#, c-format
 msgid "Content Bytes Written:"
 msgstr "Skrivna innehållsbyte:"
 
@@ -690,33 +686,31 @@ msgstr "Exporterar inte %s, exportfilnamnet tillåts inte\n"
 msgid "Exporting %s\n"
 msgstr "Exporterar %s\n"
 
-#: app/flatpak-builtins-build-finish.c:440
-#, c-format
+#: app/flatpak-builtins-build-finish.c:439
 msgid "More than one executable found\n"
 msgstr "Fler än en körbar fil funnen\n"
 
-#: app/flatpak-builtins-build-finish.c:451
+#: app/flatpak-builtins-build-finish.c:450
 #, c-format
 msgid "Using %s as command\n"
 msgstr "Använder %s som ett kommando\n"
 
-#: app/flatpak-builtins-build-finish.c:456
-#, c-format
+#: app/flatpak-builtins-build-finish.c:455
 msgid "No executable found\n"
 msgstr "Ingen körbar fil funnen\n"
 
-#: app/flatpak-builtins-build-finish.c:511
+#: app/flatpak-builtins-build-finish.c:510
 #, c-format
 msgid "Invalid --require-version argument: %s"
 msgstr "Ogiltigt argument för --require-version: %s"
 
-#: app/flatpak-builtins-build-finish.c:543
+#: app/flatpak-builtins-build-finish.c:542
 #, c-format
 msgid "Too few elements in --extra-data argument %s"
 msgstr "För få element i --extra-data-argumentet %s"
 
 # TODO: parentheses not matching?
-#: app/flatpak-builtins-build-finish.c:575
+#: app/flatpak-builtins-build-finish.c:574
 #, c-format
 msgid ""
 "Too few elements in --metadata argument %s, format should be "
@@ -724,7 +718,7 @@ msgid ""
 msgstr ""
 "För få element i --metadata-argumentet %s, formatet är GRUPP=NYCKEL[=VÄRDE]]"
 
-#: app/flatpak-builtins-build-finish.c:597
+#: app/flatpak-builtins-build-finish.c:596
 #: app/flatpak-builtins-build-init.c:458
 #, c-format
 msgid ""
@@ -733,28 +727,27 @@ msgid ""
 msgstr ""
 "För få element i --extension-argumentet %s, formatet är NAMN=VAR[=VÄRDE]"
 
-#: app/flatpak-builtins-build-finish.c:603
+#: app/flatpak-builtins-build-finish.c:602
 #: app/flatpak-builtins-build-init.c:461
 #, c-format
 msgid "Invalid extension name %s"
 msgstr "Ogiltigt tilläggsnamn %s"
 
-#: app/flatpak-builtins-build-finish.c:646
+#: app/flatpak-builtins-build-finish.c:645
 msgid "DIRECTORY - Finalize a build directory"
 msgstr "KATALOG - Slutför en byggkatalog"
 
-#: app/flatpak-builtins-build-finish.c:668
+#: app/flatpak-builtins-build-finish.c:667
 #, c-format
 msgid "Build directory %s not initialized"
 msgstr "Byggkatalog %s är inte initierad"
 
-#: app/flatpak-builtins-build-finish.c:689
+#: app/flatpak-builtins-build-finish.c:688
 #, c-format
 msgid "Build directory %s already finalized"
 msgstr "Byggkatalog %s redan slutförd"
 
-#: app/flatpak-builtins-build-finish.c:702
-#, c-format
+#: app/flatpak-builtins-build-finish.c:701
 msgid "Please review the exported files and the metadata\n"
 msgstr "Granska de exporterade filerna och metadata\n"
 
@@ -1080,12 +1073,10 @@ msgid "LOCATION - Update repository metadata"
 msgstr "PLATS - Uppdatera förrådsmetadata"
 
 #: app/flatpak-builtins-build-update-repo.c:609
-#, c-format
 msgid "Updating appstream branch\n"
 msgstr "Uppdaterar appstream-gren\n"
 
 #: app/flatpak-builtins-build-update-repo.c:638
-#, c-format
 msgid "Updating summary\n"
 msgstr "Uppdaterar sammanfattning\n"
 
@@ -1095,7 +1086,6 @@ msgid "Total objects: %u\n"
 msgstr "Totalt antal objekt: %u\n"
 
 #: app/flatpak-builtins-build-update-repo.c:666
-#, c-format
 msgid "No unreachable objects\n"
 msgstr "Inga onåbara objekt\n"
 
@@ -1374,7 +1364,6 @@ msgstr "FIL - Hämta information om en exporterad fil"
 
 #: app/flatpak-builtins-document-info.c:100
 #: app/flatpak-builtins-document-unexport.c:94
-#, c-format
 msgid "Not exported\n"
 msgstr "Inte exporterad\n"
 
@@ -1438,7 +1427,6 @@ msgid "Show permissions for applications"
 msgstr "Visa rättigheter för program"
 
 #: app/flatpak-builtins-document-list.c:161
-#, c-format
 msgid "No documents found\n"
 msgstr "Inga dokument hittades\n"
 
@@ -1578,7 +1566,7 @@ msgstr "Visa ID för programmet/exekveringsmiljön"
 
 #: app/flatpak-builtins-history.c:63 app/flatpak-builtins-list.c:64
 #: app/flatpak-builtins-ps.c:53 app/flatpak-builtins-remote-ls.c:73
-#: app/flatpak-cli-transaction.c:1435
+#: app/flatpak-cli-transaction.c:1432
 msgid "Arch"
 msgstr "Ark"
 
@@ -1589,7 +1577,7 @@ msgstr "Visa arkitekturen"
 
 #: app/flatpak-builtins-history.c:64 app/flatpak-builtins-list.c:63
 #: app/flatpak-builtins-ps.c:54 app/flatpak-builtins-remote-ls.c:72
-#: app/flatpak-builtins-search.c:48 app/flatpak-cli-transaction.c:1438
+#: app/flatpak-builtins-search.c:48 app/flatpak-cli-transaction.c:1435
 msgid "Branch"
 msgstr "Gren"
 
@@ -1606,7 +1594,7 @@ msgstr "Installation"
 msgid "Show the affected installation"
 msgstr "Visa den påverkade installationen"
 
-#: app/flatpak-builtins-history.c:66 app/flatpak-cli-transaction.c:1452
+#: app/flatpak-builtins-history.c:66 app/flatpak-cli-transaction.c:1449
 msgid "Remote"
 msgstr "Fjärrförråd"
 
@@ -1635,7 +1623,7 @@ msgstr "Visa föregående incheckning"
 msgid "Show the remote URL"
 msgstr "Visa fjärrförråds-URL"
 
-#: app/flatpak-builtins-history.c:70 app/flatpak-cli-transaction.c:700
+#: app/flatpak-builtins-history.c:70 app/flatpak-cli-transaction.c:697
 msgid "User"
 msgstr "Användare"
 
@@ -1680,12 +1668,10 @@ msgid " - Show history"
 msgstr " - Visa historik"
 
 #: app/flatpak-builtins-history.c:490
-#, c-format
 msgid "Failed to parse the --since option"
 msgstr "Misslyckades med att tolka flaggan --since"
 
 #: app/flatpak-builtins-history.c:501
-#, c-format
 msgid "Failed to parse the --until option"
 msgstr "Misslyckades med att tolka flaggan --until"
 
@@ -1768,7 +1754,6 @@ msgid "ref not present in origin"
 msgstr "ref finns inte i ursprung"
 
 #: app/flatpak-builtins-info.c:211 app/flatpak-builtins-remote-info.c:217
-#, c-format
 msgid "Warning: Commit has no flatpak metadata\n"
 msgstr "Varning: Incheckning har inga flatpak-metadata\n"
 
@@ -2024,7 +2009,6 @@ msgid "At least one REF must be specified"
 msgstr "Minst en REF måste anges"
 
 #: app/flatpak-builtins-install.c:392
-#, c-format
 msgid "Looking for matches…\n"
 msgstr "Söker efter matchningar…\n"
 
@@ -2228,12 +2212,10 @@ msgstr ""
 "matchar mönster"
 
 #: app/flatpak-builtins-mask.c:73
-#, c-format
 msgid "No masked patterns\n"
 msgstr "Inga maskerade mönster\n"
 
 #: app/flatpak-builtins-mask.c:78
-#, c-format
 msgid "Masked patterns:\n"
 msgstr "Maskerade mönster:\n"
 
@@ -2327,12 +2309,10 @@ msgstr ""
 "matchar mönster"
 
 #: app/flatpak-builtins-pin.c:75
-#, c-format
 msgid "No pinned patterns\n"
 msgstr "Inga nålade mönster\n"
 
 #: app/flatpak-builtins-pin.c:80
-#, c-format
 msgid "Pinned patterns:\n"
 msgstr "Nålade mönster:\n"
 
@@ -2341,7 +2321,6 @@ msgid "- Install flatpaks that are part of the operating system"
 msgstr "- Installera flatpak-filer som är en del av operativsystemet"
 
 #: app/flatpak-builtins-preinstall.c:118
-#, c-format
 msgid "Nothing to do.\n"
 msgstr "Inget att göra.\n"
 
@@ -2514,7 +2493,7 @@ msgstr "Följ inte omdirigeringen som satts i sammanfattningsfilen"
 msgid "Can't load uri %s: %s\n"
 msgstr "Det går inte att läsa in uri %s: %s\n"
 
-#: app/flatpak-builtins-remote-add.c:276 common/flatpak-dir.c:4643
+#: app/flatpak-builtins-remote-add.c:276 common/flatpak-dir.c:4646
 #, c-format
 msgid "Can't load file %s: %s\n"
 msgstr "Det går inte att läsa in filen %s: %s\n"
@@ -2883,7 +2862,6 @@ msgid "[%d/%d] Verifying %s…\n"
 msgstr "[%d/%d] Verifierar %s…\n"
 
 #: app/flatpak-builtins-repair.c:435
-#, c-format
 msgid "Dry run: "
 msgstr "Torrkörning: "
 
@@ -2903,7 +2881,6 @@ msgid "Deleting ref %s due to %d\n"
 msgstr "Tar bort ref %s på grund av %d\n"
 
 #: app/flatpak-builtins-repair.c:464
-#, c-format
 msgid "Checking remotes...\n"
 msgstr "Kontrollerar fjärrförråd…\n"
 
@@ -2918,22 +2895,18 @@ msgid "Remote %s for ref %s is disabled\n"
 msgstr "Fjärrförråd %s för ref %s är inaktiverat\n"
 
 #: app/flatpak-builtins-repair.c:490
-#, c-format
 msgid "Pruning objects\n"
 msgstr "Rensa objekt\n"
 
 #: app/flatpak-builtins-repair.c:498
-#, c-format
 msgid "Erasing .removed\n"
 msgstr "Tar bort .removed\n"
 
 #: app/flatpak-builtins-repair.c:524
-#, c-format
 msgid "Reinstalling refs\n"
 msgstr "Ominstallerar referenser\n"
 
 #: app/flatpak-builtins-repair.c:526
-#, c-format
 msgid "Reinstalling removed refs\n"
 msgstr "Ominstallerar borttagna referenser\n"
 
@@ -2968,7 +2941,6 @@ msgid "false"
 msgstr "falskt"
 
 #: app/flatpak-builtins-repo.c:121
-#, c-format
 msgid "Subsummaries: "
 msgstr "Undersammanfattningar: "
 
@@ -3052,7 +3024,7 @@ msgid "Installed"
 msgstr "Installerad"
 
 #. Translators: Download is used here as a noun
-#: app/flatpak-builtins-repo.c:338 app/flatpak-cli-transaction.c:1462
+#: app/flatpak-builtins-repo.c:338 app/flatpak-cli-transaction.c:1459
 msgid "Download"
 msgstr "Hämta"
 
@@ -3181,14 +3153,13 @@ msgid "Use PATH instead of the app's /app"
 msgstr "Använd SÖKVÄG istället för programmets /app"
 
 #: app/flatpak-builtins-run.c:183
-#, fuzzy
 msgid "Use FD instead of the app's /app"
-msgstr "Använd SÖKVÄG istället för programmets /app"
+msgstr "Använd FH istället för programmets /app"
 
 # Filhandtag
 #: app/flatpak-builtins-run.c:183 app/flatpak-builtins-run.c:185
 #: app/flatpak-builtins-run.c:187 app/flatpak-builtins-run.c:188
-#: common/flatpak-context.c:2672
+#: common/flatpak-context.c:2715
 msgid "FD"
 msgstr "FH"
 
@@ -3197,9 +3168,8 @@ msgid "Use PATH instead of the runtime's /usr"
 msgstr "Använd SÖKVÄG istället för exekveringsmiljöns /usr"
 
 #: app/flatpak-builtins-run.c:185
-#, fuzzy
 msgid "Use FD instead of the runtime's /usr"
-msgstr "Använd SÖKVÄG istället för exekveringsmiljöns /usr"
+msgstr "Använd FH istället för exekveringsmiljöns /usr"
 
 #: app/flatpak-builtins-run.c:186
 msgid "Clear all outside environment variables"
@@ -3209,12 +3179,16 @@ msgstr "Rensa alla yttre miljövariabler"
 msgid ""
 "Bind mount the file or directory referred to by FD to its canonicalized path"
 msgstr ""
+"Bindningsmontera filen eller katalogen som refereras till av FH till dess "
+"kanoniska sökväg"
 
 #: app/flatpak-builtins-run.c:188
 msgid ""
 "Bind mount the file or directory referred to by FD read-only to its "
 "canonicalized path"
 msgstr ""
+"Bindningsmontera filen eller katalogen som refereras till av FH skrivskyddat "
+"till dess kanoniska sökväg"
 
 #: app/flatpak-builtins-run.c:219
 msgid "APP [ARGUMENT…] - Run an app"
@@ -3227,11 +3201,11 @@ msgstr "runtime/%s/%s/%s inte installerad"
 
 #: app/flatpak-builtins-run.c:419
 msgid "app-fd and app-path cannot both be used"
-msgstr ""
+msgstr "kan inte både använda app-fd och app-path"
 
 #: app/flatpak-builtins-run.c:449
 msgid "usr-fd and usr-path cannot both be used"
-msgstr ""
+msgstr "kan inte både använda usr-fd och usr-path"
 
 #: app/flatpak-builtins-search.c:37
 msgid "Arch to search for"
@@ -3332,7 +3306,6 @@ msgstr ""
 "bort; se flatpak-pin(1):\n"
 
 #: app/flatpak-builtins-uninstall.c:370
-#, c-format
 msgid "Nothing unused to uninstall\n"
 msgstr "Inget oanvänt att avinstallera\n"
 
@@ -3357,12 +3330,10 @@ msgid "Warning: %s is not installed\n"
 msgstr "Varning: %s är inte installerad\n"
 
 #: app/flatpak-builtins-uninstall.c:490
-#, c-format
 msgid "None of the specified refs are installed"
 msgstr "Inga av de angivna referenserna är installerade"
 
 #: app/flatpak-builtins-uninstall.c:599
-#, c-format
 msgid "No app data to delete\n"
 msgstr "Inga programdata att ta bort\n"
 
@@ -3403,7 +3374,6 @@ msgid "With --commit, only one REF may be specified"
 msgstr "Med --commit får endast en REF anges"
 
 #: app/flatpak-builtins-update.c:162
-#, c-format
 msgid "Looking for updates…\n"
 msgstr "Söker efter uppdateringar…\n"
 
@@ -3413,9 +3383,8 @@ msgid "Unable to update %s: %s\n"
 msgstr "Kunde inte uppdatera %s: %s\n"
 
 #: app/flatpak-builtins-update.c:274
-#, fuzzy, c-format
 msgid "Nothing to update.\n"
-msgstr "Inget att göra.\n"
+msgstr "Inget att uppdatera.\n"
 
 #: app/flatpak-builtins-utils.c:337
 #, c-format
@@ -3500,7 +3469,6 @@ msgid "Found installed ref ‘%s’ (%s). Is this correct?"
 msgstr "Hittade installerad ref ”%s” (%s). Stämmer detta?"
 
 #: app/flatpak-builtins-utils.c:534
-#, c-format
 msgid "All of the above"
 msgstr "Alla ovanstående"
 
@@ -3765,17 +3733,17 @@ msgstr "Autentisering krävs för fjärrförrådet ”%s”\n"
 msgid "Open browser?"
 msgstr "Öppna webbläsare?"
 
-#: app/flatpak-cli-transaction.c:699
+#: app/flatpak-cli-transaction.c:696
 #, c-format
 msgid "Login required remote %s (realm %s)\n"
 msgstr "Inloggning krävde fjärrförrådet %s (rike %s)\n"
 
-#: app/flatpak-cli-transaction.c:704
+#: app/flatpak-cli-transaction.c:701
 msgid "Password"
 msgstr "Lösenord"
 
 #. Only runtimes can be pinned
-#: app/flatpak-cli-transaction.c:759
+#: app/flatpak-cli-transaction.c:756
 #, c-format
 msgid ""
 "\n"
@@ -3786,7 +3754,7 @@ msgstr ""
 "Info: (nålad) exekveringsmiljö %s%s%s gren %s%s%s har nått slutet på sin "
 "livstid, till förmån för %s%s%s gren %s%s%s\n"
 
-#: app/flatpak-cli-transaction.c:765
+#: app/flatpak-cli-transaction.c:762
 #, c-format
 msgid ""
 "\n"
@@ -3797,7 +3765,7 @@ msgstr ""
 "Info: exekveringsmiljö %s%s%s gren %s%s%s har nått slutet på sin livstid, "
 "till förmån för %s%s%s gren %s%s%s\n"
 
-#: app/flatpak-cli-transaction.c:768
+#: app/flatpak-cli-transaction.c:765
 #, c-format
 msgid ""
 "\n"
@@ -3809,7 +3777,7 @@ msgstr ""
 "för %s%s%s gren %s%s%s\n"
 
 #. Only runtimes can be pinned
-#: app/flatpak-cli-transaction.c:780
+#: app/flatpak-cli-transaction.c:777
 #, c-format
 msgid ""
 "\n"
@@ -3819,7 +3787,7 @@ msgstr ""
 "Info: (nålad) exekveringsmiljö %s%s%s gren %s%s%s har nått slutet på sin "
 "livstid, med anledning:\n"
 
-#: app/flatpak-cli-transaction.c:786
+#: app/flatpak-cli-transaction.c:783
 #, c-format
 msgid ""
 "\n"
@@ -3829,7 +3797,7 @@ msgstr ""
 "Info: exekveringsmiljö %s%s%s gren %s%s%s har nått slutet på sin livstid, "
 "med anledning:\n"
 
-#: app/flatpak-cli-transaction.c:789
+#: app/flatpak-cli-transaction.c:786
 #, c-format
 msgid ""
 "\n"
@@ -3839,88 +3807,85 @@ msgstr ""
 "Info: program %s%s%s gren %s%s%s har nått slutet på sin livstid, med "
 "anledning:\n"
 
-#: app/flatpak-cli-transaction.c:963
-#, c-format
+#: app/flatpak-cli-transaction.c:960
 msgid "Info: applications using this extension:\n"
 msgstr "Info: program använder detta tillägg:\n"
 
-#: app/flatpak-cli-transaction.c:965
-#, c-format
+#: app/flatpak-cli-transaction.c:962
 msgid "Info: applications using this runtime:\n"
 msgstr "Info: program använder denna exekveringsmiljö:\n"
 
-#: app/flatpak-cli-transaction.c:984
+#: app/flatpak-cli-transaction.c:981
 msgid "Replace?"
 msgstr "Ersätt?"
 
-#: app/flatpak-cli-transaction.c:987 app/flatpak-quiet-transaction.c:247
-#, c-format
+#: app/flatpak-cli-transaction.c:984 app/flatpak-quiet-transaction.c:247
 msgid "Updating to rebased version\n"
 msgstr "Uppdaterar till ombaserad version\n"
 
-#: app/flatpak-cli-transaction.c:1011
+#: app/flatpak-cli-transaction.c:1008
 #, c-format
 msgid "Failed to rebase %s to %s: "
 msgstr "Misslyckades med att ombasera %s till %s: "
 
-#: app/flatpak-cli-transaction.c:1277
+#: app/flatpak-cli-transaction.c:1274
 #, c-format
 msgid "New %s%s%s permissions:"
 msgstr "Nya rättigheter för %s%s%s:"
 
-#: app/flatpak-cli-transaction.c:1279
+#: app/flatpak-cli-transaction.c:1276
 #, c-format
 msgid "%s%s%s permissions:"
 msgstr "Rättigheter för %s%s%s:"
 
-#: app/flatpak-cli-transaction.c:1343
+#: app/flatpak-cli-transaction.c:1340
 msgid "Warning: "
 msgstr "Varning: "
 
 #. translators: This is short for operation, the title of a one-char column
-#: app/flatpak-cli-transaction.c:1442
+#: app/flatpak-cli-transaction.c:1439
 msgid "Op"
 msgstr "Åtg"
 
 #. Avoid resizing the download column too much,
 #. * by making the title as long as typical content
 #.
-#: app/flatpak-cli-transaction.c:1458 app/flatpak-cli-transaction.c:1503
+#: app/flatpak-cli-transaction.c:1455 app/flatpak-cli-transaction.c:1500
 msgid "partial"
 msgstr "partiell"
 
-#: app/flatpak-cli-transaction.c:1535
+#: app/flatpak-cli-transaction.c:1532
 msgid "Proceed with these changes to the user installation?"
 msgstr "Fortsätt med dessa ändringar till användarinstallationen?"
 
-#: app/flatpak-cli-transaction.c:1537
+#: app/flatpak-cli-transaction.c:1534
 msgid "Proceed with these changes to the system installation?"
 msgstr "Fortsätt med dessa ändringar till systeminstallationen?"
 
-#: app/flatpak-cli-transaction.c:1539
+#: app/flatpak-cli-transaction.c:1536
 #, c-format
 msgid "Proceed with these changes to the %s?"
 msgstr "Fortsätt med dessa ändringar till %s?"
 
-#: app/flatpak-cli-transaction.c:1711
+#: app/flatpak-cli-transaction.c:1707
 msgid "Changes complete."
 msgstr "Ändringar slutförda."
 
-#: app/flatpak-cli-transaction.c:1713
+#: app/flatpak-cli-transaction.c:1709
 msgid "Uninstall complete."
 msgstr "Avinstallation slutförd."
 
-#: app/flatpak-cli-transaction.c:1715
+#: app/flatpak-cli-transaction.c:1711
 msgid "Installation complete."
 msgstr "Installation slutförd."
 
-#: app/flatpak-cli-transaction.c:1717
+#: app/flatpak-cli-transaction.c:1713
 msgid "Updates complete."
 msgstr "Uppdateringar slutförda."
 
 #. For updates/!stop_on_first_error we already printed all errors so we make up
 #. a different one.
-#: app/flatpak-cli-transaction.c:1750
+#: app/flatpak-cli-transaction.c:1746
 msgid "There were one or more errors"
 msgstr "Det fanns ett eller flera fel"
 
@@ -4327,16 +4292,16 @@ msgstr "Varning: Misslyckades med att avinstallera %s: %s\n"
 msgid "Error: Failed to uninstall %s: %s\n"
 msgstr "Fel: Misslyckades med att avinstallera %s: %s\n"
 
-#: app/flatpak-quiet-transaction.c:166 common/flatpak-dir.c:11475
+#: app/flatpak-quiet-transaction.c:166 common/flatpak-dir.c:11477
 #, c-format
 msgid "%s already installed"
 msgstr "%s redan installerad"
 
-#: app/flatpak-quiet-transaction.c:168 common/flatpak-dir.c:3622
-#: common/flatpak-dir.c:4321 common/flatpak-dir.c:16968
+#: app/flatpak-quiet-transaction.c:168 common/flatpak-dir.c:3625
+#: common/flatpak-dir.c:4324 common/flatpak-dir.c:16968
 #: common/flatpak-dir.c:17258 common/flatpak-dir-utils.c:166
-#: common/flatpak-dir-utils.c:259 common/flatpak-transaction.c:2736
-#: common/flatpak-transaction.c:2791
+#: common/flatpak-dir-utils.c:259 common/flatpak-transaction.c:2752
+#: common/flatpak-transaction.c:2807
 #, c-format
 msgid "%s not installed"
 msgstr "%s inte installerad"
@@ -4370,48 +4335,47 @@ msgstr "Misslyckades med att ombasera %s till %s: %s\n"
 msgid "No authenticator configured for remote `%s`"
 msgstr "Ingen autentiserare konfigurerad för fjärrförrådet ”%s”"
 
-#: common/flatpak-context.c:637 common/flatpak-context.c:649
+#: common/flatpak-context.c:641 common/flatpak-context.c:653
 #, c-format
 msgid "Invalid permission syntax: %s"
 msgstr "Ogiltig rättighetssyntax: %s"
 
-#: common/flatpak-context.c:1207
+#: common/flatpak-context.c:1250
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Okänd delningstyp %s, giltiga typer är: %s"
 
-#: common/flatpak-context.c:1228
+#: common/flatpak-context.c:1271
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Okänd policytyp %s, giltiga typer är: %s"
 
-#: common/flatpak-context.c:1266
+#: common/flatpak-context.c:1309
 #, c-format
 msgid "Invalid dbus name %s"
 msgstr "Ogiltigt dbusnamn %s"
 
-#: common/flatpak-context.c:1279
+#: common/flatpak-context.c:1322
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Okänd uttagstyp %s, giltiga typer är: %s"
 
-#: common/flatpak-context.c:1294
+#: common/flatpak-context.c:1337
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Okänd enhetstyp %s, giltiga typer är: %s"
 
-#: common/flatpak-context.c:1308
+#: common/flatpak-context.c:1351
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Okänd funktionstyp %s, giltiga typer är: %s"
 
-#: common/flatpak-context.c:1840
+#: common/flatpak-context.c:1883
 #, c-format
 msgid "Filesystem location \"%s\" contains \"..\""
 msgstr "Filsystemsplatsen ”%s” innehåller ”..”"
 
-#: common/flatpak-context.c:1882
-#, c-format
+#: common/flatpak-context.c:1925
 msgid ""
 "--filesystem=/ is not available, use --filesystem=host for a similar result"
 msgstr ""
@@ -4419,7 +4383,7 @@ msgstr ""
 "liknande resultat"
 
 # host and home are hardcoded
-#: common/flatpak-context.c:1916
+#: common/flatpak-context.c:1959
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, host-os, host-"
@@ -4428,257 +4392,252 @@ msgstr ""
 "Okänd filsystemsplats %s, giltiga platser är: host, host-os, host-etc, host-"
 "root, home, xdg-*[/…], ~/kat, /kat"
 
-#: common/flatpak-context.c:2015
+#: common/flatpak-context.c:2058
 #, c-format
 msgid "Invalid syntax for %s: %s"
 msgstr "Ogiltig syntax för %s: %s"
 
-#: common/flatpak-context.c:2142
-#, c-format
+#: common/flatpak-context.c:2185
 msgid "fallback-x11 can not be conditional"
 msgstr "fallback-x11 kan inte vara villkorlig"
 
-#: common/flatpak-context.c:2318
+#: common/flatpak-context.c:2361
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Ogiltigt miljöformat %s"
 
-#: common/flatpak-context.c:2399
+#: common/flatpak-context.c:2442
 #, c-format
 msgid "Environment variable name must not contain '=': %s"
 msgstr "Miljövariabeln får inte innehålla '=': %s"
 
-#: common/flatpak-context.c:2527 common/flatpak-context.c:2535
-#, c-format
+#: common/flatpak-context.c:2570 common/flatpak-context.c:2578
 msgid "--add-policy arguments must be in the form SUBSYSTEM.KEY=VALUE"
 msgstr ""
 "Argument till --add-policy måste vara på formen UNDERSYSTEM.NYCKEL=VÄRDE"
 
-#: common/flatpak-context.c:2542
-#, c-format
+#: common/flatpak-context.c:2585
 msgid "--add-policy values can't start with \"!\""
 msgstr "Värden till --add-policy får inte starta med ”!”"
 
-#: common/flatpak-context.c:2567 common/flatpak-context.c:2575
-#, c-format
+#: common/flatpak-context.c:2610 common/flatpak-context.c:2618
 msgid "--remove-policy arguments must be in the form SUBSYSTEM.KEY=VALUE"
 msgstr ""
 "Argument till --remove-policy måste vara på formen UNDERSYSTEM.NYCKEL=VÄRDE"
 
-#: common/flatpak-context.c:2582
-#, c-format
+#: common/flatpak-context.c:2625
 msgid "--remove-policy values can't start with \"!\""
 msgstr "Värden till --remove-policy får inte starta med ”!”"
 
-#: common/flatpak-context.c:2657
+#: common/flatpak-context.c:2700
 msgid "Share with host"
 msgstr "Dela med värd"
 
-#: common/flatpak-context.c:2657 common/flatpak-context.c:2658
+#: common/flatpak-context.c:2700 common/flatpak-context.c:2701
 msgid "SHARE"
 msgstr "DELNING"
 
-#: common/flatpak-context.c:2658
+#: common/flatpak-context.c:2701
 msgid "Unshare with host"
 msgstr "Avsluta delning med värd"
 
-#: common/flatpak-context.c:2659
+#: common/flatpak-context.c:2702
 msgid "Require conditions to be met for a subsystem to get shared"
 msgstr "Kräv att villkor möts för att ett undersystem ska delas"
 
-#: common/flatpak-context.c:2659
+#: common/flatpak-context.c:2702
 msgid "SHARE:CONDITION"
 msgstr "DELNING:VILLKOR"
 
-#: common/flatpak-context.c:2660
+#: common/flatpak-context.c:2703
 msgid "Expose socket to app"
 msgstr "Exponera uttag för program"
 
-#: common/flatpak-context.c:2660 common/flatpak-context.c:2661
+#: common/flatpak-context.c:2703 common/flatpak-context.c:2704
 msgid "SOCKET"
 msgstr "UTTAG"
 
-#: common/flatpak-context.c:2661
+#: common/flatpak-context.c:2704
 msgid "Don't expose socket to app"
 msgstr "Exponera inte detta uttag för program"
 
-#: common/flatpak-context.c:2662
+#: common/flatpak-context.c:2705
 msgid "Require conditions to be met for a socket to get exposed"
 msgstr "Kräv att villkor möts för att ett uttag ska exponeras"
 
-#: common/flatpak-context.c:2662
+#: common/flatpak-context.c:2705
 msgid "SOCKET:CONDITION"
 msgstr "UTTAG:VILLKOR"
 
-#: common/flatpak-context.c:2663
+#: common/flatpak-context.c:2706
 msgid "Expose device to app"
 msgstr "Exponera enhet för program"
 
-#: common/flatpak-context.c:2663 common/flatpak-context.c:2664
+#: common/flatpak-context.c:2706 common/flatpak-context.c:2707
 msgid "DEVICE"
 msgstr "ENHET"
 
-#: common/flatpak-context.c:2664
+#: common/flatpak-context.c:2707
 msgid "Don't expose device to app"
 msgstr "Exponera inte enhet för program"
 
-#: common/flatpak-context.c:2665
+#: common/flatpak-context.c:2708
 msgid "Require conditions to be met for a device to get exposed"
 msgstr "Kräv att villkor möts för att en enhet ska exponeras"
 
-#: common/flatpak-context.c:2665
+#: common/flatpak-context.c:2708
 msgid "DEVICE:CONDITION"
 msgstr "ENHET:VILLKOR"
 
-#: common/flatpak-context.c:2666
+#: common/flatpak-context.c:2709
 msgid "Allow feature"
 msgstr "Tillåt funktion"
 
-#: common/flatpak-context.c:2666 common/flatpak-context.c:2667
+#: common/flatpak-context.c:2709 common/flatpak-context.c:2710
 msgid "FEATURE"
 msgstr "FUNKTION"
 
-#: common/flatpak-context.c:2667
+#: common/flatpak-context.c:2710
 msgid "Don't allow feature"
 msgstr "Tillåt inte funktion"
 
-#: common/flatpak-context.c:2668
+#: common/flatpak-context.c:2711
 msgid "Require conditions to be met for a feature to get allowed"
 msgstr "Kräv att villkor möts för att en funktion ska tillåtas"
 
-#: common/flatpak-context.c:2668
+#: common/flatpak-context.c:2711
 msgid "FEATURE:CONDITION"
 msgstr "FUNKTION:VILLKOR"
 
 # :ro can't be translated
-#: common/flatpak-context.c:2669
+#: common/flatpak-context.c:2712
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr "Exponera filsystem för program (:ro för skrivskyddat)"
 
 # :ro can't be translated
-#: common/flatpak-context.c:2669
+#: common/flatpak-context.c:2712
 msgid "FILESYSTEM[:ro]"
 msgstr "FILSYSTEM[:ro]"
 
-#: common/flatpak-context.c:2670
+#: common/flatpak-context.c:2713
 msgid "Don't expose filesystem to app"
 msgstr "Exponera inte filsystem för program"
 
-#: common/flatpak-context.c:2670
+#: common/flatpak-context.c:2713
 msgid "FILESYSTEM"
 msgstr "FILSYSTEM"
 
-#: common/flatpak-context.c:2671
+#: common/flatpak-context.c:2714
 msgid "Set environment variable"
 msgstr "Ställ in miljövariabel"
 
-#: common/flatpak-context.c:2671
+#: common/flatpak-context.c:2714
 msgid "VAR=VALUE"
 msgstr "VAR=VÄRDE"
 
-#: common/flatpak-context.c:2672
+#: common/flatpak-context.c:2715
 msgid "Read environment variables in env -0 format from FD"
 msgstr "Läs miljövariabler i formatet env -0 från FH"
 
-#: common/flatpak-context.c:2673
+#: common/flatpak-context.c:2716
 msgid "Remove variable from environment"
 msgstr "Ta bort variabel från miljö"
 
-#: common/flatpak-context.c:2673
+#: common/flatpak-context.c:2716
 msgid "VAR"
 msgstr "VAR"
 
-#: common/flatpak-context.c:2674
+#: common/flatpak-context.c:2717
 msgid "Allow app to own name on the session bus"
 msgstr "Tillåt program att äga namn på sessionsbussen"
 
-#: common/flatpak-context.c:2674 common/flatpak-context.c:2675
-#: common/flatpak-context.c:2676 common/flatpak-context.c:2677
-#: common/flatpak-context.c:2678 common/flatpak-context.c:2679
-#: common/flatpak-context.c:2680
+#: common/flatpak-context.c:2717 common/flatpak-context.c:2718
+#: common/flatpak-context.c:2719 common/flatpak-context.c:2720
+#: common/flatpak-context.c:2721 common/flatpak-context.c:2722
+#: common/flatpak-context.c:2723
 msgid "DBUS_NAME"
 msgstr "DBUSNAMN"
 
-#: common/flatpak-context.c:2675
+#: common/flatpak-context.c:2718
 msgid "Allow app to talk to name on the session bus"
 msgstr "Tillåt program att prata med namn på sessionsbussen"
 
-#: common/flatpak-context.c:2676
+#: common/flatpak-context.c:2719
 msgid "Don't allow app to talk to name on the session bus"
 msgstr "Tillåt inte program att prata med namn på sessionsbussen"
 
-#: common/flatpak-context.c:2677
+#: common/flatpak-context.c:2720
 msgid "Allow app to own name on the system bus"
 msgstr "Tillåt program att äga namn på systembussen"
 
-#: common/flatpak-context.c:2678
+#: common/flatpak-context.c:2721
 msgid "Allow app to talk to name on the system bus"
 msgstr "Tillåt program att prata med namn på systembussen"
 
-#: common/flatpak-context.c:2679
+#: common/flatpak-context.c:2722
 msgid "Don't allow app to talk to name on the system bus"
 msgstr "Tillåt inte program att prata med namn på systembussen"
 
-#: common/flatpak-context.c:2680
+#: common/flatpak-context.c:2723
 msgid "Allow app to own name on the a11y bus"
 msgstr "Tillåt program att äga namn på a11y-bussen"
 
-#: common/flatpak-context.c:2681
+#: common/flatpak-context.c:2724
 msgid "Add generic policy option"
 msgstr "Lägg till alternativ för generell policy"
 
-#: common/flatpak-context.c:2681 common/flatpak-context.c:2682
+#: common/flatpak-context.c:2724 common/flatpak-context.c:2725
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "UNDERSYSTEM.NYCKEL=VÄRDE"
 
-#: common/flatpak-context.c:2682
+#: common/flatpak-context.c:2725
 msgid "Remove generic policy option"
 msgstr "Ta bort alternativet för generell policy"
 
-#: common/flatpak-context.c:2683
+#: common/flatpak-context.c:2726
 msgid "Add USB device to enumerables"
 msgstr "Lägg till USB-enhet till uppräkningsbara"
 
-#: common/flatpak-context.c:2683 common/flatpak-context.c:2684
+#: common/flatpak-context.c:2726 common/flatpak-context.c:2727
 msgid "VENDOR_ID:PRODUCT_ID"
 msgstr "TILLVERKAR-ID:PRODUKT-ID"
 
-#: common/flatpak-context.c:2684
+#: common/flatpak-context.c:2727
 msgid "Add USB device to hidden list"
 msgstr "Lägg till USB-enhet till dold lista"
 
-#: common/flatpak-context.c:2685
+#: common/flatpak-context.c:2728
 msgid "A list of USB devices that are enumerable"
 msgstr "En lista över USB-enheter som är uppräkningsbara"
 
-#: common/flatpak-context.c:2685
+#: common/flatpak-context.c:2728
 msgid "LIST"
 msgstr "LISTA"
 
-#: common/flatpak-context.c:2686
+#: common/flatpak-context.c:2729
 msgid "File containing a list of USB devices to make enumerable"
 msgstr "Fil som innehåller en lista över USB-enheter att göra uppräkningsbara"
 
-#: common/flatpak-context.c:2686 common/flatpak-context.c:2687
+#: common/flatpak-context.c:2729 common/flatpak-context.c:2730
 msgid "FILENAME"
 msgstr "FILNAMN"
 
 # https://github.com/flatpak/flatpak/commit/d5909171bbd7f0157066e2b73007d326fa74df88
-#: common/flatpak-context.c:2687
+#: common/flatpak-context.c:2730
 msgid "Persist home directory subpath"
 msgstr "Gör undersökväg i hemkatalog beständig"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-context.c:2689
+#: common/flatpak-context.c:2732
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Kräv inte en körande session (inget cgroups-skapande)"
 
-#: common/flatpak-context.c:3718
+#: common/flatpak-context.c:3761
 #, c-format
 msgid "Not replacing \"%s\" with tmpfs: %s"
 msgstr "Ersätter inte ”%s” med tmpfs: %s"
 
-#: common/flatpak-context.c:3726
+#: common/flatpak-context.c:3769
 #, c-format
 msgid "Not sharing \"%s\" with sandbox: %s"
 msgstr "Delar inte ”%s” med sandlåda: %s"
@@ -4687,398 +4646,392 @@ msgstr "Delar inte ”%s” med sandlåda: %s"
 #. * the path not existing, it seems reasonable to make more of a fuss
 #. * about the home directory not existing or otherwise being unusable,
 #. * so this is intentionally not using cannot_export()
-#: common/flatpak-context.c:3828
+#: common/flatpak-context.c:3871
 #, c-format
 msgid "Not allowing home directory access: %s"
 msgstr "Tillåter inte åtkomst till hemkatalog: %s"
 
-#: common/flatpak-context.c:4062
+#: common/flatpak-context.c:4105
 #, c-format
 msgid "Unable to provide a temporary home directory in the sandbox: %s"
 msgstr "Kunde inte tillhandahålla en temporär hemkatalog i sandlådan: %s"
 
-#: common/flatpak-dir.c:442
+#: common/flatpak-dir.c:441
 #, c-format
 msgid "Configured collection ID ‘%s’ not in summary file"
 msgstr "Konfigurerat samlings-ID ”%s” inte i sammanfattningsfil"
 
-#: common/flatpak-dir.c:587
+#: common/flatpak-dir.c:586
 #, c-format
 msgid "Unable to load summary from remote %s: %s"
 msgstr "Kunde inte läsa in sammanfattning från fjärrförrådet %s: %s"
 
 # sebras: how to translate in here?
-#: common/flatpak-dir.c:764 common/flatpak-dir.c:800 common/flatpak-dir.c:906
+#: common/flatpak-dir.c:763 common/flatpak-dir.c:799 common/flatpak-dir.c:905
 #, c-format
 msgid "No such ref '%s' in remote %s"
 msgstr "Ingen sådan ref ”%s” i fjärrförrådet %s"
 
-#: common/flatpak-dir.c:891 common/flatpak-dir.c:1051 common/flatpak-dir.c:1080
-#: common/flatpak-dir.c:1092
+#: common/flatpak-dir.c:890 common/flatpak-dir.c:1050 common/flatpak-dir.c:1079
+#: common/flatpak-dir.c:1091
 #, c-format
 msgid "No entry for %s in remote %s summary flatpak cache"
 msgstr "Ingen post för %s i flatpak-sammanfattningscache för fjärrförrådet %s"
 
-#: common/flatpak-dir.c:1069
+#: common/flatpak-dir.c:1068
 #, c-format
 msgid "No summary or Flatpak cache available for remote %s"
 msgstr ""
 "Ingen sammanfattning eller Flatpak-cache tillgänglig för fjärrförrådet %s"
 
-#: common/flatpak-dir.c:1097
+#: common/flatpak-dir.c:1096
 #, c-format
 msgid "Missing xa.data in summary for remote %s"
 msgstr "Saknar xa.data i sammanfattning för fjärrförrådet %s"
 
-#: common/flatpak-dir.c:1103 common/flatpak-dir.c:1546
+#: common/flatpak-dir.c:1102 common/flatpak-dir.c:1545
 #, c-format
 msgid "Unsupported summary version %d for remote %s"
 msgstr "Sammanfattningsversion %d som inte stöds för fjärrförrådet %s"
 
-#: common/flatpak-dir.c:1200
+#: common/flatpak-dir.c:1199
 msgid "Remote OCI index has no registry uri"
 msgstr "OCI-index för fjärrförråd har ingen register-uri"
 
-#: common/flatpak-dir.c:1261
+#: common/flatpak-dir.c:1260
 #, c-format
 msgid "Couldn't find ref %s in remote %s"
 msgstr "Det gick inte att hitta ref %s i fjärrförrådet %s"
 
-#: common/flatpak-dir.c:1288 common/flatpak-dir.c:1381
-#, fuzzy, c-format
+#: common/flatpak-dir.c:1287 common/flatpak-dir.c:1380
+#, c-format
 msgid "Commit has no requested ref ‘%s’ in ref binding metadata (found: ‘%s’)"
-msgstr "Incheckning har ingen begärd ref ”%s” i refbindningsmetadata"
+msgstr ""
+"Incheckning har ingen begärd ref ”%s” i refbindningsmetadata (hittat: ”%s”)"
 
-#: common/flatpak-dir.c:1413
+#: common/flatpak-dir.c:1412
 #, c-format
 msgid "Configured collection ID ‘%s’ not in binding metadata"
 msgstr "Konfigurerat samlings-ID ”%s” inte i bindningsmetadata"
 
-#: common/flatpak-dir.c:1449 common/flatpak-dir.c:5645
+#: common/flatpak-dir.c:1448 common/flatpak-dir.c:5648
 #, c-format
 msgid "Couldn't find latest checksum for ref %s in remote %s"
 msgstr ""
 "Det gick inte att hitta senaste kontrollsumma för ref %s i fjärrförrådet %s"
 
-#: common/flatpak-dir.c:1516 common/flatpak-dir.c:1552
+#: common/flatpak-dir.c:1515 common/flatpak-dir.c:1551
 #, c-format
 msgid "No entry for %s in remote %s summary flatpak sparse cache"
 msgstr ""
 "Ingen post för %s i gles flatpak-sammanfattningscache för fjärrförrådet %s"
 
-#: common/flatpak-dir.c:2540
+#: common/flatpak-dir.c:2539
 #, c-format
 msgid "Commit metadata for %s not matching expected metadata"
 msgstr "Incheckningsmetadata för %s matchar inte förväntade metadata"
 
-#: common/flatpak-dir.c:2823
+#: common/flatpak-dir.c:2826
 msgid "Unable to connect to system bus"
 msgstr "Kunde inte ansluta till systembussen"
 
-#: common/flatpak-dir.c:3419
+#: common/flatpak-dir.c:3422
 msgid "User installation"
 msgstr "Användarinstallation"
 
-#: common/flatpak-dir.c:3426
+#: common/flatpak-dir.c:3429
 #, c-format
 msgid "System (%s) installation"
 msgstr "Systeminstallation (%s)"
 
-#: common/flatpak-dir.c:3472
+#: common/flatpak-dir.c:3475
 #, c-format
 msgid "No overrides found for %s"
 msgstr "Inga åsidosättningar funna för %s"
 
-#: common/flatpak-dir.c:3625
+#: common/flatpak-dir.c:3628
 #, c-format
 msgid "%s (commit %s) not installed"
 msgstr "%s (incheckning %s) inte installerad"
 
-#: common/flatpak-dir.c:4650
+#: common/flatpak-dir.c:4653
 #, c-format
 msgid "Error parsing system flatpakrepo file for %s: %s"
 msgstr "Fel vid tolkning av systemets flatpakrepo-fil för %s: %s"
 
-#: common/flatpak-dir.c:4735
+#: common/flatpak-dir.c:4738
 #, c-format
 msgid "While opening repository %s: "
 msgstr "Medan förråd %s öppnas: "
 
-#: common/flatpak-dir.c:5004
+#: common/flatpak-dir.c:5007
 #, c-format
 msgid "The config key %s is not set"
 msgstr "Konfigurationsnyckeln %s har inte satts"
 
-#: common/flatpak-dir.c:5140
+#: common/flatpak-dir.c:5143
 #, c-format
 msgid "No current %s pattern matching %s"
 msgstr "Inget aktuellt %s-mönster matchar %s"
 
-#: common/flatpak-dir.c:5422
+#: common/flatpak-dir.c:5425
 msgid "No appstream commit to deploy"
 msgstr "Ingen appstream-incheckning att distribuera"
 
-#: common/flatpak-dir.c:5941 common/flatpak-dir.c:7266
-#: common/flatpak-dir.c:10881 common/flatpak-dir.c:11618
+#: common/flatpak-dir.c:5945 common/flatpak-dir.c:7262
+#: common/flatpak-dir.c:10883 common/flatpak-dir.c:11619
 msgid "Can't pull from untrusted non-gpg verified remote"
 msgstr ""
 "Det går inte att hämta från ej betrott fjärrförråd som ej är gpg-verifierat"
 
-#: common/flatpak-dir.c:6376 common/flatpak-dir.c:6591
+#: common/flatpak-dir.c:6380 common/flatpak-dir.c:6595
 msgid "Extra data not supported for non-gpg-verified local system installs"
 msgstr ""
 "Extra data stöds inte för lokala systeminstallationer som ej verifierats med "
 "gpg"
 
-#: common/flatpak-dir.c:6415 common/flatpak-dir.c:6782
+#: common/flatpak-dir.c:6419 common/flatpak-dir.c:6786
 #, c-format
 msgid "Invalid checksum for extra data uri %s"
 msgstr "Ogiltig kontrollsumma för extra data-uri %s"
 
-#: common/flatpak-dir.c:6424
+#: common/flatpak-dir.c:6428
 #, c-format
 msgid "Empty name for extra data uri %s"
 msgstr "Tomt namn för extra data-uri %s"
 
-#: common/flatpak-dir.c:6432
+#: common/flatpak-dir.c:6436
 #, c-format
 msgid "Unsupported extra data uri %s"
 msgstr "Extra data-uri %s som ej stöds"
 
-#: common/flatpak-dir.c:6461
+#: common/flatpak-dir.c:6465
 #, c-format
 msgid "Failed to load local extra-data %s: %s"
 msgstr "Misslyckades med att läsa lokala extra data %s: %s"
 
-#: common/flatpak-dir.c:6469
+#: common/flatpak-dir.c:6473
 #, c-format
 msgid "Wrong size for extra-data %s"
 msgstr "Fel storlek för extra data %s"
 
-#: common/flatpak-dir.c:6488
+#: common/flatpak-dir.c:6492
 #, c-format
 msgid "While downloading %s: "
 msgstr "Medan %s hämtas: "
 
-#: common/flatpak-dir.c:6498
+#: common/flatpak-dir.c:6502
 #, c-format
 msgid "Wrong size for extra data %s"
 msgstr "Fel storlek för extra data %s"
 
-#: common/flatpak-dir.c:6507
+#: common/flatpak-dir.c:6511
 #, c-format
 msgid "Invalid checksum for extra data %s"
 msgstr "Ogiltig kontrollsumma för extra data %s"
 
-#: common/flatpak-dir.c:7096 common/flatpak-dir.c:7349
+#: common/flatpak-dir.c:7099 common/flatpak-dir.c:7345
 #, c-format
 msgid "While pulling %s from remote %s: "
 msgstr "Medan %s hämtas från fjärrförrådet %s: "
 
-#: common/flatpak-dir.c:7290 common/flatpak-repo-utils.c:3886
+#: common/flatpak-dir.c:7286 common/flatpak-repo-utils.c:3877
 msgid "GPG signatures found, but none are in trusted keyring"
 msgstr "GPG-signaturer hittades, men ingen är i den betrodda nyckelringen"
 
-#: common/flatpak-dir.c:7307
+#: common/flatpak-dir.c:7303
 #, c-format
 msgid "Commit for ‘%s’ has no ref binding"
 msgstr "Incheckning för ”%s” har ingen refbindning"
 
-#: common/flatpak-dir.c:7312
+#: common/flatpak-dir.c:7308
 #, c-format
 msgid "Commit for ‘%s’ is not in expected bound refs: %s"
 msgstr "Incheckning för ”%s” är inte bland förväntade bundna referenser: %s"
 
-#: common/flatpak-dir.c:7488
+#: common/flatpak-dir.c:7484
 msgid "Only applications can be made current"
 msgstr "Endast program kan göras aktuella"
 
-#: common/flatpak-dir.c:8192
+#: common/flatpak-dir.c:8183 common/flatpak-dir.c:8195
 msgid "Not enough memory"
 msgstr "Inte tillräckligt med minne"
 
-#: common/flatpak-dir.c:8211
+#: common/flatpak-dir.c:8214
 msgid "Failed to read from exported file"
 msgstr "Misslyckades med att läsa från exporterad fil"
 
-#: common/flatpak-dir.c:8401
+#: common/flatpak-dir.c:8404
 msgid "Error reading mimetype xml file"
 msgstr "Fel vid läsning av xml-fil för mimetyp"
 
-#: common/flatpak-dir.c:8406
+#: common/flatpak-dir.c:8409
 msgid "Invalid mimetype xml file"
 msgstr "Ogiltig xml-fil för mimetyp"
 
-#: common/flatpak-dir.c:8492
+#: common/flatpak-dir.c:8495
 #, c-format
 msgid "D-Bus service file '%s' has wrong name"
 msgstr "D-Bus-tjänstfilen ”%s” har fel namn"
 
-#: common/flatpak-dir.c:8647
+#: common/flatpak-dir.c:8650
 #, c-format
 msgid "Invalid Exec argument %s"
 msgstr "Ogiltigt Exec-argument %s"
 
-#: common/flatpak-dir.c:9115
+#: common/flatpak-dir.c:9117
 msgid "While getting detached metadata: "
 msgstr "Under hämtning av frånkopplade metadata: "
 
-#: common/flatpak-dir.c:9120 common/flatpak-dir.c:9125
-#: common/flatpak-dir.c:9129
+#: common/flatpak-dir.c:9122 common/flatpak-dir.c:9127
+#: common/flatpak-dir.c:9131
 msgid "Extra data missing in detached metadata"
 msgstr "Extra data saknas i frånkopplade metadata"
 
-#: common/flatpak-dir.c:9133
+#: common/flatpak-dir.c:9135
 msgid "While creating extradir: "
 msgstr "Under tiden extrakatalog skapas: "
 
-#: common/flatpak-dir.c:9154 common/flatpak-dir.c:9187
+#: common/flatpak-dir.c:9156 common/flatpak-dir.c:9189
 msgid "Invalid checksum for extra data"
 msgstr "Ogiltig kontrollsumma för extra data"
 
-#: common/flatpak-dir.c:9183
+#: common/flatpak-dir.c:9185
 msgid "Wrong size for extra data"
 msgstr "Fel storlek för extra data"
 
-#: common/flatpak-dir.c:9196
+#: common/flatpak-dir.c:9198
 #, c-format
 msgid "While writing extra data file '%s': "
 msgstr "Under skrivning av extra data-filen ”%s”: "
 
-#: common/flatpak-dir.c:9204
+#: common/flatpak-dir.c:9206
 #, c-format
 msgid "Extra data %s missing in detached metadata"
 msgstr "Extra data %s saknas i frånkopplade metadata"
 
-#: common/flatpak-dir.c:9278
-#, c-format
+#: common/flatpak-dir.c:9280
 msgid "Unable to get runtime key from metadata"
 msgstr "Kunde inte få nyckel för exekveringsmiljö från metadata"
 
-#: common/flatpak-dir.c:9402
+#: common/flatpak-dir.c:9404
 #, c-format
 msgid "apply_extra script failed, exit status %d"
 msgstr "misslyckades med skriptet apply_extra, avslutningsstatus %d"
 
 #. Translators: The placeholder is for an app ref.
-#: common/flatpak-dir.c:9591
+#: common/flatpak-dir.c:9593
 #, c-format
 msgid "Installing %s is not allowed by the policy set by your administrator"
 msgstr ""
 "Installation av %s tillåts inte av policyn som har satts av din administratör"
 
-#: common/flatpak-dir.c:9690
+#: common/flatpak-dir.c:9692
 #, c-format
 msgid "While trying to resolve ref %s: "
 msgstr "Under upplösningsförsök för ref %s: "
 
-#: common/flatpak-dir.c:9702
+#: common/flatpak-dir.c:9704
 #, c-format
 msgid "%s is not available"
 msgstr "%s är inte tillgängligt"
 
-#: common/flatpak-dir.c:9714 common/flatpak-dir.c:11495
+#: common/flatpak-dir.c:9716 common/flatpak-dir.c:11497
 #, c-format
 msgid "%s commit %s already installed"
 msgstr "%s incheckning %s redan installerad"
 
-#: common/flatpak-dir.c:9721
+#: common/flatpak-dir.c:9723
 msgid "Can't create deploy directory"
 msgstr "Det går inte att skapa distributionskatalog"
 
-#: common/flatpak-dir.c:9729
+#: common/flatpak-dir.c:9731
 #, c-format
 msgid "Failed to read commit %s: "
 msgstr "Misslyckades läsa incheckning %s: "
 
-#: common/flatpak-dir.c:9750
+#: common/flatpak-dir.c:9752
 #, c-format
 msgid "While trying to checkout %s into %s: "
 msgstr "Under utcheckningsförsök av %s i %s: "
 
-#: common/flatpak-dir.c:9769
+#: common/flatpak-dir.c:9771
 msgid "While trying to checkout metadata subpath: "
 msgstr "Under utcheckningsförsök av metadataundersökväg: "
 
-#: common/flatpak-dir.c:9801
+#: common/flatpak-dir.c:9803
 #, c-format
 msgid "While trying to checkout subpath ‘%s’: "
 msgstr "Under utcheckningsförsök av undersökvägen ”%s”: "
 
-#: common/flatpak-dir.c:9811
+#: common/flatpak-dir.c:9813
 msgid "While trying to remove existing extra dir: "
 msgstr "Under försök att ta bort befintlig extra katalog: "
 
-#: common/flatpak-dir.c:9822
+#: common/flatpak-dir.c:9824
 msgid "While trying to apply extra data: "
 msgstr "Under försök att tillämpa extra data: "
 
-#: common/flatpak-dir.c:9849
+#: common/flatpak-dir.c:9851
 #, c-format
 msgid "Invalid commit ref %s: "
 msgstr "Ogiltig incheckningsref %s: "
 
-#: common/flatpak-dir.c:9857 common/flatpak-dir.c:9869
+#: common/flatpak-dir.c:9859 common/flatpak-dir.c:9871
 #, c-format
 msgid "Deployed ref %s does not match commit (%s)"
 msgstr "Distribuerad ref %s matchar inte incheckning (%s)"
 
-#: common/flatpak-dir.c:9863
+#: common/flatpak-dir.c:9865
 #, c-format
 msgid "Deployed ref %s branch does not match commit (%s)"
 msgstr "Distribuerad referens %s-gren matchar inte incheckning (%s)"
 
-#: common/flatpak-dir.c:10125 common/flatpak-installation.c:1911
+#: common/flatpak-dir.c:10127 common/flatpak-installation.c:1926
 #, c-format
 msgid "%s branch %s already installed"
 msgstr "%s gren %s redan installerad"
 
-#: common/flatpak-dir.c:10985
+#: common/flatpak-dir.c:10987
 #, c-format
 msgid "Could not unmount revokefs-fuse filesystem at %s: "
 msgstr "Det gick inte att avmontera revokefs-fuse-filsystem på %s: "
 
-#: common/flatpak-dir.c:11289
+#: common/flatpak-dir.c:11291
 #, c-format
 msgid "This version of %s is already installed"
 msgstr "Denna version av %s är redan installerad"
 
-#: common/flatpak-dir.c:11302
-#, c-format
+#: common/flatpak-dir.c:11304
 msgid "Can't change remote during bundle install"
 msgstr "Kan inte ändra fjärrförråd under buntinstallering"
 
-#: common/flatpak-dir.c:11571
-msgid "Can't update to a specific commit without root permissions"
-msgstr ""
-"Det går inte att uppdatera till en specifik incheckning utan root-rättigheter"
-
-#: common/flatpak-dir.c:11852
+#: common/flatpak-dir.c:11853
 #, c-format
 msgid "Can't remove %s, it is needed for: %s"
 msgstr "Det går inte att ta bort %s, det behövs för: %s"
 
-#: common/flatpak-dir.c:11912 common/flatpak-installation.c:2067
+#: common/flatpak-dir.c:11913 common/flatpak-installation.c:2082
 #, c-format
 msgid "%s branch %s is not installed"
 msgstr "%s gren %s är inte installerad"
 
-#: common/flatpak-dir.c:12165
+#: common/flatpak-dir.c:12166
 #, c-format
 msgid "%s commit %s not installed"
 msgstr "%s incheckning %s inte installerad"
 
-#: common/flatpak-dir.c:12501
+#: common/flatpak-dir.c:12502
 #, c-format
 msgid "Pruning repo failed: %s"
 msgstr "Rensning av förråd misslyckades: %s"
 
-#: common/flatpak-dir.c:12669 common/flatpak-dir.c:12675
+#: common/flatpak-dir.c:12670 common/flatpak-dir.c:12676
 #, c-format
 msgid "Failed to load filter '%s'"
 msgstr "Misslyckades med att läsa in filtret ”%s”"
 
-#: common/flatpak-dir.c:12681
+#: common/flatpak-dir.c:12682
 #, c-format
 msgid "Failed to parse filter '%s'"
 msgstr "Misslyckades med att tolka filtret ”%s”"
@@ -5158,7 +5111,7 @@ msgstr "Det gick inte att hitta installationen %s"
 msgid "Invalid file format, no %s group"
 msgstr "Ogiltigt filformat, ingen %s-grupp"
 
-#: common/flatpak-dir.c:15617 common/flatpak-repo-utils.c:2836
+#: common/flatpak-dir.c:15617 common/flatpak-repo-utils.c:2827
 #, c-format
 msgid "Invalid version %s, only 1 supported"
 msgstr "Ogiltig version %s, endast 1 stöds"
@@ -5173,7 +5126,7 @@ msgstr "Ogiltigt filformat, ingen %s angiven"
 msgid "Invalid file format, gpg key invalid"
 msgstr "Ogiltigt filformat, gpg-nyckel ogiltig"
 
-#: common/flatpak-dir.c:15675 common/flatpak-repo-utils.c:2917
+#: common/flatpak-dir.c:15675 common/flatpak-repo-utils.c:2908
 msgid "Collection ID requires GPG key to be provided"
 msgstr "Samlings-ID kräver att GPG-nyckel tillhandahålls"
 
@@ -5209,43 +5162,42 @@ msgstr "Ingen konfiguration angavs för fjärrförrådet %s"
 msgid "Skipping deletion of mirror ref (%s, %s)…\n"
 msgstr "Hoppar över borttagning av spegelref (%s, %s)…\n"
 
-#: common/flatpak-exports.c:931
-#, c-format
+#: common/flatpak-exports.c:942
 msgid "An absolute path is required"
 msgstr "En absolut sökväg krävs"
 
-#: common/flatpak-exports.c:948
+#: common/flatpak-exports.c:959
 #, c-format
 msgid "Unable to open path \"%s\": %s"
 msgstr "Kunde inte öppna sökvägen ”%s”: %s"
 
-#: common/flatpak-exports.c:955
+#: common/flatpak-exports.c:966
 #, c-format
 msgid "Unable to get file type of \"%s\": %s"
 msgstr "Kunde inte erhålla filtypen för ”%s”: %s"
 
-#: common/flatpak-exports.c:964
+#: common/flatpak-exports.c:975
 #, c-format
 msgid "File \"%s\" has unsupported type 0o%o"
 msgstr "Filen ”%s” har typen 0o%o som inte stöds"
 
-#: common/flatpak-exports.c:970
+#: common/flatpak-exports.c:981
 #, c-format
 msgid "Unable to get filesystem information for \"%s\": %s"
 msgstr "Kunde inte hämta filsystemsinformation för ”%s”: %s"
 
-#: common/flatpak-exports.c:980
+#: common/flatpak-exports.c:991
 #, c-format
 msgid "Ignoring blocking autofs path \"%s\""
 msgstr "Ignorerar blockerande autofs-sökväg ”%s”"
 
-#: common/flatpak-exports.c:996 common/flatpak-exports.c:1009
-#: common/flatpak-exports.c:1022
+#: common/flatpak-exports.c:1007 common/flatpak-exports.c:1020
+#: common/flatpak-exports.c:1033
 #, c-format
 msgid "Path \"%s\" is reserved by Flatpak"
 msgstr "Sökvägen ”%s” är reserverad av Flatpak"
 
-#: common/flatpak-exports.c:1076
+#: common/flatpak-exports.c:1087
 #, c-format
 msgid "Unable to resolve symbolic link \"%s\": %s"
 msgstr "Kunde inte slå upp symbolisk länk ”%s”: %s"
@@ -5285,128 +5237,127 @@ msgstr "Ref ”%s” hittades inte i registret"
 msgid "Multiple images in registry, specify a ref with --ref"
 msgstr "Flera avbilder i registret, ange en ref med --ref"
 
-#: common/flatpak-installation.c:834
+#: common/flatpak-installation.c:849
 #, c-format
 msgid "Ref %s not installed"
 msgstr "Ref %s inte installerad"
 
-#: common/flatpak-installation.c:875
+#: common/flatpak-installation.c:890
 #, c-format
 msgid "App %s not installed"
 msgstr "Program %s inte installerat"
 
-#: common/flatpak-installation.c:1395
+#: common/flatpak-installation.c:1410
 #, c-format
 msgid "Remote '%s' already exists"
 msgstr "Fjärrförrådet ”%s” existerar redan"
 
-#: common/flatpak-installation.c:1946
+#: common/flatpak-installation.c:1961
 #, c-format
 msgid "As requested, %s was only pulled, but not installed"
 msgstr "Som begärt hämtades bara %s, men installerades inte"
 
-#: common/flatpak-instance.c:533 common/flatpak-instance.c:687
-#: common/flatpak-instance.c:728
+#: common/flatpak-instance.c:546 common/flatpak-instance.c:700
+#: common/flatpak-instance.c:741
 #, c-format
 msgid "Unable to create directory %s"
 msgstr "Kunde inte skapa katalogen %s"
 
-#: common/flatpak-instance.c:554
+#: common/flatpak-instance.c:567
 #, c-format
 msgid "Unable to lock %s"
 msgstr "Kunde inte låsa %s"
 
-#: common/flatpak-instance.c:627
+#: common/flatpak-instance.c:640
 #, c-format
 msgid "Unable to create temporary directory in %s"
 msgstr "Kunde inte skapa temporär katalog i %s"
 
-#: common/flatpak-instance.c:639
+#: common/flatpak-instance.c:652
 #, c-format
 msgid "Unable to create file %s"
 msgstr "Kunde inte skapa filen %s"
 
-#: common/flatpak-instance.c:646
+#: common/flatpak-instance.c:659
 #, c-format
 msgid "Unable to update symbolic link %s/%s"
 msgstr "Kunde inte uppdatera symbolisk länk %s/%s"
 
-#: common/flatpak-oci-registry.c:1197
+#: common/flatpak-oci-registry.c:1195
 msgid "Only Bearer authentication supported"
 msgstr "Endast Bearer-autentisering stöds"
 
-#: common/flatpak-oci-registry.c:1206
+#: common/flatpak-oci-registry.c:1204
 msgid "Only realm in authentication request"
 msgstr "Endast rike i autentiseringsbegäran"
 
-#: common/flatpak-oci-registry.c:1213
+#: common/flatpak-oci-registry.c:1211
 msgid "Invalid realm in authentication request"
 msgstr "Ogiltigt rike i autentiseringsbegäran"
 
-#: common/flatpak-oci-registry.c:1283
+#: common/flatpak-oci-registry.c:1281
 #, c-format
 msgid "Authorization failed: %s"
 msgstr "Auktorisering misslyckades: %s"
 
-#: common/flatpak-oci-registry.c:1285
+#: common/flatpak-oci-registry.c:1283
 msgid "Authorization failed"
 msgstr "Auktorisering misslyckades"
 
-#: common/flatpak-oci-registry.c:1289
+#: common/flatpak-oci-registry.c:1287
 #, c-format
 msgid "Unexpected response status %d when requesting token: %s"
 msgstr "Oväntad svarsstatus %d då token begärdes: %s"
 
-#: common/flatpak-oci-registry.c:1300
+#: common/flatpak-oci-registry.c:1298
 msgid "Invalid authentication request response"
 msgstr "Ogiltigt svar på autentiseringsbegäran"
 
-#: common/flatpak-oci-registry.c:1731
-#, c-format
+#: common/flatpak-oci-registry.c:1729
 msgid "Flatpak was compiled without zstd support"
 msgstr "Flatpak kompilerades utan stöd för zstd"
 
-#: common/flatpak-oci-registry.c:1923 common/flatpak-oci-registry.c:1975
-#: common/flatpak-oci-registry.c:2004 common/flatpak-oci-registry.c:2059
-#: common/flatpak-oci-registry.c:2115 common/flatpak-oci-registry.c:2193
+#: common/flatpak-oci-registry.c:1921 common/flatpak-oci-registry.c:1973
+#: common/flatpak-oci-registry.c:2002 common/flatpak-oci-registry.c:2057
+#: common/flatpak-oci-registry.c:2113 common/flatpak-oci-registry.c:2191
 msgid "Invalid delta file format"
 msgstr "Ogiltigt deltafilformat"
 
-#: common/flatpak-oci-registry.c:3198 common/flatpak-oci-registry.c:3382
+#: common/flatpak-oci-registry.c:3211 common/flatpak-oci-registry.c:3390
 msgid "Invalid OCI image config"
 msgstr "Ogiltig OCI-avbildskonfiguration"
 
-#: common/flatpak-oci-registry.c:3260 common/flatpak-oci-registry.c:3531
+#: common/flatpak-oci-registry.c:3273 common/flatpak-oci-registry.c:3539
 #, c-format
 msgid "Wrong layer checksum, expected %s, was %s"
 msgstr "Fel kontrollsumma för lager, förväntade %s, var %s"
 
-#: common/flatpak-oci-registry.c:3359
+#: common/flatpak-oci-registry.c:3367
 #, c-format
 msgid "No ref specified for OCI image %s"
 msgstr "Ingen ref angiven för OCI-avbild %s"
 
-#: common/flatpak-oci-registry.c:3369
+#: common/flatpak-oci-registry.c:3377
 #, c-format
 msgid "Wrong ref (%s) specified for OCI image %s, expected %s"
 msgstr "Fel ref (%s) angiven för OCI-avbild %s, förväntade %s"
 
-#: common/flatpak-progress.c:236
+#: common/flatpak-progress.c:239
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Hämtar metadata: %u/(beräknad) %s"
 
-#: common/flatpak-progress.c:260
+#: common/flatpak-progress.c:266
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Hämtar: %s/%s"
 
-#: common/flatpak-progress.c:280
+#: common/flatpak-progress.c:286
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Hämtar extra data: %s/%s"
 
-#: common/flatpak-progress.c:285
+#: common/flatpak-progress.c:291
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Hämtar filer: %d/%d %s"
@@ -5570,54 +5521,53 @@ msgid "GPG verification must be enabled when a collection ID is set"
 msgstr "GPG-verifiering måste vara aktiverat då ett samlings-ID har satts"
 
 #: common/flatpak-repo-utils.c:344
-#, c-format
 msgid "No extra data sources"
 msgstr "Inga extra data-källor"
 
-#: common/flatpak-repo-utils.c:2817
+#: common/flatpak-repo-utils.c:2808
 #, c-format
 msgid "Invalid %s: Missing group ‘%s’"
 msgstr "Ogiltig %s: Saknar grupp ”%s”"
 
-#: common/flatpak-repo-utils.c:2826
+#: common/flatpak-repo-utils.c:2817
 #, c-format
 msgid "Invalid %s: Missing key ‘%s’"
 msgstr "Ogiltig %s: Saknar nyckel ”%s”"
 
-#: common/flatpak-repo-utils.c:2876
+#: common/flatpak-repo-utils.c:2867
 msgid "Invalid gpg key"
 msgstr "Ogiltig gpg-nyckel"
 
-#: common/flatpak-repo-utils.c:3217
+#: common/flatpak-repo-utils.c:3208
 #, c-format
 msgid "Error copying 64x64 icon for component %s: %s\n"
 msgstr "Fel vid kopiering av 64x64-ikon för komponent %s: %s\n"
 
-#: common/flatpak-repo-utils.c:3223
+#: common/flatpak-repo-utils.c:3214
 #, c-format
 msgid "Error copying 128x128 icon for component %s: %s\n"
 msgstr "Fel vid kopiering av 128x128-ikon för komponent %s: %s\n"
 
-#: common/flatpak-repo-utils.c:3362
+#: common/flatpak-repo-utils.c:3353
 #, c-format
 msgid "%s is end-of-life, ignoring for appstream"
 msgstr "%s har nått slutet på sin livstid, ignorerar för appstream"
 
-#: common/flatpak-repo-utils.c:3397
+#: common/flatpak-repo-utils.c:3388
 #, c-format
 msgid "No appstream data for %s: %s\n"
 msgstr "Inga appstream-data för %s: %s\n"
 
-#: common/flatpak-repo-utils.c:3744
+#: common/flatpak-repo-utils.c:3735
 msgid "Invalid bundle, no ref in metadata"
 msgstr "Ogiltig bunt, ingen ref i metadata"
 
-#: common/flatpak-repo-utils.c:3846
+#: common/flatpak-repo-utils.c:3837
 #, c-format
 msgid "Collection ‘%s’ of bundle doesn’t match collection ‘%s’ of remote"
 msgstr "Samlingen ”%s” för bunt matchar inte samlingen ”%s” för fjärrförråd"
 
-#: common/flatpak-repo-utils.c:3923
+#: common/flatpak-repo-utils.c:3914
 msgid "Metadata in header and app are inconsistent"
 msgstr "Metadata i huvud och program är inkonsekventa"
 
@@ -5670,35 +5620,40 @@ msgstr "Misslyckades med att blockera systemanrop %d: %s"
 msgid "Failed to export bpf: %s"
 msgstr "Misslyckades med att exportera bpf: %s"
 
-#: common/flatpak-run.c:2587
+#: common/flatpak-run.c:2588
 #, c-format
 msgid "Failed to open ‘%s’"
 msgstr "Misslyckades med att öppna ”%s”"
 
-#: common/flatpak-run.c:2597
+#: common/flatpak-run.c:2600
 #, c-format
 msgid ""
 "Directory forwarding needs version 4 of the document portal (have version %d)"
 msgstr ""
 "Katalogvidarebefordran behöver version 4 av dokumentportalen (har version %d)"
 
-#: common/flatpak-run.c:2915
+#: common/flatpak-run.c:2732
+#, c-format
+msgid "Invalid path ‘%s’"
+msgstr "Ogiltig sökväg ”%s”"
+
+#: common/flatpak-run.c:2921
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "misslyckades med ldconfig, avslutningsstatus %d"
 
-#: common/flatpak-run.c:2922
+#: common/flatpak-run.c:2928
 msgid "Can't open generated ld.so.cache"
 msgstr "Det går inte att öppna genererad ld.so.cache"
 
 #. Translators: The placeholder is for an app ref.
-#: common/flatpak-run.c:3045
+#: common/flatpak-run.c:3051
 #, c-format
 msgid "Running %s is not allowed by the policy set by your administrator"
 msgstr ""
 "Körning av %s tillåts inte av policyn som har satts av din administratör"
 
-#: common/flatpak-run.c:3202
+#: common/flatpak-run.c:3208
 msgid ""
 "\"flatpak run\" is not intended to be run as `sudo flatpak run`. Use `sudo "
 "-i` or `su -l` instead and invoke \"flatpak run\" from inside the new shell."
@@ -5706,19 +5661,19 @@ msgstr ""
 "”flatpak run” är inte avsett att köras som ”sudo flatpak run”, använd ”sudo "
 "-i” eller ”su -l” istället och anropa ”flatpak run” inifrån det nya skalet."
 
-#: common/flatpak-run.c:3413
+#: common/flatpak-run.c:3419
 #, c-format
 msgid "Failed to migrate from %s: %s"
 msgstr "Misslyckades att migrera från %s: %s"
 
-#: common/flatpak-run.c:3434
+#: common/flatpak-run.c:3440
 #, c-format
 msgid "Failed to migrate old app data directory %s to new name %s: %s"
 msgstr ""
 "Misslyckades med att migrera gammal programdatakatalog %s till nytt namn %s: "
 "%s"
 
-#: common/flatpak-run.c:3443
+#: common/flatpak-run.c:3449
 #, c-format
 msgid "Failed to create symlink while migrating %s: %s"
 msgstr "Misslyckades med att skapa symbolisk länk vid migrering av %s: %s"
@@ -5735,57 +5690,57 @@ msgstr "Kunde inte skapa sync-rör"
 msgid "Failed to sync with dbus proxy"
 msgstr "Misslyckades med att synkronisera med dbus-proxy"
 
-#: common/flatpak-transaction.c:2275
+#: common/flatpak-transaction.c:2291
 #, c-format
 msgid "Warning: Problem looking for related refs: %s"
 msgstr "Varning: Problem vid sökning efter relaterade referenser: %s"
 
-#: common/flatpak-transaction.c:2493
+#: common/flatpak-transaction.c:2509
 #, c-format
 msgid "The application %s requires the runtime %s which was not found"
 msgstr "Programmet %s kräver exekveringsmiljön %s som inte hittades"
 
-#: common/flatpak-transaction.c:2509
+#: common/flatpak-transaction.c:2525
 #, c-format
 msgid "The application %s requires the runtime %s which is not installed"
 msgstr "Programmet %s kräver exekveringsmiljön %s som inte är installerad"
 
-#: common/flatpak-transaction.c:2641
+#: common/flatpak-transaction.c:2657
 #, c-format
 msgid "Can't uninstall %s which is needed by %s"
 msgstr "Det går inte att avinstallera %s som behövs av %s"
 
-#: common/flatpak-transaction.c:2740
+#: common/flatpak-transaction.c:2756
 #, c-format
 msgid "Remote %s disabled, ignoring %s update"
 msgstr "Fjärrförråd %s inaktiverat, ignorerar uppdatering för %s"
 
-#: common/flatpak-transaction.c:2773
+#: common/flatpak-transaction.c:2789
 #, c-format
 msgid "%s is already installed"
 msgstr "%s är redan installerad"
 
-#: common/flatpak-transaction.c:2776
+#: common/flatpak-transaction.c:2792
 #, c-format
 msgid "%s is already installed from remote %s"
 msgstr "%s är redan installerad från fjärrförrådet %s"
 
-#: common/flatpak-transaction.c:3120
+#: common/flatpak-transaction.c:3136
 #, c-format
 msgid "Invalid .flatpakref: %s"
 msgstr "Ogiltig .flatpakref: %s"
 
-#: common/flatpak-transaction.c:3161
+#: common/flatpak-transaction.c:3177
 msgid "Warning: Could not mark already installed apps as preinstalled"
 msgstr ""
 "Varning: Kunde inte markera redan installerade program som förinstallerade"
 
-#: common/flatpak-transaction.c:3382
+#: common/flatpak-transaction.c:3398
 #, c-format
 msgid "Error updating remote metadata for '%s': %s"
 msgstr "Fel vid uppdatering av fjärrmetadata för ”%s”: %s"
 
-#: common/flatpak-transaction.c:3885
+#: common/flatpak-transaction.c:3901
 #, c-format
 msgid ""
 "Warning: Treating remote fetch error as non-fatal since %s is already "
@@ -5794,54 +5749,54 @@ msgstr ""
 "Varning: Behandlar fjärrhämtningsfel som icke ödesdigert då %s redan är "
 "installerad: %s"
 
-#: common/flatpak-transaction.c:4209
+#: common/flatpak-transaction.c:4225
 #, c-format
 msgid "No authenticator installed for remote '%s'"
 msgstr "Ingen autentiserare installerad för fjärrförrådet ”%s”"
 
-#: common/flatpak-transaction.c:4313 common/flatpak-transaction.c:4320
+#: common/flatpak-transaction.c:4329 common/flatpak-transaction.c:4336
 #, c-format
 msgid "Failed to get tokens for ref: %s"
 msgstr "Misslyckades med att erhålla token för ref: %s"
 
-#: common/flatpak-transaction.c:4315 common/flatpak-transaction.c:4322
+#: common/flatpak-transaction.c:4331 common/flatpak-transaction.c:4338
 msgid "Failed to get tokens for ref"
 msgstr "Misslyckades med att erhålla token för ref"
 
-#: common/flatpak-transaction.c:4580
+#: common/flatpak-transaction.c:4596
 #, c-format
 msgid "Ref %s from %s matches more than one transaction operation"
 msgstr "Ref %s från %s matchar mer än en transaktionsåtgärd"
 
-#: common/flatpak-transaction.c:4581 common/flatpak-transaction.c:4591
+#: common/flatpak-transaction.c:4597 common/flatpak-transaction.c:4607
 msgid "any remote"
 msgstr "alla fjärrförråd"
 
-#: common/flatpak-transaction.c:4590
+#: common/flatpak-transaction.c:4606
 #, c-format
 msgid "No transaction operation found for ref %s from %s"
 msgstr "Ingen transaktionsåtgärd hittades för ref %s från %s"
 
-#: common/flatpak-transaction.c:4713
+#: common/flatpak-transaction.c:4729
 #, c-format
 msgid "Flatpakrepo URL %s not file, HTTP or HTTPS"
 msgstr "Flatpakrepo-URL %s är inte file, HTTP eller HTTPS"
 
-#: common/flatpak-transaction.c:4719
+#: common/flatpak-transaction.c:4735
 #, c-format
 msgid "Can't load dependent file %s: "
 msgstr "Det går inte att läsa in beroende fil %s: "
 
-#: common/flatpak-transaction.c:4727
+#: common/flatpak-transaction.c:4743
 #, c-format
 msgid "Invalid .flatpakrepo: %s"
 msgstr "Ogiltig .flatpakrepo: %s"
 
-#: common/flatpak-transaction.c:5454
+#: common/flatpak-transaction.c:5470
 msgid "Transaction already executed"
 msgstr "Transaktion redan utförd"
 
-#: common/flatpak-transaction.c:5469
+#: common/flatpak-transaction.c:5485
 msgid ""
 "Refusing to operate on a user installation as root! This can lead to "
 "incorrect file ownership and permission errors."
@@ -5849,16 +5804,16 @@ msgstr ""
 "Vägrar att operera på en användarinstallation som root! Detta kan leda till "
 "felaktigt filägarskap och rättighetsfel."
 
-#: common/flatpak-transaction.c:5567 common/flatpak-transaction.c:5580
+#: common/flatpak-transaction.c:5583 common/flatpak-transaction.c:5596
 msgid "Aborted by user"
 msgstr "Avbröts av användare"
 
-#: common/flatpak-transaction.c:5605
+#: common/flatpak-transaction.c:5621
 #, c-format
 msgid "Skipping %s due to previous error"
 msgstr "Hoppar över %s på grund av tidigare fel"
 
-#: common/flatpak-transaction.c:5659
+#: common/flatpak-transaction.c:5675
 #, c-format
 msgid "Aborted due to failure (%s)"
 msgstr "Avbröts på grund av fel (%s)"
@@ -5906,42 +5861,35 @@ msgid "URI is not absolute, and no base URI was provided"
 msgstr "URI är inte absolut, och ingen bas-URI angavs"
 
 #: common/flatpak-usb.c:83
-#, c-format
 msgid "USB device query 'all' must not have data"
 msgstr "USB-enhetsfrågan ”all” får inte ha data"
 
 #: common/flatpak-usb.c:102
-#, c-format
 msgid "USB query rule 'cls' must be in the form CLASS:SUBCLASS or CLASS:*"
 msgstr ""
 "USB-frågeregeln ”cls” måste vara på formen KLASS:UNDERKLASS eller KLASS:*"
 
 #: common/flatpak-usb.c:111
-#, c-format
 msgid "Invalid USB class"
 msgstr "Ogiltig USB-klass"
 
 #: common/flatpak-usb.c:125
-#, c-format
 msgid "Invalid USB subclass"
 msgstr "Ogiltig USB-underklass"
 
 #: common/flatpak-usb.c:141 common/flatpak-usb.c:148
-#, c-format
 msgid "USB query rule 'dev' must have a valid 4-digit hexadecimal product id"
 msgstr ""
 "USB-frågeregeln ”dev” måste ha ett giltigt fyrsiffrigt hexadecimalt produkt-"
 "ID"
 
 #: common/flatpak-usb.c:164 common/flatpak-usb.c:171
-#, c-format
 msgid "USB query rule 'vnd' must have a valid 4-digit hexadecimal vendor id"
 msgstr ""
 "USB-frågeregeln ”vnd” måste ha ett giltigt fyrsiffrigt hexadecimalt "
 "tillverkar-ID"
 
 #: common/flatpak-usb.c:205
-#, c-format
 msgid "USB device queries must be in the form TYPE:DATA"
 msgstr "USB-enhetsfrågor måste vara på formen TYP:DATA"
 
@@ -5951,22 +5899,18 @@ msgid "Unknown USB query rule %s"
 msgstr "Okänd USB-frågeregel %s"
 
 #: common/flatpak-usb.c:248
-#, c-format
 msgid "Empty USB query"
 msgstr "Tom USB-fråga"
 
 #: common/flatpak-usb.c:274
-#, c-format
 msgid "Multiple USB query rules of the same type is not supported"
 msgstr "Flera USB-frågeregler av samma typ stöds inte"
 
 #: common/flatpak-usb.c:283
-#, c-format
 msgid "'all' must not contain extra query rules"
 msgstr "”all” får inte innehålla extra frågeregler"
 
 #: common/flatpak-usb.c:291
-#, c-format
 msgid "USB queries with 'dev' must also specify vendors"
 msgstr "USB-frågor med ”dev” måste också ange tillverkare"
 
@@ -6029,45 +5973,41 @@ msgstr "Inte ett OCI-fjärrförråd"
 msgid "Invalid token"
 msgstr "Ogiltig token"
 
-#: portal/flatpak-portal.c:2292
-#, c-format
+#: portal/flatpak-portal.c:2304
 msgid "No portal support found"
 msgstr "Inget portalstöd hittades"
 
-#: portal/flatpak-portal.c:2298
+#: portal/flatpak-portal.c:2310
 msgid "Deny"
 msgstr "Neka"
 
-#: portal/flatpak-portal.c:2300
+#: portal/flatpak-portal.c:2312
 msgid "Update"
 msgstr "Uppdatera"
 
-#: portal/flatpak-portal.c:2305
+#: portal/flatpak-portal.c:2317
 #, c-format
 msgid "Update %s?"
 msgstr "Uppdatera %s?"
 
-#: portal/flatpak-portal.c:2317
+#: portal/flatpak-portal.c:2329
 msgid "The application wants to update itself."
 msgstr "Programmet vill uppdatera sig själv."
 
-#: portal/flatpak-portal.c:2318
+#: portal/flatpak-portal.c:2330
 msgid "Update access can be changed any time from the privacy settings."
 msgstr ""
 "Uppdateringsåtkomst kan ändras när som helst från sekretessinställningarna."
 
-#: portal/flatpak-portal.c:2343
-#, c-format
+#: portal/flatpak-portal.c:2355
 msgid "Application update not allowed"
 msgstr "Programuppdatering inte tillåten"
 
-#: portal/flatpak-portal.c:2501
-#, c-format
+#: portal/flatpak-portal.c:2516
 msgid "Self update not supported, new version requires new permissions"
 msgstr "Självuppdatering stöds inte, nya versionen kräver nya rättigheter"
 
-#: portal/flatpak-portal.c:2684 portal/flatpak-portal.c:2702
-#, c-format
+#: portal/flatpak-portal.c:2699 portal/flatpak-portal.c:2717
 msgid "Update ended unexpectedly"
 msgstr "Uppdateringen avslutades oväntat"
 
@@ -6120,13 +6060,47 @@ msgid "Update signed runtime"
 msgstr "Uppdatera signerad exekveringsmiljö"
 
 #. SECURITY:
+#. - Normal users need admin authentication to downgrade an
+#. application system-wide, as downgrading may install an older
+#. version with known vulnerabilities or unverified changes.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to downgrade without authenticating.
+#. - Note that authorizing this action also authorizes
+#. org.freedesktop.Flatpak.app-update, as a downgrade implies
+#. the ability to update.
+#: system-helper/org.freedesktop.Flatpak.policy.in:100
+msgid "Update application to older version"
+msgstr "Uppdatera program till äldre version"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:101
+msgid "Authentication is required to downgrade an application"
+msgstr "Autentisering krävs för att nedgradera ett program"
+
+#. SECURITY:
+#. - Normal users need admin authentication to downgrade a
+#. runtime system-wide, as downgrading may install an older
+#. version with known vulnerabilities or unverified changes.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to downgrade without authenticating.
+#. - Note that authorizing this action also authorizes
+#. org.freedesktop.Flatpak.runtime-update, as a downgrade implies
+#. the ability to update.
+#: system-helper/org.freedesktop.Flatpak.policy.in:122
+msgid "Update runtime to older version"
+msgstr "Uppdatera exekveringsmiljö till äldre version"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:123
+msgid "Authentication is required to downgrade a runtime"
+msgstr "Autentisering krävs för att nedgradera en exekveringsmiljö"
+
+#. SECURITY:
 #. - Normal users do not need authentication to update metadata
 #. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:94
+#: system-helper/org.freedesktop.Flatpak.policy.in:138
 msgid "Update remote metadata"
 msgstr "Uppdatera fjärrförrådmetadata"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:95
+#: system-helper/org.freedesktop.Flatpak.policy.in:139
 msgid "Authentication is required to update remote info"
 msgstr "Autentisering krävs för att uppdatera fjärrförrådsinfo"
 
@@ -6135,22 +6109,22 @@ msgstr "Autentisering krävs för att uppdatera fjärrförrådsinfo"
 #. OSTree repository
 #. - Note that we install polkit rules that allow local users
 #. in the wheel group to modify repos without authenticating.
-#: system-helper/org.freedesktop.Flatpak.policy.in:111
+#: system-helper/org.freedesktop.Flatpak.policy.in:155
 msgid "Update system repository"
 msgstr "Uppdaterar systemförråd"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:112
+#: system-helper/org.freedesktop.Flatpak.policy.in:156
 msgid "Authentication is required to modify a system repository"
 msgstr "Autentisering krävs för att ändra ett systemförråd"
 
 #. SECURITY:
 #. - Normal users need admin authentication to install software
 #. system-wide.
-#: system-helper/org.freedesktop.Flatpak.policy.in:126
+#: system-helper/org.freedesktop.Flatpak.policy.in:170
 msgid "Install bundle"
 msgstr "Installera bunt"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:127
+#: system-helper/org.freedesktop.Flatpak.policy.in:171
 msgid "Authentication is required to install software from $(path)"
 msgstr "Autentisering krävs för att installera program från $(path)"
 
@@ -6159,11 +6133,11 @@ msgstr "Autentisering krävs för att installera program från $(path)"
 #. system-wide.
 #. - Note that we install polkit rules that allow local users
 #. in the wheel group to uninstall without authenticating.
-#: system-helper/org.freedesktop.Flatpak.policy.in:144
+#: system-helper/org.freedesktop.Flatpak.policy.in:188
 msgid "Uninstall runtime"
 msgstr "Avinstallera exekveringsmiljö"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:145
+#: system-helper/org.freedesktop.Flatpak.policy.in:189
 msgid "Authentication is required to uninstall software"
 msgstr "Autentisering krävs för att avinstallera program"
 
@@ -6172,33 +6146,33 @@ msgstr "Autentisering krävs för att avinstallera program"
 #. system-wide.
 #. - Note that we install polkit rules that allow local users
 #. in the wheel group to uninstall without authenticating.
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
+#: system-helper/org.freedesktop.Flatpak.policy.in:205
 msgid "Uninstall app"
 msgstr "Avinstallera program"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
+#: system-helper/org.freedesktop.Flatpak.policy.in:206
 msgid "Authentication is required to uninstall $(ref)"
 msgstr "Autentisering krävs för att avinstallera $(ref)"
 
 #. SECURITY:
 #. - Normal users need admin authentication to configure system-wide
 #. software repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:177
+#: system-helper/org.freedesktop.Flatpak.policy.in:221
 msgid "Configure Remote"
 msgstr "Konfigurera fjärrförråd"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:178
+#: system-helper/org.freedesktop.Flatpak.policy.in:222
 msgid "Authentication is required to configure software repositories"
 msgstr "Autentisering krävs för att konfigurera programförråd"
 
 #. SECURITY:
 #. - Normal users need admin authentication to configure the system-wide
 #. Flatpak installation.
-#: system-helper/org.freedesktop.Flatpak.policy.in:192
+#: system-helper/org.freedesktop.Flatpak.policy.in:236
 msgid "Configure"
 msgstr "Konfigurera"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:193
+#: system-helper/org.freedesktop.Flatpak.policy.in:237
 msgid "Authentication is required to configure software installation"
 msgstr "Autentisering krävs för att konfigurera programinstallationen"
 
@@ -6208,11 +6182,11 @@ msgstr "Autentisering krävs för att konfigurera programinstallationen"
 #. to update the system when unattended.
 #. - Changing this to anything other than 'yes' will break unattended
 #. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:210
+#: system-helper/org.freedesktop.Flatpak.policy.in:254
 msgid "Update appstream"
 msgstr "Uppdatera appstream"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:211
+#: system-helper/org.freedesktop.Flatpak.policy.in:255
 msgid "Authentication is required to update information about software"
 msgstr "Autentisering krävs för att uppdatera information om program"
 
@@ -6222,11 +6196,11 @@ msgstr "Autentisering krävs för att uppdatera information om program"
 #. to update the system when unattended.
 #. - Changing this to anything other than 'yes' will break unattended
 #. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:228
+#: system-helper/org.freedesktop.Flatpak.policy.in:272
 msgid "Update metadata"
 msgstr "Uppdatera metadata"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:229
+#: system-helper/org.freedesktop.Flatpak.policy.in:273
 msgid "Authentication is required to update metadata"
 msgstr "Autentisering krävs för att uppdatera metadata"
 
@@ -6277,11 +6251,11 @@ msgstr "Autentisering krävs för att uppdatera metadata"
 #. users’ parental controls policies to true.
 #. * Set the malcontent `is-system-installation-allowed` property of
 #. all users’ parental controls policies to true.
-#: system-helper/org.freedesktop.Flatpak.policy.in:287
+#: system-helper/org.freedesktop.Flatpak.policy.in:331
 msgid "Override parental controls for installs"
 msgstr "Åsidosätt föräldrakontroller för installationer"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:288
+#: system-helper/org.freedesktop.Flatpak.policy.in:332
 msgid ""
 "Authentication is required to install software which is restricted by your "
 "parental controls policy"
@@ -6302,17 +6276,22 @@ msgstr ""
 #. insecure or unsupported) app is a worse outcome than automatically
 #. installing an update which has radically different content from the
 #. version of the app which the parent originally vetted and installed.
-#: system-helper/org.freedesktop.Flatpak.policy.in:313
+#: system-helper/org.freedesktop.Flatpak.policy.in:357
 msgid "Override parental controls for updates"
 msgstr "Åsidosätt föräldrakontroller för uppdateringar"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:314
+#: system-helper/org.freedesktop.Flatpak.policy.in:358
 msgid ""
 "Authentication is required to update software which is restricted by your "
 "parental controls policy"
 msgstr ""
 "Autentisering krävs för att uppdatera program som begränsas av din policy "
 "för föräldrakontroller"
+
+#~ msgid "Can't update to a specific commit without root permissions"
+#~ msgstr ""
+#~ "Det går inte att uppdatera till en specifik incheckning utan root-"
+#~ "rättigheter"
 
 #~ msgid "Installed:"
 #~ msgstr "Installerad:"


### PR DESCRIPTION
Update translation in Swedish from Damned Lies: https://l10n.gnome.org/vertimus/2513/1018/112/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.