### PR TITLE
[1.18] Revert "http: Reset curl TLS options between transfers"

### DIFF
--- a/common/flatpak-utils-http.c
+++ b/common/flatpak-utils-http.c
@@ -628,10 +628,6 @@ flatpak_download_http_uri_once (FlatpakHttpSession    *session,
   curl_easy_setopt (curl, CURLOPT_WRITEDATA, (void *)data);
   curl_easy_setopt (curl, CURLOPT_HEADERDATA, (void *)data);
 
-  curl_easy_setopt (curl, CURLOPT_CAINFO, NULL);
-  curl_easy_setopt (curl, CURLOPT_SSLCERT, NULL);
-  curl_easy_setopt (curl, CURLOPT_SSLKEY, NULL);
-
   if (data->certificates)
     {
       if (data->certificates->ca_cert_file)


### PR DESCRIPTION
This reverts commit 420ce9142825368043649eb83ae4ae118f56caee.

Apparently we do depend on the session-set certificates in some situations. We should fix that, but until someone puts in the effort to do so, reverting this will at least unbreak things.

(cherry picked from commit e61ae2114c35de05dd656928133aa6f8dd15c4e4)