### PR TITLE
libglnx: Retry openat2 on EAGAIN in glnx_chaseat_full

### DIFF
--- a/subprojects/libglnx/glnx-chase.c
+++ b/subprojects/libglnx/glnx-chase.c
@@ -684,7 +684,10 @@ glnx_chaseat_full (int                 dirfd,
         .resolve = openat2_resolve,
       };
 
-      fd = openat2 (dirfd, path, &how, sizeof (how));
+      do
+        fd = openat2 (dirfd, path, &how, sizeof (how));
+      while (fd < 0 && errno == EAGAIN);
+
       if (fd < 0)
         {
           /* If the syscall is not implemented (ENOSYS) or blocked by


### PR DESCRIPTION
openat2 with RESOLVE_BENEATH can fail with EAGAIN when the kernel cannot guarantee that a ".." component did not escape (race condition or potential attack), as documented in openat2(2). Flatpak launches intermittently abort with "Extension ... has invalid merge-dirs" when this happens while opening GL extension merge-dirs.

Retry the syscall on EAGAIN, as suggested by @swick . The race resolves in a few iterations in practice.