### PR TITLE
tests: Don't specify planned number of tests up-front

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -42,6 +42,8 @@ if [ -e "$test_srcdir/installed-tests.sh" ]; then
     . "$test_srcdir/installed-tests.sh"
 fi
 
+test_number=0
+
 # All the asserts and ok functions below are wrapped such that they
 # don't output any set -x traces of their internals (but still echo
 # errors to stderr). This way the log output focuses on tracing what
@@ -55,7 +57,8 @@ assert_not_reached () {
 
 ok () {
     { { local BASH_XTRACEFD=3; } 2> /dev/null
-        echo "ok $@";
+        test_number=$(( test_number + 1 ))
+        echo "ok $test_number - $*";
         echo "================ $(basename ${BASH_SOURCE[1]}):${BASH_LINENO[0]} - $@ ================" >&2;
     } 3> /dev/null
 }
@@ -585,6 +588,7 @@ skip_one_without_bwrap () {
     if "${_flatpak_bwrap_works}"; then
         return 1
     else
+        test_number=$(( test_number + 1 ))
         echo "ok $* # SKIP Cannot run bwrap"
         return 0
     fi

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -56,6 +56,18 @@ plan_tests () {
     } 3> /dev/null
 }
 
+done_testing () {
+    { { local BASH_XTRACEFD=3; } 2> /dev/null
+    if [ -z "$planned_tests" ]; then
+        echo "1..$test_number"
+    elif [ "$planned_tests" != "$test_number" ]; then
+        echo "Bail out! Expected $planned_tests tests, but saw $test_number tests"
+        exit 1
+    fi
+    echo "# Done testing"
+    } 3> /dev/null
+}
+
 # All the asserts and ok functions below are wrapped such that they
 # don't output any set -x traces of their internals (but still echo
 # errors to stderr). This way the log output focuses on tracing what

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -42,7 +42,19 @@ if [ -e "$test_srcdir/installed-tests.sh" ]; then
     . "$test_srcdir/installed-tests.sh"
 fi
 
+planned_tests=
 test_number=0
+
+plan_tests () {
+    { { local BASH_XTRACEFD=3; } 2> /dev/null
+    if [ -n "$planned_tests" ]; then
+        echo "Bail out! plan_tests called more than once"
+        exit 1
+    fi
+    planned_tests="$1"
+    echo "1..$planned_tests"
+    } 3> /dev/null
+}
 
 # All the asserts and ok functions below are wrapped such that they
 # don't output any set -x traces of their internals (but still echo
@@ -571,6 +583,9 @@ have_working_bwrap() {
 
 # Use to skip all of these tests
 skip() {
+    if [ -n "$planned_tests" ]; then
+        assert_not_reached "Cannot call skip after plan_tests"
+    fi
     echo "1..0 # SKIP" "$@"
     exit 0
 }

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -42,28 +42,11 @@ if [ -e "$test_srcdir/installed-tests.sh" ]; then
     . "$test_srcdir/installed-tests.sh"
 fi
 
-planned_tests=
 test_number=0
-
-plan_tests () {
-    { { local BASH_XTRACEFD=3; } 2> /dev/null
-    if [ -n "$planned_tests" ]; then
-        echo "Bail out! plan_tests called more than once"
-        exit 1
-    fi
-    planned_tests="$1"
-    echo "1..$planned_tests"
-    } 3> /dev/null
-}
 
 done_testing () {
     { { local BASH_XTRACEFD=3; } 2> /dev/null
-    if [ -z "$planned_tests" ]; then
-        echo "1..$test_number"
-    elif [ "$planned_tests" != "$test_number" ]; then
-        echo "Bail out! Expected $planned_tests tests, but saw $test_number tests"
-        exit 1
-    fi
+    echo "1..$test_number"
     echo "# Done testing"
     } 3> /dev/null
 }

--- a/tests/test-auth.sh
+++ b/tests/test-auth.sh
@@ -22,8 +22,6 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 
-plan_tests 4
-
 setup_repo
 
 commit_to_obj () {

--- a/tests/test-auth.sh
+++ b/tests/test-auth.sh
@@ -176,3 +176,5 @@ ${FLATPAK} ${U} install --noninteractive test-repo org.test.Hello master >&2
 assert_file_has_content ${XDG_RUNTIME_DIR}/request "no-interaction"
 
 ok "--noninteractive sends no-interaction to the authenticator"
+
+done_testing

--- a/tests/test-auth.sh
+++ b/tests/test-auth.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 . $(dirname $0)/libtest.sh
 
 
-echo "1..4"
+plan_tests 4
 
 setup_repo
 

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-echo "1..11"
+plan_tests 11
 
 ${FLATPAK} --version > version_out
 

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-plan_tests 11
-
 ${FLATPAK} --version > version_out
 
 VERSION=`cat "$test_builddir/package_version.txt"`

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -126,3 +126,5 @@ for cmd in config make-current override remote-add repair; do
 done
 
 ok "ONE_DIR commands"
+
+done_testing

--- a/tests/test-build-update-repo.sh
+++ b/tests/test-build-update-repo.sh
@@ -27,8 +27,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 5
-
 # Configure a repository, then set a collection ID on it and check that the ID
 # is saved in the config file.
 setup_repo

--- a/tests/test-build-update-repo.sh
+++ b/tests/test-build-update-repo.sh
@@ -67,3 +67,5 @@ ${FLATPAK} build-update-repo --default-branch=no-such-branch repos/test >&2
 assert_file_has_content repos/test/config '^default-branch=no-such-branch$'
 
 ok "can update default branch"
+
+done_testing

--- a/tests/test-build-update-repo.sh
+++ b/tests/test-build-update-repo.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..5"
+plan_tests 5
 
 # Configure a repository, then set a collection ID on it and check that the ID
 # is saved in the config file.

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 9
-
 mkdir bundles
 
 setup_repo

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..9"
+plan_tests 9
 
 mkdir bundles
 

--- a/tests/test-bundle.sh
+++ b/tests/test-bundle.sh
@@ -185,3 +185,5 @@ run org.test.Hello &> hello_out
 assert_file_has_content hello_out '^Hello world, from a sandboxUPDATED2$'
 
 ok "update as bundle"
+
+done_testing

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -231,3 +231,4 @@ EOF
 
 ok "complete list --columns=arch,"
 
+done_testing

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -27,7 +27,7 @@ skip_revokefs_without_fuse
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-echo "1..17"
+plan_tests 17
 
 setup_repo
 install_repo

--- a/tests/test-completion.sh
+++ b/tests/test-completion.sh
@@ -27,8 +27,6 @@ skip_revokefs_without_fuse
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-plan_tests 17
-
 setup_repo
 install_repo
 

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -54,3 +54,5 @@ ${FLATPAK} config --get languages > get_out
 assert_file_has_content get_out "^[*]unset[*]"
 
 ok "config unset"
+
+done_testing

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-plan_tests 5
-
 ${FLATPAK} config --list > list_out
 assert_file_has_content list_out "^languages:"
 

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # This test looks for specific localized strings.
 export LC_ALL=C
 
-echo "1..5"
+plan_tests 5
 
 ${FLATPAK} config --list > list_out
 assert_file_has_content list_out "^languages:"

--- a/tests/test-default-remotes.sh
+++ b/tests/test-default-remotes.sh
@@ -38,7 +38,7 @@ Homepage=https://the.homepage/
 Icon=https://the.icon/
 EOF
 
-echo "1..5"
+plan_tests 5
 
 mkdir -p $FLATPAK_CONFIG_DIR/remotes.d
 

--- a/tests/test-default-remotes.sh
+++ b/tests/test-default-remotes.sh
@@ -38,8 +38,6 @@ Homepage=https://the.homepage/
 Icon=https://the.icon/
 EOF
 
-plan_tests 5
-
 mkdir -p $FLATPAK_CONFIG_DIR/remotes.d
 
 ${FLATPAK} -vv --system  remotes > remotes

--- a/tests/test-default-remotes.sh
+++ b/tests/test-default-remotes.sh
@@ -131,3 +131,5 @@ assert_file_has_content remotes "added-default"
 assert_remote_has_no_config added-default xa.filter
 
 ok "override default filter"
+
+done_testing

--- a/tests/test-extension-branch-follow.sh
+++ b/tests/test-extension-branch-follow.sh
@@ -105,3 +105,5 @@ else
 fi
 
 ok "extension branch follow"
+
+done_testing

--- a/tests/test-extension-branch-follow.sh
+++ b/tests/test-extension-branch-follow.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..1"
+plan_tests 1
 
 setup_repo () {
     mkdir -p repos

--- a/tests/test-extension-branch-follow.sh
+++ b/tests/test-extension-branch-follow.sh
@@ -8,8 +8,6 @@ set -euo pipefail
 
 skip_without_bwrap
 
-plan_tests 1
-
 setup_repo () {
     mkdir -p repos
     ostree init --repo=repos/test --mode=archive-z2

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -176,3 +176,5 @@ assert_has_extension_file /app multiversion/master/extension-org.test.Multiversi
 assert_has_extension_file /app multiversion/notmaster/extension-org.test.Multiversion.notmaster:not-master
 
 ok "app extensions"
+
+done_testing

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..2"
+plan_tests 2
 
 make_extension () {
     local ID=$1

--- a/tests/test-extensions.sh
+++ b/tests/test-extensions.sh
@@ -23,8 +23,6 @@ set -euo pipefail
 
 skip_without_bwrap
 
-plan_tests 2
-
 make_extension () {
     local ID=$1
     local VERSION=$2

--- a/tests/test-extra-data.sh
+++ b/tests/test-extra-data.sh
@@ -137,3 +137,5 @@ if test -f "${G_TEST_BUILDDIR}/apply-extra-static"; then
 else
     ok "# SKIP install+run extra data app with NoRuntime apply-extra-static not found"
 fi
+
+done_testing

--- a/tests/test-extra-data.sh
+++ b/tests/test-extra-data.sh
@@ -45,7 +45,7 @@ curl "${EXTRA_DATA_URL}" -o "${DOWNLOADED_EXTRA_DATA}"
 EXTRA_DATA_SIZE=$(stat --printf="%s" "${DOWNLOADED_EXTRA_DATA}")
 EXTRA_DATA_SHA256=$(sha256sum "${DOWNLOADED_EXTRA_DATA}" | cut -f1 -d' ')
 
-echo "1..3"
+plan_tests 3
 
 # build the app with the extra data
 EXTRA_DATA="--extra-data=test:${EXTRA_DATA_SHA256}:${EXTRA_DATA_SIZE}:${EXTRA_DATA_SIZE}:${EXTRA_DATA_URL}"

--- a/tests/test-extra-data.sh
+++ b/tests/test-extra-data.sh
@@ -45,8 +45,6 @@ curl "${EXTRA_DATA_URL}" -o "${DOWNLOADED_EXTRA_DATA}"
 EXTRA_DATA_SIZE=$(stat --printf="%s" "${DOWNLOADED_EXTRA_DATA}")
 EXTRA_DATA_SHA256=$(sha256sum "${DOWNLOADED_EXTRA_DATA}" | cut -f1 -d' ')
 
-plan_tests 3
-
 # build the app with the extra data
 EXTRA_DATA="--extra-data=test:${EXTRA_DATA_SHA256}:${EXTRA_DATA_SIZE}:${EXTRA_DATA_SIZE}:${EXTRA_DATA_URL}"
 BUILD_FINISH_ARGS=${EXTRA_DATA} make_updated_app ${REPONAME} ${COLLECTION_ID} ${BRANCH} UPDATE1

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -24,7 +24,7 @@ if ! journalctl --user --since="${HISTORY_START_TIME}" | grep -q "${MESSAGE}"; t
     skip "Cannot read back from Journal with journalctl"
 fi
 
-echo "1..1"
+plan_tests 1
 
 mkdir -p ${TEST_DATA_DIR}/system-history-installation
 mkdir -p ${FLATPAK_CONFIG_DIR}/installations.d

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -24,8 +24,6 @@ if ! journalctl --user --since="${HISTORY_START_TIME}" | grep -q "${MESSAGE}"; t
     skip "Cannot read back from Journal with journalctl"
 fi
 
-plan_tests 1
-
 mkdir -p ${TEST_DATA_DIR}/system-history-installation
 mkdir -p ${FLATPAK_CONFIG_DIR}/installations.d
 cat << EOF > ${FLATPAK_CONFIG_DIR}/installations.d/history-installation.conf

--- a/tests/test-history.sh
+++ b/tests/test-history.sh
@@ -206,3 +206,5 @@ rm -f ${FLATPAK_CONFIG_DIR}/installations.d/history-inst.conf
 rm -rf ${TEST_DATA_DIR}/system-history-installation
 
 ok "history looks correct"
+
+done_testing

--- a/tests/test-http-utils.sh
+++ b/tests/test-http-utils.sh
@@ -65,7 +65,7 @@ have_xattrs() {
     setfattr -n user.testvalue -v somevalue $1/test-xattrs > /dev/null 2>&1
 }
 
-echo "1..6"
+plan_tests 6
 
 # Without anything else, cached for 30 minutes
 assert_ok "/" $test_tmpdir/output

--- a/tests/test-http-utils.sh
+++ b/tests/test-http-utils.sh
@@ -158,3 +158,5 @@ if command -v setfattr >/dev/null &&
 else
     ok "xattrs # skip No setfattr or /var/tmp has user no xattr support"
 fi
+
+done_testing

--- a/tests/test-http-utils.sh
+++ b/tests/test-http-utils.sh
@@ -65,8 +65,6 @@ have_xattrs() {
     setfattr -n user.testvalue -v somevalue $1/test-xattrs > /dev/null 2>&1
 }
 
-plan_tests 6
-
 # Without anything else, cached for 30 minutes
 assert_ok "/" $test_tmpdir/output
 assert_cached "/" $test_tmpdir/output

--- a/tests/test-info.sh
+++ b/tests/test-info.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 skip_revokefs_without_fuse
 
-echo "1..9"
+plan_tests 9
 
 INCLUDE_SPECIAL_CHARACTER=1 setup_repo
 install_repo

--- a/tests/test-info.sh
+++ b/tests/test-info.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 
 skip_revokefs_without_fuse
 
-plan_tests 9
-
 INCLUDE_SPECIAL_CHARACTER=1 setup_repo
 install_repo
 

--- a/tests/test-info.sh
+++ b/tests/test-info.sh
@@ -68,3 +68,5 @@ ${FLATPAK} info org.test.Hello > info
 assert_file_has_content info "^Hello world test app: org\.test\.Hello - Print a greeting$"
 
 ok "info (name header)"
+
+done_testing

--- a/tests/test-metadata-validation.sh
+++ b/tests/test-metadata-validation.sh
@@ -156,3 +156,5 @@ assert_not_has_dir $FL_DIR/app/org.test.Malicious/current/active
 cleanup_repo
 
 ok "app with mismatched metadata (in summary) can't be installed"
+
+done_testing

--- a/tests/test-metadata-validation.sh
+++ b/tests/test-metadata-validation.sh
@@ -8,8 +8,6 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-plan_tests 7
-
 setup_repo
 
 COUNTER=1

--- a/tests/test-metadata-validation.sh
+++ b/tests/test-metadata-validation.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo "1..7"
+plan_tests 7
 
 setup_repo
 

--- a/tests/test-metainfo-export.sh
+++ b/tests/test-metainfo-export.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 
 source "$(dirname "$0")/libtest.sh"
 
-plan_tests 2
-
 setup_repo
 install_repo
 

--- a/tests/test-metainfo-export.sh
+++ b/tests/test-metainfo-export.sh
@@ -77,3 +77,5 @@ assert_file_has_content "${APP_DIR}/export/share/metainfo/releases/${APP_ID}.rel
   '<release version="1.0.0" date="2026-06-14"/>'
 
 ok "install exported metainfo and releases"
+
+done_testing

--- a/tests/test-metainfo-export.sh
+++ b/tests/test-metainfo-export.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/libtest.sh"
 
-echo "1..2"
+plan_tests 2
 
 setup_repo
 install_repo

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..1"
+plan_tests 1
 
 # Start the fake OCI registry server
 

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 
 skip_without_bwrap
 
-plan_tests 1
-
 # Start the fake OCI registry server
 
 httpd oci-registry-server.py --dir=.

--- a/tests/test-oci-auth.sh
+++ b/tests/test-oci-auth.sh
@@ -67,3 +67,5 @@ run org.test.Hello > hello_out
 assert_file_has_content hello_out '^Hello world, from a sandbox$'
 
 ok "install from auth-protected OCI registry"
+
+done_testing

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -424,3 +424,5 @@ $client add-signature hello "${digest}" "$(pwd)/oci/app-image-signature-2"
 ${FLATPAK} ${U} install -y oci-registry-sig org.test.Hello >&2
 
 ok "signed images"
+
+done_testing

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..18"
+plan_tests 18
 
 # Start the fake registry server
 

--- a/tests/test-oci-registry.sh
+++ b/tests/test-oci-registry.sh
@@ -23,8 +23,6 @@ set -euo pipefail
 
 skip_without_bwrap
 
-plan_tests 18
-
 # Start the fake registry server
 
 if [ x${USE_HTTPS} = xyes ] ; then

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_bwrap
 
-echo "1..4"
+plan_tests 4
 
 setup_repo_no_add oci
 

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -108,3 +108,5 @@ ${FLATPAK} --user remotes --show-disabled > remotes-list
 assert_file_has_content remotes-list '^platform-origin'
 
 ok "install oci archive"
+
+done_testing

--- a/tests/test-oci.sh
+++ b/tests/test-oci.sh
@@ -23,8 +23,6 @@ set -euo pipefail
 
 skip_without_bwrap
 
-plan_tests 4
-
 setup_repo_no_add oci
 
 mkdir -p oci

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -500,3 +500,5 @@ if ! skip_one_without_bwrap "runtime override --nofilesystem=host:reset"; then
 
   ok "runtime override --nofilesystem=host:reset"
 fi
+
+done_testing

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -17,7 +17,7 @@ reset_overrides () {
     assert_file_empty info
 }
 
-echo "1..20"
+plan_tests 20
 
 setup_repo
 install_repo

--- a/tests/test-override.sh
+++ b/tests/test-override.sh
@@ -17,8 +17,6 @@ reset_overrides () {
     assert_file_empty info
 }
 
-plan_tests 20
-
 setup_repo
 install_repo
 

--- a/tests/test-preinstall.sh
+++ b/tests/test-preinstall.sh
@@ -291,3 +291,5 @@ ${FLATPAK} ${U} remote-modify --url="http://no.127.0.0.1:${port}/test" test2-rep
 ${FLATPAK} ${U} -vvvv preinstall -y --sideload-repo=${SIDELOAD_REPO} >&2
 
 ok "sideload with network failure"
+
+done_testing

--- a/tests/test-preinstall.sh
+++ b/tests/test-preinstall.sh
@@ -82,8 +82,6 @@ setup_repo test2
 make_updated_app test2 org.test.Collection.test2 master HELLO2_MASTER_C2 org.test.Hello2
 make_updated_app test2 org.test.Collection.test2 master HELLO2_MASTER_C3 org.test.Hello3
 
-plan_tests 12
-
 # just checking that the test remote got added
 port=$(cat httpd-port)
 assert_remote_has_config test-repo url "http://127.0.0.1:${port}/test"

--- a/tests/test-preinstall.sh
+++ b/tests/test-preinstall.sh
@@ -82,7 +82,7 @@ setup_repo test2
 make_updated_app test2 org.test.Collection.test2 master HELLO2_MASTER_C2 org.test.Hello2
 make_updated_app test2 org.test.Collection.test2 master HELLO2_MASTER_C3 org.test.Hello3
 
-echo "1..12"
+plan_tests 12
 
 # just checking that the test remote got added
 port=$(cat httpd-port)

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-plan_tests 5
-
 create_commit() {
     # Wrap this to avoid set -x showing the commands
     { { local BASH_XTRACEFD=3; } 2> /dev/null

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -299,3 +299,5 @@ rm -rf repo/objects/*/*.commitmeta2
 diff -r repo ostree-repo >&2
 
 ok "Compare with ostree prune"
+
+done_testing

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo "1..5"
+plan_tests 5
 
 create_commit() {
     # Wrap this to avoid set -x showing the commands

--- a/tests/test-repair.sh
+++ b/tests/test-repair.sh
@@ -8,8 +8,6 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-plan_tests 2
-
 setup_repo
 ${FLATPAK} ${U} install -y test-repo org.test.Hello >&2
 

--- a/tests/test-repair.sh
+++ b/tests/test-repair.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo "1..2"
+plan_tests 2
 
 setup_repo
 ${FLATPAK} ${U} install -y test-repo org.test.Hello >&2

--- a/tests/test-repair.sh
+++ b/tests/test-repair.sh
@@ -51,3 +51,5 @@ ${FLATPAK} ${U} uninstall -y org.test.Platform org.test.Hello >&2
 ${FLATPAK} ${U} remote-delete test-repo >&2
 
 ok "repair --reinstall-all preserves pin state"
+
+done_testing

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 47
-
 #Regular repo
 setup_repo
 

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -1085,3 +1085,5 @@ ${FLATPAK} ${U} remote-add --if-not-exists new-repo test.flatpakrepo >&2
 assert_remote_has_no_config new-repo xa.filter
 
 ok "flatpakrepo"
+
+done_testing

--- a/tests/test-repo.sh
+++ b/tests/test-repo.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..47"
+plan_tests 47
 
 #Regular repo
 setup_repo

--- a/tests/test-run-custom.sh
+++ b/tests/test-run-custom.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 12
-
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
 setup_repo "" "" stable

--- a/tests/test-run-custom.sh
+++ b/tests/test-run-custom.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..12"
+plan_tests 12
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly

--- a/tests/test-run-custom.sh
+++ b/tests/test-run-custom.sh
@@ -198,3 +198,5 @@ while read fdpath; do
 done < hello_out
 
 ok "check no fd leak"
+
+done_testing

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 32
-
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly
 setup_repo "" "" stable

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..32"
+plan_tests 32
 
 # Use stable rather than master as the branch so we can test that the run
 # command automatically finds the branch correctly

--- a/tests/test-run.sh
+++ b/tests/test-run.sh
@@ -737,3 +737,5 @@ else
     ok "file-forwarding valid path # SKIP (no document portal)"
     ok "file-forwarding empty path # SKIP (no document portal)"
 fi
+
+done_testing

--- a/tests/test-seccomp.sh
+++ b/tests/test-seccomp.sh
@@ -9,8 +9,6 @@ set -euo pipefail
 skip_without_seccomp
 skip_without_bwrap
 
-plan_tests 18
-
 setup_repo
 install_repo
 

--- a/tests/test-seccomp.sh
+++ b/tests/test-seccomp.sh
@@ -75,7 +75,7 @@ for extra_argv in "" "--allow=multiarch"; do
   e=0
   try_syscall "ioctl TIOCSTI CVE-2019-10063" || e="$?"
   if test "$e" = "$ENOENT"; then
-    echo "ok # SKIP Cannot replicate CVE-2019-10063 on 32-bit architecture"
+    ok "# SKIP Cannot replicate CVE-2019-10063 on 32-bit architecture"
   else
     assert_streq "$e" "$EPERM"
     ok "ioctl TIOCSTI with high bits blocked (CVE-2019-10063)"

--- a/tests/test-seccomp.sh
+++ b/tests/test-seccomp.sh
@@ -99,3 +99,5 @@ for extra_argv in "" "--allow=multiarch"; do
   assert_streq "$e" "$EFAULT"
   ok "prctl not blocked"
 done
+
+done_testing

--- a/tests/test-seccomp.sh
+++ b/tests/test-seccomp.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 skip_without_seccomp
 skip_without_bwrap
 
-echo "1..18"
+plan_tests 18
 
 setup_repo
 install_repo

--- a/tests/test-sideload.sh
+++ b/tests/test-sideload.sh
@@ -27,7 +27,7 @@ USE_COLLECTIONS_IN_CLIENT=yes
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..9"
+plan_tests 9
 
 #Regular repo
 setup_repo

--- a/tests/test-sideload.sh
+++ b/tests/test-sideload.sh
@@ -27,8 +27,6 @@ USE_COLLECTIONS_IN_CLIENT=yes
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 9
-
 #Regular repo
 setup_repo
 

--- a/tests/test-sideload.sh
+++ b/tests/test-sideload.sh
@@ -208,3 +208,5 @@ assert_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=true$'
 assert_not_file_has_content ${FL_DIR}/repo/config '^gpg-verify-summary=false$'
 
 ok "migrate to gpg-verify-summary"
+
+done_testing

--- a/tests/test-subset.sh
+++ b/tests/test-subset.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..3"
+plan_tests 3
 
 EXPORT_ARGS="--subset=subset1 --subset=subset2" setup_repo
 

--- a/tests/test-subset.sh
+++ b/tests/test-subset.sh
@@ -112,3 +112,5 @@ assert_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml o
 assert_not_file_has_content $FL_DIR/appstream/test-repo/$ARCH/active/appstream.xml org.test.NoSubset.desktop
 
 ok "remote subset switching works"
+
+done_testing

--- a/tests/test-subset.sh
+++ b/tests/test-subset.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 3
-
 EXPORT_ARGS="--subset=subset1 --subset=subset2" setup_repo
 
 $FLATPAK repo repos/test > repo-info.txt

--- a/tests/test-summaries.sh
+++ b/tests/test-summaries.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-echo "1..2"
+plan_tests 2
 
 setup_repo
 

--- a/tests/test-summaries.sh
+++ b/tests/test-summaries.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
-plan_tests 2
-
 setup_repo
 
 sha256() {

--- a/tests/test-summaries.sh
+++ b/tests/test-summaries.sh
@@ -261,3 +261,5 @@ assert_not_file_has_content httpd-log summaries/${ACTIVE_SUBSET}.gz
 assert_not_file_has_content httpd-log summaries/${OLD_ACTIVE_SUBSET}-${ACTIVE_SUBSET}.delta
 
 ok subsummary fetching and caching
+
+done_testing

--- a/tests/test-unused.sh
+++ b/tests/test-unused.sh
@@ -27,7 +27,7 @@ export USE_SYSTEMDIR=yes
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..3"
+plan_tests 3
 
 setup_empty_repo &> /dev/null
 

--- a/tests/test-unused.sh
+++ b/tests/test-unused.sh
@@ -27,8 +27,6 @@ export USE_SYSTEMDIR=yes
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 3
-
 setup_empty_repo &> /dev/null
 
 # Manually add the user remote too

--- a/tests/test-unused.sh
+++ b/tests/test-unused.sh
@@ -432,3 +432,5 @@ if [ $(cat newly-unused.txt | wc -l) -ne 10 ]; then
 fi
 
 ok "list unused exclude"
+
+done_testing

--- a/tests/test-update-portal.sh
+++ b/tests/test-update-portal.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 6
-
 setup_repo
 install_repo
 

--- a/tests/test-update-portal.sh
+++ b/tests/test-update-portal.sh
@@ -127,3 +127,5 @@ make_updated_app test "" master UPDATE45
 run_with_sandboxed_bus ${test_builddir}/test-update-portal update monitor.pid >&2
 
 ok "update with changed permissions"
+
+done_testing

--- a/tests/test-update-portal.sh
+++ b/tests/test-update-portal.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..6"
+plan_tests 6
 
 setup_repo
 install_repo

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..3"
+plan_tests 3
 
 # Configure a repository without a collection ID and pull it locally.
 setup_repo

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -111,3 +111,5 @@ assert_file_has_content ${FL_DIR}/repo/config '^collection-id=org\.test\.Collect
 assert_not_file_has_content ${FL_DIR}/repo/config '^collection-id=net\.malicious\.NewCollection$'
 
 ok "3 update repo config with different collection ID"
+
+done_testing

--- a/tests/test-update-remote-configuration.sh
+++ b/tests/test-update-remote-configuration.sh
@@ -27,8 +27,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 3
-
 # Configure a repository without a collection ID and pull it locally.
 setup_repo
 install_repo

--- a/tests/test-upgrade-from-header.sh
+++ b/tests/test-upgrade-from-header.sh
@@ -7,8 +7,6 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-plan_tests 6
-
 # Override the httpd function to enable header logging before setup_repo calls
 # it. The web-server.py will log Flatpak-Ref and Flatpak-Upgrade-From headers
 # to httpd-headers-log.

--- a/tests/test-upgrade-from-header.sh
+++ b/tests/test-upgrade-from-header.sh
@@ -88,3 +88,5 @@ ok "Flatpak-Upgrade-From header sent when remote tracking ref is missing"
 assert_file_has_content httpd-headers-log "Flatpak-Ref: ${APP_REF}"
 
 ok "Flatpak-Ref header sent when remote tracking ref is missing"
+
+done_testing

--- a/tests/test-upgrade-from-header.sh
+++ b/tests/test-upgrade-from-header.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 skip_without_bwrap
 skip_revokefs_without_fuse
 
-echo "1..6"
+plan_tests 6
 
 # Override the httpd function to enable header logging before setup_repo calls
 # it. The web-server.py will log Flatpak-Ref and Flatpak-Upgrade-From headers


### PR DESCRIPTION
* tests: Track and emit TAP test numbers in shell script tests
    
    This will help us to emit correct TAP syntax, without having to always
    declare up-front how many tests we are going to run.

* tests: Add a function to declare the "plan", instead of direct echo
    
    This is approximately the equivalent of 'plan' in Perl Test::More:
    it announces how many tests we plan to run.

* tests: At the end of each test, explicitly log that we have finished
    
    This is the equivalent of the function of the same name in Perl's
    Test::More. If we already emitted a test plan, it asserts that the
    number of tests we planned to do equals the number we actually did.
    
    If not, it assumes that however many tests we have done, that's all of
    the tests that we intend to do - this can be useful in test scripts
    that routinely increase in length, like test-run.sh which is becoming
    rather long (and has frequent conflicts for the "plan" line when we
    cherry-pick new test coverage to older branches).

* tests: Consistently Use the "no plan" style for TAP tests
    
    Instead of announcing ahead of time how many tests will be run, just
    log 1..32 or similar at the end, from the done_testing function.
    
    This should go some way towards preventing unnecessary cherry-pick
    conflicts when tests added to this script get backported.
    
    Resolves: https://github.com/flatpak/flatpak/issues/6793

* tests: Drop plan_tests function, no longer used

---

This is going to be a bit annoying for backports to stable-branches at first, but no worse than the current situation. We could backport these tests improvements (they only touch tests and not production code, and are not too intrusive), or we could accept that 1.18.x is going to continue to be a bit annoying but at least backporting from 1.21.x to 1.20.x will be easier.