### PR TITLE
transaction, remote-info: Include extra-data in download size estimate

### DIFF
--- a/app/flatpak-builtins-remote-info.c
+++ b/app/flatpak-builtins-remote-info.c
@@ -227,6 +227,8 @@ flatpak_builtin_remote_info (int argc, char **argv, GCancellable *cancellable, G
           installed_size = GUINT64_FROM_BE (var_metadata_lookup_uint64 (commit_metadata, "xa.installed-size", 0));
           download_size = GUINT64_FROM_BE (var_metadata_lookup_uint64 (commit_metadata, "xa.download-size", 0));
 
+          flatpak_commit_add_extra_data_sizes (commit_v, &installed_size, &download_size);
+
           formatted_installed_size = g_format_size (installed_size);
           formatted_download_size = g_format_size (download_size);
           formatted_timestamp = format_timestamp (timestamp);

--- a/common/flatpak-repo-utils-private.h
+++ b/common/flatpak-repo-utils-private.h
@@ -140,6 +140,9 @@ gboolean flatpak_repo_collect_sizes (OstreeRepo   *repo,
                                      GError      **error);
 GVariant *flatpak_commit_get_extra_data_sources (GVariant *commitv,
                                                  GError  **error);
+void flatpak_commit_add_extra_data_sizes (GVariant *commitv,
+                                              guint64  *installed_size,
+                                              guint64  *download_size);
 GVariant *flatpak_repo_get_extra_data_sources (OstreeRepo   *repo,
                                                const char   *rev,
                                                GCancellable *cancellable,

--- a/common/flatpak-repo-utils.c
+++ b/common/flatpak-repo-utils.c
@@ -497,17 +497,16 @@ flatpak_repo_collect_sizes (OstreeRepo   *repo,
   return _flatpak_repo_collect_sizes (repo, root, NULL, installed_size, download_size, cancellable, error);
 }
 
-static void
-flatpak_repo_collect_extra_data_sizes (OstreeRepo *repo,
-                                       const char *rev,
-                                       guint64    *installed_size,
-                                       guint64    *download_size)
+void
+flatpak_commit_add_extra_data_sizes (GVariant *commitv,
+                                         guint64  *installed_size,
+                                         guint64  *download_size)
 {
   g_autoptr(GVariant) extra_data_sources = NULL;
   gsize n_extra_data;
   int i;
 
-  extra_data_sources = flatpak_repo_get_extra_data_sources (repo, rev, NULL, NULL);
+  extra_data_sources = flatpak_commit_get_extra_data_sources (commitv, NULL);
   if (extra_data_sources == NULL)
     return;
 
@@ -530,6 +529,22 @@ flatpak_repo_collect_extra_data_sizes (OstreeRepo *repo,
       if (download_size)
         *download_size += extra_download_size;
     }
+}
+
+static void
+flatpak_repo_collect_extra_data_sizes (OstreeRepo *repo,
+                                       const char *rev,
+                                       guint64    *installed_size,
+                                       guint64    *download_size)
+{
+  g_autoptr(GVariant) commitv = NULL;
+
+  if (!ostree_repo_load_variant (repo,
+                                 OSTREE_OBJECT_TYPE_COMMIT,
+                                 rev, &commitv, NULL))
+    return;
+
+  flatpak_commit_add_extra_data_sizes (commitv, installed_size, download_size);
 }
 
 /* Loads the old compat summary file from a local repo */

--- a/common/flatpak-transaction.c
+++ b/common/flatpak-transaction.c
@@ -3656,9 +3656,13 @@ resolve_op_from_commit (FlatpakTransaction *self,
   metadata_bytes = g_bytes_new (xa_metadata, strlen (xa_metadata));
 
   if (g_variant_lookup (commit_metadata, "xa.download-size", "t", &download_size))
-    op->download_size = GUINT64_FROM_BE (download_size);
+    download_size = GUINT64_FROM_BE (download_size);
   if (g_variant_lookup (commit_metadata, "xa.installed-size", "t", &installed_size))
-    op->installed_size = GUINT64_FROM_BE (installed_size);
+    installed_size = GUINT64_FROM_BE (installed_size);
+
+  flatpak_commit_add_extra_data_sizes (commit_data, &installed_size, &download_size);
+  op->download_size = download_size;
+  op->installed_size = installed_size;
 
   g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE, "s", &op->eol);
   g_variant_lookup (commit_metadata, OSTREE_COMMIT_META_KEY_ENDOFLIFE_REBASE, "s", &op->eol_rebase);


### PR DESCRIPTION
flatpak update --commit and flatpak remote-info read the download size from xa.download-size in the commit metadata, which only covers the ostree file objects and not extra-data. The summary cache path used by a regular flatpak update does add extra-data sizes, so the two differed: extra-data apps like com.jetbrains.Rider showed 1.3 MB instead of 1.6 GB.

Add flatpak_commit_add_extra_data_sizes() to sum the extra-data sizes from a commit variant, and use it in resolve_op_from_commit() and remote-info so they match the summary path. 

Fixes: https://github.com/flatpak/flatpak/issues/5947