### PR TITLE
docs: Added ostree to the Fedora install commands in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Note: Older versions of Ubuntu/Debian, such as `Ubuntu 24.04`, may require also 
 git clone https://github.com/flatpak/flatpak
 cd flatpak
 sudo dnf builddep flatpak
-sudo dnf install gettext-devel socat
+sudo dnf install gettext-devel socat ostree
 git submodule update --init
 meson setup --prefix=/usr --sysconfdir=/etc --localstatedir=/var -Dinstalled_tests=true -Dselinux_module=enabled -Dsystem_bubblewrap=bwrap -Dsystem_dbus_proxy=xdg-dbus-proxy _build
 meson compile -C _build


### PR DESCRIPTION
Install documentation for Fedora is outdated, it's relying on `sudo dnf builddep flatpak` to install `ostree`, but `ostree` was trimmed down in the attached commit to only pull `ostree-libs`.

Without `ostree` the tests on a fresh Fedora install result in 10 passes, 55 fails and 1 skip. With `ostree`, all pass.

No issue on the Debian side.

[ab28215 Avoid pulling in all of ostree and only depend on ostree-libs subpackage](https://src.fedoraproject.org/rpms/flatpak/c/ab28215630a74650fd63042e84b32c66a37da304?branch=rawhide)