### PR TITLE
cli: Return non-zero exit code when a non-fatal update fails

### DIFF
--- a/app/flatpak-cli-transaction.c
+++ b/app/flatpak-cli-transaction.c
@@ -557,7 +557,7 @@ operation_error (FlatpakTransaction            *transaction,
   else
     text = g_strdup ("(internal error, please report)");
 
-  if (!non_fatal && self->first_operation_error == NULL)
+  if (self->first_operation_error == NULL)
     {
       /* Here we go to great lengths not to split the sentences. See
        * https://wiki.gnome.org/TranslationProject/DevGuidelines/Never%20split%20sentences


### PR DESCRIPTION
flatpak update continues past errors for related extensions (like .Locale), which are marked non-fatal so the rest of the update can proceed. But the operation_error callback only recorded the first error when non_fatal was unset, so a failed extension download was silently ignored and flatpak update returned exit code 0.

Always record the first operation error, regardless of non_fatal, so the CLI returns a non-zero exit code while still continuing with the remaining operations.

Fixes: https://github.com/flatpak/flatpak/issues/5400