### PR TITLE
remote-delete: Add --unused option

### DIFF
--- a/app/flatpak-builtins-remote-delete.c
+++ b/app/flatpak-builtins-remote-delete.c
@@ -34,11 +34,106 @@
 #include "flatpak-quiet-transaction.h"
 
 static gboolean opt_force;
+static gboolean opt_unused;
 
 static GOptionEntry delete_options[] = {
   { "force", 0, 0, G_OPTION_ARG_NONE, &opt_force, N_("Remove remote even if in use"), NULL },
+  { "unused", 0, 0, G_OPTION_ARG_NONE, &opt_unused, N_("Remove all remotes that are not in use"), NULL },
   { NULL }
 };
+
+static gboolean
+remove_unused_remotes (GPtrArray    *dirs,
+                       GCancellable *cancellable,
+                       GError      **error)
+{
+  g_autoptr(GPtrArray) unused_remotes = NULL;
+
+  unused_remotes = g_ptr_array_new_with_free_func ((GDestroyNotify) remote_dir_pair_free);
+
+  for (int dir_index = 0; dir_index < dirs->len; dir_index++)
+    {
+      FlatpakDir *dir = g_ptr_array_index (dirs, dir_index);
+      g_autoptr(GHashTable) used_remotes = NULL;
+      g_autoptr(GPtrArray) refs = NULL;
+      g_auto(GStrv) remotes = NULL;
+
+      refs = flatpak_dir_find_installed_refs (dir, NULL, NULL, NULL,
+                                              FLATPAK_KINDS_APP | FLATPAK_KINDS_RUNTIME,
+                                              0, error);
+      if (refs == NULL)
+        return FALSE;
+
+      used_remotes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+      for (int ref_index = 0; ref_index < refs->len; ref_index++)
+        {
+          FlatpakDecomposed *ref = g_ptr_array_index (refs, ref_index);
+          g_autofree char *origin = flatpak_dir_get_origin (dir, ref, cancellable, error);
+
+          if (origin == NULL && error != NULL && *error != NULL)
+            return FALSE;
+          if (origin != NULL)
+            g_hash_table_add (used_remotes, g_steal_pointer (&origin));
+        }
+
+      remotes = flatpak_dir_list_remotes (dir, cancellable, error);
+      if (remotes == NULL)
+        return FALSE;
+
+      for (int remote_index = 0; remotes[remote_index] != NULL; remote_index++)
+        {
+          if (!g_hash_table_contains (used_remotes, remotes[remote_index]))
+            g_ptr_array_add (unused_remotes, remote_dir_pair_new (remotes[remote_index], dir));
+        }
+    }
+
+  if (unused_remotes->len == 0)
+    return TRUE;
+
+  for (int dir_index = 0; dir_index < dirs->len; dir_index++)
+    {
+      FlatpakDir *dir = g_ptr_array_index (dirs, dir_index);
+      gboolean printed_heading = FALSE;
+
+      for (int unused_index = 0; unused_index < unused_remotes->len; unused_index++)
+        {
+          RemoteDirPair *pair = g_ptr_array_index (unused_remotes, unused_index);
+
+          if (pair->dir != dir)
+            continue;
+
+          if (!printed_heading)
+            {
+              g_print (_("Unused remotes in the %s installation:\n"),
+                       flatpak_dir_get_name_cached (dir));
+              printed_heading = TRUE;
+            }
+          g_print ("  %s\n", pair->remote_name);
+        }
+
+      if (printed_heading)
+        g_print ("\n");
+    }
+
+  if (!flatpak_yes_no_prompt (TRUE, _("Remove all unused remotes?")))
+    return TRUE;
+
+  for (int removal_index = 0; removal_index < unused_remotes->len; removal_index++)
+    {
+      RemoteDirPair *pair = g_ptr_array_index (unused_remotes, removal_index);
+
+      if (!flatpak_dir_remove_remote (pair->dir, FALSE, pair->remote_name,
+                                      cancellable, error))
+        return FALSE;
+    }
+
+  g_print (ngettext ("Removed %u unused remote.\n",
+                     "Removed %u unused remotes.\n",
+                     unused_remotes->len),
+           unused_remotes->len);
+
+  return TRUE;
+}
 
 
 gboolean
@@ -50,7 +145,7 @@ flatpak_builtin_remote_delete (int argc, char **argv, GCancellable *cancellable,
   gboolean removed_all_refs = FALSE;
   const char *remote_name;
 
-  context = g_option_context_new (_("NAME - Delete a remote repository"));
+  context = g_option_context_new (_("[NAME] - Delete a remote repository"));
   g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
 
   g_option_context_add_main_entries (context, delete_options, NULL);
@@ -58,6 +153,14 @@ flatpak_builtin_remote_delete (int argc, char **argv, GCancellable *cancellable,
   if (!flatpak_option_context_parse (context, NULL, &argc, &argv,
                                      FLATPAK_BUILTIN_FLAG_STANDARD_DIRS, &dirs, cancellable, error))
     return FALSE;
+
+  if (opt_unused)
+    {
+      if (argc > 1)
+        return usage_error (context, _("NAME and --unused are mutually exclusive"), error);
+
+      return remove_unused_remotes (dirs, cancellable, error);
+    }
 
   if (argc < 2)
     return usage_error (context, _("NAME must be specified"), error);
@@ -141,7 +244,6 @@ flatpak_complete_remote_delete (FlatpakCompletion *completion)
 {
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(GPtrArray) dirs = NULL;
-  int i;
 
   context = g_option_context_new ("");
   if (!flatpak_option_context_parse (context, delete_options, &completion->argc, &completion->argv,
@@ -156,15 +258,17 @@ flatpak_complete_remote_delete (FlatpakCompletion *completion)
       flatpak_complete_options (completion, delete_options);
       flatpak_complete_options (completion, user_entries);
 
-      for (i = 0; i < dirs->len; i++)
+      if (!opt_unused)
         {
-          FlatpakDir *dir = g_ptr_array_index (dirs, i);
-          int j;
-          g_auto(GStrv) remotes = flatpak_dir_list_remotes (dir, NULL, NULL);
-          if (remotes == NULL)
-            return FALSE;
-          for (j = 0; remotes[j] != NULL; j++)
-            flatpak_complete_word (completion, "%s ", remotes[j]);
+          for (int dir_index = 0; dir_index < dirs->len; dir_index++)
+            {
+              FlatpakDir *dir = g_ptr_array_index (dirs, dir_index);
+              g_auto(GStrv) remotes = flatpak_dir_list_remotes (dir, NULL, NULL);
+              if (remotes == NULL)
+                return FALSE;
+              for (int remote_index = 0; remotes[remote_index] != NULL; remote_index++)
+                flatpak_complete_word (completion, "%s ", remotes[remote_index]);
+            }
         }
 
       break;

--- a/doc/flatpak-remote-delete.xml
+++ b/doc/flatpak-remote-delete.xml
@@ -34,6 +34,11 @@
                 <arg choice="opt" rep="repeat">OPTION</arg>
                 <arg choice="plain">NAME</arg>
             </cmdsynopsis>
+            <cmdsynopsis>
+                <command>flatpak remote-delete</command>
+                <arg choice="opt" rep="repeat">OPTION</arg>
+                <arg choice="plain"><option>--unused</option></arg>
+            </cmdsynopsis>
     </refsynopsisdiv>
 
     <refsect1>
@@ -44,10 +49,19 @@
             <arg choice="plain">NAME</arg> is the name of an existing remote.
         </para>
         <para>
+            With <option>--unused</option>, all configured remotes which are not
+            the origin of an installed app or runtime are listed, grouped by
+            installation. After one confirmation, all the listed remotes are
+            removed. <option>--unused</option> cannot be combined with
+            <arg choice="plain">NAME</arg>. If no unused remotes are found, the
+            command exits successfully without prompting.
+        </para>
+        <para>
             Unless overridden with the <option>--system</option>, <option>--user</option>, or <option>--installation</option> options,
-            this command uses either the default system-wide installation or the
-            per-user one, depending on which has the specified
-            <arg choice="plain">REMOTE</arg>.
+            named deletion uses either the default system-wide installation or
+            the per-user one, depending on which has the specified
+            <arg choice="plain">REMOTE</arg>. With <option>--unused</option>, all
+            standard installations available to the command are examined.
         </para>
 
     </refsect1>
@@ -104,6 +118,16 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--unused</option></term>
+
+                <listitem><para>
+                    Remove every remote which is not the origin of an installed
+                    app or runtime. This option cannot be combined with
+                    <arg choice="plain">NAME</arg>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-v</option></term>
                 <term><option>--verbose</option></term>
 
@@ -127,6 +151,9 @@
 
         <para>
             <command>$ flatpak --user remote-delete dried-raisins</command>
+        </para>
+        <para>
+            <command>$ flatpak remote-delete --unused</command>
         </para>
     </refsect1>
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -384,6 +384,7 @@ tests = {
     'user,oldsummary',
     'system,oldsummary',
   ]},
+  'remote-delete-unused': {'wrap': ['system-norevokefs']},
   'history': {},
   'sideload': {'wrap': ['user', 'system']},
   'default-remotes': {},

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -27,7 +27,7 @@ skip_revokefs_without_fuse
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-echo "1..17"
+echo "1..18"
 
 setup_repo
 install_repo
@@ -178,6 +178,13 @@ done
 
 ok "complete non-NO_DIR commands"
 
+${FLATPAK} complete "flatpak remote-delete --" 24 "--" > complete_out
+assert_file_has_content complete_out "^--unused "
+${FLATPAK} complete "flatpak remote-delete --unused " 31 "" > complete_out
+assert_not_file_has_content complete_out "^test-repo "
+
+ok "complete remote-delete options"
+
 ${FLATPAK} complete "flatpak list --columns=" 24 "--columns=" | sort > complete_out
 (diff -u complete_out - || exit 1) <<EOF
 active
@@ -230,4 +237,3 @@ arch,version
 EOF
 
 ok "complete list --columns=arch,"
-

--- a/tests/test-remote-delete-unused.sh
+++ b/tests/test-remote-delete-unused.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+skip_without_bwrap
+skip_revokefs_without_fuse
+
+echo "1..6"
+
+setup_repo
+install_repo
+port=$(cat httpd-port)
+SELECTOR=${U:---system}
+
+add_remote () {
+    local installation=$1
+    shift
+    ${FLATPAK} ${installation} remote-add --no-gpg-verify "$1" "http://127.0.0.1:${port}/test" >&2
+}
+
+run_interactive () {
+    local answer=$1
+    local installation=$2
+    shift
+    shift
+    printf '%s\n' "${answer}" | python3 -c \
+        'import os, pty, sys; raise SystemExit(os.waitstatus_to_exitcode(pty.spawn(sys.argv[1:])))' \
+        ${FLATPAK} ${installation} "$@"
+}
+
+add_remote "${SELECTOR}" unused-one
+add_remote "${SELECTOR}" unused-two
+run_interactive y "${SELECTOR}" remote-delete --unused > delete-log
+${FLATPAK} ${SELECTOR} remotes > remotes
+assert_file_has_content remotes "^test-repo"
+assert_not_file_has_content remotes "unused-one"
+assert_not_file_has_content remotes "unused-two"
+test "$(grep -c "Remove all unused remotes?" delete-log)" = 1
+assert_file_has_content delete-log "Remove all unused remotes[?] \[Y/n\]"
+assert_file_has_content delete-log "Removed 2 unused remotes\."
+ok "delete multiple unused remotes with one confirmation"
+
+add_remote "${SELECTOR}" unused-declined
+run_interactive n "${SELECTOR}" remote-delete --unused > delete-log
+${FLATPAK} ${SELECTOR} remotes > remotes
+assert_file_has_content remotes "^unused-declined"
+ok "decline without deleting remotes"
+
+${FLATPAK} ${SELECTOR} remote-delete --force unused-declined
+${FLATPAK} ${SELECTOR} remote-delete --unused > delete-log
+assert_file_empty delete-log
+ok "no unused remotes exits without prompting"
+
+if ${FLATPAK} ${SELECTOR} remote-delete --unused test-repo > delete-log 2>&1; then
+    assert_not_reached "--unused with NAME should fail"
+fi
+assert_file_has_content delete-log "NAME and --unused are mutually exclusive"
+ok "reject --unused with NAME"
+
+add_remote "${SELECTOR}" unused-selected
+add_remote "${INVERT_U}" unused-other
+run_interactive y "${SELECTOR}" remote-delete --unused > delete-log
+${FLATPAK} ${SELECTOR} remotes > selected-remotes
+${FLATPAK} ${INVERT_U} remotes > other-remotes
+assert_not_file_has_content selected-remotes "unused-selected"
+assert_file_has_content other-remotes "^unused-other"
+ok "respect explicit installation selector"
+
+run_interactive y remote-delete --unused > delete-log
+${FLATPAK} ${INVERT_U} remotes > other-remotes
+assert_not_file_has_content other-remotes "unused-other"
+assert_file_has_content delete-log "unused-other"
+ok "search standard installations by default"


### PR DESCRIPTION
As I keep installing apps for testing, my systems tend to have many unused remotes, this helps cleaning them up easier