### PR TITLE
libtest: Fix undefined variable reference if all test-cases are skipped

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -578,9 +578,6 @@ have_working_bwrap() {
 
 # Use to skip all of these tests
 skip() {
-    if [ -n "$planned_tests" ]; then
-        assert_not_reached "Cannot call skip after plan_tests"
-    fi
     echo "1..0 # SKIP" "$@"
     exit 0
 }


### PR DESCRIPTION
Fixes: f0ce1311 "tests: Drop plan_tests function, no longer used"