### PR TITLE
Avoid %c in error messages

### DIFF
--- a/common/flatpak-ref-utils.c
+++ b/common/flatpak-ref-utils.c
@@ -144,8 +144,11 @@ flatpak_is_valid_name (const char *string,
     }
   else if (G_UNLIKELY (!is_valid_initial_name_character (*s, last_element)))
     {
+      g_autofree char *first = flatpak_describe_invalid_first_char (s);
+
       flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                          _("Name can't start with %c"), *s);
+                          _("Name can't start with \"%s\""),
+                          first);
       goto out;
     }
 
@@ -166,24 +169,30 @@ flatpak_is_valid_name (const char *string,
             }
           if (!is_valid_initial_name_character (*s, last_element))
             {
+              g_autofree char *first = flatpak_describe_invalid_first_char (s);
+
               if (*s == '-')
                 flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
                                     _("Only last name segment can contain -"));
               else
                 flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                                    _("Name segment can't start with %c"), *s);
+                                    _("Name segment can't start with \"%s\""),
+                                    first);
               goto out;
             }
           dot_count++;
         }
       else if (G_UNLIKELY (!is_valid_name_character (*s, last_element)))
         {
+          g_autofree char *first = flatpak_describe_invalid_first_char (s);
+
           if (*s == '-')
             flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
                                 _("Only last name segment can contain -"));
           else
             flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                                _("Name can't contain %c"), *s);
+                                _("Name can't contain \"%s\""),
+                                first);
           goto out;
         }
       s += 1;
@@ -319,8 +328,11 @@ flatpak_is_valid_arch (const char *string,
     {
       if (G_UNLIKELY (!is_valid_arch_character (*string)))
         {
+          g_autofree char *first = flatpak_describe_invalid_first_char (string);
+
           flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                              _("Arch can't contain %c"), *string);
+                              _("Arch can't contain \"%s\""),
+                              first);
           return FALSE;
         }
       string += 1;
@@ -391,8 +403,11 @@ flatpak_is_valid_branch (const char *string,
   s = string;
   if (G_UNLIKELY (!is_valid_initial_branch_character (*s)))
     {
+      g_autofree char *first = flatpak_describe_invalid_first_char (s);
+
       flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                          _("Branch can't start with %c"), *s);
+                          _("Branch can't start with \"%s\""),
+                          first);
       goto out;
     }
 
@@ -401,8 +416,11 @@ flatpak_is_valid_branch (const char *string,
     {
       if (G_UNLIKELY (!is_valid_branch_character (*s)))
         {
+          g_autofree char *first = flatpak_describe_invalid_first_char (s);
+
           flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                              _("Branch can't contain %c"), *s);
+                              _("Branch can't contain \"%s\""),
+                              first);
           goto out;
         }
       s += 1;
@@ -588,8 +606,11 @@ flatpak_is_valid_remote_name (const char *string,
 
   if (G_UNLIKELY (!is_valid_initial_remote_name_character (*string)))
     {
+      g_autofree char *first = flatpak_describe_invalid_first_char (string);
+
       flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                          _("Remote name can't start with %c"), *string);
+                          _("Remote name can't start with \"%s\""),
+                          first);
       return FALSE;
     }
   string++;
@@ -598,8 +619,11 @@ flatpak_is_valid_remote_name (const char *string,
     {
       if (G_UNLIKELY (!is_valid_remote_name_character (*string)))
         {
+          g_autofree char *first = flatpak_describe_invalid_first_char (string);
+
           flatpak_fail_error (error, FLATPAK_ERROR_INVALID_NAME,
-                              _("Remote name can't contain %c"), *string);
+                              _("Remote name can't contain \"%s\""),
+                              first);
           return FALSE;
         }
       string++;

--- a/common/flatpak-utils-private.h
+++ b/common/flatpak-utils-private.h
@@ -361,6 +361,8 @@ char * flatpak_escape_string (const char        *s,
 gboolean flatpak_validate_path_characters (const char *path,
                                            GError    **error);
 
+char *flatpak_describe_invalid_first_char (const char *s);
+
 gboolean running_under_sudo_root (void);
 
 void flatpak_set_debugging (gboolean debugging);

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -2533,6 +2533,37 @@ flatpak_validate_path_characters (const char *path,
   return TRUE;
 }
 
+/*
+ * Describe the first character of @s in a way that is useful for
+ * error messages about invalid strings.
+ */
+char *
+flatpak_describe_invalid_first_char (const char *s)
+{
+  gunichar c = g_utf8_get_char_validated (s, -1);
+
+  /* If s starts with valid UTF-8 and the character is printable,
+   * represent it as itself, for example:
+   * Branch can't contain "x" */
+  if (c > 0 && g_unichar_isprint (c) && !g_unichar_iszerowidth (c))
+    {
+      char buf[7] = { 0 };
+
+      g_unichar_to_utf8 (c, buf);
+      return g_strdup (buf);
+    }
+
+  /* If s starts with valid UTF-8 but the character is unprintable,
+   * represent it in Unicode codepoint notation, for example:
+   * Branch can't contain "U+000A" */
+  if (c != (gunichar) -1 && c != (gunichar) -2)
+    return g_strdup_printf ("U+%04X", c);
+
+  /* If it wasn't even valid UTF-8, resort to representing the byte:
+   * Branch can't contain "\xFF" */
+  return g_strdup_printf ("\\x%02X", (unsigned char) *s);
+}
+
 gboolean
 running_under_sudo_root (void)
 {

--- a/common/flatpak-utils.c
+++ b/common/flatpak-utils.c
@@ -742,7 +742,6 @@ flatpak_filter_glob_to_regexp (const char  *glob,
   while (*glob != 0)
     {
       char c = *glob;
-      glob++;
 
       if (c == '/')
         {
@@ -774,9 +773,14 @@ flatpak_filter_glob_to_regexp (const char  *glob,
         }
       else
         {
-          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Invalid glob character '%c'"), c);
+          g_autofree char *first = flatpak_describe_invalid_first_char (glob);
+
+          flatpak_fail_error (error, FLATPAK_ERROR_INVALID_DATA, _("Invalid glob character '%s'"),
+                              first);
           return NULL;
         }
+
+      glob++;
     }
 
   while (parts < 3)

--- a/po/bg.po
+++ b/po/bg.po
@@ -6097,8 +6097,8 @@ msgstr "Твърде много части в шаблона по Unix"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Неправилен знак „%c“ в шаблона по Unix"
+msgid "Invalid glob character '%s'"
+msgstr "Неправилен знак „%s“ в шаблона по Unix"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -5960,7 +5960,7 @@ msgstr ""
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
+msgid "Invalid glob character '%s'"
 msgstr ""
 
 #: common/flatpak-utils.c:831

--- a/po/da.po
+++ b/po/da.po
@@ -6009,8 +6009,8 @@ msgstr "For mange argumenter i glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Ugyldigt glob-tegn '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "Ugyldigt glob-tegn '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -5980,7 +5980,7 @@ msgstr "Zu viele Argumente"
 
 #: common/flatpak-utils.c:777
 #, fuzzy, c-format
-msgid "Invalid glob character '%c'"
+msgid "Invalid glob character '%s'"
 msgstr "Ungültige Prozesskennung %s"
 
 #: common/flatpak-utils.c:831

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5961,8 +5961,8 @@ msgstr "Too many segments in glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Invalid glob character '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "Invalid glob character '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/eo.po
+++ b/po/eo.po
@@ -5951,8 +5951,8 @@ msgstr "Tro da segmentoj en globo"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Nevalida globa signo '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "Nevalida globa signo '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -6074,8 +6074,8 @@ msgstr "Demasiados argumentos en el glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Caracter de glob «%c» no válido"
+msgid "Invalid glob character '%s'"
+msgstr "Caracter de glob «%s» no válido"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -5837,7 +5837,7 @@ msgstr ""
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
+msgid "Invalid glob character '%s'"
 msgstr ""
 
 #: common/flatpak-utils.c:831

--- a/po/hi.po
+++ b/po/hi.po
@@ -5924,8 +5924,8 @@ msgstr "ग्लोब में बहुत सारे खंड"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "अमान्य ग्लोब वर्ण '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "अमान्य ग्लोब वर्ण '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -6003,8 +6003,8 @@ msgstr "Previše segmenata u globalnoj naredbi"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Neispravan znak „%c” u globalnoj naredbi"
+msgid "Invalid glob character '%s'"
+msgstr "Neispravan znak „%s” u globalnoj naredbi"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/id.po
+++ b/po/id.po
@@ -5989,8 +5989,8 @@ msgstr "Terlalu banyak segmen pada glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Karakter glob tidak valid '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "Karakter glob tidak valid '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/ka.po
+++ b/po/ka.po
@@ -6045,8 +6045,8 @@ msgstr "გლობში მეტისმეტად ბევრი სე
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "არასწორი გლობის სიმბოლო '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "არასწორი გლობის სიმბოლო '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/kk.po
+++ b/po/kk.po
@@ -6032,8 +6032,8 @@ msgstr "Глобта сегменттер тым көп"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Глоб таңбасы жарамсыз: '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "Глоб таңбасы жарамсыз: '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -6028,8 +6028,8 @@ msgstr "Te veel segmenten in glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Ongeldig glob-teken ‘%c’"
+msgid "Invalid glob character '%s'"
+msgstr "Ongeldig glob-teken ‘%s’"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -6084,8 +6084,8 @@ msgstr "Za dużo segmentów we wzorcu"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Nieprawidłowy znak wzorca „%c”"
+msgid "Invalid glob character '%s'"
+msgstr "Nieprawidłowy znak wzorca „%s”"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/pt.po
+++ b/po/pt.po
@@ -5984,8 +5984,8 @@ msgstr "Número excessivo de argumentos no glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Caractere de glob “%c” inválido"
+msgid "Invalid glob character '%s'"
+msgstr "Caractere de glob “%s” inválido"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6019,8 +6019,8 @@ msgstr "Número excessivo de argumentos no glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Caractere de glob “%c” inválido"
+msgid "Invalid glob character '%s'"
+msgstr "Caractere de glob “%s” inválido"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -6049,8 +6049,8 @@ msgstr "Prea multe segmente în glob"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Caracter de glob nevalid „%c”"
+msgid "Invalid glob character '%s'"
+msgstr "Caracter de glob nevalid „%s”"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -6035,8 +6035,8 @@ msgstr "Слишком много частей в glob'е"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Недопустимый знак '%c' в glob'е"
+msgid "Invalid glob character '%s'"
+msgstr "Недопустимый знак '%s' в glob'е"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -5981,8 +5981,8 @@ msgstr "Preveč segmentov v glob-u"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Neveljaven znak glob »%c«"
+msgid "Invalid glob character '%s'"
+msgstr "Neveljaven znak glob »%s«"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/sr.po
+++ b/po/sr.po
@@ -6000,8 +6000,8 @@ msgstr "Превише делова у глобу"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Неисправан знак глоба „%c“"
+msgid "Invalid glob character '%s'"
+msgstr "Неисправан знак глоба „%s“"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -6014,8 +6014,8 @@ msgstr "För många segment i matchning"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Ogiltigt matchningstecken ”%c”"
+msgid "Invalid glob character '%s'"
+msgstr "Ogiltigt matchningstecken ”%s”"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -6006,8 +6006,8 @@ msgstr "Glob’da çok fazla bölüm"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Geçersiz glob karakter '%c'"
+msgid "Invalid glob character '%s'"
+msgstr "Geçersiz glob karakter '%s'"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -6065,8 +6065,8 @@ msgstr "Забагато аргументів у виразі-заміннику
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "Некоректний символ у виразі-заміннику, «%c»"
+msgid "Invalid glob character '%s'"
+msgstr "Некоректний символ у виразі-заміннику, «%s»"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5831,8 +5831,8 @@ msgstr "Glob 中太多分段"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "无效的 glob 字符“%c”"
+msgid "Invalid glob character '%s'"
+msgstr "无效的 glob 字符“%s”"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5914,8 +5914,8 @@ msgstr "glob 中的區段過多"
 
 #: common/flatpak-utils.c:777
 #, c-format
-msgid "Invalid glob character '%c'"
-msgstr "「%c」glob 字元無效"
+msgid "Invalid glob character '%s'"
+msgstr "「%s」glob 字元無效"
 
 #: common/flatpak-utils.c:831
 #, c-format

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -183,6 +183,7 @@ foreach testcase : c_tests
       args : [exe],
       depends : runtime_repo,
       env : test_env,
+      protocol : 'tap',
       timeout : options.get('timeout', 30),
     )
   endif

--- a/tests/test-ref-utils.c
+++ b/tests/test-ref-utils.c
@@ -5,10 +5,13 @@
 
 #include "config.h"
 
+#include <locale.h>
+
 #include <glib.h>
 
 #include "flatpak.h"
 #include "flatpak-ref-utils-private.h"
+#include "flatpak-utils-private.h"
 
 #include "tests/testlib.h"
 
@@ -33,6 +36,7 @@ test_valid_arch (void)
     "path/../traversal",
     "path_traversal/..",
     "\xc3\xa1",   /* U+00E1 LATIN SMALL LETTER A WITH ACUTE */
+    "\xff",       /* not valid UTF-8 */
     "a\xc3\xa1",
   };
   static const struct
@@ -75,11 +79,13 @@ test_valid_arch (void)
   for (size_t i = 0; i < G_N_ELEMENTS (bad); i++)
     {
       g_autoptr(GError) local_error = NULL;
+      g_autofree char *escaped = flatpak_escape_string (bad[i], FLATPAK_ESCAPE_DO_NOT_QUOTE);
       gboolean ok = flatpak_is_valid_arch (bad[i], -1, &local_error);
 
       g_test_message ("bad architecture \"%s\" -> %s",
-                      bad[i], ok ? "wrongly accepted" : local_error->message);
+                      escaped, ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 
@@ -90,6 +96,7 @@ test_valid_arch (void)
       g_test_message ("empty architecture -> %s",
                       ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 }
@@ -116,6 +123,7 @@ test_valid_branch (void)
     "path-traversal/..",
     "path/../traversal",
     "\xc3\xa1",   /* U+00E1 LATIN SMALL LETTER A WITH ACUTE */
+    "\xff",       /* not valid UTF-8 */
     "a\xc3\xa1",
   };
   static const struct
@@ -158,11 +166,13 @@ test_valid_branch (void)
   for (size_t i = 0; i < G_N_ELEMENTS (bad); i++)
     {
       g_autoptr(GError) local_error = NULL;
+      g_autofree char *escaped = flatpak_escape_string (bad[i], FLATPAK_ESCAPE_DO_NOT_QUOTE);
       gboolean ok = flatpak_is_valid_branch (bad[i], -1, &local_error);
 
       g_test_message ("bad branch \"%s\" -> %s",
-                      bad[i], ok ? "wrongly accepted" : local_error->message);
+                      escaped, ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 
@@ -173,6 +183,7 @@ test_valid_branch (void)
       g_test_message ("empty branch -> %s",
                       ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 }
@@ -201,6 +212,7 @@ test_valid_name (void)
     "org.7_zip.Archiver",
     "org._7-zip.Archiver",
     "\xc3\xa1",   /* U+00E1 LATIN SMALL LETTER A WITH ACUTE */
+    "\xff",       /* not valid UTF-8 */
     "a\xc3\xa1",
     NAME_CHAR_x256,
   };
@@ -244,11 +256,13 @@ test_valid_name (void)
   for (size_t i = 0; i < G_N_ELEMENTS (bad); i++)
     {
       g_autoptr(GError) local_error = NULL;
+      g_autofree char *escaped = flatpak_escape_string (bad[i], FLATPAK_ESCAPE_DO_NOT_QUOTE);
       gboolean ok = flatpak_is_valid_name (bad[i], -1, &local_error);
 
       g_test_message ("bad app name \"%s\" -> %s",
-                      bad[i], ok ? "wrongly accepted" : local_error->message);
+                      escaped, ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 
@@ -259,6 +273,7 @@ test_valid_name (void)
       g_test_message ("empty app name -> %s",
                       ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 }
@@ -285,6 +300,7 @@ test_valid_remote_name (void)
     "path/../traversal",
     "path-traversal/..",
     "\xc3\xa1",   /* U+00E1 LATIN SMALL LETTER A WITH ACUTE */
+    "\xff",       /* not valid UTF-8 */
     "a\xc3\xa1",
   };
   static const struct
@@ -327,11 +343,13 @@ test_valid_remote_name (void)
   for (size_t i = 0; i < G_N_ELEMENTS (bad); i++)
     {
       g_autoptr(GError) local_error = NULL;
+      g_autofree char *escaped = flatpak_escape_string (bad[i], FLATPAK_ESCAPE_DO_NOT_QUOTE);
       gboolean ok = flatpak_is_valid_remote_name (bad[i], -1, &local_error);
 
       g_test_message ("bad remote name \"%s\" -> %s",
-                      bad[i], ok ? "wrongly accepted" : local_error->message);
+                      escaped, ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 
@@ -342,6 +360,7 @@ test_valid_remote_name (void)
       g_test_message ("empty remote name -> %s",
                       ok ? "wrongly accepted" : local_error->message);
       g_assert_nonnull (local_error);
+      g_assert_true (g_utf8_validate (local_error->message, -1, NULL));
       g_assert_false (ok);
     }
 }
@@ -349,6 +368,8 @@ test_valid_remote_name (void)
 int
 main (int argc, char *argv[])
 {
+  setlocale (LC_ALL, "");
+
   g_test_init (&argc, &argv, NULL);
 
   g_test_add_func ("/ref-utils/valid-arch", test_valid_arch);

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -834,6 +834,14 @@ test_filter_parser (void)
      "deny *\n"
      "allow org.foo.bar extra\n",
      FLATPAK_ERROR_INVALID_DATA
+    },
+    {
+     "deny \xf0\x9f\x98\xb9",
+     FLATPAK_ERROR_INVALID_DATA
+    },
+    {
+     "deny \xff",
+     FLATPAK_ERROR_INVALID_DATA
     }
   };
   gboolean ret;
@@ -841,12 +849,15 @@ test_filter_parser (void)
 
   for (i = 0; i < G_N_ELEMENTS(filters); i++)
     {
+      g_autofree char *escaped = flatpak_escape_string (filters[i].filter, FLATPAK_ESCAPE_DO_NOT_QUOTE);
       g_autoptr(GError) error = NULL;
       g_autoptr(GRegex) allow_refs = NULL;
       g_autoptr(GRegex) deny_refs = NULL;
 
       ret = flatpak_parse_filters (filters[i].filter, &allow_refs, &deny_refs, &error);
       g_assert_error (error, FLATPAK_ERROR, filters[i].expected_error);
+      g_test_message ("Invalid filter \"%s\" -> %s", escaped, error->message);
+      g_assert_true (g_utf8_validate (error->message, -1, NULL));
       g_assert_true (ret == FALSE);
       g_assert_true (allow_refs == NULL);
       g_assert_true (deny_refs == NULL);

--- a/tests/testcommon.c
+++ b/tests/testcommon.c
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#include <locale.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -999,6 +1000,35 @@ test_dconf_paths (void)
 }
 
 static void
+test_describe_invalid_char (void)
+{
+  static const char * const inputs[] =
+  {
+    ".",
+    "-",
+    "abc",
+    "\n",
+    "\xc3\xa6",           /* U+00E6 LATIN SMALL LETTER AE */
+    "\xcc\x88",           /* U+0308 COMBINING DIAERESIS */
+    "\xef\xbb\xbf",       /* U+FEFF ZERO WIDTH NO-BREAK SPACE */
+    "\xf0\x9f\x98\xb9",   /* U+1F639 CAT FACE WITH TEARS OF JOY */
+    "\xf0\x9f",           /* truncated valid UTF-8 */
+    "\xff",               /* not valid UTF-8 */
+  };
+
+  for (size_t i = 0; i < G_N_ELEMENTS (inputs); i++)
+    {
+      g_autofree char *escaped = flatpak_escape_string (inputs[i], FLATPAK_ESCAPE_DO_NOT_QUOTE);
+      g_autofree char *output = flatpak_describe_invalid_first_char (inputs[i]);
+
+      g_test_message ("First character of \"%s\": \"%s\"", escaped, output);
+      g_assert_nonnull (output);
+      g_assert_true (g_utf8_validate (escaped, -1, NULL));
+      g_assert_true (g_utf8_validate (output, -1, NULL));
+    }
+}
+
+static void
 test_envp_cmp (void)
 {
   static const char * const unsorted[] =
@@ -1353,6 +1383,8 @@ main (int argc, char *argv[])
 {
   int res;
 
+  setlocale (LC_ALL, "");
+
   g_test_init (&argc, &argv, NULL);
 
   g_test_add_func ("/common/has-path-prefix", test_has_path_prefix);
@@ -1370,6 +1402,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/common/dconf-app-id", test_dconf_app_id);
   g_test_add_func ("/common/dconf-paths", test_dconf_paths);
   g_test_add_func ("/common/decompose-ref", test_decompose);
+  g_test_add_func ("/common/describe-invalid-char", test_describe_invalid_char);
   g_test_add_func ("/common/envp-cmp", test_envp_cmp);
   g_test_add_func ("/common/needs-quoting", test_needs_quoting);
   g_test_add_func ("/common/quote-argv", test_quote_argv);


### PR DESCRIPTION
* utils: Add a function to describe invalid characters in strings
    
    Until now we have been using `%c` to show invalid characters, but in
    general that will corrupt our output if the input is non-ASCII,
    because the individual bytes of a UTF-8 string are not valid UTF-8 alone.

* utils: Avoid corrupting our output if an invalid glob is not UTF-8

* po: Update translations for "Invalid glob character" where obvious

* ref-utils: Always produce valid UTF-8 in validation error messages
    
    While I'm changing the translatable string anyway, this also
    incorporates a suggestion from #6753 to quote the invalid character, so
    that output is clearer in the case where the invalid character is
    whitespace.
    
    Thanks: Christian Stadelmann

* Revert "tests: Avoid Meson's strict TAP parsing for now"
    
    Now that our error messages are valid UTF-8, we should no longer need to
    do this.
    
    This reverts commit 242e9893e7977cdda871771bf8c2aaa5806c8a7b.