### PR TITLE
remote-info, remote-ls: Refresh AppStream cache before showing versio…

### DIFF
--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -188,6 +188,15 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
 
       flatpak_get_window_size (&rows, &cols);
 
+      if (!opt_cached)
+        {
+          g_autoptr(GError) appstream_error = NULL;
+
+          if (!update_appstream (dirs, remote, arch, FLATPAK_APPSTREAM_TTL,
+                                 TRUE, cancellable, &appstream_error))
+            g_info ("Failed to refresh AppStream data: %s", appstream_error->message);
+        }
+
       flatpak_dir_load_appstream_data (preferred_dir, remote, arch, mdata, NULL, NULL);
       cpt = metadata_find_component (mdata, flatpak_decomposed_get_ref (ref));
       if (cpt)

--- a/app/flatpak-builtins-remote-ls.c
+++ b/app/flatpak-builtins-remote-ls.c
@@ -121,7 +121,13 @@ strip_last_element (const char *id,
 }
 
 static gboolean
-ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, Column *columns, GCancellable *cancellable, GError **error)
+ls_remote (GPtrArray     *dirs,
+           GHashTable    *refs_hash,
+           const char   **arches,
+           const char    *app_runtime,
+           Column        *columns,
+           GCancellable  *cancellable,
+           GError       **error)
 {
   g_autoptr(FlatpakTablePrinter) printer = NULL;
   guint n_keys;
@@ -232,6 +238,15 @@ ls_remote (GHashTable *refs_hash, const char **arches, const char *app_runtime, 
 
       if (need_appstream_data)
         {
+          if (!opt_cached)
+            {
+              g_autoptr(GError) appstream_error = NULL;
+
+              if (!update_appstream (dirs, remote, NULL, FLATPAK_APPSTREAM_TTL,
+                                     TRUE, cancellable, &appstream_error))
+                g_info ("Failed to refresh AppStream data: %s", appstream_error->message);
+            }
+
           mdata = as_metadata_new ();
           flatpak_dir_load_appstream_data (dir, remote, NULL, mdata, NULL, NULL);
         }
@@ -501,7 +516,7 @@ flatpak_builtin_remote_ls (int argc, char **argv, GCancellable *cancellable, GEr
   if (columns == NULL)
     return FALSE;
 
-  return ls_remote (refs_hash, arches, opt_app_runtime, columns, cancellable, error);
+  return ls_remote (dirs, refs_hash, arches, opt_app_runtime, columns, cancellable, error);
 }
 
 gboolean


### PR DESCRIPTION

flatpak remote-info and remote-ls --updates load version information from a locally cached AppStream XML file that only gets refreshed during 'flatpak update'. This causes remote-info to show stale version numbers when a new version has been published.

Fix this by calling update_appstream() before loading cached AppStream data, unless --cached is specified. Use FLATPAK_APPSTREAM_TTL (1 day) to avoid re-downloading on every invocation.

Fixes: https://github.com/flatpak/flatpak/issues/5974