### PR TITLE
tests: Avoid Meson's strict TAP parsing for now

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -183,7 +183,6 @@ foreach testcase : c_tests
       args : [exe],
       depends : runtime_repo,
       env : test_env,
-      protocol : 'tap',
       timeout : options.get('timeout', 30),
     )
   endif


### PR DESCRIPTION
Older versions of Meson parsed TAP output very strictly, and would fail the test when a `g_test_message()` mentions non-UTF-8, which results in GLib adding a prefix on stdout that is not valid TAP syntax.

Ideally our error messages should all be valid UTF-8 even if the input is not, but that's a larger refactor that shouldn't block security fix releases, so for now just tell Meson to get the tests' pass/fail status from their exit status rather than parsing their stdout.

---

cc @swick 

This fixes the build regression in 1.19.0. I'll try to propose a PR later to fix the error messages properly, but please don't block security releases on that.