### PR TITLE
context: Strip trailing slashes from --persist paths

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -1497,10 +1497,22 @@ flatpak_context_set_persistent (FlatpakContext *context,
                                 const char     *path,
                                 GError        **error)
 {
-  if (!flatpak_validate_path_characters (path, error))
+  size_t len;
+  g_autofree char *stripped = NULL;
+
+  len = strlen (path);
+  while (len > 0 && path[len - 1] == '/')
+    len--;
+
+  if (len == 0)
+    return TRUE;
+
+  stripped = g_strndup (path, len);
+
+  if (!flatpak_validate_path_characters (stripped, error))
     return FALSE;
 
-  g_hash_table_insert (context->persistent, g_strdup (path), GINT_TO_POINTER (1));
+  g_hash_table_insert (context->persistent, g_strdup (stripped), GINT_TO_POINTER (1));
   return TRUE;
 }
 

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -969,6 +969,41 @@ test_sockets_evaluate_conditions_has_wayland (FlatpakContextConditions condition
 }
 
 static void
+test_persist_trailing_slash (void)
+{
+  g_autoptr(FlatpakContext) context = flatpak_context_new ();
+  g_autoptr(GError) local_error = NULL;
+
+  context_parse_args (context, &local_error, "--persist=folder/", NULL);
+  g_assert_no_error (local_error);
+  g_assert_true (g_hash_table_contains (context->persistent, "folder"));
+  g_assert_false (g_hash_table_contains (context->persistent, "folder/"));
+
+  g_hash_table_remove_all (context->persistent);
+
+  context_parse_args (context, &local_error, "--persist=foo/bar/", NULL);
+  g_assert_no_error (local_error);
+  g_assert_true (g_hash_table_contains (context->persistent, "foo/bar"));
+  g_assert_false (g_hash_table_contains (context->persistent, "foo/bar/"));
+
+  g_hash_table_remove_all (context->persistent);
+
+  context_parse_args (context, &local_error, "--persist=/", NULL);
+  g_assert_no_error (local_error);
+  g_assert_cmpuint (g_hash_table_size (context->persistent), ==, 0);
+
+  context_parse_args (context, &local_error, "--persist=a///", NULL);
+  g_assert_no_error (local_error);
+  g_assert_true (g_hash_table_contains (context->persistent, "a"));
+
+  g_hash_table_remove_all (context->persistent);
+
+  context_parse_args (context, &local_error, "--persist=no-trailing-slash", NULL);
+  g_assert_no_error (local_error);
+  g_assert_true (g_hash_table_contains (context->persistent, "no-trailing-slash"));
+}
+
+static void
 test_sockets (void)
 {
   FlatpakContextSockets sockets;
@@ -1031,6 +1066,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/context/env", test_context_env);
   g_test_add_func ("/context/env-fd", test_context_env_fd);
   g_test_add_func ("/context/merge-fs", test_context_merge_fs);
+  g_test_add_func ("/context/persist-trailing-slash", test_persist_trailing_slash);
   g_test_add_func ("/context/validate-path-args", test_validate_path_args);
   g_test_add_func ("/context/validate-path-meta", test_validate_path_meta);
   g_test_add_func ("/context/devices", test_devices);


### PR DESCRIPTION
--persist=folder/ makes the sandbox create ~/folder/folder instead of
~/folder. The same happens in mkdir_p_open_nofollow_at when
g_path_get_dirname("folder/") returns "folder" instead of ".", creating
an extra directory level (e.g. appdir/folder/folder/).

Strip trailing slashes in flatpak_context_set_persistent to normalize
--persist paths. Do the same in mkdir_p_open_nofollow_at via a shared
strip_trailing_slashes helper.

Fixes: https://github.com/flatpak/flatpak/issues/1469