### PR TITLE
system-helper: Track the right unique sender name for pulls

### DIFF
--- a/system-helper/flatpak-system-helper.c
+++ b/system-helper/flatpak-system-helper.c
@@ -1541,6 +1541,7 @@ ongoing_pull_new (FlatpakSystemHelper   *object,
                   GError               **error)
 {
   GDBusConnection *connection = g_dbus_method_invocation_get_connection (invocation);
+  const char *sender = g_dbus_method_invocation_get_sender (invocation);
   g_autoptr(OngoingPull) pull = NULL;
   g_autoptr(GSubprocessLauncher) launcher = NULL;
   int sockets[2], exit_sockets[2];
@@ -1553,13 +1554,13 @@ ongoing_pull_new (FlatpakSystemHelper   *object,
   pull->cancellable = g_cancellable_new ();
   pull->uid = uid;
   pull->preserve_pull = FALSE;
-  pull->unique_name = g_strdup (g_dbus_connection_get_unique_name (connection));
+  pull->unique_name = g_strdup (sender);
 
   pull->watch_id = g_bus_watch_name_on_connection (connection,
                                                    pull->unique_name,
                                                    G_BUS_NAME_WATCHER_FLAGS_NONE, NULL,
                                                    name_vanished_cb,
-                                                   g_strdup (g_dbus_connection_get_unique_name (connection)),
+                                                   g_strdup (sender),
                                                    g_free);
 
   if (socketpair (AF_UNIX, SOCK_SEQPACKET, 0, sockets) == -1)


### PR DESCRIPTION
The code used the connection name, which is the unique sender name of the system-helper itself. Fix this and use the sender name of the invocation.