### PR TITLE
system-helper: Handle NULL entries in cache_dirs_in_use iteration

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1523,6 +1523,10 @@ name_vanished_cb (GDBusConnection *connection, const gchar *name, gpointer user_
   while (g_hash_table_iter_next (&iter, NULL, &value))
     {
       OngoingPull *pull = (OngoingPull *) value;
+
+      if (pull == NULL)
+        continue;
+
       if (g_strcmp0 (pull->unique_name, unique_name) == 0)
         {
           g_ptr_array_add (cleanup_pulls, pull);


### PR DESCRIPTION
The cache_dirs_in_use tracks the cache dirs, and which pull it is associated with. It can also be associated with no pull anymore in which case the value is NULL.

The iteration over cache_dirs_in_use thus needs to handle NULL values.