### PR TITLE
context: Drop g_hash_table_new_similar usage which requires glib 2.72

### DIFF
--- a/common/flatpak-context.c
+++ b/common/flatpak-context.c
@@ -4483,8 +4483,7 @@ FlatpakContextSockets
 flatpak_context_compute_allowed_sockets (FlatpakContext                   *context,
                                          FlatpakContextConditionEvaluator  evaluator)
 {
-  g_autoptr(GHashTable) permissions =
-    g_hash_table_new_similar (context->socket_permissions);
+  g_autoptr(GHashTable) permissions = flatpak_permissions_new ();
   GHashTableIter iter;
   gpointer key, value;
   FlatpakPermission *fallback_x11;


### PR DESCRIPTION
We require glib 2.46, so we can't rely on g_hash_table_new_similar.

Fixes: 17cb1135 ("context: Keep fallback-x11 separate from x11 conditionals")