### PR TITLE
Update libglnx to fix EAGAIN from openat2

### DIFF
--- a/glnx-chase.c
+++ b/glnx-chase.c
@@ -684,7 +684,10 @@ glnx_chaseat_full (int                 dirfd,
         .resolve = openat2_resolve,
       };
 
-      fd = openat2 (dirfd, path, &how, sizeof (how));
+      do
+        fd = openat2 (dirfd, path, &how, sizeof (how));
+      while (fd < 0 && errno == EAGAIN);
+
       if (fd < 0)
         {
           /* If the syscall is not implemented (ENOSYS) or blocked by

--- a/glnx-fdio.c
+++ b/glnx-fdio.c
@@ -710,12 +710,28 @@ copy_symlink_at (int                   src_dfd,
                  GCancellable         *cancellable,
                  GError              **error)
 {
-  g_autofree char *buf = glnx_readlinkat_malloc (src_dfd, src_subpath, cancellable, error);
+  g_autofree char *buf = NULL;
+  glnx_autofd int fd = -1;
+  g_autofree char *target = NULL;
+
+  buf = glnx_readlinkat_malloc (src_dfd, src_subpath, cancellable, error);
   if (!buf)
     return FALSE;
 
   if (TEMP_FAILURE_RETRY (symlinkat (buf, dest_dfd, dest_subpath)) != 0)
     return glnx_throw_errno_prefix (error, "symlinkat");
+
+  fd = TEMP_FAILURE_RETRY (openat (dest_dfd, dest_subpath,
+                                   O_PATH | O_NOFOLLOW | O_CLOEXEC));
+  if (fd < 0)
+    return glnx_throw_errno_prefix (error, "openat(O_PATH)");
+
+  target = glnx_readlinkat_malloc (fd, "", cancellable, error);
+  if (!target)
+    return FALSE;
+
+  if (strcmp (buf, target) != 0)
+    return glnx_throw (error, "Symlink target changed during copy");
 
   if (!(copyflags & GLNX_FILE_COPY_NOXATTRS))
     {
@@ -725,14 +741,12 @@ copy_symlink_at (int                   src_dfd,
                                          cancellable, error))
         return FALSE;
 
-      if (!glnx_dfd_name_set_all_xattrs (dest_dfd, dest_subpath, xattrs,
-                                         cancellable, error))
+      if (!glnx_fd_set_all_xattrs (fd, xattrs, cancellable, error))
         return FALSE;
     }
 
-  if (TEMP_FAILURE_RETRY (fchownat (dest_dfd, dest_subpath,
-                                    src_stbuf->st_uid, src_stbuf->st_gid,
-                                    AT_SYMLINK_NOFOLLOW)) != 0)
+  if (TEMP_FAILURE_RETRY (fchownat (fd, "", src_stbuf->st_uid, src_stbuf->st_gid,
+                                    AT_EMPTY_PATH)) != 0)
     return glnx_throw_errno_prefix (error, "fchownat");
 
   return TRUE;

--- a/glnx-xattrs.c
+++ b/glnx-xattrs.c
@@ -338,25 +338,12 @@ glnx_dfd_name_set_all_xattrs (int            dfd,
 gboolean
 glnx_fd_set_all_xattrs (int            fd,
                         GVariant      *xattrs,
-                        G_GNUC_UNUSED GCancellable *cancellable,
+                        GCancellable  *cancellable,
                         GError       **error)
 {
-  const guint n = g_variant_n_children (xattrs);
-  for (guint i = 0; i < n; i++)
-    {
-      const guint8* name;
-      g_autoptr(GVariant) value = NULL;
-      g_variant_get_child (xattrs, i, "(^&ay@ay)",
-                           &name, &value);
-
-      gsize value_len;
-      const guint8* value_data = g_variant_get_fixed_array (value, &value_len, 1);
-
-      if (TEMP_FAILURE_RETRY (fsetxattr (fd, (char*)name, (char*)value_data, value_len, 0)) < 0)
-        return glnx_throw_errno_prefix (error, "Setting xattrs: fsetxattr(%s)", name);
-    }
-
-  return TRUE;
+  char buf[PATH_MAX];
+  snprintf (buf, sizeof (buf), "/proc/self/fd/%d", fd);
+  return set_all_xattrs_for_path (buf, xattrs, cancellable, error);
 }
 
 /**

--- a/glnx-xattrs.c
+++ b/glnx-xattrs.c
@@ -70,20 +70,12 @@ canonicalize_xattrs (char    *xattr_string,
 
 static gboolean
 read_xattr_name_array (const char *path,
-                       int         fd,
                        const char *xattrs,
                        size_t      len,
                        GVariantBuilder *builder,
                        GError  **error)
 {
-  gboolean ret = FALSE;
   const char *p;
-  int r;
-  const char *funcstr;
-
-  g_assert (path != NULL || fd != -1);
-
-  funcstr = fd != -1 ? "fgetxattr" : "lgetxattr";
 
   for (p = xattrs; p < xattrs+len; p = p + strlen (p) + 1)
     {
@@ -92,27 +84,20 @@ read_xattr_name_array (const char *path,
       g_autoptr(GBytes) bytes = NULL;
 
     again:
-      if (fd != -1)
-        bytes_read = fgetxattr (fd, p, NULL, 0);
-      else
-        bytes_read = lgetxattr (path, p, NULL, 0);
+      bytes_read = lgetxattr (path, p, NULL, 0);
       if (bytes_read < 0)
         {
           if (errno == ENODATA)
             continue;
 
-          glnx_set_prefix_error_from_errno (error, "%s", funcstr);
-          goto out;
+          glnx_set_prefix_error_from_errno (error, "%s", "lgetxattr");
+          return FALSE;
         }
       if (bytes_read == 0)
         continue;
 
       buf = g_malloc (bytes_read);
-      if (fd != -1)
-        r = fgetxattr (fd, p, buf, bytes_read);
-      else
-        r = lgetxattr (path, p, buf, bytes_read);
-      if (r < 0)
+      if (lgetxattr (path, p, buf, bytes_read) < 0)
         {
           if (errno == ERANGE)
             {
@@ -122,8 +107,8 @@ read_xattr_name_array (const char *path,
           else if (errno == ENODATA)
             continue;
 
-          glnx_set_prefix_error_from_errno (error, "%s", funcstr);
-          goto out;
+          glnx_set_prefix_error_from_errno (error, "%s", "lgetxattr");
+          return FALSE;
         }
 
       bytes = g_bytes_new_take (g_steal_pointer (&buf), bytes_read);
@@ -132,36 +117,25 @@ read_xattr_name_array (const char *path,
                              variant_new_ay_bytes (bytes));
     }
 
-  ret = TRUE;
- out:
-  return ret;
+  return TRUE;
 }
 
 static gboolean
 get_xattrs_impl (const char      *path,
-                 int              fd,
                  GVariant       **out_xattrs,
                  G_GNUC_UNUSED GCancellable *cancellable,
                  GError         **error)
 {
-  gboolean ret = FALSE;
   ssize_t bytes_read, real_size;
   g_autofree char *xattr_names = NULL;
   g_autofree char *xattr_names_canonical = NULL;
   GVariantBuilder builder;
-  gboolean builder_initialized = FALSE;
   g_autoptr(GVariant) ret_xattrs = NULL;
 
-  g_assert (path != NULL || fd != -1);
-
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(ayay)"));
-  builder_initialized = TRUE;
 
  again:
-  if (path)
-    bytes_read = llistxattr (path, NULL, 0);
-  else
-    bytes_read = flistxattr (fd, NULL, 0);
+  bytes_read = llistxattr (path, NULL, 0);
 
   if (bytes_read < 0)
     {
@@ -174,10 +148,7 @@ get_xattrs_impl (const char      *path,
   else if (bytes_read > 0)
     {
       xattr_names = g_malloc (bytes_read);
-      if (path)
-        real_size = llistxattr (path, xattr_names, bytes_read);
-      else
-        real_size = flistxattr (fd, xattr_names, bytes_read);
+      real_size = llistxattr (path, xattr_names, bytes_read);
       if (real_size < 0)
         {
           if (errno == ERANGE)
@@ -192,22 +163,21 @@ get_xattrs_impl (const char      *path,
         {
           xattr_names_canonical = canonicalize_xattrs (xattr_names, real_size);
 
-          if (!read_xattr_name_array (path, fd, xattr_names_canonical, real_size, &builder, error))
+          if (!read_xattr_name_array (path, xattr_names_canonical, real_size, &builder, error))
             goto out;
         }
     }
 
   ret_xattrs = g_variant_builder_end (&builder);
-  builder_initialized = FALSE;
   g_variant_ref_sink (ret_xattrs);
-  
-  ret = TRUE;
+
   if (out_xattrs)
     *out_xattrs = g_steal_pointer (&ret_xattrs);
+  return TRUE;
+
  out:
-  if (!builder_initialized)
-    g_variant_builder_clear (&builder);
-  return ret;
+  g_variant_builder_clear (&builder);
+  return FALSE;
 }
 
 /**
@@ -231,7 +201,7 @@ glnx_fd_get_all_xattrs (int            fd,
 {
   char buf[PATH_MAX];
   snprintf (buf, sizeof (buf), "/proc/self/fd/%d", fd);
-  return get_xattrs_impl (buf, -1, out_xattrs, cancellable, error);
+  return get_xattrs_impl (buf, out_xattrs, cancellable, error);
 }
 
 /**
@@ -254,7 +224,7 @@ glnx_dfd_name_get_all_xattrs (int            dfd,
 {
   if (G_IN_SET(dfd, AT_FDCWD, -1))
     {
-      return get_xattrs_impl (name, -1, out_xattrs, cancellable, error);
+      return get_xattrs_impl (name, out_xattrs, cancellable, error);
     }
   else
     {
@@ -263,7 +233,7 @@ glnx_dfd_name_get_all_xattrs (int            dfd,
        * https://mail.gnome.org/archives/ostree-list/2014-February/msg00017.html
        */
       snprintf (buf, sizeof (buf), "/proc/self/fd/%d/%s", dfd, name);
-      return get_xattrs_impl (buf, -1, out_xattrs, cancellable, error);
+      return get_xattrs_impl (buf, out_xattrs, cancellable, error);
     }
 }
 

--- a/glnx-xattrs.c
+++ b/glnx-xattrs.c
@@ -229,8 +229,9 @@ glnx_fd_get_all_xattrs (int            fd,
                         GCancellable  *cancellable,
                         GError       **error)
 {
-  return get_xattrs_impl (NULL, fd, out_xattrs,
-                          cancellable, error);
+  char buf[PATH_MAX];
+  snprintf (buf, sizeof (buf), "/proc/self/fd/%d", fd);
+  return get_xattrs_impl (buf, -1, out_xattrs, cancellable, error);
 }
 
 /**

--- a/tests/test-libglnx-fdio.c
+++ b/tests/test-libglnx-fdio.c
@@ -356,6 +356,30 @@ test_filecopy (void)
 }
 
 static void
+test_copy_symlink (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+  struct stat stbuf;
+  g_autofree char *target = NULL;
+
+  if (symlinkat ("sometarget", AT_FDCWD, "srclink") < 0)
+    return (void) glnx_throw_errno_prefix (error, "symlinkat");
+
+  if (!glnx_file_copy_at (AT_FDCWD, "srclink", NULL, AT_FDCWD, "dstlink",
+                          GLNX_FILE_COPY_NOXATTRS, NULL, error))
+    return;
+
+  if (!glnx_fstatat (AT_FDCWD, "dstlink", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+  g_assert (S_ISLNK (stbuf.st_mode));
+
+  target = glnx_readlinkat_malloc (AT_FDCWD, "dstlink", NULL, error);
+  if (!target)
+    return;
+  g_assert_cmpstr (target, ==, "sometarget");
+}
+
+static void
 test_filecopy_procfs (void)
 {
   const char * const pseudo_files[] =
@@ -674,6 +698,7 @@ int main (int argc, char **argv)
   g_test_add_func ("/tmpfile", test_tmpfile);
   g_test_add_func ("/stdio-file", test_stdio_file);
   g_test_add_func ("/filecopy", test_filecopy);
+  g_test_add_func ("/copy-symlink", test_copy_symlink);
   g_test_add_func ("/filecopy-procfs", test_filecopy_procfs);
   g_test_add_func ("/renameat2-noreplace", test_renameat2_noreplace);
   g_test_add_func ("/renameat2-exchange", test_renameat2_exchange);


### PR DESCRIPTION
    Update subtree: libglnx 2026-08-18
    
    * glnx_file_copy_at: Use O_PATH fd for xattr and ownership operations
    * xattrs: Drop fd-based code paths from get_xattrs_impl
    * xattrs: Use /proc/self/fd path in glnx_fd_set_all_xattrs
    * xattrs: Use /proc/self/fd path in glnx_fd_get_all_xattrs
    * chase: Handle EAGAIN from openat2
    
    The EAGAIN handling in openat2 fixes a bug which would prevent
    extensions from being populated in the sandbox:
    
    Closes: #6783
    Signed-off-by: Sebastian Wick <sebastian.wick@redhat.com>
