### PR TITLE
subprojects: Update dbus-proxy.wrap to v0.1.8

### DIFF
--- a/subprojects/dbus-proxy.wrap
+++ b/subprojects/dbus-proxy.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/flatpak/xdg-dbus-proxy
-# 0.1.7
-revision = 6a170fa77e3cbecb48f9dd2478fe5c0a119eb467
+# 0.1.8
+revision = f0fe358bb3a864a722f348cb942f30a29aafb9b2
 depth = 1


### PR DESCRIPTION
Version 0.1.7 contains a security vulnerability, so let's bump it to a version which does not.