### PR TITLE
po: Fix reversed zh_CN translation of --if-not-exists

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2336,7 +2336,7 @@ msgstr " - 列出正在运行的沙盒"
 
 #: app/flatpak-builtins-remote-add.c:66
 msgid "Do nothing if the provided remote exists"
-msgstr "如果提供的远程仓库不存在则不进行任何操作"
+msgstr "如果提供的远程仓库已存在则不进行任何操作"
 
 #: app/flatpak-builtins-remote-add.c:67
 msgid "LOCATION specifies a configuration file, not the repo location"


### PR DESCRIPTION
The zh_CN translation of the `--if-not-exists` option for `flatpak remote-add` is reversed.

  English (msgid): "Do nothing if the provided remote exists"
  Current zh_CN (msgstr): "如果提供的远程仓库不存在则不进行任何操作"
      (literally: "do nothing if the remote does NOT exist" — wrong)
  Fixed: "如果提供的远程仓库已存在则不进行任何操作"
      (literally: "do nothing if the remote already exists" — correct)

  Verified on Flatpak 1.18.0 with LANG=zh_CN.UTF-8:
  `flatpak remote-add --if-not-exists` exits 0 and leaves an existing
  remote untouched, which matches the corrected wording.

  Side note: the man page (doc/flatpak-remote-add.xml) says "...already exists"
  while the code help string says "...exists"; same meaning, minor wording
  difference between the two.