### PR TITLE
completion: Validate cursor position

### DIFF
--- a/app/flatpak-complete.c
+++ b/app/flatpak-complete.c
@@ -24,6 +24,9 @@
 #include "flatpak-installation.h"
 #include "flatpak-utils-private.h"
 
+#include <errno.h>
+#include <limits.h>
+
 /* Uncomment to get debug traces in /tmp/flatpak-completion-debug.txt (nice
  * to not have it interfere with stdout/stderr)
  */
@@ -571,22 +574,24 @@ flatpak_completion_new (const char *arg_line,
 {
   FlatpakCompletion *completion;
   g_autofree char *initial_completion_line = NULL;
-  int _point;
+  long point;
   char *endp;
   int cur_begin;
   int i;
 
-  _point = strtol (arg_point, &endp, 10);
-  if (endp == arg_point || *endp != '\0')
+  errno = 0;
+  point = strtol (arg_point, &endp, 10);
+  if (errno == ERANGE || endp == arg_point || *endp != '\0' ||
+      point < 0 || point > INT_MAX)
     return NULL;
 
   /* Ensure we're not going oob if we got weird arguments. */
-  _point = MIN (_point, strlen (arg_line));
+  point = MIN ((size_t) point, strlen (arg_line));
 
   completion = g_new0 (FlatpakCompletion, 1);
   completion->line = g_strdup (arg_line);
   completion->shell_cur = g_strdup (arg_cur);
-  completion->point = _point;
+  completion->point = (int) point;
 
   flatpak_completion_debug ("========================================");
   flatpak_completion_debug ("completion_point=%d", completion->point);

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -30,6 +30,27 @@ export LC_ALL=C
 setup_repo
 install_repo
 
+for point in -1 -42 nope 1x 9999999999999999999999999999999999999999 2147483648; do
+  if ${FLATPAK} complete "flatpak b" "$point" "b" > complete_out 2> complete_err; then
+    assert_not_reached "Invalid completion cursor '$point' was accepted"
+  fi
+  assert_file_empty complete_out
+  assert_file_empty complete_err
+done
+
+${FLATPAK} complete "flatpak b" 9 "b" | sort > complete_end
+for point in 9 42; do
+  ${FLATPAK} complete "flatpak b" "$point" "b" | sort > complete_out
+  diff -u complete_end complete_out
+done
+
+${FLATPAK} complete "flatpak b" 0 "b" > complete_out 2> complete_err || :
+assert_file_empty complete_out
+assert_file_empty complete_err
+${FLATPAK} complete "flatpak b" 8 "b" > complete_out
+
+ok "validate completion cursor"
+
 ${FLATPAK} complete "flatpak a" 9 "a" | sort > complete_out
 (diff -u complete_out - || exit 1) <<EOF
 EOF


### PR DESCRIPTION
Parse the cursor as a long before narrowing it to the completion structure's integer field. This lets malformed, negative, and overflowing positions fail before they can index outside the command-line buffer, while preserving the existing behavior of clamping positive positions beyond the line length.