### PR TITLE
install: Support --or-update with flatpakrefs

### DIFF
--- a/app/flatpak-builtins-install.c
+++ b/app/flatpak-builtins-install.c
@@ -265,6 +265,9 @@ install_from (FlatpakDir *dir,
   if (transaction == NULL)
     return FALSE;
 
+  if (opt_or_update)
+    flatpak_transaction_set_reinstall (transaction, TRUE);
+
   if (!flatpak_transaction_add_install_flatpakref (transaction, file_data, error))
     return FALSE;
 

--- a/common/flatpak-dir-private.h
+++ b/common/flatpak-dir-private.h
@@ -865,6 +865,7 @@ void                  flatpak_dir_prune_origin_remote                       (Fla
 gboolean              flatpak_dir_create_remote_for_ref_file                (FlatpakDir                    *self,
                                                                              GKeyFile                      *keyfile,
                                                                              const char                    *default_arch,
+                                                                             gboolean                       allow_installed,
                                                                              char                         **remote_name_out,
                                                                              char                         **collection_id_out,
                                                                              FlatpakDecomposed            **ref_out,

--- a/common/flatpak-dir.c
+++ b/common/flatpak-dir.c
@@ -15688,6 +15688,7 @@ gboolean
 flatpak_dir_create_remote_for_ref_file (FlatpakDir         *self,
                                         GKeyFile           *keyfile,
                                         const char         *default_arch,
+                                        gboolean            allow_installed,
                                         char              **remote_name_out,
                                         char              **collection_id_out,
                                         FlatpakDecomposed **ref_out,
@@ -15712,7 +15713,7 @@ flatpak_dir_create_remote_for_ref_file (FlatpakDir         *self,
     return FALSE;
 
   deploy_dir = flatpak_dir_get_if_deployed (self, ref, NULL, NULL);
-  if (deploy_dir != NULL)
+  if (deploy_dir != NULL && !allow_installed)
     {
       g_set_error (error, FLATPAK_ERROR, FLATPAK_ERROR_ALREADY_INSTALLED,
                    is_runtime ? _("Runtime %s, branch %s is already installed") :

--- a/common/flatpak-installation.c
+++ b/common/flatpak-installation.c
@@ -1849,7 +1849,8 @@ flatpak_installation_install_ref_file (FlatpakInstallation *self,
                                   0, error))
     return FALSE;
 
-  if (!flatpak_dir_create_remote_for_ref_file (dir, keyfile, NULL, &remote, &collection_id, &ref, error))
+  if (!flatpak_dir_create_remote_for_ref_file (dir, keyfile, NULL, FALSE,
+                                               &remote, &collection_id, &ref, error))
     return NULL;
 
   if (!flatpak_installation_drop_caches (self, cancellable, error))

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -4887,7 +4887,7 @@ flatpak_transaction_resolve_flatpakrefs (FlatpakTransaction *self,
                                                   cancellable, error))
         return FALSE;
 
-      if (!flatpak_dir_create_remote_for_ref_file (priv->dir, flatpakref, priv->default_arch,
+      if (!flatpak_dir_create_remote_for_ref_file (priv->dir, flatpakref, priv->default_arch, priv->reinstall,
                                                    &remote, NULL, &ref, error))
         return FALSE;
 

--- a/system-helper/flatpak-system-helper-utils.c
+++ b/system-helper/flatpak-system-helper-utils.c
@@ -1,0 +1,96 @@
+#include "config.h"
+
+#include "flatpak-dir-private.h"
+#include "flatpak-system-helper.h"
+
+static FlatpakSystemHelperDeployAction
+deploy_action_for_ref_kind(FlatpakRefKind ref_kind,
+                           FlatpakSystemHelperDeployAction app_action,
+                           FlatpakSystemHelperDeployAction runtime_action)
+{
+  switch (ref_kind)
+  {
+  case FLATPAK_REF_KIND_APP:
+    return app_action;
+  case FLATPAK_REF_KIND_RUNTIME:
+    return runtime_action;
+  }
+
+  g_assert_not_reached();
+  return app_action;
+}
+
+FlatpakSystemHelperDeployAction
+flatpak_system_helper_get_deploy_action(guint32 flags,
+                                        FlatpakRefKind ref_kind,
+                                        FlatpakSystemHelperRefState ref_state)
+{
+  if ((flags & (FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT |
+                FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL)) != 0)
+    return deploy_action_for_ref_kind(ref_kind,
+                                      FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL,
+                                      FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL);
+
+  switch (ref_state)
+  {
+  case FLATPAK_SYSTEM_HELPER_REF_NOT_INSTALLED:
+    return deploy_action_for_ref_kind(ref_kind,
+                                      FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL,
+                                      FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL);
+  case FLATPAK_SYSTEM_HELPER_REF_INSTALLED:
+    break;
+  }
+  g_assert(ref_state == FLATPAK_SYSTEM_HELPER_REF_INSTALLED);
+
+  if ((flags & FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE) != 0)
+    return deploy_action_for_ref_kind(ref_kind,
+                                      FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_DOWNGRADE,
+                                      FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_DOWNGRADE);
+
+  return deploy_action_for_ref_kind(ref_kind,
+                                    FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_UPDATE,
+                                    FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_UPDATE);
+}
+
+const char *
+flatpak_system_helper_deploy_action_to_polkit_action(FlatpakSystemHelperDeployAction action)
+{
+  switch (action)
+  {
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL:
+    return "org.freedesktop.Flatpak.app-install";
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_UPDATE:
+    return "org.freedesktop.Flatpak.app-update";
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_DOWNGRADE:
+    return "org.freedesktop.Flatpak.app-downgrade";
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL:
+    return "org.freedesktop.Flatpak.runtime-install";
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_UPDATE:
+    return "org.freedesktop.Flatpak.runtime-update";
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_DOWNGRADE:
+    return "org.freedesktop.Flatpak.runtime-downgrade";
+  }
+
+  g_assert_not_reached();
+  return NULL;
+}
+
+FlatpakSystemHelperDeployAuthorization
+flatpak_system_helper_get_deploy_authorization(FlatpakSystemHelperDeployAction action)
+{
+  switch (action)
+  {
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL:
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL:
+    return FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_INSTALL;
+
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_UPDATE:
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_DOWNGRADE:
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_UPDATE:
+  case FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_DOWNGRADE:
+    return FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_UPDATE;
+  }
+
+  g_assert_not_reached();
+  return FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_INSTALL;
+}

--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1942,7 +1942,10 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
         {
           g_autoptr(GError) error = NULL;
           g_autoptr(FlatpakDecomposed) ref = NULL;
-          gboolean is_app, is_install;
+          FlatpakRefKind ref_kind;
+          FlatpakSystemHelperDeployAction deploy_action;
+          FlatpakSystemHelperDeployAuthorization deploy_authorization;
+          FlatpakSystemHelperRefState ref_state = FLATPAK_SYSTEM_HELPER_REF_NOT_INSTALLED;
 
           ref = flatpak_decomposed_new_from_ref (ref_str, &error);
           if (ref == NULL)
@@ -1965,14 +1968,12 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
            */
 
           if ((flags & FLATPAK_HELPER_DEPLOY_FLAGS_APP_HINT) != 0)
-            is_app = TRUE;
+            ref_kind = FLATPAK_REF_KIND_APP;
           else
-            is_app = flatpak_decomposed_is_app (ref);
+            ref_kind = flatpak_decomposed_get_kind (ref);
 
-          if ((flags & FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT) != 0 ||
-              (flags & FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL) != 0)
-            is_install = TRUE;
-          else
+          if ((flags & (FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT |
+                        FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL)) == 0)
             {
               g_autoptr(FlatpakDir) system = dir_get_system (installation,
                                                              invocation,
@@ -1986,37 +1987,24 @@ flatpak_authorize_method_handler (GDBusInterfaceSkeleton *interface,
                   return FALSE;
                 }
 
-              is_install = !dir_ref_is_installed (system, ref);
+              if (dir_ref_is_installed (system, ref))
+                ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED;
             }
 
-          if (!is_install)
-            g_object_set_data (G_OBJECT (invocation),
-                               "authorized-as-update",
-                               GINT_TO_POINTER (TRUE));
+          deploy_action = flatpak_system_helper_get_deploy_action (flags, ref_kind,
+                                                                   ref_state);
+          action = flatpak_system_helper_deploy_action_to_polkit_action (deploy_action);
+          deploy_authorization = flatpak_system_helper_get_deploy_authorization (deploy_action);
 
-          if (is_install)
+          switch (deploy_authorization)
             {
-              if (is_app)
-                action = "org.freedesktop.Flatpak.app-install";
-              else
-                action = "org.freedesktop.Flatpak.runtime-install";
-            }
-          else
-            {
-              if (is_app)
-                {
-                  if ((flags & FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE) != 0)
-                    action = "org.freedesktop.Flatpak.app-downgrade";
-                  else
-                    action = "org.freedesktop.Flatpak.app-update";
-                }
-              else
-                {
-                  if ((flags & FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE) != 0)
-                    action = "org.freedesktop.Flatpak.runtime-downgrade";
-                  else
-                    action = "org.freedesktop.Flatpak.runtime-update";
-                }
+            case FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_INSTALL:
+              break;
+            case FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_UPDATE:
+              g_object_set_data (G_OBJECT (invocation),
+                                 "authorized-as-update",
+                                 GINT_TO_POINTER (TRUE));
+              break;
             }
         }
 

--- a/system-helper/flatpak-system-helper.h
+++ b/system-helper/flatpak-system-helper.h
@@ -18,8 +18,39 @@
 #ifndef __FLATPAK_SYSTEM_HELPER_H__
 #define __FLATPAK_SYSTEM_HELPER_H__
 
+#include <glib.h>
+#include "flatpak-ref.h"
+
 #define FLATPAK_SYSTEM_HELPER_BUS_NAME "org.freedesktop.Flatpak.SystemHelper"
 #define FLATPAK_SYSTEM_HELPER_PATH "/org/freedesktop/Flatpak/SystemHelper"
 #define FLATPAK_SYSTEM_HELPER_INTERFACE FLATPAK_SYSTEM_HELPER_BUS_NAME
+
+typedef enum
+{
+  FLATPAK_SYSTEM_HELPER_REF_NOT_INSTALLED,
+  FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+} FlatpakSystemHelperRefState;
+
+typedef enum
+{
+  FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL,
+  FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_UPDATE,
+  FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_DOWNGRADE,
+  FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL,
+  FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_UPDATE,
+  FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_DOWNGRADE,
+} FlatpakSystemHelperDeployAction;
+
+typedef enum
+{
+  FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_INSTALL,
+  FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_UPDATE,
+} FlatpakSystemHelperDeployAuthorization;
+
+FlatpakSystemHelperDeployAction flatpak_system_helper_get_deploy_action (guint32                      flags,
+                                                                        FlatpakRefKind               ref_kind,
+                                                                        FlatpakSystemHelperRefState  ref_state);
+const char *flatpak_system_helper_deploy_action_to_polkit_action (FlatpakSystemHelperDeployAction action);
+FlatpakSystemHelperDeployAuthorization flatpak_system_helper_get_deploy_authorization (FlatpakSystemHelperDeployAction action);
 
 #endif

--- a/system-helper/meson.build
+++ b/system-helper/meson.build
@@ -14,7 +14,10 @@ executable(
   ],
   install : true,
   install_dir : get_option('libexecdir'),
-  sources : ['flatpak-system-helper.c'],
+  sources : [
+    'flatpak-system-helper.c',
+    'flatpak-system-helper-utils.c',
+  ],
 )
 
 configure_file(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -124,6 +124,11 @@ c_tests = [
     ],
   }],
   ['test-locale-utils', {}],
+  ['test-system-helper', {
+    'extra_sources' : [
+      project_source_root / 'system-helper/flatpak-system-helper-utils.c',
+    ],
+  }],
   ['test-portal', {
     'extra_sources' : [
       portal_gdbus[0],

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..47"
+echo "1..48"
 
 #Regular repo
 setup_repo
@@ -290,6 +290,41 @@ else
 fi
 
 ok "install flatpakref sets collection-id on remote if available"
+
+setup_repo_no_add flatpakref-update org.test.Collection.Flatpakref
+make_updated_app flatpakref-update org.test.Collection.Flatpakref master FLATPAKREF_UPDATE
+
+cat << EOF > org.test.Hello-update.flatpakref
+[Flatpak Ref]
+Name=org.test.Hello
+Branch=master
+Url=http://127.0.0.1:$(cat httpd-port)/flatpakref-update
+SuggestRemoteName=alltheupdates
+GPGKey=${FL_GPG_BASE64}
+RuntimeRepo=http://127.0.0.1:$(cat httpd-port)/flatpakref/flatpakref-repo.flatpakrepo
+EOF
+
+if [ x${USE_COLLECTIONS_IN_CLIENT-} == xyes ]; then
+    echo "DeploySideloadCollectionID=org.test.Collection.Flatpakref" >> org.test.Hello-update.flatpakref
+fi
+
+ORIGINAL_COMMIT=$(${FLATPAK} ${U} info --show-commit org.test.Hello)
+ORIGINAL_ORIGIN=$(${FLATPAK} ${U} info --show-origin org.test.Hello)
+UPDATED_COMMIT=$(ostree rev-parse --repo=repos/flatpakref-update app/org.test.Hello/${ARCH}/master)
+assert_not_streq "$ORIGINAL_COMMIT" "$UPDATED_COMMIT"
+
+if ${FLATPAK} ${U} install -y org.test.Hello-update.flatpakref &> install-error-log; then
+    assert_not_reached "Should not replace a flatpakref install without --or-update"
+fi
+assert_file_has_content install-error-log "already installed"
+assert_streq "$(${FLATPAK} ${U} info --show-commit org.test.Hello)" "$ORIGINAL_COMMIT"
+assert_streq "$(${FLATPAK} ${U} info --show-origin org.test.Hello)" "$ORIGINAL_ORIGIN"
+
+${FLATPAK} ${U} install -y --or-update org.test.Hello-update.flatpakref >&2
+assert_streq "$(${FLATPAK} ${U} info --show-commit org.test.Hello)" "$UPDATED_COMMIT"
+assert_streq "$(${FLATPAK} ${U} info --show-origin org.test.Hello)" "alltheupdates"
+
+ok "flatpakref --or-update replaces from new remote"
 
 ${FLATPAK} ${U} uninstall -y org.test.Platform org.test.Hello >&2
 

--- a/tests/test-system-helper.c
+++ b/tests/test-system-helper.c
@@ -1,0 +1,131 @@
+#include "config.h"
+
+#include <glib.h>
+
+#include "flatpak-dir-private.h"
+#include "../system-helper/flatpak-system-helper.h"
+
+typedef struct
+{
+  guint32 flags;
+  FlatpakRefKind ref_kind;
+  FlatpakSystemHelperRefState ref_state;
+  FlatpakSystemHelperDeployAction expected_action;
+} DeployActionTest;
+
+static void
+assert_deploy_action(DeployActionTest test)
+{
+  FlatpakSystemHelperDeployAction action;
+
+  action = flatpak_system_helper_get_deploy_action(test.flags,
+                                                   test.ref_kind,
+                                                   test.ref_state);
+
+  g_assert_cmpint(action, ==, test.expected_action);
+}
+
+static void
+test_deploy_action_selection(void)
+{
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_NONE,
+      .ref_kind = FLATPAK_REF_KIND_APP,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_UPDATE,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE,
+      .ref_kind = FLATPAK_REF_KIND_APP,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_DOWNGRADE,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL |
+               FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE,
+      .ref_kind = FLATPAK_REF_KIND_APP,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_REINSTALL,
+      .ref_kind = FLATPAK_REF_KIND_RUNTIME,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_INSTALL_HINT,
+      .ref_kind = FLATPAK_REF_KIND_APP,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_NONE,
+      .ref_kind = FLATPAK_REF_KIND_RUNTIME,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_NOT_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE,
+      .ref_kind = FLATPAK_REF_KIND_APP,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_NOT_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_NONE,
+      .ref_kind = FLATPAK_REF_KIND_RUNTIME,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_UPDATE,
+  });
+  assert_deploy_action((DeployActionTest){
+      .flags = FLATPAK_HELPER_DEPLOY_FLAGS_ALLOW_DOWNGRADE,
+      .ref_kind = FLATPAK_REF_KIND_RUNTIME,
+      .ref_state = FLATPAK_SYSTEM_HELPER_REF_INSTALLED,
+      .expected_action = FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_DOWNGRADE,
+  });
+}
+
+static void
+test_deploy_action_polkit_names(void)
+{
+  g_assert_cmpstr(flatpak_system_helper_deploy_action_to_polkit_action(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL),
+                  ==, "org.freedesktop.Flatpak.app-install");
+  g_assert_cmpstr(flatpak_system_helper_deploy_action_to_polkit_action(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_UPDATE),
+                  ==, "org.freedesktop.Flatpak.app-update");
+  g_assert_cmpstr(flatpak_system_helper_deploy_action_to_polkit_action(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_DOWNGRADE),
+                  ==, "org.freedesktop.Flatpak.app-downgrade");
+  g_assert_cmpstr(flatpak_system_helper_deploy_action_to_polkit_action(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL),
+                  ==, "org.freedesktop.Flatpak.runtime-install");
+  g_assert_cmpstr(flatpak_system_helper_deploy_action_to_polkit_action(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_UPDATE),
+                  ==, "org.freedesktop.Flatpak.runtime-update");
+  g_assert_cmpstr(flatpak_system_helper_deploy_action_to_polkit_action(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_DOWNGRADE),
+                  ==, "org.freedesktop.Flatpak.runtime-downgrade");
+}
+
+static void
+test_deploy_action_authorization(void)
+{
+  g_assert_cmpint(flatpak_system_helper_get_deploy_authorization(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_INSTALL),
+                  ==, FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_INSTALL);
+  g_assert_cmpint(flatpak_system_helper_get_deploy_authorization(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_INSTALL),
+                  ==, FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_INSTALL);
+  g_assert_cmpint(flatpak_system_helper_get_deploy_authorization(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_UPDATE),
+                  ==, FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_UPDATE);
+  g_assert_cmpint(flatpak_system_helper_get_deploy_authorization(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_APP_DOWNGRADE),
+                  ==, FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_UPDATE);
+  g_assert_cmpint(flatpak_system_helper_get_deploy_authorization(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_UPDATE),
+                  ==, FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_UPDATE);
+  g_assert_cmpint(flatpak_system_helper_get_deploy_authorization(FLATPAK_SYSTEM_HELPER_DEPLOY_ACTION_RUNTIME_DOWNGRADE),
+                  ==, FLATPAK_SYSTEM_HELPER_DEPLOY_AUTHORIZATION_UPDATE);
+}
+
+int main(int argc, char **argv)
+{
+  g_test_init(&argc, &argv, NULL);
+
+  g_test_add_func("/system-helper/deploy-action/selection", test_deploy_action_selection);
+  g_test_add_func("/system-helper/deploy-action/polkit-names", test_deploy_action_polkit_names);
+  g_test_add_func("/system-helper/deploy-action/authorization", test_deploy_action_authorization);
+
+  return g_test_run();
+}


### PR DESCRIPTION
Allow .flatpakref installs to reuse reinstall semantics when
--or-update is set, so an already installed ref can be replaced
from the source declared by the ref 

Keep ordinary REMOTE REF handling unchanged.