### PR TITLE
Update Brazilian Portuguese translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,22 +5,29 @@
 # Bruno Lopes <brunolopesdsilv@gmail.com>, 2020-2021.
 # Matheus Barbosa <mdpb.matheus@gmail.com>, 2022.
 # Álvaro Burns <>, 2025.
-# Rafael Fontenelle <rafaelff@gnome.org>, 2017-2026.
 # Miguel Peçanha <pecanhamiguel@gmail.com>, 2026.
+# Rafael Fontenelle <rafaelff@gnome.org>, 2017-2026.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: flatpak main\n"
 "Report-Msgid-Bugs-To: https://github.com/flatpak/flatpak/issues\n"
-"POT-Creation-Date: 2026-05-27 16:39+0200\n"
-"PO-Revision-Date: 2026-06-15 15:00-0300\n"
-"Last-Translator: Miguel Peçanha <pecanhamiguel@gmail.com>\n"
+"POT-Creation-Date: 2026-07-29 09:42+0000\n"
+"PO-Revision-Date: 2026-08-01 11:08-0300\n"
+"Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.9\n"
+"X-Generator: Gtranslator 50.0\n"
+"X-DL-VCS-Web: https://github.com/flatpak/flatpak\n"
+"X-DL-Lang: pt_BR\n"
+"X-DL-Module: flatpak\n"
+"X-DL-Branch: main\n"
+"X-DL-Domain: po\n"
+"X-DL-State: Translating\n"
+"Language-Team: Brazilian Portuguese <https://br.gnome.org/traducao/>\n"
 
 #: app/flatpak-builtins-build-bundle.c:59
 msgid "Export runtime instead of app"
@@ -247,7 +254,7 @@ msgstr "Registra o log das chamadas de barramento de sistema"
 msgid "DIRECTORY [COMMAND [ARGUMENT…]] - Build in directory"
 msgstr "DIRETÓRIO [COMANDO [ARGUMENTO…]] – Compila no diretório"
 
-#: app/flatpak-builtins-build.c:285 app/flatpak-builtins-build-finish.c:656
+#: app/flatpak-builtins-build.c:285 app/flatpak-builtins-build-finish.c:655
 msgid "DIRECTORY must be specified"
 msgstr "DIRETÓRIO deve ser especificado"
 
@@ -270,8 +277,7 @@ msgstr "Nenhum ponto de extensão correspondendo %s em %s"
 msgid "Missing '=' in bind mount option '%s'"
 msgstr "Faltando “=” na opção de montagem associativa “%s”"
 
-#: app/flatpak-builtins-build.c:679 common/flatpak-run.c:3961
-#, c-format
+#: app/flatpak-builtins-build.c:679 common/flatpak-run.c:3977
 msgid "Unable to start app"
 msgstr "Não foi possível iniciar o aplicativo"
 
@@ -467,7 +473,7 @@ msgid "Mark build as end-of-life, to be replaced with the given ID"
 msgstr "Marca a compilação como fim de vida, a ser substituída com o ID dado"
 
 #: app/flatpak-builtins-build-export.c:74
-#: app/flatpak-builtins-document-list.c:49 app/flatpak-cli-transaction.c:1427
+#: app/flatpak-builtins-document-list.c:49 app/flatpak-cli-transaction.c:1424
 msgid "ID"
 msgstr "ID"
 
@@ -531,7 +537,6 @@ msgstr ""
 "nome base"
 
 #: app/flatpak-builtins-build-export.c:746
-#, c-format
 msgid "No slashes allowed in extra data name"
 msgstr "Nenhuma barra permitida no nome de dados extras"
 
@@ -541,7 +546,6 @@ msgid "Invalid format for sha256 checksum: '%s'"
 msgstr "Formato inválido para a soma de verificação sha256: “%s”"
 
 #: app/flatpak-builtins-build-export.c:768
-#, c-format
 msgid "Extra data sizes of zero not supported"
 msgstr "Tamanhos zerado de dados extras sem suporte"
 
@@ -563,7 +567,7 @@ msgid "‘%s’ is not a valid collection ID: %s"
 msgstr "“%s” não é um ID de coleção válido: %s"
 
 #: app/flatpak-builtins-build-export.c:904
-#: app/flatpak-builtins-build-finish.c:684
+#: app/flatpak-builtins-build-finish.c:683
 msgid "No name specified in the metadata"
 msgstr "Nenhum nome especificado nos metadados"
 
@@ -593,7 +597,6 @@ msgid "Content Written: %u\n"
 msgstr "Conteúdo escrito: %u\n"
 
 #: app/flatpak-builtins-build-export.c:1171
-#, c-format
 msgid "Content Bytes Written:"
 msgstr "Conteúdo de bytes escritos:"
 
@@ -694,32 +697,30 @@ msgstr "Não exportando %s, nome de arquivo de exportação não permitido\n"
 msgid "Exporting %s\n"
 msgstr "Exportando %s\n"
 
-#: app/flatpak-builtins-build-finish.c:440
-#, c-format
+#: app/flatpak-builtins-build-finish.c:439
 msgid "More than one executable found\n"
 msgstr "Mais de um executável localizado\n"
 
-#: app/flatpak-builtins-build-finish.c:451
+#: app/flatpak-builtins-build-finish.c:450
 #, c-format
 msgid "Using %s as command\n"
 msgstr "Usando %s como comando\n"
 
-#: app/flatpak-builtins-build-finish.c:456
-#, c-format
+#: app/flatpak-builtins-build-finish.c:455
 msgid "No executable found\n"
 msgstr "Nenhum executável localizado\n"
 
-#: app/flatpak-builtins-build-finish.c:511
+#: app/flatpak-builtins-build-finish.c:510
 #, c-format
 msgid "Invalid --require-version argument: %s"
 msgstr "Argumento --require-version inválido: %s"
 
-#: app/flatpak-builtins-build-finish.c:543
+#: app/flatpak-builtins-build-finish.c:542
 #, c-format
 msgid "Too few elements in --extra-data argument %s"
 msgstr "Elementos insuficientes no argumento de --extra-data %s"
 
-#: app/flatpak-builtins-build-finish.c:575
+#: app/flatpak-builtins-build-finish.c:574
 #, c-format
 msgid ""
 "Too few elements in --metadata argument %s, format should be "
@@ -728,7 +729,7 @@ msgstr ""
 "Elementos insuficientes no argumento de --metadata %s, formato deve ser "
 "GRUPO=CHAVE[=VALOR]"
 
-#: app/flatpak-builtins-build-finish.c:597
+#: app/flatpak-builtins-build-finish.c:596
 #: app/flatpak-builtins-build-init.c:458
 #, c-format
 msgid ""
@@ -738,28 +739,27 @@ msgstr ""
 "Elementos insuficientes no argumento de --extension %s, formato deve ser "
 "NOME=VAR[=VALOR]"
 
-#: app/flatpak-builtins-build-finish.c:603
+#: app/flatpak-builtins-build-finish.c:602
 #: app/flatpak-builtins-build-init.c:461
 #, c-format
 msgid "Invalid extension name %s"
 msgstr "Nome de extensão inválido %s"
 
-#: app/flatpak-builtins-build-finish.c:646
+#: app/flatpak-builtins-build-finish.c:645
 msgid "DIRECTORY - Finalize a build directory"
 msgstr "DIRETÓRIO – Finaliza um diretório de compilação"
 
-#: app/flatpak-builtins-build-finish.c:668
+#: app/flatpak-builtins-build-finish.c:667
 #, c-format
 msgid "Build directory %s not initialized"
 msgstr "Diretório de compilação %s não inicializado"
 
-#: app/flatpak-builtins-build-finish.c:689
+#: app/flatpak-builtins-build-finish.c:688
 #, c-format
 msgid "Build directory %s already finalized"
 msgstr "Diretório de compilação %s já finalizado"
 
-#: app/flatpak-builtins-build-finish.c:702
-#, c-format
+#: app/flatpak-builtins-build-finish.c:701
 msgid "Please review the exported files and the metadata\n"
 msgstr "Por favor, reveja os arquivos exportados e os metadados\n"
 
@@ -1086,12 +1086,10 @@ msgid "LOCATION - Update repository metadata"
 msgstr "LOCALIZAÇÃO – Atualiza metadados de um repositório"
 
 #: app/flatpak-builtins-build-update-repo.c:609
-#, c-format
 msgid "Updating appstream branch\n"
 msgstr "Atualizando ramo do appstream\n"
 
 #: app/flatpak-builtins-build-update-repo.c:638
-#, c-format
 msgid "Updating summary\n"
 msgstr "Atualizando resumo\n"
 
@@ -1101,7 +1099,6 @@ msgid "Total objects: %u\n"
 msgstr "Objetos totais: %u\n"
 
 #: app/flatpak-builtins-build-update-repo.c:666
-#, c-format
 msgid "No unreachable objects\n"
 msgstr "Nenhum objeto alcançável\n"
 
@@ -1374,7 +1371,6 @@ msgstr "ARQUIVO – Obtém informações sobre um arquivo exportado"
 
 #: app/flatpak-builtins-document-info.c:100
 #: app/flatpak-builtins-document-unexport.c:94
-#, c-format
 msgid "Not exported\n"
 msgstr "Não exportado\n"
 
@@ -1438,7 +1434,6 @@ msgid "Show permissions for applications"
 msgstr "Mostra permissões para aplicativos"
 
 #: app/flatpak-builtins-document-list.c:161
-#, c-format
 msgid "No documents found\n"
 msgstr "Nenhum documento localizado\n"
 
@@ -1577,7 +1572,7 @@ msgstr "Mostra o ID de aplicativo/runtime"
 
 #: app/flatpak-builtins-history.c:63 app/flatpak-builtins-list.c:64
 #: app/flatpak-builtins-ps.c:53 app/flatpak-builtins-remote-ls.c:73
-#: app/flatpak-cli-transaction.c:1435
+#: app/flatpak-cli-transaction.c:1432
 msgid "Arch"
 msgstr "Arq."
 
@@ -1588,7 +1583,7 @@ msgstr "Mostra a arquitetura"
 
 #: app/flatpak-builtins-history.c:64 app/flatpak-builtins-list.c:63
 #: app/flatpak-builtins-ps.c:54 app/flatpak-builtins-remote-ls.c:72
-#: app/flatpak-builtins-search.c:48 app/flatpak-cli-transaction.c:1438
+#: app/flatpak-builtins-search.c:48 app/flatpak-cli-transaction.c:1435
 msgid "Branch"
 msgstr "Ramo"
 
@@ -1605,7 +1600,7 @@ msgstr "Instalação"
 msgid "Show the affected installation"
 msgstr "Mostra a instalação afetada"
 
-#: app/flatpak-builtins-history.c:66 app/flatpak-cli-transaction.c:1452
+#: app/flatpak-builtins-history.c:66 app/flatpak-cli-transaction.c:1449
 msgid "Remote"
 msgstr "Remoto"
 
@@ -1634,7 +1629,7 @@ msgstr "Mostra o commit anterior"
 msgid "Show the remote URL"
 msgstr "Mostra o ID do remoto"
 
-#: app/flatpak-builtins-history.c:70 app/flatpak-cli-transaction.c:700
+#: app/flatpak-builtins-history.c:70 app/flatpak-cli-transaction.c:697
 msgid "User"
 msgstr "Usuário"
 
@@ -1679,12 +1674,10 @@ msgid " - Show history"
 msgstr " – Mostra histórico"
 
 #: app/flatpak-builtins-history.c:490
-#, c-format
 msgid "Failed to parse the --since option"
 msgstr "Falha ao analisar a opção --since"
 
 #: app/flatpak-builtins-history.c:501
-#, c-format
 msgid "Failed to parse the --until option"
 msgstr "Falha ao analisar a opção --until"
 
@@ -1766,7 +1759,6 @@ msgid "ref not present in origin"
 msgstr "ref não presente na origem"
 
 #: app/flatpak-builtins-info.c:211 app/flatpak-builtins-remote-info.c:217
-#, c-format
 msgid "Warning: Commit has no flatpak metadata\n"
 msgstr "Aviso: O commit tem nenhum metadado de flatpak\n"
 
@@ -2021,7 +2013,6 @@ msgid "At least one REF must be specified"
 msgstr "Pelo menos um REF deve ser especificado"
 
 #: app/flatpak-builtins-install.c:392
-#, c-format
 msgid "Looking for matches…\n"
 msgstr "Procurando por correspondências…\n"
 
@@ -2225,12 +2216,10 @@ msgstr ""
 "padrões"
 
 #: app/flatpak-builtins-mask.c:73
-#, c-format
 msgid "No masked patterns\n"
 msgstr "Nenhum padrão mascarado\n"
 
 #: app/flatpak-builtins-mask.c:78
-#, c-format
 msgid "Masked patterns:\n"
 msgstr "Padrões mascarados:\n"
 
@@ -2324,12 +2313,10 @@ msgstr ""
 "padrões"
 
 #: app/flatpak-builtins-pin.c:75
-#, c-format
 msgid "No pinned patterns\n"
 msgstr "Nenhum padrão fixado\n"
 
 #: app/flatpak-builtins-pin.c:80
-#, c-format
 msgid "Pinned patterns:\n"
 msgstr "Padrões fixados:\n"
 
@@ -2338,7 +2325,6 @@ msgid "- Install flatpaks that are part of the operating system"
 msgstr "- Instalar flatpaks que são parte do sistema operacional"
 
 #: app/flatpak-builtins-preinstall.c:118
-#, c-format
 msgid "Nothing to do.\n"
 msgstr "Nada para fazer.\n"
 
@@ -2512,7 +2498,7 @@ msgstr "Não segue o redirecionamento definido no arquivo de resumo"
 msgid "Can't load uri %s: %s\n"
 msgstr "Não foi possível carregar a uri %s: %s\n"
 
-#: app/flatpak-builtins-remote-add.c:276 common/flatpak-dir.c:4643
+#: app/flatpak-builtins-remote-add.c:276 common/flatpak-dir.c:4646
 #, c-format
 msgid "Can't load file %s: %s\n"
 msgstr "Não foi possível carregar o arquivo %s: %s\n"
@@ -2878,7 +2864,6 @@ msgid "[%d/%d] Verifying %s…\n"
 msgstr "[%d/%d] Verificando %s…\n"
 
 #: app/flatpak-builtins-repair.c:435
-#, c-format
 msgid "Dry run: "
 msgstr "Simulação: "
 
@@ -2898,7 +2883,6 @@ msgid "Deleting ref %s due to %d\n"
 msgstr "Excluindo ref %s devido a %d\n"
 
 #: app/flatpak-builtins-repair.c:464
-#, c-format
 msgid "Checking remotes...\n"
 msgstr "Verificando remotos...\n"
 
@@ -2913,22 +2897,18 @@ msgid "Remote %s for ref %s is disabled\n"
 msgstr "O remoto %s para ref %s está desabilitado\n"
 
 #: app/flatpak-builtins-repair.c:490
-#, c-format
 msgid "Pruning objects\n"
 msgstr "Suprimindo objetos\n"
 
 #: app/flatpak-builtins-repair.c:498
-#, c-format
 msgid "Erasing .removed\n"
 msgstr "Apagando .removed\n"
 
 #: app/flatpak-builtins-repair.c:524
-#, c-format
 msgid "Reinstalling refs\n"
 msgstr "Reinstalando refs\n"
 
 #: app/flatpak-builtins-repair.c:526
-#, c-format
 msgid "Reinstalling removed refs\n"
 msgstr "Reinstalando refs removidas\n"
 
@@ -2963,7 +2943,6 @@ msgid "false"
 msgstr "falso"
 
 #: app/flatpak-builtins-repo.c:121
-#, c-format
 msgid "Subsummaries: "
 msgstr "Sub-resumos: "
 
@@ -3047,7 +3026,7 @@ msgid "Installed"
 msgstr "Instalado"
 
 #. Translators: Download is used here as a noun
-#: app/flatpak-builtins-repo.c:338 app/flatpak-cli-transaction.c:1462
+#: app/flatpak-builtins-repo.c:338 app/flatpak-cli-transaction.c:1459
 msgid "Download"
 msgstr "Baixar"
 
@@ -3185,7 +3164,7 @@ msgstr "Usa FD em vez do /app do aplicativo"
 
 #: app/flatpak-builtins-run.c:183 app/flatpak-builtins-run.c:185
 #: app/flatpak-builtins-run.c:187 app/flatpak-builtins-run.c:188
-#: common/flatpak-context.c:2672
+#: common/flatpak-context.c:2715
 msgid "FD"
 msgstr "FD"
 
@@ -3205,12 +3184,16 @@ msgstr "Remove definição de todas variáveis de ambiente externas"
 msgid ""
 "Bind mount the file or directory referred to by FD to its canonicalized path"
 msgstr ""
+"Realiza montagem associativa (bind) do arquivo ou diretório referido pelo "
+"descritor de arquivo ao seu caminho canônico."
 
 #: app/flatpak-builtins-run.c:188
 msgid ""
 "Bind mount the file or directory referred to by FD read-only to its "
 "canonicalized path"
 msgstr ""
+"Realiza montagem associativa (bind) do arquivo ou diretório referido pelo "
+"descritor de arquivo somente leitura ao seu caminho canônico."
 
 #: app/flatpak-builtins-run.c:219
 msgid "APP [ARGUMENT…] - Run an app"
@@ -3223,11 +3206,11 @@ msgstr "runtime/%s/%s/%s não instalado"
 
 #: app/flatpak-builtins-run.c:419
 msgid "app-fd and app-path cannot both be used"
-msgstr ""
+msgstr "app-fd e app-path não podem ser usados juntos"
 
 #: app/flatpak-builtins-run.c:449
 msgid "usr-fd and usr-path cannot both be used"
-msgstr ""
+msgstr "usr-fd e usr-path não podem ser usados juntos"
 
 #: app/flatpak-builtins-search.c:37
 msgid "Arch to search for"
@@ -3328,7 +3311,6 @@ msgstr ""
 "flatpak-pin(1):\n"
 
 #: app/flatpak-builtins-uninstall.c:370
-#, c-format
 msgid "Nothing unused to uninstall\n"
 msgstr "Nada não usado para desinstalar\n"
 
@@ -3353,12 +3335,10 @@ msgid "Warning: %s is not installed\n"
 msgstr "Aviso: %s não está instalado\n"
 
 #: app/flatpak-builtins-uninstall.c:490
-#, c-format
 msgid "None of the specified refs are installed"
 msgstr "Nenhuma das refs especificadas estão instaladas"
 
 #: app/flatpak-builtins-uninstall.c:599
-#, c-format
 msgid "No app data to delete\n"
 msgstr "Nenhum dado de aplicativo para excluir\n"
 
@@ -3399,7 +3379,6 @@ msgid "With --commit, only one REF may be specified"
 msgstr "Com --commit, apenas um REF pode ser especificado"
 
 #: app/flatpak-builtins-update.c:162
-#, c-format
 msgid "Looking for updates…\n"
 msgstr "Procurando por atualizações…\n"
 
@@ -3409,7 +3388,6 @@ msgid "Unable to update %s: %s\n"
 msgstr "Não foi possível atualizar %s: %s\n"
 
 #: app/flatpak-builtins-update.c:274
-#, c-format
 msgid "Nothing to update.\n"
 msgstr "Nada para atualizar.\n"
 
@@ -3496,7 +3474,6 @@ msgid "Found installed ref ‘%s’ (%s). Is this correct?"
 msgstr "Localizada ref instalada “%s” (%s). Isso está correto?"
 
 #: app/flatpak-builtins-utils.c:534
-#, c-format
 msgid "All of the above"
 msgstr "Todas acima"
 
@@ -3760,17 +3737,17 @@ msgstr "Autenticação necessária para remoto “%s”\n"
 msgid "Open browser?"
 msgstr "Abrir navegador?"
 
-#: app/flatpak-cli-transaction.c:699
+#: app/flatpak-cli-transaction.c:696
 #, c-format
 msgid "Login required remote %s (realm %s)\n"
 msgstr "A autenticação exigiu o remoto %s (domínio %s)\n"
 
-#: app/flatpak-cli-transaction.c:704
+#: app/flatpak-cli-transaction.c:701
 msgid "Password"
 msgstr "Senha"
 
 #. Only runtimes can be pinned
-#: app/flatpak-cli-transaction.c:759
+#: app/flatpak-cli-transaction.c:756
 #, c-format
 msgid ""
 "\n"
@@ -3781,7 +3758,7 @@ msgstr ""
 "Info: (fixado) o runtime %s%s%s ramo %s%s%s chegou ao fim de vida, em favor "
 "de %s%s%s ramo %s%s%s\n"
 
-#: app/flatpak-cli-transaction.c:765
+#: app/flatpak-cli-transaction.c:762
 #, c-format
 msgid ""
 "\n"
@@ -3792,7 +3769,7 @@ msgstr ""
 "Info: o runtime %s%s%s ramo %s%s%s chegou ao fim de vida, em favor de %s%s%s "
 "ramo %s%s%s\n"
 
-#: app/flatpak-cli-transaction.c:768
+#: app/flatpak-cli-transaction.c:765
 #, c-format
 msgid ""
 "\n"
@@ -3804,7 +3781,7 @@ msgstr ""
 "%s%s%s ramo %s%s%s\n"
 
 #. Only runtimes can be pinned
-#: app/flatpak-cli-transaction.c:780
+#: app/flatpak-cli-transaction.c:777
 #, c-format
 msgid ""
 "\n"
@@ -3814,7 +3791,7 @@ msgstr ""
 "Info: (fixado) o runtime %s%s%s ramo %s%s%s chegou ao fim de vida, com "
 "motivo:\n"
 
-#: app/flatpak-cli-transaction.c:786
+#: app/flatpak-cli-transaction.c:783
 #, c-format
 msgid ""
 "\n"
@@ -3823,7 +3800,7 @@ msgstr ""
 "\n"
 "Info: o runtime %s%s%s ramo %s%s%s chegou ao fim de vida, com motivo:\n"
 
-#: app/flatpak-cli-transaction.c:789
+#: app/flatpak-cli-transaction.c:786
 #, c-format
 msgid ""
 "\n"
@@ -3832,88 +3809,85 @@ msgstr ""
 "\n"
 "Info: o aplicativo %s%s%s ramo %s%s%s chegou ao fim de vida, com motivo:\n"
 
-#: app/flatpak-cli-transaction.c:963
-#, c-format
+#: app/flatpak-cli-transaction.c:960
 msgid "Info: applications using this extension:\n"
 msgstr "Info: aplicativos que usam este runtime:\n"
 
-#: app/flatpak-cli-transaction.c:965
-#, c-format
+#: app/flatpak-cli-transaction.c:962
 msgid "Info: applications using this runtime:\n"
 msgstr "Info: aplicativos que usam este runtime:\n"
 
-#: app/flatpak-cli-transaction.c:984
+#: app/flatpak-cli-transaction.c:981
 msgid "Replace?"
 msgstr "Substituir?"
 
-#: app/flatpak-cli-transaction.c:987 app/flatpak-quiet-transaction.c:247
-#, c-format
+#: app/flatpak-cli-transaction.c:984 app/flatpak-quiet-transaction.c:247
 msgid "Updating to rebased version\n"
 msgstr "Atualizando para a versão após rebase\n"
 
-#: app/flatpak-cli-transaction.c:1011
+#: app/flatpak-cli-transaction.c:1008
 #, c-format
 msgid "Failed to rebase %s to %s: "
 msgstr "Falha ao realizar rebase de %s para %s: "
 
-#: app/flatpak-cli-transaction.c:1277
+#: app/flatpak-cli-transaction.c:1274
 #, c-format
 msgid "New %s%s%s permissions:"
 msgstr "Novas permissões de %s%s%s:"
 
-#: app/flatpak-cli-transaction.c:1279
+#: app/flatpak-cli-transaction.c:1276
 #, c-format
 msgid "%s%s%s permissions:"
 msgstr "Permissões de %s%s%s:"
 
-#: app/flatpak-cli-transaction.c:1343
+#: app/flatpak-cli-transaction.c:1340
 msgid "Warning: "
 msgstr "Aviso: "
 
 #. translators: This is short for operation, the title of a one-char column
-#: app/flatpak-cli-transaction.c:1442
+#: app/flatpak-cli-transaction.c:1439
 msgid "Op"
 msgstr "Op"
 
 #. Avoid resizing the download column too much,
 #. * by making the title as long as typical content
 #.
-#: app/flatpak-cli-transaction.c:1458 app/flatpak-cli-transaction.c:1503
+#: app/flatpak-cli-transaction.c:1455 app/flatpak-cli-transaction.c:1500
 msgid "partial"
 msgstr "parcial"
 
-#: app/flatpak-cli-transaction.c:1535
+#: app/flatpak-cli-transaction.c:1532
 msgid "Proceed with these changes to the user installation?"
 msgstr "Prosseguir com essas alterações para a instalação de usuário?"
 
-#: app/flatpak-cli-transaction.c:1537
+#: app/flatpak-cli-transaction.c:1534
 msgid "Proceed with these changes to the system installation?"
 msgstr "Prosseguir com essas alterações para a instalação da sistema?"
 
-#: app/flatpak-cli-transaction.c:1539
+#: app/flatpak-cli-transaction.c:1536
 #, c-format
 msgid "Proceed with these changes to the %s?"
 msgstr "Prosseguir com essas alterações ao %s?"
 
-#: app/flatpak-cli-transaction.c:1711
+#: app/flatpak-cli-transaction.c:1707
 msgid "Changes complete."
 msgstr "Alterações concluídas."
 
-#: app/flatpak-cli-transaction.c:1713
+#: app/flatpak-cli-transaction.c:1709
 msgid "Uninstall complete."
 msgstr "Desinstalação concluída."
 
-#: app/flatpak-cli-transaction.c:1715
+#: app/flatpak-cli-transaction.c:1711
 msgid "Installation complete."
 msgstr "Instalação concluída."
 
-#: app/flatpak-cli-transaction.c:1717
+#: app/flatpak-cli-transaction.c:1713
 msgid "Updates complete."
 msgstr "Atualização concluída."
 
 #. For updates/!stop_on_first_error we already printed all errors so we make up
 #. a different one.
-#: app/flatpak-cli-transaction.c:1750
+#: app/flatpak-cli-transaction.c:1746
 msgid "There were one or more errors"
 msgstr "Houve um ou mais erros"
 
@@ -4322,16 +4296,16 @@ msgstr "Aviso: Falha ao desinstalar %s: %s\n"
 msgid "Error: Failed to uninstall %s: %s\n"
 msgstr "Erro: Falha ao desinstalar %s: %s\n"
 
-#: app/flatpak-quiet-transaction.c:166 common/flatpak-dir.c:11475
+#: app/flatpak-quiet-transaction.c:166 common/flatpak-dir.c:11477
 #, c-format
 msgid "%s already installed"
 msgstr "%s já instalado"
 
-#: app/flatpak-quiet-transaction.c:168 common/flatpak-dir.c:3622
-#: common/flatpak-dir.c:4321 common/flatpak-dir.c:16968
+#: app/flatpak-quiet-transaction.c:168 common/flatpak-dir.c:3625
+#: common/flatpak-dir.c:4324 common/flatpak-dir.c:16968
 #: common/flatpak-dir.c:17258 common/flatpak-dir-utils.c:166
-#: common/flatpak-dir-utils.c:259 common/flatpak-transaction.c:2736
-#: common/flatpak-transaction.c:2791
+#: common/flatpak-dir-utils.c:259 common/flatpak-transaction.c:2752
+#: common/flatpak-transaction.c:2807
 #, c-format
 msgid "%s not installed"
 msgstr "%s não instalado"
@@ -4365,55 +4339,54 @@ msgstr "Falha ao realizar rebase de %s para %s: %s\n"
 msgid "No authenticator configured for remote `%s`"
 msgstr "Nenhum autenticador configurador para remoto “%s”"
 
-#: common/flatpak-context.c:637 common/flatpak-context.c:649
+#: common/flatpak-context.c:641 common/flatpak-context.c:653
 #, c-format
 msgid "Invalid permission syntax: %s"
 msgstr "Sintaxe de permissão inválida: %s"
 
-#: common/flatpak-context.c:1207
+#: common/flatpak-context.c:1250
 #, c-format
 msgid "Unknown share type %s, valid types are: %s"
 msgstr "Tipo de compartilhamento desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-context.c:1228
+#: common/flatpak-context.c:1271
 #, c-format
 msgid "Unknown policy type %s, valid types are: %s"
 msgstr "Tipo de política desconhecida %s, tipos válidos são: %s"
 
-#: common/flatpak-context.c:1266
+#: common/flatpak-context.c:1309
 #, c-format
 msgid "Invalid dbus name %s"
 msgstr "Nome de dbus inválido %s"
 
-#: common/flatpak-context.c:1279
+#: common/flatpak-context.c:1322
 #, c-format
 msgid "Unknown socket type %s, valid types are: %s"
 msgstr "Tipo de soquete desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-context.c:1294
+#: common/flatpak-context.c:1337
 #, c-format
 msgid "Unknown device type %s, valid types are: %s"
 msgstr "Tipo de dispositivo desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-context.c:1308
+#: common/flatpak-context.c:1351
 #, c-format
 msgid "Unknown feature type %s, valid types are: %s"
 msgstr "Tipo de recurso desconhecido %s, tipos válidos são: %s"
 
-#: common/flatpak-context.c:1840
+#: common/flatpak-context.c:1883
 #, c-format
 msgid "Filesystem location \"%s\" contains \"..\""
 msgstr "A localização do sistema de arquivos “%s” contém “..”"
 
-#: common/flatpak-context.c:1882
-#, c-format
+#: common/flatpak-context.c:1925
 msgid ""
 "--filesystem=/ is not available, use --filesystem=host for a similar result"
 msgstr ""
 "--filesystem=/ não está disponível, use --filesystem=host para um resultado "
 "similar"
 
-#: common/flatpak-context.c:1916
+#: common/flatpak-context.c:1959
 #, c-format
 msgid ""
 "Unknown filesystem location %s, valid locations are: host, host-os, host-"
@@ -4422,258 +4395,253 @@ msgstr ""
 "Localização de sistema de arquivos desconhecida %s, localizações válidas "
 "são: host, host-os, host-etc, host-root, home, xdg-*[/…], ~/dir, /dir"
 
-#: common/flatpak-context.c:2015
+#: common/flatpak-context.c:2058
 #, c-format
 msgid "Invalid syntax for %s: %s"
 msgstr "Sintaxe inválida para %s: %s"
 
-#: common/flatpak-context.c:2142
-#, c-format
+#: common/flatpak-context.c:2185
 msgid "fallback-x11 can not be conditional"
 msgstr "fallback-x11 não pode ser condicional"
 
-#: common/flatpak-context.c:2318
+#: common/flatpak-context.c:2361
 #, c-format
 msgid "Invalid env format %s"
 msgstr "Formato de env inválido %s"
 
-#: common/flatpak-context.c:2399
+#: common/flatpak-context.c:2442
 #, c-format
 msgid "Environment variable name must not contain '=': %s"
 msgstr "O nome de variável de ambiente não pode conter “=”: %s"
 
-#: common/flatpak-context.c:2527 common/flatpak-context.c:2535
-#, c-format
+#: common/flatpak-context.c:2570 common/flatpak-context.c:2578
 msgid "--add-policy arguments must be in the form SUBSYSTEM.KEY=VALUE"
 msgstr ""
 "Os argumentos de --add-policy devem estar no formato SUBSISTEMA.CHAVE=VALOR"
 
-#: common/flatpak-context.c:2542
-#, c-format
+#: common/flatpak-context.c:2585
 msgid "--add-policy values can't start with \"!\""
 msgstr "os valores de --add-policy não podem iniciar com “!”"
 
-#: common/flatpak-context.c:2567 common/flatpak-context.c:2575
-#, c-format
+#: common/flatpak-context.c:2610 common/flatpak-context.c:2618
 msgid "--remove-policy arguments must be in the form SUBSYSTEM.KEY=VALUE"
 msgstr ""
 "Os argumentos de --remove-policy devem estar no formato "
 "SUBSISTEMA.CHAVE=VALOR"
 
-#: common/flatpak-context.c:2582
-#, c-format
+#: common/flatpak-context.c:2625
 msgid "--remove-policy values can't start with \"!\""
 msgstr "Os valores de --remove-policy não podem iniciar com “!”"
 
-#: common/flatpak-context.c:2657
+#: common/flatpak-context.c:2700
 msgid "Share with host"
 msgstr "Compartilha com o host"
 
-#: common/flatpak-context.c:2657 common/flatpak-context.c:2658
+#: common/flatpak-context.c:2700 common/flatpak-context.c:2701
 msgid "SHARE"
 msgstr "COMPARTILHAMENTO"
 
-#: common/flatpak-context.c:2658
+#: common/flatpak-context.c:2701
 msgid "Unshare with host"
 msgstr "Desfaz compartilhamento com o host"
 
-#: common/flatpak-context.c:2659
+#: common/flatpak-context.c:2702
 msgid "Require conditions to be met for a subsystem to get shared"
 msgstr ""
 "Exige que condições sejam atendidas para um subsistema ser compartilhado"
 
-#: common/flatpak-context.c:2659
+#: common/flatpak-context.c:2702
 msgid "SHARE:CONDITION"
 msgstr "COMPARTILHAMENTO:CONDIÇÃO"
 
-#: common/flatpak-context.c:2660
+#: common/flatpak-context.c:2703
 msgid "Expose socket to app"
 msgstr "Expõe o soquete para o aplicativo"
 
-#: common/flatpak-context.c:2660 common/flatpak-context.c:2661
+#: common/flatpak-context.c:2703 common/flatpak-context.c:2704
 msgid "SOCKET"
 msgstr "SOQUETE"
 
-#: common/flatpak-context.c:2661
+#: common/flatpak-context.c:2704
 msgid "Don't expose socket to app"
 msgstr "Não expõe o soquete para o aplicativo"
 
-#: common/flatpak-context.c:2662
+#: common/flatpak-context.c:2705
 msgid "Require conditions to be met for a socket to get exposed"
 msgstr "Exige que condições sejam atendidas para um soquete ser exposto"
 
-#: common/flatpak-context.c:2662
+#: common/flatpak-context.c:2705
 msgid "SOCKET:CONDITION"
 msgstr "SOQUETE:CONDIÇÃO"
 
-#: common/flatpak-context.c:2663
+#: common/flatpak-context.c:2706
 msgid "Expose device to app"
 msgstr "Expõe o dispositivo para o aplicativo"
 
-#: common/flatpak-context.c:2663 common/flatpak-context.c:2664
+#: common/flatpak-context.c:2706 common/flatpak-context.c:2707
 msgid "DEVICE"
 msgstr "DISPOSITIVO"
 
-#: common/flatpak-context.c:2664
+#: common/flatpak-context.c:2707
 msgid "Don't expose device to app"
 msgstr "Não expõe o dispositivo para o aplicativo"
 
-#: common/flatpak-context.c:2665
+#: common/flatpak-context.c:2708
 msgid "Require conditions to be met for a device to get exposed"
 msgstr "Exige que condições sejam atendidas para um dispositivo ser exposto"
 
-#: common/flatpak-context.c:2665
+#: common/flatpak-context.c:2708
 msgid "DEVICE:CONDITION"
 msgstr "DISPOSITIVO:CONDIÇÃO"
 
-#: common/flatpak-context.c:2666
+#: common/flatpak-context.c:2709
 msgid "Allow feature"
 msgstr "Permite a funcionalidade"
 
-#: common/flatpak-context.c:2666 common/flatpak-context.c:2667
+#: common/flatpak-context.c:2709 common/flatpak-context.c:2710
 msgid "FEATURE"
 msgstr "FUNCIONALIDADE"
 
-#: common/flatpak-context.c:2667
+#: common/flatpak-context.c:2710
 msgid "Don't allow feature"
 msgstr "Não permite funcionalidade"
 
-#: common/flatpak-context.c:2668
+#: common/flatpak-context.c:2711
 msgid "Require conditions to be met for a feature to get allowed"
 msgstr ""
 "Exige que condições sejam atendidas para uma funcionalidade ser exposta"
 
-#: common/flatpak-context.c:2668
+#: common/flatpak-context.c:2711
 msgid "FEATURE:CONDITION"
 msgstr "FUNCIONALIDADE:CONDIÇÃO"
 
-#: common/flatpak-context.c:2669
+#: common/flatpak-context.c:2712
 msgid "Expose filesystem to app (:ro for read-only)"
 msgstr ""
 "Expõe o sistema de arquivos para o aplicativo (:ro para somente leitura)"
 
-#: common/flatpak-context.c:2669
+#: common/flatpak-context.c:2712
 msgid "FILESYSTEM[:ro]"
 msgstr "SISTEMA_DE_ARQUIVOS[:ro]"
 
-#: common/flatpak-context.c:2670
+#: common/flatpak-context.c:2713
 msgid "Don't expose filesystem to app"
 msgstr "Não expõe o sistema de arquivos para o aplicativo"
 
-#: common/flatpak-context.c:2670
+#: common/flatpak-context.c:2713
 msgid "FILESYSTEM"
 msgstr "SISTEMA_DE_ARQUIVOS"
 
-#: common/flatpak-context.c:2671
+#: common/flatpak-context.c:2714
 msgid "Set environment variable"
 msgstr "Define uma variável de ambiente"
 
-#: common/flatpak-context.c:2671
+#: common/flatpak-context.c:2714
 msgid "VAR=VALUE"
 msgstr "VAR=VALOR"
 
-#: common/flatpak-context.c:2672
+#: common/flatpak-context.c:2715
 msgid "Read environment variables in env -0 format from FD"
 msgstr "Lê as variáveis de ambiente no formato env -0 do FD"
 
-#: common/flatpak-context.c:2673
+#: common/flatpak-context.c:2716
 msgid "Remove variable from environment"
 msgstr "Remove a variável do ambiente"
 
-#: common/flatpak-context.c:2673
+#: common/flatpak-context.c:2716
 msgid "VAR"
 msgstr "VAR"
 
-#: common/flatpak-context.c:2674
+#: common/flatpak-context.c:2717
 msgid "Allow app to own name on the session bus"
 msgstr "Permite o aplicativo ter um nome no barramento de sessão"
 
-#: common/flatpak-context.c:2674 common/flatpak-context.c:2675
-#: common/flatpak-context.c:2676 common/flatpak-context.c:2677
-#: common/flatpak-context.c:2678 common/flatpak-context.c:2679
-#: common/flatpak-context.c:2680
+#: common/flatpak-context.c:2717 common/flatpak-context.c:2718
+#: common/flatpak-context.c:2719 common/flatpak-context.c:2720
+#: common/flatpak-context.c:2721 common/flatpak-context.c:2722
+#: common/flatpak-context.c:2723
 msgid "DBUS_NAME"
 msgstr "NOME_DBUS"
 
-#: common/flatpak-context.c:2675
+#: common/flatpak-context.c:2718
 msgid "Allow app to talk to name on the session bus"
 msgstr "Permite o aplicativo falar com um nome no barramento de sessão"
 
-#: common/flatpak-context.c:2676
+#: common/flatpak-context.c:2719
 msgid "Don't allow app to talk to name on the session bus"
 msgstr "Proíbe o aplicativo de falar com um nome no barramento de sessão"
 
-#: common/flatpak-context.c:2677
+#: common/flatpak-context.c:2720
 msgid "Allow app to own name on the system bus"
 msgstr "Permite o aplicativo ter um nome no barramento de sistema"
 
-#: common/flatpak-context.c:2678
+#: common/flatpak-context.c:2721
 msgid "Allow app to talk to name on the system bus"
 msgstr "Permite o aplicativo falar com um nome no barramento de sistema"
 
-#: common/flatpak-context.c:2679
+#: common/flatpak-context.c:2722
 msgid "Don't allow app to talk to name on the system bus"
 msgstr "Proíbe o aplicativo de falar com um nome no barramento de sistema"
 
-#: common/flatpak-context.c:2680
+#: common/flatpak-context.c:2723
 msgid "Allow app to own name on the a11y bus"
 msgstr "Permite o aplicativo ter o nome no barramento a11y"
 
-#: common/flatpak-context.c:2681
+#: common/flatpak-context.c:2724
 msgid "Add generic policy option"
 msgstr "Adiciona uma opção de política genérica"
 
-#: common/flatpak-context.c:2681 common/flatpak-context.c:2682
+#: common/flatpak-context.c:2724 common/flatpak-context.c:2725
 msgid "SUBSYSTEM.KEY=VALUE"
 msgstr "SUBSISTEMA.CHAVE=VALOR"
 
-#: common/flatpak-context.c:2682
+#: common/flatpak-context.c:2725
 msgid "Remove generic policy option"
 msgstr "Remove uma opção de política genérica"
 
-#: common/flatpak-context.c:2683
+#: common/flatpak-context.c:2726
 msgid "Add USB device to enumerables"
 msgstr "Adiciona um dispositivo USB para enumeráveis"
 
-#: common/flatpak-context.c:2683 common/flatpak-context.c:2684
+#: common/flatpak-context.c:2726 common/flatpak-context.c:2727
 msgid "VENDOR_ID:PRODUCT_ID"
 msgstr "ID_FORNECEDOR:ID_PRODUTO"
 
-#: common/flatpak-context.c:2684
+#: common/flatpak-context.c:2727
 msgid "Add USB device to hidden list"
 msgstr "Adiciona um dispositivo USB para lista oculta"
 
-#: common/flatpak-context.c:2685
+#: common/flatpak-context.c:2728
 msgid "A list of USB devices that are enumerable"
 msgstr "Uma lista de dispositivos USB que são enumeráveis"
 
-#: common/flatpak-context.c:2685
+#: common/flatpak-context.c:2728
 msgid "LIST"
 msgstr "LISTA"
 
-#: common/flatpak-context.c:2686
+#: common/flatpak-context.c:2729
 msgid "File containing a list of USB devices to make enumerable"
 msgstr "Arquivo contendo uma lista de dispositivos USB para fazer enumeráveis"
 
-#: common/flatpak-context.c:2686 common/flatpak-context.c:2687
+#: common/flatpak-context.c:2729 common/flatpak-context.c:2730
 msgid "FILENAME"
 msgstr "ARQUIVO"
 
-#: common/flatpak-context.c:2687
+#: common/flatpak-context.c:2730
 msgid "Persist home directory subpath"
 msgstr "Persiste o subcaminho do diretório pessoal"
 
 #. This is not needed/used anymore, so hidden, but we accept it for backwards compat
-#: common/flatpak-context.c:2689
+#: common/flatpak-context.c:2732
 msgid "Don't require a running session (no cgroups creation)"
 msgstr "Não exige uma sessão em execução (sem criação de cgroups)"
 
-#: common/flatpak-context.c:3718
+#: common/flatpak-context.c:3761
 #, c-format
 msgid "Not replacing \"%s\" with tmpfs: %s"
 msgstr "Não será substituído “%s” por tmpfs: %s"
 
-#: common/flatpak-context.c:3726
+#: common/flatpak-context.c:3769
 #, c-format
 msgid "Not sharing \"%s\" with sandbox: %s"
 msgstr "Não será compartilhado “%s” com caixa de proteção: %s"
@@ -4682,396 +4650,391 @@ msgstr "Não será compartilhado “%s” com caixa de proteção: %s"
 #. * the path not existing, it seems reasonable to make more of a fuss
 #. * about the home directory not existing or otherwise being unusable,
 #. * so this is intentionally not using cannot_export()
-#: common/flatpak-context.c:3828
+#: common/flatpak-context.c:3871
 #, c-format
 msgid "Not allowing home directory access: %s"
 msgstr "Não será permitido acesso ao diretório pessoal: %s"
 
-#: common/flatpak-context.c:4062
+#: common/flatpak-context.c:4105
 #, c-format
 msgid "Unable to provide a temporary home directory in the sandbox: %s"
 msgstr ""
 "Não foi possível fornecer um diretório pessoal temporário no sandbox: %s"
 
-#: common/flatpak-dir.c:442
+#: common/flatpak-dir.c:441
 #, c-format
 msgid "Configured collection ID ‘%s’ not in summary file"
 msgstr "O ID de coleção “%s” configurado não está no arquivo de resumo"
 
-#: common/flatpak-dir.c:587
+#: common/flatpak-dir.c:586
 #, c-format
 msgid "Unable to load summary from remote %s: %s"
 msgstr "Não foi possível carregar resumo do remoto %s: %s"
 
-#: common/flatpak-dir.c:764 common/flatpak-dir.c:800 common/flatpak-dir.c:906
+#: common/flatpak-dir.c:763 common/flatpak-dir.c:799 common/flatpak-dir.c:905
 #, c-format
 msgid "No such ref '%s' in remote %s"
 msgstr "Ref inexistente “%s” no remoto %s"
 
-#: common/flatpak-dir.c:891 common/flatpak-dir.c:1051 common/flatpak-dir.c:1080
-#: common/flatpak-dir.c:1092
+#: common/flatpak-dir.c:890 common/flatpak-dir.c:1050 common/flatpak-dir.c:1079
+#: common/flatpak-dir.c:1091
 #, c-format
 msgid "No entry for %s in remote %s summary flatpak cache"
 msgstr "Nenhuma entrada para %s no cache de flatpak do sumário do remoto %s"
 
-#: common/flatpak-dir.c:1069
+#: common/flatpak-dir.c:1068
 #, c-format
 msgid "No summary or Flatpak cache available for remote %s"
 msgstr "Nenhum sumário ou cache do Flatpak disponível para o remoto %s"
 
-#: common/flatpak-dir.c:1097
+#: common/flatpak-dir.c:1096
 #, c-format
 msgid "Missing xa.data in summary for remote %s"
 msgstr "Faltando xa.data no resumo para %s remoto"
 
-#: common/flatpak-dir.c:1103 common/flatpak-dir.c:1546
+#: common/flatpak-dir.c:1102 common/flatpak-dir.c:1545
 #, c-format
 msgid "Unsupported summary version %d for remote %s"
 msgstr "Versão de resumo %d não suportada para %s remoto"
 
-#: common/flatpak-dir.c:1200
+#: common/flatpak-dir.c:1199
 msgid "Remote OCI index has no registry uri"
 msgstr "Índice de OCI remoto tem nenhuma uri de registro"
 
-#: common/flatpak-dir.c:1261
+#: common/flatpak-dir.c:1260
 #, c-format
 msgid "Couldn't find ref %s in remote %s"
 msgstr "Não foi possível localizar a ref %s no remoto %s"
 
-#: common/flatpak-dir.c:1288 common/flatpak-dir.c:1381
+#: common/flatpak-dir.c:1287 common/flatpak-dir.c:1380
 #, c-format
 msgid "Commit has no requested ref ‘%s’ in ref binding metadata (found: ‘%s’)"
-msgstr "O commit não tem solicitação de ref ‘%s’ nos metadados de associação de ref (localizado: ‘%s’)"
+msgstr ""
+"O commit não tem solicitação de ref ‘%s’ nos metadados de associação de ref "
+"(localizado: ‘%s’)"
 
-#: common/flatpak-dir.c:1413
+#: common/flatpak-dir.c:1412
 #, c-format
 msgid "Configured collection ID ‘%s’ not in binding metadata"
 msgstr "O ID de coleção “%s” configurado não está nos metadados de associação"
 
-#: common/flatpak-dir.c:1449 common/flatpak-dir.c:5645
+#: common/flatpak-dir.c:1448 common/flatpak-dir.c:5648
 #, c-format
 msgid "Couldn't find latest checksum for ref %s in remote %s"
 msgstr ""
 "Não foi possível localizar a última soma de verificação para a ref %s no "
 "remoto %s"
 
-#: common/flatpak-dir.c:1516 common/flatpak-dir.c:1552
+#: common/flatpak-dir.c:1515 common/flatpak-dir.c:1551
 #, c-format
 msgid "No entry for %s in remote %s summary flatpak sparse cache"
 msgstr ""
 "Nenhuma entrada para %s no cache esparso de flatpak do resumo do remoto %s"
 
-#: common/flatpak-dir.c:2540
+#: common/flatpak-dir.c:2539
 #, c-format
 msgid "Commit metadata for %s not matching expected metadata"
 msgstr "Metadados do commit para %s não correspondem aos metadados esperados"
 
-#: common/flatpak-dir.c:2823
+#: common/flatpak-dir.c:2826
 msgid "Unable to connect to system bus"
 msgstr "Não foi possível conectar ao barramento de sistema"
 
-#: common/flatpak-dir.c:3419
+#: common/flatpak-dir.c:3422
 msgid "User installation"
 msgstr "Instalação do usuário"
 
-#: common/flatpak-dir.c:3426
+#: common/flatpak-dir.c:3429
 #, c-format
 msgid "System (%s) installation"
 msgstr "Instalação do sistema (%s)"
 
-#: common/flatpak-dir.c:3472
+#: common/flatpak-dir.c:3475
 #, c-format
 msgid "No overrides found for %s"
 msgstr "Nenhuma substituição localizada para %s"
 
-#: common/flatpak-dir.c:3625
+#: common/flatpak-dir.c:3628
 #, c-format
 msgid "%s (commit %s) not installed"
 msgstr "%s (commit %s) não instalado"
 
-#: common/flatpak-dir.c:4650
+#: common/flatpak-dir.c:4653
 #, c-format
 msgid "Error parsing system flatpakrepo file for %s: %s"
 msgstr "Erro ao analisar o arquivo de flatpakrepo de sistema para %s: %s"
 
-#: common/flatpak-dir.c:4735
+#: common/flatpak-dir.c:4738
 #, c-format
 msgid "While opening repository %s: "
 msgstr "Ao abrir o repositório %s: "
 
-#: common/flatpak-dir.c:5004
+#: common/flatpak-dir.c:5007
 #, c-format
 msgid "The config key %s is not set"
 msgstr "A chave de configuração %s não está definida"
 
-#: common/flatpak-dir.c:5140
+#: common/flatpak-dir.c:5143
 #, c-format
 msgid "No current %s pattern matching %s"
 msgstr "Nenhum padrão %s atual correspondendo a %s"
 
-#: common/flatpak-dir.c:5422
+#: common/flatpak-dir.c:5425
 msgid "No appstream commit to deploy"
 msgstr "Nenhum commit de appstream para implementar"
 
-#: common/flatpak-dir.c:5941 common/flatpak-dir.c:7266
-#: common/flatpak-dir.c:10881 common/flatpak-dir.c:11618
+#: common/flatpak-dir.c:5945 common/flatpak-dir.c:7262
+#: common/flatpak-dir.c:10883 common/flatpak-dir.c:11619
 msgid "Can't pull from untrusted non-gpg verified remote"
 msgstr "Não foi possível obter de remoto sem gpg verificada e não confiado"
 
-#: common/flatpak-dir.c:6376 common/flatpak-dir.c:6591
+#: common/flatpak-dir.c:6380 common/flatpak-dir.c:6595
 msgid "Extra data not supported for non-gpg-verified local system installs"
 msgstr ""
 "Sem suporte a dados extras para instalações de sistema local sem gpg "
 "verificada"
 
-#: common/flatpak-dir.c:6415 common/flatpak-dir.c:6782
+#: common/flatpak-dir.c:6419 common/flatpak-dir.c:6786
 #, c-format
 msgid "Invalid checksum for extra data uri %s"
 msgstr "Soma de verificação inválida para uri dados extras %s"
 
-#: common/flatpak-dir.c:6424
+#: common/flatpak-dir.c:6428
 #, c-format
 msgid "Empty name for extra data uri %s"
 msgstr "Nome vazio para uri de dados extras %s"
 
-#: common/flatpak-dir.c:6432
+#: common/flatpak-dir.c:6436
 #, c-format
 msgid "Unsupported extra data uri %s"
 msgstr "Sem suporte à uri de dados extras %s"
 
-#: common/flatpak-dir.c:6461
+#: common/flatpak-dir.c:6465
 #, c-format
 msgid "Failed to load local extra-data %s: %s"
 msgstr "Falha ao carregar extra-data local %s: %s"
 
-#: common/flatpak-dir.c:6469
+#: common/flatpak-dir.c:6473
 #, c-format
 msgid "Wrong size for extra-data %s"
 msgstr "Tamanho inválido para extra-data %s"
 
-#: common/flatpak-dir.c:6488
+#: common/flatpak-dir.c:6492
 #, c-format
 msgid "While downloading %s: "
 msgstr "Enquanto baixava %s: "
 
-#: common/flatpak-dir.c:6498
+#: common/flatpak-dir.c:6502
 #, c-format
 msgid "Wrong size for extra data %s"
 msgstr "Tamanho inválido para dados extras %s"
 
-#: common/flatpak-dir.c:6507
+#: common/flatpak-dir.c:6511
 #, c-format
 msgid "Invalid checksum for extra data %s"
 msgstr "Soma de verificação inválida para dados extras %s"
 
-#: common/flatpak-dir.c:7096 common/flatpak-dir.c:7349
+#: common/flatpak-dir.c:7099 common/flatpak-dir.c:7345
 #, c-format
 msgid "While pulling %s from remote %s: "
 msgstr "Enquanto executava pull de %s a partir do remoto %s: "
 
-#: common/flatpak-dir.c:7290 common/flatpak-repo-utils.c:3886
+#: common/flatpak-dir.c:7286 common/flatpak-repo-utils.c:3877
 msgid "GPG signatures found, but none are in trusted keyring"
 msgstr "Assinaturas GPG localizadas, mas nenhuma está no chaveiro de confiadas"
 
-#: common/flatpak-dir.c:7307
+#: common/flatpak-dir.c:7303
 #, c-format
 msgid "Commit for ‘%s’ has no ref binding"
 msgstr "O commit para “%s” tem nenhuma associação de ref"
 
-#: common/flatpak-dir.c:7312
+#: common/flatpak-dir.c:7308
 #, c-format
 msgid "Commit for ‘%s’ is not in expected bound refs: %s"
 msgstr "O commit para “%s” não está nas refs limites esperados: %s"
 
-#: common/flatpak-dir.c:7488
+#: common/flatpak-dir.c:7484
 msgid "Only applications can be made current"
 msgstr "Apenas aplicativos podem ser atualizados"
 
-#: common/flatpak-dir.c:8192
+#: common/flatpak-dir.c:8183 common/flatpak-dir.c:8195
 msgid "Not enough memory"
 msgstr "Memória insuficiente"
 
-#: common/flatpak-dir.c:8211
+#: common/flatpak-dir.c:8214
 msgid "Failed to read from exported file"
 msgstr "Falha ao ler do arquivo exportado"
 
-#: common/flatpak-dir.c:8401
+#: common/flatpak-dir.c:8404
 msgid "Error reading mimetype xml file"
 msgstr "Erro ao ler o arquivo xml de tipo mime"
 
-#: common/flatpak-dir.c:8406
+#: common/flatpak-dir.c:8409
 msgid "Invalid mimetype xml file"
 msgstr "Arquivo inválido de xml de tipo mim"
 
-#: common/flatpak-dir.c:8492
+#: common/flatpak-dir.c:8495
 #, c-format
 msgid "D-Bus service file '%s' has wrong name"
 msgstr "O arquivo de serviço D-Bus “%s” tem um nome errado"
 
-#: common/flatpak-dir.c:8647
+#: common/flatpak-dir.c:8650
 #, c-format
 msgid "Invalid Exec argument %s"
 msgstr "Exec com argumento inválido %s"
 
-#: common/flatpak-dir.c:9115
+#: common/flatpak-dir.c:9117
 msgid "While getting detached metadata: "
 msgstr "Enquanto obtinha metadados destacados: "
 
-#: common/flatpak-dir.c:9120 common/flatpak-dir.c:9125
-#: common/flatpak-dir.c:9129
+#: common/flatpak-dir.c:9122 common/flatpak-dir.c:9127
+#: common/flatpak-dir.c:9131
 msgid "Extra data missing in detached metadata"
 msgstr "Dados extras faltando nos metadados destacados"
 
-#: common/flatpak-dir.c:9133
+#: common/flatpak-dir.c:9135
 msgid "While creating extradir: "
 msgstr "Enquanto criava extradir: "
 
-#: common/flatpak-dir.c:9154 common/flatpak-dir.c:9187
+#: common/flatpak-dir.c:9156 common/flatpak-dir.c:9189
 msgid "Invalid checksum for extra data"
 msgstr "Soma de verificação inválida para dados extras"
 
-#: common/flatpak-dir.c:9183
+#: common/flatpak-dir.c:9185
 msgid "Wrong size for extra data"
 msgstr "Tamanho inválido para dados extras"
 
-#: common/flatpak-dir.c:9196
+#: common/flatpak-dir.c:9198
 #, c-format
 msgid "While writing extra data file '%s': "
 msgstr "Enquanto escrevia o arquivo de dados extras “%s”: "
 
-#: common/flatpak-dir.c:9204
+#: common/flatpak-dir.c:9206
 #, c-format
 msgid "Extra data %s missing in detached metadata"
 msgstr "Dados extras %s faltando nos metadados destacados"
 
-#: common/flatpak-dir.c:9278
-#, c-format
+#: common/flatpak-dir.c:9280
 msgid "Unable to get runtime key from metadata"
 msgstr "Não foi possível obter a chave da runtime pelos metadados"
 
-#: common/flatpak-dir.c:9402
+#: common/flatpak-dir.c:9404
 #, c-format
 msgid "apply_extra script failed, exit status %d"
 msgstr "script apply_extra falhou, status de saída %d"
 
 #. Translators: The placeholder is for an app ref.
-#: common/flatpak-dir.c:9591
+#: common/flatpak-dir.c:9593
 #, c-format
 msgid "Installing %s is not allowed by the policy set by your administrator"
 msgstr "Instalar %s não é permitido pela política definida pelo administrador"
 
-#: common/flatpak-dir.c:9690
+#: common/flatpak-dir.c:9692
 #, c-format
 msgid "While trying to resolve ref %s: "
 msgstr "Enquanto tentava resolver ref %s: "
 
-#: common/flatpak-dir.c:9702
+#: common/flatpak-dir.c:9704
 #, c-format
 msgid "%s is not available"
 msgstr "%s não está disponível"
 
-#: common/flatpak-dir.c:9714 common/flatpak-dir.c:11495
+#: common/flatpak-dir.c:9716 common/flatpak-dir.c:11497
 #, c-format
 msgid "%s commit %s already installed"
 msgstr "%s commit %s já está instalado"
 
-#: common/flatpak-dir.c:9721
+#: common/flatpak-dir.c:9723
 msgid "Can't create deploy directory"
 msgstr "Não foi possível criar um diretório de deploy"
 
-#: common/flatpak-dir.c:9729
+#: common/flatpak-dir.c:9731
 #, c-format
 msgid "Failed to read commit %s: "
 msgstr "Falha ao ler commit %s: "
 
-#: common/flatpak-dir.c:9750
+#: common/flatpak-dir.c:9752
 #, c-format
 msgid "While trying to checkout %s into %s: "
 msgstr "Enquanto tentava fazer checkout de %s para %s: "
 
-#: common/flatpak-dir.c:9769
+#: common/flatpak-dir.c:9771
 msgid "While trying to checkout metadata subpath: "
 msgstr "Enquanto tentava fazer checkout do subcaminho de metadados: "
 
-#: common/flatpak-dir.c:9801
+#: common/flatpak-dir.c:9803
 #, c-format
 msgid "While trying to checkout subpath ‘%s’: "
 msgstr "Enquanto tentava fazer checkout do subcaminho “%s”: "
 
-#: common/flatpak-dir.c:9811
+#: common/flatpak-dir.c:9813
 msgid "While trying to remove existing extra dir: "
 msgstr "Enquanto tentava remover diretório extra existente: "
 
-#: common/flatpak-dir.c:9822
+#: common/flatpak-dir.c:9824
 msgid "While trying to apply extra data: "
 msgstr "Enquanto tentava aplicar dados extras: "
 
-#: common/flatpak-dir.c:9849
+#: common/flatpak-dir.c:9851
 #, c-format
 msgid "Invalid commit ref %s: "
 msgstr "Ref de commit inválido %s: "
 
-#: common/flatpak-dir.c:9857 common/flatpak-dir.c:9869
+#: common/flatpak-dir.c:9859 common/flatpak-dir.c:9871
 #, c-format
 msgid "Deployed ref %s does not match commit (%s)"
 msgstr "Ref implementado %s não coincide com o commit (%s)"
 
-#: common/flatpak-dir.c:9863
+#: common/flatpak-dir.c:9865
 #, c-format
 msgid "Deployed ref %s branch does not match commit (%s)"
 msgstr "O ramo da ref implementado %s não coincide com o commit (%s)"
 
-#: common/flatpak-dir.c:10125 common/flatpak-installation.c:1911
+#: common/flatpak-dir.c:10127 common/flatpak-installation.c:1926
 #, c-format
 msgid "%s branch %s already installed"
 msgstr "%s ramo %s já está instalado"
 
-#: common/flatpak-dir.c:10985
+#: common/flatpak-dir.c:10987
 #, c-format
 msgid "Could not unmount revokefs-fuse filesystem at %s: "
 msgstr "Não foi possível desmontar o sistema de arquivos revokefs-fuse em %s: "
 
-#: common/flatpak-dir.c:11289
+#: common/flatpak-dir.c:11291
 #, c-format
 msgid "This version of %s is already installed"
 msgstr "Essa versão de %s já está instalada"
 
-#: common/flatpak-dir.c:11302
-#, c-format
+#: common/flatpak-dir.c:11304
 msgid "Can't change remote during bundle install"
 msgstr "Não é possível alterar remoto durante instalação de pacote"
 
-#: common/flatpak-dir.c:11571
-msgid "Can't update to a specific commit without root permissions"
-msgstr ""
-"Não é possível atualizar para um commit específico sem permissões de root"
-
-#: common/flatpak-dir.c:11852
+#: common/flatpak-dir.c:11853
 #, c-format
 msgid "Can't remove %s, it is needed for: %s"
 msgstr "Não foi possível remover %s, pois é necessário para: %s"
 
-#: common/flatpak-dir.c:11912 common/flatpak-installation.c:2067
+#: common/flatpak-dir.c:11913 common/flatpak-installation.c:2082
 #, c-format
 msgid "%s branch %s is not installed"
 msgstr "%s ramo %s não está instalado"
 
-#: common/flatpak-dir.c:12165
+#: common/flatpak-dir.c:12166
 #, c-format
 msgid "%s commit %s not installed"
 msgstr "%s commit %s não instalado"
 
-#: common/flatpak-dir.c:12501
+#: common/flatpak-dir.c:12502
 #, c-format
 msgid "Pruning repo failed: %s"
 msgstr "A supressão de repositório falhou: %s"
 
-#: common/flatpak-dir.c:12669 common/flatpak-dir.c:12675
+#: common/flatpak-dir.c:12670 common/flatpak-dir.c:12676
 #, c-format
 msgid "Failed to load filter '%s'"
 msgstr "Falha ao carregar o filtro “%s”"
 
-#: common/flatpak-dir.c:12681
+#: common/flatpak-dir.c:12682
 #, c-format
 msgid "Failed to parse filter '%s'"
 msgstr "Falha ao analisar o filtro “%s”"
@@ -5149,7 +5112,7 @@ msgstr "Não foi possível localizar instalação de %s"
 msgid "Invalid file format, no %s group"
 msgstr "Formato de arquivo inválido, grupo %s inexistente"
 
-#: common/flatpak-dir.c:15617 common/flatpak-repo-utils.c:2836
+#: common/flatpak-dir.c:15617 common/flatpak-repo-utils.c:2827
 #, c-format
 msgid "Invalid version %s, only 1 supported"
 msgstr "Versão inválida %s, há suporte apenas a 1"
@@ -5164,7 +5127,7 @@ msgstr "Formato de arquivo inválido, nenhuma %s especificada"
 msgid "Invalid file format, gpg key invalid"
 msgstr "Formato de arquivo inválido, chave gpg inválida"
 
-#: common/flatpak-dir.c:15675 common/flatpak-repo-utils.c:2917
+#: common/flatpak-dir.c:15675 common/flatpak-repo-utils.c:2908
 msgid "Collection ID requires GPG key to be provided"
 msgstr "ID de coleção requer que a chave GPG seja fornecida"
 
@@ -5199,44 +5162,43 @@ msgstr "Nenhuma configuração para o remoto %s especificado"
 msgid "Skipping deletion of mirror ref (%s, %s)…\n"
 msgstr "Ignorando exclusão de ref espelho (%s, %s)…\n"
 
-#: common/flatpak-exports.c:931
-#, c-format
+#: common/flatpak-exports.c:942
 msgid "An absolute path is required"
 msgstr "Um caminho absoluto é exigido"
 
-#: common/flatpak-exports.c:948
+#: common/flatpak-exports.c:959
 #, c-format
 msgid "Unable to open path \"%s\": %s"
 msgstr "Não foi possível abrir o caminho “%s”: %s"
 
-#: common/flatpak-exports.c:955
+#: common/flatpak-exports.c:966
 #, c-format
 msgid "Unable to get file type of \"%s\": %s"
 msgstr "Não foi possível obter o tipo de arquivo de “%s”: %s"
 
-#: common/flatpak-exports.c:964
+#: common/flatpak-exports.c:975
 #, c-format
 msgid "File \"%s\" has unsupported type 0o%o"
 msgstr "O aplicativo “%s” tem o tipo não suportado 0o%o"
 
-#: common/flatpak-exports.c:970
+#: common/flatpak-exports.c:981
 #, c-format
 msgid "Unable to get filesystem information for \"%s\": %s"
 msgstr ""
 "Não foi possível obter as informações de sistema de arquivos para “%s”: %s"
 
-#: common/flatpak-exports.c:980
+#: common/flatpak-exports.c:991
 #, c-format
 msgid "Ignoring blocking autofs path \"%s\""
 msgstr "Ignorando o bloqueio do caminho de autofs “%s”"
 
-#: common/flatpak-exports.c:996 common/flatpak-exports.c:1009
-#: common/flatpak-exports.c:1022
+#: common/flatpak-exports.c:1007 common/flatpak-exports.c:1020
+#: common/flatpak-exports.c:1033
 #, c-format
 msgid "Path \"%s\" is reserved by Flatpak"
 msgstr "O caminho \"%s\" está reservado pelo Flatpak"
 
-#: common/flatpak-exports.c:1076
+#: common/flatpak-exports.c:1087
 #, c-format
 msgid "Unable to resolve symbolic link \"%s\": %s"
 msgstr "Não foi possível resolver o link simbólico “%s”: %s"
@@ -5276,128 +5238,127 @@ msgstr "Ref “%s” não localizado no registro"
 msgid "Multiple images in registry, specify a ref with --ref"
 msgstr "Várias imagens no registro, especifique uma ref com --ref"
 
-#: common/flatpak-installation.c:834
+#: common/flatpak-installation.c:849
 #, c-format
 msgid "Ref %s not installed"
 msgstr "Ref %s não instalado"
 
-#: common/flatpak-installation.c:875
+#: common/flatpak-installation.c:890
 #, c-format
 msgid "App %s not installed"
 msgstr "Aplicativo %s não instalado"
 
-#: common/flatpak-installation.c:1395
+#: common/flatpak-installation.c:1410
 #, c-format
 msgid "Remote '%s' already exists"
 msgstr "O remoto “%s” já existe"
 
-#: common/flatpak-installation.c:1946
+#: common/flatpak-installation.c:1961
 #, c-format
 msgid "As requested, %s was only pulled, but not installed"
 msgstr "Conforme requisitado, %s foi obtida, mas não instalada"
 
-#: common/flatpak-instance.c:533 common/flatpak-instance.c:687
-#: common/flatpak-instance.c:728
+#: common/flatpak-instance.c:546 common/flatpak-instance.c:700
+#: common/flatpak-instance.c:741
 #, c-format
 msgid "Unable to create directory %s"
 msgstr "Não foi possível criar um diretório %s"
 
-#: common/flatpak-instance.c:554
+#: common/flatpak-instance.c:567
 #, c-format
 msgid "Unable to lock %s"
 msgstr "Não foi possível travar %s"
 
-#: common/flatpak-instance.c:627
+#: common/flatpak-instance.c:640
 #, c-format
 msgid "Unable to create temporary directory in %s"
 msgstr "Não foi possível criar um diretório temporário em %s"
 
-#: common/flatpak-instance.c:639
+#: common/flatpak-instance.c:652
 #, c-format
 msgid "Unable to create file %s"
 msgstr "Não foi possível criar o arquivo %s"
 
-#: common/flatpak-instance.c:646
+#: common/flatpak-instance.c:659
 #, c-format
 msgid "Unable to update symbolic link %s/%s"
 msgstr "Não foi possível atualizar o link simbólico %s/%s"
 
-#: common/flatpak-oci-registry.c:1197
+#: common/flatpak-oci-registry.c:1195
 msgid "Only Bearer authentication supported"
 msgstr "Há suporte apenas à autenticação via token (Bearer)"
 
-#: common/flatpak-oci-registry.c:1206
+#: common/flatpak-oci-registry.c:1204
 msgid "Only realm in authentication request"
 msgstr "Apenas reino na solicitação de autenticação"
 
-#: common/flatpak-oci-registry.c:1213
+#: common/flatpak-oci-registry.c:1211
 msgid "Invalid realm in authentication request"
 msgstr "Reino inválido na solicitação de autenticação"
 
-#: common/flatpak-oci-registry.c:1283
+#: common/flatpak-oci-registry.c:1281
 #, c-format
 msgid "Authorization failed: %s"
 msgstr "Autorização falhou: %s"
 
-#: common/flatpak-oci-registry.c:1285
+#: common/flatpak-oci-registry.c:1283
 msgid "Authorization failed"
 msgstr "Autorização falhou"
 
-#: common/flatpak-oci-registry.c:1289
+#: common/flatpak-oci-registry.c:1287
 #, c-format
 msgid "Unexpected response status %d when requesting token: %s"
 msgstr "Status de resposta inesperada %d ao solicitar token: %s"
 
-#: common/flatpak-oci-registry.c:1300
+#: common/flatpak-oci-registry.c:1298
 msgid "Invalid authentication request response"
 msgstr "Resposta inválida à solicitação de autenticação"
 
-#: common/flatpak-oci-registry.c:1731
-#, c-format
+#: common/flatpak-oci-registry.c:1729
 msgid "Flatpak was compiled without zstd support"
 msgstr "Flatpak foi compilado sem suporte a zstd"
 
-#: common/flatpak-oci-registry.c:1923 common/flatpak-oci-registry.c:1975
-#: common/flatpak-oci-registry.c:2004 common/flatpak-oci-registry.c:2059
-#: common/flatpak-oci-registry.c:2115 common/flatpak-oci-registry.c:2193
+#: common/flatpak-oci-registry.c:1921 common/flatpak-oci-registry.c:1973
+#: common/flatpak-oci-registry.c:2002 common/flatpak-oci-registry.c:2057
+#: common/flatpak-oci-registry.c:2113 common/flatpak-oci-registry.c:2191
 msgid "Invalid delta file format"
 msgstr "Formato de arquivo delta inválido"
 
-#: common/flatpak-oci-registry.c:3198 common/flatpak-oci-registry.c:3382
+#: common/flatpak-oci-registry.c:3211 common/flatpak-oci-registry.c:3390
 msgid "Invalid OCI image config"
 msgstr "Configuração de imagem OCI inválida"
 
-#: common/flatpak-oci-registry.c:3260 common/flatpak-oci-registry.c:3531
+#: common/flatpak-oci-registry.c:3273 common/flatpak-oci-registry.c:3539
 #, c-format
 msgid "Wrong layer checksum, expected %s, was %s"
 msgstr "Soma de verificação de camada errada, esperava %s, era %s"
 
-#: common/flatpak-oci-registry.c:3359
+#: common/flatpak-oci-registry.c:3367
 #, c-format
 msgid "No ref specified for OCI image %s"
 msgstr "Nenhuma ref especificada para a imagem OCI %s"
 
-#: common/flatpak-oci-registry.c:3369
+#: common/flatpak-oci-registry.c:3377
 #, c-format
 msgid "Wrong ref (%s) specified for OCI image %s, expected %s"
 msgstr "Ref errada (%s) especificada para a imagem OCI %s, esperava %s"
 
-#: common/flatpak-progress.c:236
+#: common/flatpak-progress.c:239
 #, c-format
 msgid "Downloading metadata: %u/(estimating) %s"
 msgstr "Baixando metadados: %u/(estimando) %s"
 
-#: common/flatpak-progress.c:260
+#: common/flatpak-progress.c:266
 #, c-format
 msgid "Downloading: %s/%s"
 msgstr "Baixando: %s/%s"
 
-#: common/flatpak-progress.c:280
+#: common/flatpak-progress.c:286
 #, c-format
 msgid "Downloading extra data: %s/%s"
 msgstr "Baixando dados extras: %s/%s"
 
-#: common/flatpak-progress.c:285
+#: common/flatpak-progress.c:291
 #, c-format
 msgid "Downloading files: %d/%d %s"
 msgstr "Baixando arquivos: %d/%d %s"
@@ -5562,54 +5523,53 @@ msgstr ""
 "Verificação GPG deve estar habilitada quando um ID de coleção for definido"
 
 #: common/flatpak-repo-utils.c:344
-#, c-format
 msgid "No extra data sources"
 msgstr "Nenhuma fonte de dados extras"
 
-#: common/flatpak-repo-utils.c:2817
+#: common/flatpak-repo-utils.c:2808
 #, c-format
 msgid "Invalid %s: Missing group ‘%s’"
 msgstr "%s inválido: Faltando grupo “%s”"
 
-#: common/flatpak-repo-utils.c:2826
+#: common/flatpak-repo-utils.c:2817
 #, c-format
 msgid "Invalid %s: Missing key ‘%s’"
 msgstr "%s inválido: Faltando chave “%s”"
 
-#: common/flatpak-repo-utils.c:2876
+#: common/flatpak-repo-utils.c:2867
 msgid "Invalid gpg key"
 msgstr "Chave gpg inválida"
 
-#: common/flatpak-repo-utils.c:3217
+#: common/flatpak-repo-utils.c:3208
 #, c-format
 msgid "Error copying 64x64 icon for component %s: %s\n"
 msgstr "Erro ao copiar ícone 64x64 para componente %s: %s\n"
 
-#: common/flatpak-repo-utils.c:3223
+#: common/flatpak-repo-utils.c:3214
 #, c-format
 msgid "Error copying 128x128 icon for component %s: %s\n"
 msgstr "Erro ao copiar ícone 128x128 para componente %s: %s\n"
 
-#: common/flatpak-repo-utils.c:3362
+#: common/flatpak-repo-utils.c:3353
 #, c-format
 msgid "%s is end-of-life, ignoring for appstream"
 msgstr "%s está em fim de vida, ignorando para appstream"
 
-#: common/flatpak-repo-utils.c:3397
+#: common/flatpak-repo-utils.c:3388
 #, c-format
 msgid "No appstream data for %s: %s\n"
 msgstr "Nenhum dado de appstream para %s: %s\n"
 
-#: common/flatpak-repo-utils.c:3744
+#: common/flatpak-repo-utils.c:3735
 msgid "Invalid bundle, no ref in metadata"
 msgstr "Pacote inválido, nenhuma ref nos metadados"
 
-#: common/flatpak-repo-utils.c:3846
+#: common/flatpak-repo-utils.c:3837
 #, c-format
 msgid "Collection ‘%s’ of bundle doesn’t match collection ‘%s’ of remote"
 msgstr "A coleção “%s” de pacotes não correspondem à coleção “%s” do remoto"
 
-#: common/flatpak-repo-utils.c:3923
+#: common/flatpak-repo-utils.c:3914
 msgid "Metadata in header and app are inconsistent"
 msgstr "Metadados no cabeçalho e aplicativo estão inconsistentes"
 
@@ -5662,12 +5622,12 @@ msgstr "Falha ao bloquear a chamada de sistema %d: %s"
 msgid "Failed to export bpf: %s"
 msgstr "Falha ao exportar bpf: %s"
 
-#: common/flatpak-run.c:2587
+#: common/flatpak-run.c:2588
 #, c-format
 msgid "Failed to open ‘%s’"
 msgstr "Falha ao abrir “%s”"
 
-#: common/flatpak-run.c:2597
+#: common/flatpak-run.c:2600
 #, c-format
 msgid ""
 "Directory forwarding needs version 4 of the document portal (have version %d)"
@@ -5675,23 +5635,28 @@ msgstr ""
 "Encaminhamento de diretório precisa da versão 4 do portal de documento (tem "
 "a versão %d)"
 
-#: common/flatpak-run.c:2915
+#: common/flatpak-run.c:2732
+#, c-format
+msgid "Invalid path ‘%s’"
+msgstr "Caminho inválido “%s”"
+
+#: common/flatpak-run.c:2921
 #, c-format
 msgid "ldconfig failed, exit status %d"
 msgstr "ldconfig falhou, status de saída %d"
 
-#: common/flatpak-run.c:2922
+#: common/flatpak-run.c:2928
 msgid "Can't open generated ld.so.cache"
 msgstr "Não foi possível abrir o ld.so.cache gerado"
 
 #. Translators: The placeholder is for an app ref.
-#: common/flatpak-run.c:3045
+#: common/flatpak-run.c:3051
 #, c-format
 msgid "Running %s is not allowed by the policy set by your administrator"
 msgstr ""
 "A execução de %s não é permitida pela política definida pelo administrador"
 
-#: common/flatpak-run.c:3202
+#: common/flatpak-run.c:3208
 msgid ""
 "\"flatpak run\" is not intended to be run as `sudo flatpak run`. Use `sudo "
 "-i` or `su -l` instead and invoke \"flatpak run\" from inside the new shell."
@@ -5700,19 +5665,19 @@ msgstr ""
 "`sudo -i` ou `su -l` no lugar e invoque “flatpak run” de dentro do novo "
 "shell."
 
-#: common/flatpak-run.c:3413
+#: common/flatpak-run.c:3419
 #, c-format
 msgid "Failed to migrate from %s: %s"
 msgstr "Falha ao migrar de %s: %s"
 
-#: common/flatpak-run.c:3434
+#: common/flatpak-run.c:3440
 #, c-format
 msgid "Failed to migrate old app data directory %s to new name %s: %s"
 msgstr ""
 "Falha ao migrar o diretório de dados antigo %s do aplicativo para o novo "
 "nome %s: %s"
 
-#: common/flatpak-run.c:3443
+#: common/flatpak-run.c:3449
 #, c-format
 msgid "Failed to create symlink while migrating %s: %s"
 msgstr "Falha ao criar link simbólico ao migrar %s: %s"
@@ -5729,57 +5694,57 @@ msgstr "Não foi possível criar um pipe de sincronização"
 msgid "Failed to sync with dbus proxy"
 msgstr "Falha ao sincronizar com proxy de dbus"
 
-#: common/flatpak-transaction.c:2275
+#: common/flatpak-transaction.c:2291
 #, c-format
 msgid "Warning: Problem looking for related refs: %s"
 msgstr "Aviso: Problema ao procurar por refs relacionadas: %s"
 
-#: common/flatpak-transaction.c:2493
+#: common/flatpak-transaction.c:2509
 #, c-format
 msgid "The application %s requires the runtime %s which was not found"
 msgstr "O aplicativo %s requer o runtime %s, que não foi localizado"
 
-#: common/flatpak-transaction.c:2509
+#: common/flatpak-transaction.c:2525
 #, c-format
 msgid "The application %s requires the runtime %s which is not installed"
 msgstr "O aplicativo %s requer o runtime %s, que não está instalado"
 
-#: common/flatpak-transaction.c:2641
+#: common/flatpak-transaction.c:2657
 #, c-format
 msgid "Can't uninstall %s which is needed by %s"
 msgstr "Não foi possível desinstalar %s, o qual é necessário para %s"
 
-#: common/flatpak-transaction.c:2740
+#: common/flatpak-transaction.c:2756
 #, c-format
 msgid "Remote %s disabled, ignoring %s update"
 msgstr "Remoto %s desabilitado, ignorando atualização de %s"
 
-#: common/flatpak-transaction.c:2773
+#: common/flatpak-transaction.c:2789
 #, c-format
 msgid "%s is already installed"
 msgstr "%s já está instalado"
 
-#: common/flatpak-transaction.c:2776
+#: common/flatpak-transaction.c:2792
 #, c-format
 msgid "%s is already installed from remote %s"
 msgstr "%s já está instalada pelo remoto %s"
 
-#: common/flatpak-transaction.c:3120
+#: common/flatpak-transaction.c:3136
 #, c-format
 msgid "Invalid .flatpakref: %s"
 msgstr ".flatpakref inválido: %s"
 
-#: common/flatpak-transaction.c:3161
+#: common/flatpak-transaction.c:3177
 msgid "Warning: Could not mark already installed apps as preinstalled"
 msgstr ""
 "Aviso: Não foi possível marcar aplicativos já instalados como pré-instalados"
 
-#: common/flatpak-transaction.c:3382
+#: common/flatpak-transaction.c:3398
 #, c-format
 msgid "Error updating remote metadata for '%s': %s"
 msgstr "Erro ao atualizar metadados de remoto para “%s”: %s"
 
-#: common/flatpak-transaction.c:3885
+#: common/flatpak-transaction.c:3901
 #, c-format
 msgid ""
 "Warning: Treating remote fetch error as non-fatal since %s is already "
@@ -5788,54 +5753,54 @@ msgstr ""
 "Aviso: Tratando erro de obtenção de remoto como não fatal, já que %s já está "
 "instalado: %s"
 
-#: common/flatpak-transaction.c:4209
+#: common/flatpak-transaction.c:4225
 #, c-format
 msgid "No authenticator installed for remote '%s'"
 msgstr "Nenhum autenticador instalado para remoto “%s”"
 
-#: common/flatpak-transaction.c:4313 common/flatpak-transaction.c:4320
+#: common/flatpak-transaction.c:4329 common/flatpak-transaction.c:4336
 #, c-format
 msgid "Failed to get tokens for ref: %s"
 msgstr "Falha ao obter tokens para ref: %s"
 
-#: common/flatpak-transaction.c:4315 common/flatpak-transaction.c:4322
+#: common/flatpak-transaction.c:4331 common/flatpak-transaction.c:4338
 msgid "Failed to get tokens for ref"
 msgstr "Falha ao obter tokens para ref"
 
-#: common/flatpak-transaction.c:4580
+#: common/flatpak-transaction.c:4596
 #, c-format
 msgid "Ref %s from %s matches more than one transaction operation"
 msgstr "A ref %s de %s corresponde a mais de uma operação de transação"
 
-#: common/flatpak-transaction.c:4581 common/flatpak-transaction.c:4591
+#: common/flatpak-transaction.c:4597 common/flatpak-transaction.c:4607
 msgid "any remote"
 msgstr "qualquer remoto"
 
-#: common/flatpak-transaction.c:4590
+#: common/flatpak-transaction.c:4606
 #, c-format
 msgid "No transaction operation found for ref %s from %s"
 msgstr "Nenhuma operação de transação localizada para a ref %s de %s"
 
-#: common/flatpak-transaction.c:4713
+#: common/flatpak-transaction.c:4729
 #, c-format
 msgid "Flatpakrepo URL %s not file, HTTP or HTTPS"
 msgstr "URL de Flatpakrepo %s não é arquivo, HTTP ou HTTPS"
 
-#: common/flatpak-transaction.c:4719
+#: common/flatpak-transaction.c:4735
 #, c-format
 msgid "Can't load dependent file %s: "
 msgstr "Não foi possível carregar o arquivo dependente %s: "
 
-#: common/flatpak-transaction.c:4727
+#: common/flatpak-transaction.c:4743
 #, c-format
 msgid "Invalid .flatpakrepo: %s"
 msgstr ".flatpakrepo inválido: %s"
 
-#: common/flatpak-transaction.c:5454
+#: common/flatpak-transaction.c:5470
 msgid "Transaction already executed"
 msgstr "Transação já executada"
 
-#: common/flatpak-transaction.c:5469
+#: common/flatpak-transaction.c:5485
 msgid ""
 "Refusing to operate on a user installation as root! This can lead to "
 "incorrect file ownership and permission errors."
@@ -5843,16 +5808,16 @@ msgstr ""
 "Recusando-se a operar em uma instalação de usuário como root! Isso pode "
 "levar à propriedade incorreta do arquivo e a erros de permissão."
 
-#: common/flatpak-transaction.c:5567 common/flatpak-transaction.c:5580
+#: common/flatpak-transaction.c:5583 common/flatpak-transaction.c:5596
 msgid "Aborted by user"
 msgstr "Abortado pelo usuário"
 
-#: common/flatpak-transaction.c:5605
+#: common/flatpak-transaction.c:5621
 #, c-format
 msgid "Skipping %s due to previous error"
 msgstr "Ignorando %s por causa do erro anterior"
 
-#: common/flatpak-transaction.c:5659
+#: common/flatpak-transaction.c:5675
 #, c-format
 msgid "Aborted due to failure (%s)"
 msgstr "Abortado devido a falha (%s)"
@@ -5900,43 +5865,36 @@ msgid "URI is not absolute, and no base URI was provided"
 msgstr "A URI não é absoluta e nenhuma URI base foi fornecida"
 
 #: common/flatpak-usb.c:83
-#, c-format
 msgid "USB device query 'all' must not have data"
 msgstr "A consulta de dispositivo USB 'all' não deve ter dados"
 
 #: common/flatpak-usb.c:102
-#, c-format
 msgid "USB query rule 'cls' must be in the form CLASS:SUBCLASS or CLASS:*"
 msgstr ""
 "A regra de consulta USB 'cls' deve estar no formato CLASSE:SUBCLASSE ou "
 "CLASSE:*"
 
 #: common/flatpak-usb.c:111
-#, c-format
 msgid "Invalid USB class"
 msgstr "Classe USB inválida"
 
 #: common/flatpak-usb.c:125
-#, c-format
 msgid "Invalid USB subclass"
 msgstr "Subclasse USB inválida"
 
 #: common/flatpak-usb.c:141 common/flatpak-usb.c:148
-#, c-format
 msgid "USB query rule 'dev' must have a valid 4-digit hexadecimal product id"
 msgstr ""
 "A regra de consulta USB 'dev' deve ter um ID de produto válido hexadecimal "
 "de 4 dígitos"
 
 #: common/flatpak-usb.c:164 common/flatpak-usb.c:171
-#, c-format
 msgid "USB query rule 'vnd' must have a valid 4-digit hexadecimal vendor id"
 msgstr ""
 "A regra de consulta USB 'vnd' deve ter um ID de fornecedor válido "
 "hexadecimal de 4 dígitos"
 
 #: common/flatpak-usb.c:205
-#, c-format
 msgid "USB device queries must be in the form TYPE:DATA"
 msgstr "As consultas de dispositivos USB devem estar no formato TIPO:DADOS"
 
@@ -5946,22 +5904,18 @@ msgid "Unknown USB query rule %s"
 msgstr "Regra de consulta USB desconhecida %s"
 
 #: common/flatpak-usb.c:248
-#, c-format
 msgid "Empty USB query"
 msgstr "Consulta USB vazia"
 
 #: common/flatpak-usb.c:274
-#, c-format
 msgid "Multiple USB query rules of the same type is not supported"
 msgstr "Várias regras de consulta USB do mesmo tipo não são suportadas"
 
 #: common/flatpak-usb.c:283
-#, c-format
 msgid "'all' must not contain extra query rules"
 msgstr "'all' não deve conter regras de consulta extras"
 
 #: common/flatpak-usb.c:291
-#, c-format
 msgid "USB queries with 'dev' must also specify vendors"
 msgstr "Consultas USB com 'dev' também devem especificar fornecedores"
 
@@ -6024,46 +5978,42 @@ msgstr "Não é um remoto OCI"
 msgid "Invalid token"
 msgstr "Token inválido"
 
-#: portal/flatpak-portal.c:2292
-#, c-format
+#: portal/flatpak-portal.c:2304
 msgid "No portal support found"
 msgstr "Não foi localizado suporte a portal"
 
-#: portal/flatpak-portal.c:2298
+#: portal/flatpak-portal.c:2310
 msgid "Deny"
 msgstr "Negar"
 
-#: portal/flatpak-portal.c:2300
+#: portal/flatpak-portal.c:2312
 msgid "Update"
 msgstr "Atualizar"
 
-#: portal/flatpak-portal.c:2305
+#: portal/flatpak-portal.c:2317
 #, c-format
 msgid "Update %s?"
 msgstr "Atualizar %s?"
 
-#: portal/flatpak-portal.c:2317
+#: portal/flatpak-portal.c:2329
 msgid "The application wants to update itself."
 msgstr "O aplicativo deseja atualizar a si próprio."
 
-#: portal/flatpak-portal.c:2318
+#: portal/flatpak-portal.c:2330
 msgid "Update access can be changed any time from the privacy settings."
 msgstr ""
 "Acesso a atualização pode ser alterado a qualquer momento a partir das "
 "configurações de privacidade."
 
-#: portal/flatpak-portal.c:2343
-#, c-format
+#: portal/flatpak-portal.c:2355
 msgid "Application update not allowed"
 msgstr "Atualização de aplicativo não permitida"
 
-#: portal/flatpak-portal.c:2501
-#, c-format
+#: portal/flatpak-portal.c:2516
 msgid "Self update not supported, new version requires new permissions"
 msgstr "Sem suporte à autoatualização, nova versão requer novas permissões"
 
-#: portal/flatpak-portal.c:2684 portal/flatpak-portal.c:2702
-#, c-format
+#: portal/flatpak-portal.c:2699 portal/flatpak-portal.c:2717
 msgid "Update ended unexpectedly"
 msgstr "Atualização encerrada inesperadamente"
 
@@ -6116,13 +6066,47 @@ msgid "Update signed runtime"
 msgstr "Atualizar runtime assinado"
 
 #. SECURITY:
+#. - Normal users need admin authentication to downgrade an
+#. application system-wide, as downgrading may install an older
+#. version with known vulnerabilities or unverified changes.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to downgrade without authenticating.
+#. - Note that authorizing this action also authorizes
+#. org.freedesktop.Flatpak.app-update, as a downgrade implies
+#. the ability to update.
+#: system-helper/org.freedesktop.Flatpak.policy.in:100
+msgid "Update application to older version"
+msgstr "Atualizar aplicativo para uma versão mais antiga"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:101
+msgid "Authentication is required to downgrade an application"
+msgstr "Autenticação é necessária para retroceder a versão de um aplicativo"
+
+#. SECURITY:
+#. - Normal users need admin authentication to downgrade a
+#. runtime system-wide, as downgrading may install an older
+#. version with known vulnerabilities or unverified changes.
+#. - Note that we install polkit rules that allow local users
+#. in the wheel group to downgrade without authenticating.
+#. - Note that authorizing this action also authorizes
+#. org.freedesktop.Flatpak.runtime-update, as a downgrade implies
+#. the ability to update.
+#: system-helper/org.freedesktop.Flatpak.policy.in:122
+msgid "Update runtime to older version"
+msgstr "Atualizar runtime para uma versão mais antiga"
+
+#: system-helper/org.freedesktop.Flatpak.policy.in:123
+msgid "Authentication is required to downgrade a runtime"
+msgstr "Autenticação é necessária para retroceder a versão de um runtime"
+
+#. SECURITY:
 #. - Normal users do not need authentication to update metadata
 #. from signed repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:94
+#: system-helper/org.freedesktop.Flatpak.policy.in:138
 msgid "Update remote metadata"
 msgstr "Atualizar metadados remotos"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:95
+#: system-helper/org.freedesktop.Flatpak.policy.in:139
 msgid "Authentication is required to update remote info"
 msgstr "Autenticação é necessária para atualizar informações de remoto"
 
@@ -6131,22 +6115,22 @@ msgstr "Autenticação é necessária para atualizar informações de remoto"
 #. OSTree repository
 #. - Note that we install polkit rules that allow local users
 #. in the wheel group to modify repos without authenticating.
-#: system-helper/org.freedesktop.Flatpak.policy.in:111
+#: system-helper/org.freedesktop.Flatpak.policy.in:155
 msgid "Update system repository"
 msgstr "Atualiza repositório do sistema"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:112
+#: system-helper/org.freedesktop.Flatpak.policy.in:156
 msgid "Authentication is required to modify a system repository"
 msgstr "Autenticação é necessária para modificar um repositório de sistema"
 
 #. SECURITY:
 #. - Normal users need admin authentication to install software
 #. system-wide.
-#: system-helper/org.freedesktop.Flatpak.policy.in:126
+#: system-helper/org.freedesktop.Flatpak.policy.in:170
 msgid "Install bundle"
 msgstr "Instalar pacote"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:127
+#: system-helper/org.freedesktop.Flatpak.policy.in:171
 msgid "Authentication is required to install software from $(path)"
 msgstr "Autenticação é necessária para instalar software de $(path)"
 
@@ -6155,11 +6139,11 @@ msgstr "Autenticação é necessária para instalar software de $(path)"
 #. system-wide.
 #. - Note that we install polkit rules that allow local users
 #. in the wheel group to uninstall without authenticating.
-#: system-helper/org.freedesktop.Flatpak.policy.in:144
+#: system-helper/org.freedesktop.Flatpak.policy.in:188
 msgid "Uninstall runtime"
 msgstr "Desinstalar runtime"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:145
+#: system-helper/org.freedesktop.Flatpak.policy.in:189
 msgid "Authentication is required to uninstall software"
 msgstr "Autenticação é necessária para desinstalar software"
 
@@ -6168,33 +6152,33 @@ msgstr "Autenticação é necessária para desinstalar software"
 #. system-wide.
 #. - Note that we install polkit rules that allow local users
 #. in the wheel group to uninstall without authenticating.
-#: system-helper/org.freedesktop.Flatpak.policy.in:161
+#: system-helper/org.freedesktop.Flatpak.policy.in:205
 msgid "Uninstall app"
 msgstr "Desinstalar aplicativo"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:162
+#: system-helper/org.freedesktop.Flatpak.policy.in:206
 msgid "Authentication is required to uninstall $(ref)"
 msgstr "Autenticação é necessária para desinstalar $(ref)"
 
 #. SECURITY:
 #. - Normal users need admin authentication to configure system-wide
 #. software repositories.
-#: system-helper/org.freedesktop.Flatpak.policy.in:177
+#: system-helper/org.freedesktop.Flatpak.policy.in:221
 msgid "Configure Remote"
 msgstr "Configurar remoto"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:178
+#: system-helper/org.freedesktop.Flatpak.policy.in:222
 msgid "Authentication is required to configure software repositories"
 msgstr "Autenticação é necessária para configurar os repositórios de software"
 
 #. SECURITY:
 #. - Normal users need admin authentication to configure the system-wide
 #. Flatpak installation.
-#: system-helper/org.freedesktop.Flatpak.policy.in:192
+#: system-helper/org.freedesktop.Flatpak.policy.in:236
 msgid "Configure"
 msgstr "Configurar"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:193
+#: system-helper/org.freedesktop.Flatpak.policy.in:237
 msgid "Authentication is required to configure software installation"
 msgstr "Autenticação é necessária para configurar a instalação de software"
 
@@ -6204,11 +6188,11 @@ msgstr "Autenticação é necessária para configurar a instalação de software
 #. to update the system when unattended.
 #. - Changing this to anything other than 'yes' will break unattended
 #. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:210
+#: system-helper/org.freedesktop.Flatpak.policy.in:254
 msgid "Update appstream"
 msgstr "Atualizar appstream"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:211
+#: system-helper/org.freedesktop.Flatpak.policy.in:255
 msgid "Authentication is required to update information about software"
 msgstr "Autenticação é necessária para atualizar informações sobre software"
 
@@ -6218,11 +6202,11 @@ msgstr "Autenticação é necessária para atualizar informações sobre softwar
 #. to update the system when unattended.
 #. - Changing this to anything other than 'yes' will break unattended
 #. updates.
-#: system-helper/org.freedesktop.Flatpak.policy.in:228
+#: system-helper/org.freedesktop.Flatpak.policy.in:272
 msgid "Update metadata"
 msgstr "Atualizar metadados"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:229
+#: system-helper/org.freedesktop.Flatpak.policy.in:273
 msgid "Authentication is required to update metadata"
 msgstr "Autenticação é necessária para atualizar metadados"
 
@@ -6273,11 +6257,11 @@ msgstr "Autenticação é necessária para atualizar metadados"
 #. users’ parental controls policies to true.
 #. * Set the malcontent `is-system-installation-allowed` property of
 #. all users’ parental controls policies to true.
-#: system-helper/org.freedesktop.Flatpak.policy.in:287
+#: system-helper/org.freedesktop.Flatpak.policy.in:331
 msgid "Override parental controls for installs"
 msgstr "Sobrepor controle parental para instalação"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:288
+#: system-helper/org.freedesktop.Flatpak.policy.in:332
 msgid ""
 "Authentication is required to install software which is restricted by your "
 "parental controls policy"
@@ -6298,17 +6282,21 @@ msgstr ""
 #. insecure or unsupported) app is a worse outcome than automatically
 #. installing an update which has radically different content from the
 #. version of the app which the parent originally vetted and installed.
-#: system-helper/org.freedesktop.Flatpak.policy.in:313
+#: system-helper/org.freedesktop.Flatpak.policy.in:357
 msgid "Override parental controls for updates"
 msgstr "Sobrepor controle parental para atualizações"
 
-#: system-helper/org.freedesktop.Flatpak.policy.in:314
+#: system-helper/org.freedesktop.Flatpak.policy.in:358
 msgid ""
 "Authentication is required to update software which is restricted by your "
 "parental controls policy"
 msgstr ""
 "Autenticação é necessária para atualizar software que está restrito por sua "
 "política de controle parental"
+
+#~ msgid "Can't update to a specific commit without root permissions"
+#~ msgstr ""
+#~ "Não é possível atualizar para um commit específico sem permissões de root"
 
 #~ msgid "Installed:"
 #~ msgstr "Instalado:"
@@ -6408,9 +6396,6 @@ msgstr ""
 
 #~ msgid "Failed to determine parts from ref: %s"
 #~ msgstr "Falha ao determinar partes da ref: %s"
-
-#~ msgid "Invalid arch %s"
-#~ msgstr "Arquitetura inválida %s"
 
 #~ msgid "Related ref '%s' is only partially installed"
 #~ msgstr "A ref “%s” relacionado está apenas parcialmente instalado"


### PR DESCRIPTION
Update translation in Brazilian Portuguese from Damned Lies: https://l10n.gnome.org/vertimus/2513/1018/17/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.